### PR TITLE
fix/news-composer-plugin: fix openning news in composer actions

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-composer-app/extension.js
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/extension.js
@@ -11,7 +11,11 @@ export function getActivityComposerExtensions() {
 
 export function executeExtensionAction(extension, component) {
   if(extension.hasOwnProperty('onExecute') && isFunction(extension.onExecute)) {
-    extension.onExecute(component[0]);
+    if(component) {
+      extension.onExecute(component[0]);
+    } else {
+      extension.onExecute();
+    }
   }
 }
 


### PR DESCRIPTION
We need to check the passed component if exists before executing the action in the new composer.  