### PR TITLE
New composer : Hide the old composer by default

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-common</artifactId>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-core</artifactId>

--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-notification</artifactId>

--- a/component/oauth-auth/pom.xml
+++ b/component/oauth-auth/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-component</artifactId>
   <packaging>pom</packaging>

--- a/component/service/pom.xml
+++ b/component/service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-service</artifactId>

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/metric/ActivityMetricResources.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/metric/ActivityMetricResources.java
@@ -1,0 +1,68 @@
+package org.exoplatform.social.rest.impl.metric;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.rest.resource.ResourceContainer;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.service.rest.api.VersionResources;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@Path(VersionResources.VERSION_ONE + "/social/metrics")
+public class ActivityMetricResources implements ResourceContainer {
+
+  private static final Log LOG = ExoLogger.getLogger(ActivityMetricResources.class);
+
+  private IdentityManager identityManager;
+
+  private SpaceService spaceService;
+
+  public ActivityMetricResources(IdentityManager identityManager, SpaceService spaceService) {
+    this.identityManager = identityManager;
+    this.spaceService = spaceService;
+  }
+
+  @POST
+  @Path("composer/click")
+  @RolesAllowed("users")
+  @ApiOperation(value = "Log a click action on the composer", httpMethod = "POST", response = Response.class, notes = "This logs a message when the user performs opens a composer")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Click logged"),
+          @ApiResponse(code = 400, message = "Invalid query input"), @ApiResponse(code = 500, message = "Internal server error") })
+  public Response openComposer(@Context UriInfo uriInfo,
+                               @ApiParam(value = "The clicked composer", required = true) @QueryParam("composer") String composer,
+                               @ApiParam(value = "The space id") @QueryParam("spaceId") String spaceId) {
+
+    String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
+    Identity currentUser = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, authenticatedUser, false);
+
+    Space space = null;
+    if(StringUtils.isNotBlank(spaceId)) {
+      space = spaceService.getSpaceById(spaceId);
+    }
+
+    LOG.info("service=composer operation=open_composer parameters=\"composer_type:{},space_name:{},space_id:{},user_id:{}\"",
+            composer,
+            space != null ? space.getPrettyName() : "",
+            space != null ? space.getId() : "",
+            currentUser != null ? currentUser.getId() : "");
+
+    return Response.status(Response.Status.OK).build();
+  }
+
+}

--- a/component/webui/pom.xml
+++ b/component/webui/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-webui</artifactId>

--- a/component/webui/src/main/resources/locale/social/Webui_en.properties
+++ b/component/webui/src/main/resources/locale/social/Webui_en.properties
@@ -476,7 +476,7 @@ UIUserActivitiesDisplay.label.My_Activity_Stream=My Activity Stream
 UIUserActivitiesDisplay.label.No_Updates=No Updates
 UIUserActivitiesDisplay.label.Updates={0} Updates
 UIUserActivitiesDisplay.label.activityNotFound=Activity not found.
-UIUserActivitiesDisplay.label.Status=Status
+UIUserActivitiesDisplay.label.OldComposer=Use the old composer
 
 #####################################################################################
 #                              UIAddApplicationSpace                                #

--- a/component/webui/src/main/resources/locale/social/Webui_fr.properties
+++ b/component/webui/src/main/resources/locale/social/Webui_fr.properties
@@ -476,7 +476,7 @@ UIUserActivitiesDisplay.label.My_Activity_Stream=Mon Flux d'Activit\u00E9
 UIUserActivitiesDisplay.label.No_Updates=Aucune mise \u00E0 jour
 UIUserActivitiesDisplay.label.Updates={0} Mises \u00E0 jour
 UIUserActivitiesDisplay.label.activityNotFound=Activit\u00E9 non trouv\u00E9e.
-UIUserActivitiesDisplay.label.Status=Statut
+UIUserActivitiesDisplay.label.OldComposer=Utiliser l'ancien 
 
 #####################################################################################
 #                              UIAddApplicationSpace                                #

--- a/extension/notification/pom.xml
+++ b/extension/notification/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extension</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-notification-extension</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-extension</artifactId>
   <packaging>pom</packaging>

