### PR TITLE
Fix Notification link computing

### DIFF
--- a/webapp/vue-portlet/src/main/webapp/notification-top-bar/components/ExoTopBarNotification.vue
+++ b/webapp/vue-portlet/src/main/webapp/notification-top-bar/components/ExoTopBarNotification.vue
@@ -167,7 +167,7 @@ export default {
     applyActions(item) {
       $(`#${item}`).find('li').each(function () {
         const dataLink = $(this).find('.contentSmall:first').data('link');
-        dataLink.replace('/portal/intranet', `${eXo.env.portal.context}/${eXo.env.portal.portalName}`);
+        dataLink.replace(/\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}`);
         const linkId = dataLink.split(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
         const dataId = $(this).data('id').toString();
 

--- a/webapp/vue-portlet/src/main/webapp/notification-top-bar/components/ExoTopBarNotification.vue
+++ b/webapp/vue-portlet/src/main/webapp/notification-top-bar/components/ExoTopBarNotification.vue
@@ -167,7 +167,7 @@ export default {
     applyActions(item) {
       $(`#${item}`).find('li').each(function () {
         const dataLink = $(this).find('.contentSmall:first').data('link');
-        dataLink.replace(/\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}`);
+        dataLink.replace(/\/portal\/([a-zA-Z0-9_-]+)\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
         const linkId = dataLink.split(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
         const dataId = $(this).data('id').toString();
 


### PR DESCRIPTION
When the default site is turned into 'dw', the notifications on 'intranet' site (with new notification portlet) doesn't work anymore.
Thus, this fixes the problem by making the link computing more generic.