### PR TITLE
Fix stream page navigation order and label

### DIFF
--- a/extension/war/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/extension/war/src/main/resources/locale/navigation/portal/global_en.properties
@@ -17,6 +17,7 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
 portal.global.searchResult=Search Result
+portal.global.stream=Stream
 portal.global.spaces=Spaces
 portal.global.myprofile=My Profile
 portal.global.connections=My Connections

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/portal/global/navigation.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/portal/global/navigation.xml
@@ -26,6 +26,12 @@
   <page-nodes>
 
     <node>
+      <name>stream</name>
+      <label>#{portal.global.stream}</label>
+      <page-reference>portal::global::stream</page-reference>
+    </node>
+
+    <node>
       <name>spaces</name>
       <label>#{portal.global.spaces}</label>
       <page-reference>portal::global::all-spaces</page-reference>
@@ -194,12 +200,6 @@
       <label>#{portal.global.settings}</label>
       <visibility>SYSTEM</visibility>
       <page-reference>portal::global::settings</page-reference>
-    </node>
-
-		<node>
-      <name>stream</name>
-      <label>#{portal.dw.stream}</label>
-      <page-reference>portal::global::stream</page-reference>
     </node>
 
   </page-nodes>


### PR DESCRIPTION
Stream page label should be defined in social and it must not depends on dw, in addition it should be displayed at first before spaces and people pages in nav bar