--- a/extension/war/pom.xml
+++ b/extension/war/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extension</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-extension-war</artifactId>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/service-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/service-configuration.xml
@@ -94,6 +94,10 @@
   </component>
 <!-- REST service -->
 
+  <component>
+    <type>org.exoplatform.social.rest.impl.metric.ActivityMetricResources</type>
+  </component>
+
   <!-- SUGGESTED PEOPLE -->
   <component>
     <type>org.exoplatform.social.rest.suggest.PeopleRestServices</type>

--- a/extension/war/src/main/webapp/groovy/social/webui/composer/UIComposer.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/composer/UIComposer.gtmpl
@@ -30,10 +30,55 @@
 %>
 <div id="activityComposer"></div>
 <script>
-  require(['SHARED/ActivityComposer'], function(activityComposerApp) {
+  require(['SHARED/jquery', 'SHARED/ActivityComposer'], function(jq, activityComposerApp) {
     activityComposerApp.init();
+
+    // Manage old composer switch (to be deleted if we delete the old composer)
+    let activityStreamTop = jq('.uiActivitiesDisplay .activityTop');
+    activityStreamTop.addClass('shifted');
+
+    jq('.oldComposer').click(function() {
+      let oldComposer = jq('.uiComposer');
+      oldComposer.slideToggle();
+      activityStreamTop.toggleClass('shifted');
+      
+      if(!activityStreamTop.hasClass('shifted')) {
+        let url = '/portal/rest/v1/social/metrics/composer/click?composer=legacy';
+        if(eXo.env.portal.spaceId) {
+          url += '&spaceId=' + eXo.env.portal.spaceId;
+        }
+        jq.ajax({
+          type: "POST",
+          url: url
+        });
+      }
+    });
   });
 </script>
+<style>
+  .oldComposer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    margin-bottom: 10px;
+  }
+  .uiIconOldComposer::before {
+    content: "\\e763";
+  }
+  .oldComposerButton {
+    cursor: pointer;
+    font-weight: bold;
+  }
+  .uiComposer.hidden-phone {
+    display: none;
+  }
+  .uiUserActivityStreamPortlet .activityTop, .uiDisplaySpaceActivities.uiActivitiesDisplay .activityTop {
+    transition: margin 0.4s;
+  }
+  .uiUserActivityStreamPortlet .activityTop.shifted, .uiDisplaySpaceActivities.uiActivitiesDisplay .activityTop.shifted {
+    margin: 0;
+  }
+</style>
 <%
   }
 %>
@@ -96,6 +141,10 @@
            .addScripts("UIComposer.onLoadI18n({ defaultMessage: \"$defaultMessage\", helpSearch: \"$helpSearch\", searching: \"searching\", foundNoMatch: \"$foundNoMatch\"});")
            .addScripts("UIComposer.onLoad($params);");
 %>
+<div class="oldComposer hidden-phone">
+  <a class="oldComposerButton"><%=_ctx.appRes("activity.composer.old")%></a>
+  <i class="uiIconOldComposer"></i>
+</div>
 <div class="uiComposer hidden-phone">
   <% uiform.begin() %>
   <div class="share-buttons-top button-group clearfix hide">

--- a/extension/war/src/main/webapp/groovy/social/webui/profile/UIUserActivitiesDisplay.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/profile/UIUserActivitiesDisplay.gtmpl
@@ -128,7 +128,7 @@
 	</div>
   </div>
   <div class="clearfix activityTop">
-    <button class="btn btn-primary visible-phone changeStatus pull-left pull-right"><i class="uiIconEdit"></i> <%=_ctx.appRes("UIUserActivitiesDisplay.label.Status")%></button>
+    <button class="btn btn-primary visible-phone changeStatus pull-left pull-right"><%=_ctx.appRes("activity.composer.old")%></button>
     <div class="activityStreamStatus pull-left">
       <div class="arrowBottom"></div>
       <!--<span id="noUpdates"><%=noUpdates%></span>-->
