### PR TITLE
PLF-8635 : fix encoding problem for uploaded image links

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -1128,7 +1128,6 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       updatedActivity.setHidden(existingActivity.isHidden());
       updatedActivity.setComment(existingActivity.isComment());
       updatedActivity.setLocked(existingActivity.isLocked());
-      processActivity(existingActivity);
 
       activityDAO.update(updatedActivity);
     } else {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
@@ -116,9 +116,9 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
     List<StreamItemEntity> streamItems = streamItemDAO.findStreamItemByActivityId(Long.parseLong(activityCreated.getId()));
     
     activityCreated.setTitle("Title after updated");
-    
+
     //update
-    
+
     activityStorage.updateActivity(activityCreated);
     
     ExoSocialActivity res = activityStorage.getActivity(activity.getId());
@@ -129,7 +129,14 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
     assertEquals(streamItemsRes.get(0).getUpdatedDate(),streamItems.get(0).getUpdatedDate());
 
     assertEquals("Title after updated", res.getTitle());
-    //
+
+    // Update activity again
+    String titleUpdated = "Title after updated with character = that should not be encoded";
+    activityCreated.setTitle(titleUpdated);
+    activityStorage.updateActivity(activityCreated);
+
+    assertEquals(titleUpdated, activityCreated.getTitle());
+
     tearDownActivityList.add(activity);
   }
 


### PR DESCRIPTION
Processing image title caused encoding '=' character
This processing that includes HTML sanitization is not needed for saving the activity, thus the fix will remove this unneeded code.