### PR TITLE
MAINT-26909 : Add validation for first and last name when updating user profile attributes

### DIFF
--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -502,8 +502,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
   public void testUpdateProfileAtributes() throws Exception {
     String firstName = "Johnny";
-    String lastName = "B";
-    String fullName = "Johnny B";
+    String lastName = "Bravo";
+    String fullName = "Johnny Bravo";
     String aboutMe = "AboutMe";
     String imType = "Skype";
     String imId = "johnnyB";


### PR DESCRIPTION
Add validation for first and last name when updating user profile attributes, because only letters, spaces, "-" or "'" are allowed for these fields