@@ -186,7 +186,7 @@
   <div class="clearfix activityTop">
     <!--hide Share button when show activity detail in responsive device -->
     <%if (!uicomponent.isSingleContext() && (uicomponent.isActivityStreamOwner() || uicomponent.isRelationConfirmed())) { %>   
-      <button class="btn btn-primary visible-phone changeStatus pull-left"><i class="uiIconEdit"></i> <%=_ctx.appRes("UIUserActivitiesDisplay.label.Status")%></button>
+      <button class="btn btn-primary visible-phone changeStatus pull-left"><%=_ctx.appRes("activity.composer.old")%></button>
     <% } %>
  <% if (Utils.isHomePage()) { %>
     <div class="pull-right">
@@ -219,7 +219,7 @@
 
   <!-- add more for devices -->
   <div class="clearfix activityTop">
-    <button class="btn btn-primary visible-phone changeStatus pull-left"><i class="uiIconEdit"></i> <%=_ctx.appRes("UIUserActivitiesDisplay.label.Status")%></button>  
+    <button class="btn btn-primary visible-phone changeStatus pull-left"><%=_ctx.appRes("activity.composer.old")%></button>
 	<div class="pull-right">
 	  <% uicomponent.renderChild(UIDropDownControl.class);%>
 	</div>

--- a/extension/war/src/main/webapp/groovy/social/webui/space/UISpaceActivitiesDisplay.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/space/UISpaceActivitiesDisplay.gtmpl
@@ -34,7 +34,7 @@
   <div class="clearfix activityTop">
   <!--hide Share button when show activity detail -->
   <%if (!uicomponent.isSingleContext()) { %>
-  <button class="btn btn-primary visible-phone changeStatus pull-left pull-right"><i class="uiIconEdit"></i> <%=_ctx.appRes("UIUserActivitiesDisplay.label.Status")%></button>
+  <button class="btn btn-primary visible-phone changeStatus pull-left pull-right"><%=_ctx.appRes("UIUserActivitiesDisplay.label.OldComposer")%></button>
   <%}%>
   <% if (hasActivities) { 
        def refreshTooltipButton = _ctx.appRes("UIActivity.label.Refresh");

--- a/extras/feedmash/pom.xml
+++ b/extras/feedmash/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>social-extras</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-extras-feedmash</artifactId>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-extras</artifactId>
   <packaging>pom</packaging>

--- a/extras/samples/pom.xml
+++ b/extras/samples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extras</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-extras-samples</artifactId>

--- a/extras/widget/pom.xml
+++ b/extras/widget/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extras</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-extras-widget</artifactId>
   <packaging>pom</packaging>

--- a/extras/widget/resources/pom.xml
+++ b/extras/widget/resources/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extras-widget</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-extras-widget-resources</artifactId>

--- a/extras/widget/rest/pom.xml
+++ b/extras/widget/rest/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extras-widget</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-extras-widget-rest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social</artifactId>
-  <version>6.0.x-SNAPSHOT</version>
+  <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: Social</name>
   <description>eXo Social - Enterprise Social Networking</description>
@@ -56,7 +56,7 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <org.exoplatform.commons.version>6.0.x-SNAPSHOT</org.exoplatform.commons.version>
+    <org.exoplatform.commons.version>6.0.x-activity-composer-vue-SNAPSHOT</org.exoplatform.commons.version>
     <!-- For surefire and failsafe to be compatible with jacoco -->
     <argLine>-Xmx1024m -XX:MaxPermSize=512m</argLine>
     <!-- Elasticsearch dependencies -->

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-search</artifactId>
   <packaging>pom</packaging>

--- a/search/portlet/pom.xml
+++ b/search/portlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.social</groupId>
     <artifactId>social-search</artifactId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-search-portlet</artifactId>
   <packaging>war</packaging>

--- a/search/service/pom.xml
+++ b/search/service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.social</groupId>
     <artifactId>social-search</artifactId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-search-service</artifactId>
   <packaging>jar</packaging>

--- a/webapp/juzu-portlet/pom.xml
+++ b/webapp/juzu-portlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp-juzu-portlet</artifactId>
   <packaging>jar</packaging>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp</artifactId>
   <packaging>pom</packaging>

--- a/webapp/portlet/pom.xml
+++ b/webapp/portlet/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-webapp-portlet</artifactId>

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -230,8 +230,10 @@ UIIntranetNotificationsPortlet.label.seeAll=See all
 #                                    Activity Composer                              #
 #####################################################################################
 
-activity.composer.link=Try the new composer
+activity.composer.link=Post something to {0}
+activity.composer.link.network=your network
 activity.composer.placeholder=Please don't exceed {0} characters
 activity.composer.title=Write a Short Message
 activity.composer.post=Post
 activity.composer.post.error=An error occurred when posting the message
+activity.composer.old=Use the old composer

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_fr.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_fr.properties
@@ -228,8 +228,10 @@ UIIntranetNotificationsPortlet.label.MarkAllAsRead=Marquer tout comme lu
 #                                    Activity Composer                              #
 #####################################################################################
 
-activity.composer.link=Essayez le nouveau composer
+activity.composer.link=Publier quelque chose dans {0}
+activity.composer.link.network=votre r\u00E9seau
 activity.composer.placeholder=Ne d\u00E9passez pas {0} caract\u00E8res
 activity.composer.title=\u00C9crivez un message court
 activity.composer.post=Publier
 activity.composer.post.error=Une erreur est survenue lors de la publication du message
+activity.composer.old=Utiliser l'ancien formulaire

--- a/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
@@ -2,7 +2,7 @@
   <div class="activityComposer">
     <div class="openLink">
       <a @click="openMessageComposer()">
-        <i class="uiIconGoUp"></i>{{ $t('activity.composer.link') }}
+        <i class="uiIconGoUp"></i>{{ $t('activity.composer.link').replace('{0}', postTarget) }}
       </a>
     </div>
 
@@ -89,6 +89,7 @@ export default {
     return {
       MESSAGE_MAX_LENGTH: 2000,
       MESSAGE_TIMEOUT: 5000,
+      postTarget: '',
       showMessageComposer: false,
       message: '',
       showErrorMessage: false,
@@ -126,6 +127,12 @@ export default {
       }
     }
   },
+  mounted() {
+    this.postTarget = eXo.env.portal.spaceDisplayName;
+    if(!this.postTarget) {
+      this.postTarget = this.$t('activity.composer.link.network');
+    }
+  },
   created() {
     this.activityComposerActions = getActivityComposerExtensions();
     this.activityComposerActions.forEach(action => {
@@ -139,6 +146,16 @@ export default {
     openMessageComposer: function() {
       this.$refs.richEditor.setFocus();
       this.showMessageComposer = true;
+
+      // Send metric
+      let url = '/portal/rest/v1/social/metrics/composer/click?composer=new';
+      if(eXo.env.portal.spaceId) {
+        url += `&spaceId=${eXo.env.portal.spaceId}`;
+      }
+      fetch(url, {
+        credentials: 'include',
+        method: 'POST'
+      });
     },
     getLabel: function(labelKey) {
       const label = this.$t(labelKey);

--- a/webapp/resources/pom.xml
+++ b/webapp/resources/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-webapp-resources</artifactId>

--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
@@ -757,6 +757,16 @@
           parent.find('.uiActivitiesDisplay:first').addClass('hidden-phone');
           if(parent.find('div.uiComposer.hidden-phone').length > 0) {
             parent.find('div.uiComposer.hidden-phone').removeClass('hidden-phone');
+
+            // send metric
+            let url = '/portal/rest/v1/social/metrics/composer/click?composer=legacy';
+            if(eXo.env.portal.spaceId) {
+              url += '&spaceId=' + eXo.env.portal.spaceId;
+            }
+            $.ajax({
+              type: "POST",
+              url: url
+            });
           }
 
           var composer = parent.find('.uiComposer:first');

--- a/webapp/vue-portlet/pom.xml
+++ b/webapp/vue-portlet/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.0.x-SNAPSHOT</version>
+    <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-webapp-vue-portlet</artifactId>
-  <version>6.0.x-SNAPSHOT</version>
+  <version>6.0.x-activity-composer-vue-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>eXo PLF:: Social Vue Portlet Web App</name>
   <description>eXo Social Vue Portlet Web App</description>


### PR DESCRIPTION
This improvement hides the old composer by default.
An action link allows to show it.

The style and script are all done directly in the gtmpl in order to make it easier to remove them soon.
This improvement is a temporary step since the old composer will very probably be completely removed soon.