### PR TITLE
Fix Search Connectors API to allow retrieving data from external conn…

### DIFF
--- a/webapp/portlet/src/main/webapp/search/components/SearchResults.vue
+++ b/webapp/portlet/src/main/webapp/search/components/SearchResults.vue
@@ -239,9 +239,6 @@ export default {
         }
         if (searchConnector.uri.indexOf('/') === 0) {
           options.credentials = 'include';
-        } else {
-          options.referrerPolicy = 'no-referrer';
-          options.mode = 'no-cors';
         }
         this.searching++;
         const uri = searchConnector.uri


### PR DESCRIPTION
…ectors (#165)

When attempting to add a wikipedia Search connector, I've found that the Origin information is needed. This change will avoid to hide this information when requesting Search resources from external sites

(cherry picked from commit c2da600453a401b03dce00e433f0b8942313a42d)