### PR TITLE
MAINT-24540 : Update regex to fix Notification parsing for Edge

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
@@ -52,7 +52,7 @@ import java.util.regex.Pattern;
 public class SocialNotificationUtils {
   private static final Log LOG = ExoLogger.getLogger(SocialNotificationUtils.class);
 
-  public final static Pattern IMG_SRC_REGEX = Pattern.compile("<img[^>]+((data-plugin-name\\s*=\\s*['\"]([^'\"]+)['\"][^>]+)|(src\\s*=\\s*['\"]([^'\"]+)['\"])){2}[^>]*>");
+  public final static Pattern IMG_SRC_REGEX = Pattern.compile("<img[^>]*(?:(?:src\\s*=\\s*['\"]([^'\"]+)['\"])[^>]*(?:data-plugin-name\\s*=\\s*['\"](?:[^'\"]+)['\"]))[^>]*\\/>|<img[^>]*(?:(?:data-plugin-name\\s*=\\s*['\"](?:[^'\"]+)['\"])[^>]*(?:src\\s*=\\s*['\"]([^'\"]+)['\"]))[^>]*\\/>");
 
   public final static ArgumentLiteral<String> ACTIVITY_ID = new ArgumentLiteral<String>(String.class, "activityId");
   public final static ArgumentLiteral<String> COMMENT_ID = new ArgumentLiteral<String>(String.class, "commentId");
@@ -368,7 +368,7 @@ public class SocialNotificationUtils {
       String imageBody = matcher.group(0);
 
       body = body.replace(imageBody, "<i> [" + placeholder + "] </i>");
-      startIdex = matcher.end(1);
+      startIdex = matcher.end(0);
     }
     return body;
   }

--- a/component/notification/src/test/java/org/exoplatform/social/notification/plugin/SocialNotificationUtilsTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/plugin/SocialNotificationUtilsTest.java
@@ -1,0 +1,28 @@
+package org.exoplatform.social.notification.plugin;
+
+import junit.framework.TestCase;
+import org.exoplatform.commons.notification.NotificationUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SocialNotificationUtilsTest extends TestCase {
+
+    public void testProcessImageTitle() {
+        String chromeNotification = "<p>test text for notification with Image</p><p></p><p><img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/images/repository/collaboration/054bd7057f0001012279c31b78a3bfdb\" /> </p>\n" +
+                "<p> here is another image</p>\n" +
+                "<p><img alt=\"\" class=\"pull-left\" data-plugin-name=\"selectImage\" referrerpolicy=\"no-referrer\" src=\"/portal/rest/images/repository/collaboration/054bd72f7f000101419e3a68603fdd72\" /></p>";
+        String edgeNotification = "<p>A first image from Edge <img class=\"pull-left\" alt=\"\" src=\"/portal/rest/images/repository/collaboration/04ba00e37f0001015e7c15dc245675e8\" referrerpolicy=\"no-referrer\" data-plugin-name=\"selectImage\" /></p>\n" +
+                "<p> here is another image</p>\n" +
+                "<img class=\"pull-left\" alt=\"\" src=\"/portal/rest/images/repository/collaboration/04ba00e37f0001015e7c15dc245675e8\" referrerpolicy=\"no-referrer\" data-plugin-name=\"selectImage\" />";
+        String placeHolder = "Image Inline";
+        String chromeNotificationProcessed = "<p>test text for notification with Image</p><p></p><p><i> [Image Inline] </i> </p>\n" +
+                "<p> here is another image</p>\n" +
+                "<p><i> [Image Inline] </i></p>";
+        String edgeNotificationProcessed = "<p>A first image from Edge <i> [Image Inline] </i></p>\n" +
+                "<p> here is another image</p>\n" +
+                "<i> [Image Inline] </i>";
+        assertEquals(SocialNotificationUtils.processImageTitle(chromeNotification, placeHolder), chromeNotificationProcessed);
+        assertEquals(SocialNotificationUtils.processImageTitle(edgeNotification, placeHolder), edgeNotificationProcessed);
+    }
+}


### PR DESCRIPTION
With Edge browser, Images included in notifications are not replaced with the Inline Image placeholder.
The regex was not valid for HTML produced from Edge, this fix takes care of that difference between browsers.