### PR TITLE
Fix Search Connectors API to allow retrieving data from external connectors

### DIFF
--- a/webapp/portlet/src/main/webapp/search/components/SearchResults.vue
+++ b/webapp/portlet/src/main/webapp/search/components/SearchResults.vue
@@ -239,9 +239,6 @@ export default {
         }
         if (searchConnector.uri.indexOf('/') === 0) {
           options.credentials = 'include';
-        } else {
-          options.referrerPolicy = 'no-referrer';
-          options.mode = 'no-cors';
         }
         this.searching++;
         const uri = searchConnector.uri


### PR DESCRIPTION
When attempting to add a wikipedia Search connector, I've found that the Origin information is needed. This change will avoid to hide this information when requesting Search resources from external sites