### PR TITLE
Update embed processor to display link preview with files

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/processor/EmbedProcessor.java
+++ b/component/service/src/main/java/org/exoplatform/social/processor/EmbedProcessor.java
@@ -82,7 +82,12 @@ public class EmbedProcessor extends BaseActivityProcessorPlugin {
 
            templateParams.put(TEMPLATE_PARAM_TO_PROCESS, COMMENT);
            templateParams.put(LINK, url);
-           activity.setType(LINK_ACTIVITY);
+           //if activity contains files params then add link template params to the existing ones
+           if (activity.getType().equals("files:spaces")) {
+             templateParams.putAll(activity.getTemplateParams());
+           } else {
+             activity.setType(LINK_ACTIVITY);
+           }
            activity.setTemplateParams(templateParams);
        }
      } catch (Exception e) {


### PR DESCRIPTION
In order to display link preview when files exits we should not update the activity type. However, we need to add the existing file params to the link template params to pass them to the activity builder.