### PR TITLE
SOC-6322 : Add template params when posting an activity in UserRestResourcesV1

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -659,6 +659,7 @@ public class UserRestResourcesV1 implements UserRestResources {
               .map(fileModel -> new ActivityFile(fileModel.getUploadId(), fileModel.getStorage()))
               .collect(Collectors.toList()));
     }
+    activity.setTemplateParams(model.getTemplateParams());
     CommonsUtils.getService(ActivityManager.class).saveActivityNoReturn(target, activity);
 
     logMetrics(activity);

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -17,6 +17,7 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.rest.api.ErrorResource;
 import org.exoplatform.social.rest.entity.ActivityEntity;
 import org.exoplatform.social.rest.entity.CollectionEntity;
+import org.exoplatform.social.rest.entity.DataEntity;
 import org.exoplatform.social.rest.entity.ProfileEntity;
 import org.exoplatform.social.rest.impl.user.UserRestResourcesV1;
 import org.exoplatform.social.service.test.AbstractResourceTest;
@@ -232,6 +233,22 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
     collections = (CollectionEntity) response.getEntity();
     assertEquals(2, collections.getEntities().size());
+  }
+
+  public void testAddActivityByUser() throws Exception {
+    //root posts another activity
+    String input = "{\"title\":titleOfActivity,\"templateParams\":{\"param1\": value1,\"param2\":value2}}";
+    startSessionAs("john");
+    ContainerResponse response = getResponse("POST", getURLResource("users/john/activities"), input);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    DataEntity responseEntity = (DataEntity) response.getEntity();
+    String title = (String) responseEntity.get("title");
+    assertNotNull(title);
+    assertEquals("titleOfActivity", title);
+    DataEntity templateParams = (DataEntity) responseEntity.get("templateParams");
+    assertNotNull(templateParams);
+    assertEquals(2, templateParams.size());
   }
 
   private Space getSpaceInstance(int number, String creator) throws Exception {


### PR DESCRIPTION
Actuallay when creating an activity with the Rest service UserRestResourcesV1, all template params are not loaded and saved with the activity.
The actual fix will add template params when posting an activity in UserRestResourcesV1