### PR TITLE
Fix changing user language setting with locale using country

### DIFF
--- a/webapp/portlet/src/main/webapp/user-setting-language/components/UserLanguageDrawer.vue
+++ b/webapp/portlet/src/main/webapp/user-setting-language/components/UserLanguageDrawer.vue
@@ -52,7 +52,8 @@ export default {
       this.$refs.userLanguageDrawer.open();
     },
     saveLanguage() {
-      window.location.replace(`${eXo.env.portal.context}/${this.value}/${eXo.env.portal.portalName}/settings`);
+      const lang = this.value.replace('_', '-');
+      window.location.replace(`${eXo.env.portal.context}/${lang}/${eXo.env.portal.portalName}/settings`);
     },
     cancel() {
       this.$refs.userLanguageDrawer.close();


### PR DESCRIPTION
The controller.xml defines a list of allowed languages that could be defined by user. This list of languages uses "-" instead of "_" which should both be correct. This change will convert locale code using `"_"` into `"-"` to let Gatein controllers parse the correct language code.