### PR TITLE
MAINT-26392 : Fix avatar file type validation

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -273,6 +273,8 @@ spaceMember.label.filter=Filter
 spaceMember.label.filter.all=Everyone
 spaceMember.label.filter.connections=My Connections
 
+profile.warning.message.fileType=File type is not supported, you should upload an image file
+
 #####################################################################################
 #                                    Space Settings                                 #
 #####################################################################################

--- a/webapp/portlet/src/main/webapp/profile-contact-information/components/ProfileContactIms.vue
+++ b/webapp/portlet/src/main/webapp/profile-contact-information/components/ProfileContactIms.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="user.ims.length>0">
+  <div v-if="user.ims && user.ims.length>0">
     <v-divider class="my-4"/>
     <v-flex class="d-flex">
       <div

--- a/webapp/portlet/src/main/webapp/profile-contact-information/components/ProfileContactPhone.vue
+++ b/webapp/portlet/src/main/webapp/profile-contact-information/components/ProfileContactPhone.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="user.phones.length>0">
+  <div v-if="user.phones && user.phones.length">
     <v-divider class="my-4" />
     <v-flex class="d-flex">
       <div

--- a/webapp/portlet/src/main/webapp/profile-contact-information/components/ProfileContactUrls.vue
+++ b/webapp/portlet/src/main/webapp/profile-contact-information/components/ProfileContactUrls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="user.urls && user.urls.length>0">
+  <div v-if="user.urls && user.urls.length">
     <v-divider class="my-4" />
     <v-flex class="d-flex">
       <div

--- a/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderAvatar.vue
+++ b/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderAvatar.vue
@@ -71,7 +71,11 @@ export default {
       this.sendingImage = false;
     },
     uploadAvatar(file) {
-      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
+      if (file && file.size) {
+        if (file.type && file.type.indexOf('image/') !== 0) {
+          this.$emit('error', this.$t('profile.warning.message.fileType'));
+          return;
+        }
         if (file.size > this.maxUploadSize) {
           this.$emit('error', this.$uploadService.avatarExcceedsLimitError);
           return;

--- a/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderAvatar.vue
+++ b/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderAvatar.vue
@@ -71,7 +71,7 @@ export default {
       this.sendingImage = false;
     },
     uploadAvatar(file) {
-      if (file && file.size) {
+      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
         if (file.size > this.maxUploadSize) {
           this.$emit('error', this.$uploadService.avatarExcceedsLimitError);
           return;

--- a/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderBannerButton.vue
+++ b/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderBannerButton.vue
@@ -41,7 +41,11 @@ export default {
   },
   methods: {
     uploadBanner(file) {
-      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
+      if (file && file.size) {
+        if (file.type && file.type.indexOf('image/') !== 0) {
+          this.$emit('error', this.$t('profile.warning.message.fileType'));
+          return;
+        }
         if (file.size > this.maxUploadSize) {
           this.$emit('error', this.$uploadService.bannerExcceedsLimitError);
           return;

--- a/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderBannerButton.vue
+++ b/webapp/portlet/src/main/webapp/profile-header/components/ProfileHeaderBannerButton.vue
@@ -41,7 +41,7 @@ export default {
   },
   methods: {
     uploadBanner(file) {
-      if (file && file.size) {
+      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
         if (file.size > this.maxUploadSize) {
           this.$emit('error', this.$uploadService.bannerExcceedsLimitError);
           return;

--- a/webapp/portlet/src/main/webapp/space-header/components/SpaceHeaderBannerButton.vue
+++ b/webapp/portlet/src/main/webapp/space-header/components/SpaceHeaderBannerButton.vue
@@ -38,7 +38,11 @@ export default {
   },
   methods: {
     uploadBanner(file) {
-      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
+      if (file && file.size) {
+        if (file.type && file.type.indexOf('image/') !== 0) {
+          this.$emit('error', this.$t('profile.warning.message.fileType'));
+          return;
+        }
         if (file.size > this.maxUploadSize) {
           this.$emit('error', this.$uploadService.bannerExcceedsLimitError);
           return;

--- a/webapp/portlet/src/main/webapp/space-header/components/SpaceHeaderBannerButton.vue
+++ b/webapp/portlet/src/main/webapp/space-header/components/SpaceHeaderBannerButton.vue
@@ -38,7 +38,7 @@ export default {
   },
   methods: {
     uploadBanner(file) {
-      if (file && file.size) {
+      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
         if (file.size > this.maxUploadSize) {
           this.$emit('error', this.$uploadService.bannerExcceedsLimitError);
           return;

--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingAvatar.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingAvatar.vue
@@ -73,7 +73,11 @@ export default {
       this.sendingImage = false;
     },
     uploadAvatar(file) {
-      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
+      if (file && file.size) {
+        if (file.type && file.type.indexOf('image/') !== 0) {
+          this.$emit('error', this.$t('profile.warning.message.fileType'));
+          return;
+        }
         if (file.size > this.maxUploadSizeInBytes) {
           this.$emit('error', this.$uploadService.avatarExcceedsLimitError);
           return;

--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingAvatar.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingAvatar.vue
@@ -73,7 +73,7 @@ export default {
       this.sendingImage = false;
     },
     uploadAvatar(file) {
-      if (file && file.size) {
+      if (file && file.size && file.type && file.type.indexOf('image/') === 0) {
         if (file.size > this.maxUploadSizeInBytes) {
           this.$emit('error', this.$uploadService.avatarExcceedsLimitError);
           return;


### PR DESCRIPTION
The file type of avatar and banner are already restricted in 'HTML file input' by 'accept' attribute, but in some OS, they give possibility to change type of files that could be attached. This PR will avoid uploading files different from type 'image/*'