### PR TITLE
Fix update some space properties using REST call

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -1001,20 +1001,18 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
 
     if (StringUtils.isNotBlank(model.getDisplayName())) {
       space.setDisplayName(model.getDisplayName());
+      space.setDescription(model.getDescription());
 
       if (StringUtils.isBlank(space.getPrettyName())) {
         space.setPrettyName(model.getDisplayName());
       }
     } else if (StringUtils.isNotBlank(model.getPrettyName())) {
       space.setPrettyName(model.getPrettyName());
+      space.setDescription(model.getDescription());
 
       if (StringUtils.isBlank(space.getDisplayName())) {
         space.setDisplayName(model.getPrettyName());
       }
-    }
-
-    if (StringUtils.isNotBlank(model.getDescription())) {
-      space.setDescription(model.getDescription());
     }
 
     if (StringUtils.isNotBlank(model.getTemplate())) {
@@ -1031,7 +1029,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
 
     if (StringUtils.equalsIgnoreCase(Space.HIDDEN, model.getVisibility())) {
       space.setVisibility(Space.HIDDEN);
-    } else {
+    } else if (StringUtils.equalsIgnoreCase(Space.PRIVATE, model.getVisibility())) {
       space.setVisibility(Space.PRIVATE);
     }
 
@@ -1039,7 +1037,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       space.setRegistration(Space.OPEN);
     } else if (StringUtils.equalsIgnoreCase(Space.CLOSE, model.getSubscription())) {
       space.setRegistration(Space.CLOSE);
-    } else {
+    } else if (StringUtils.equalsIgnoreCase(Space.VALIDATION, model.getSubscription())) {
       space.setRegistration(Space.VALIDATION);
     }
   }

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
@@ -206,7 +206,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
 
   public void testCreateSpace() throws Exception {
     startSessionAs("root");
-    String input = "{\"displayName\":social}";
+    String input = "{\"displayName\":\"social\",\"visibility\":\"hidden\",\"subscription\":\"open\"}";
     //root try to update demo activity
     ContainerResponse response = getResponse("POST", getURLResource("spaces/"), input);
     assertNotNull(response);
@@ -220,7 +220,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
 
   public void testGetSpace() throws Exception {
     startSessionAs("root");
-    String input = "{\"displayName\":\"test space\"}";
+    String input = "{\"displayName\":\"test space\",\"visibility\":\"hidden\",\"subscription\":\"open\"}";
     //root creates a space
     ContainerResponse response = getResponse("POST", getURLResource("spaces/"), input);
     assertNotNull(response);
@@ -243,6 +243,10 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
   public void testGetUpdateDeleteSpaceById() throws Exception {
     //root creates 1 spaces
     Space space = getSpaceInstance(1, "root");
+    space.setVisibility(Space.HIDDEN);
+    space.setRegistration(Space.CLOSE);
+    space = spaceService.updateSpace(space);
+
     startSessionAs("root");
     ContainerResponse response = service("GET", getURLResource("spaces/" + space.getId()), "", null, null);
     assertNotNull(response);
@@ -250,7 +254,8 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
 
     SpaceEntity spaceEntity = getBaseEntity(response.getEntity(), SpaceEntity.class);
     assertEquals("space1", spaceEntity.getDisplayName());
-    assertEquals(Space.PRIVATE, spaceEntity.getVisibility());
+    assertEquals(Space.HIDDEN, spaceEntity.getVisibility());
+    assertEquals(Space.CLOSE, spaceEntity.getSubscription());
 
     //root update space's description and name
     String spaceId = spaceEntity.getId();
@@ -261,6 +266,8 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
     space = spaceService.getSpaceById(spaceId);
     assertEquals("displayName_updated", space.getDisplayName());
     assertEquals("description_updated", space.getDescription());
+    assertEquals(Space.HIDDEN, spaceEntity.getVisibility());
+    assertEquals(Space.CLOSE, spaceEntity.getSubscription());
 
     //root delete his space
     response = service("DELETE", getURLResource("spaces/" + space.getId()), "", null, null);

--- a/webapp/vue-portlet/src/main/webapp/spaces-list/components/ExoSpaceCardReverse.vue
+++ b/webapp/vue-portlet/src/main/webapp/spaces-list/components/ExoSpaceCardReverse.vue
@@ -15,6 +15,7 @@
     </div>
     <v-card-text class="align-center pa-0 flex-grow-1">
       <ellipsis
+        v-show="space.description"
         :title="space.description"
         :data="space.description"
         :line-clamp="3"

--- a/webapp/vue-portlet/src/main/webapp/spaces-list/components/ExoSpaceFormDrawer.vue
+++ b/webapp/vue-portlet/src/main/webapp/spaces-list/components/ExoSpaceFormDrawer.vue
@@ -254,26 +254,18 @@ export default {
     template() {
       if (this.template && !this.space.id) {
         this.spaceTemplate = this.templates.find(temp => temp.name === this.template);
-        if (this.spaceTemplate) {
-          this.$set(this.space, 'template', this.template);
-          this.$set(this.space, 'subscription', this.spaceTemplate.registration);
-          this.$set(this.space, 'visibility', this.spaceTemplate.visibility);
-          this.$set(this.space, 'invitedMembers', this.spaceTemplate.invitees && this.spaceTemplate.invitees.split(',') || []);
-          if (this.space.invitedMembers && this.space.invitedMembers.length) {
-            this.space.invitedMembers = this.space.invitedMembers.map(user => ({
-              id: `organization:${user}`,
-              providerId: 'organization',
-              remoteId: user,
-            }));
-          }
-        }
+        this.setSpaceTemplateProperties();
       }
     },
   },
   mounted() {
     this.$root.$on('addNewSpace', () => {
       this.spaceToUpdate = null;
-      this.space = {};
+      this.space = {
+        subscription: 'open',
+        visibility: 'private',
+      };
+      this.setSpaceTemplateProperties();
       this.title= this.$t('spacesList.label.addNewSpace');
       this.$refs.spaceFormDrawer.open();
     });
@@ -287,6 +279,21 @@ export default {
       });
   },
   methods: {
+    setSpaceTemplateProperties() {
+      if (this.spaceTemplate) {
+        this.$set(this.space, 'template', this.template);
+        this.$set(this.space, 'subscription', this.spaceTemplate.registration);
+        this.$set(this.space, 'visibility', this.spaceTemplate.visibility);
+        this.$set(this.space, 'invitedMembers', this.spaceTemplate.invitees && this.spaceTemplate.invitees.split(',') || []);
+        if (this.space.invitedMembers && this.space.invitedMembers.length) {
+          this.space.invitedMembers = this.space.invitedMembers.map(user => ({
+            id: `organization:${user}`,
+            providerId: 'organization',
+            remoteId: user,
+          }));
+        }
+      }
+    },
     editSpace(space) {
       space = space.detail && space.detail.data || space;
       if (!space || !space.id) {
@@ -337,7 +344,7 @@ export default {
           invitedMembers: this.space.invitedMembers,
         })
           .then(space => {
-            Object.assign(this.spaceToUpdate, space, {managers: this.spaceToUpdate.managers});
+            Object.assign(this.spaceToUpdate, space, {managers: this.spaceToUpdate.managers}, {description: space.description || ''});
             this.spaceSaved = true;
 
             window.setTimeout(() => {

--- a/webapp/vue-portlet/src/main/webapp/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/vue-portlet/src/main/webapp/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -15,7 +15,7 @@
       </v-list-item-action>
     </v-list-item>
 
-    <v-list-item v-if="enabledNotificationLabels && enabledNotificationLabels.length" dense>
+    <v-list-item v-if="hasNotificationSettings" dense>
       <v-list-item-content class="pa-0">
         <v-list-item-title class="text-wrap">
           <template v-if="enabledDigestLabel">
@@ -60,6 +60,12 @@ export default {
   computed: {
     label() {
       return this.settings && this.settings.pluginLabels && this.settings.pluginLabels[this.plugin.type];
+    },
+    hasInstantNotificationSettings() {
+      return this.enabledNotificationLabels && this.enabledNotificationLabels.length || this.enabledDigest;
+    },
+    hasNotificationSettings() {
+      return this.hasInstantNotificationSettings || this.enabledDigest;
     },
     enabledDigest() {
       return this.settings && this.settings.emailDigestChoices && this.settings.emailDigestChoices.find(choice => choice && choice.channelActive && choice.channelId === this.settings.emailChannel && choice.pluginId === this.plugin.type);


### PR DESCRIPTION
When submitting space form to update just some properties and when the `visibility` (same for  `subscription`) are not present in request body, the space visibility will turned into 'PRIVATE' by default.
This fix ensures to not change `visibility` nor `subscription` only when explicitly added in request body.
And a second issue is fixed to display chosen digest in notification settings UI even when no 'instant notification' setting is chosen.