### PR TITLE
Maint-26430 : Feature New Composer :  When exceeding 1300 char in the new composer a wrong label is displayed

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
@@ -157,7 +157,7 @@ export default {
     message() {
       const pureText = this.message ? this.message.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, '').trim() : '';
       if (pureText.length > this.MESSAGE_MAX_LENGTH) {
-        if (this.activityComposerHintAction === null) {
+        if (this.activityComposerHintAction === null && eXo.env.portal.spaceDisplayName !== '') {
           this.activityComposerHintAction = getActivityComposerHintActionExtensions();
         }
       } else {


### PR DESCRIPTION
Problem : when exceeding 1300 char in the new composer in the activity stream the action switch to an article is displayed so the fix is adding a check for existing space
