### PR TITLE
MAINT-27021 Fix users search when user doesn't have lastName (#211)

### DIFF
--- a/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementList.vue
@@ -217,15 +217,9 @@ export default {
         const entities = data.entities || data.users;
         entities.forEach(user => {
           user.statusLabel = user.enabled ? this.$t('UsersManagement.status.enabled') : this.$t('UsersManagement.status.disabled');
-          if (user.firstname) {
-            user.firstName = user.firstname;
-          }
-          if (user.username) {
-            user.userName = user.username;
-          }
-          if (user.lastname) {
-            user.lastName = user.lastname;
-          }
+          user.userName = user.userName || user.username || '';
+          user.firstName = user.firstName || user.firstname || '';
+          user.lastName = user.lastName || user.lastname || '';
         });
         this.users = entities;
         this.totalSize = data && data.size || 0;


### PR DESCRIPTION
Previously, the users injection was allowing to create users without lastName nor firstName, thus the search UI that assumed that those field aren't empty will throw errors. Consequently, the search process is blocked by this error. This fix will replace 'null' values of those fields by empty string.