### PR TITLE
MAINT-26897 Fix Activity composer performances

### DIFF
--- a/extension/war/src/main/webapp/groovy/social/webui/activity/UIDefaultActivity.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/activity/UIDefaultActivity.gtmpl
@@ -87,6 +87,7 @@
   //params for init UIActivity javascript object
   def params = """ {
     activityId: '${activity.id}',
+    activityBody: `${activity.title}`,
     placeholderComment: '${placeholder}',
     inputWriteAComment: '$inputWriteAComment',
     commentMinCharactersAllowed: '${uicomponent.getCommentMinCharactersAllowed()}',
@@ -99,19 +100,9 @@
     labels: $labels
   } """
 
-  String ckEditorType = new StringBuilder("editActivity").append(activity.id);
-  //params for init edit composer component
-  def composerParams = """ {
-    activityId: '${activity.id}',
-    composerAction: 'update',
-    ckEditorType: '${ckEditorType}',
-    activityBody: `${activity.title}`
-  } """
-
   jsManager.require("SHARED/jquery", "jq")
            .require("SHARED/bts_tooltip").addScripts("jq('*[rel=\"tooltip\"]').tooltip();")
-           .require("SHARED/social-ui-activity", "activity").addScripts("activity.onLoad($params);")
-           .require("SHARED/ActivityComposer", "activityComposer").addScripts("activityComposer.init($composerParams);");
+           .require("SHARED/social-ui-activity", "activity").addScripts("activity.onLoad($params);");
 
   //make sures commentFormFocused is set to false to prevent any refresh to focus, only focus after post a comment
   uicomponent.setCommentFormFocused(false);
@@ -133,7 +124,7 @@
           <%
           if(activityEditable || activityDeletable ){
           %>
-          <div id="activityComposer"></div>
+          <div id="activityComposer${activity.id}"></div>
           <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink ">
           <div class="dropdown-toggle" data-toggle="dropdown">
           <i class="uiIconActivityAction uiIconLightGray">

--- a/extension/war/src/main/webapp/groovy/social/webui/activity/UILinkActivity.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/activity/UILinkActivity.gtmpl
@@ -77,9 +77,15 @@
   }"""
   def spaceGroupId = uicomponent.getSpaceGroupId();
 
+  String activityLink = new StringBuilder("<p><a id='editActivityLinkPreview' href='").append(uicomponent.getLinkSource())
+                        .append("'>").append(uicomponent.getLinkSource()).append("</a></p>");
+  def activityTitle = uicomponent.getDefaultTitle();
+  String activityBody = new StringBuilder(activityTitle.split('<oembed>')[0]).append(activityLink);
+
   //params for init UIActivity javascript object
   def params = """ {
     activityId: '${activity.id}',
+    activityBody: `${activityBody}`,
     placeholderComment: '${placeholder}',
     inputWriteAComment: '$inputWriteAComment',
     commentMinCharactersAllowed: '${uicomponent.getCommentMinCharactersAllowed()}',
@@ -92,24 +98,9 @@
     labels: $labels
   }""";
 
-  String activityLink = new StringBuilder("<p><a id='editActivityLinkPreview' href='").append(uicomponent.getLinkSource())
-                        .append("'>").append(uicomponent.getLinkSource()).append("</a></p>");
-  def activityTitle = uicomponent.getDefaultTitle();
-  String activityBody = new StringBuilder(activityTitle.split('<oembed>')[0]).append(activityLink);
-  String ckEditorType = new StringBuilder("editActivity").append(activity.id);
-
-  //params for init edit composer component
-  def composerParams = """ {
-    activityId: '${activity.id}',
-    composerAction: 'update',
-    ckEditorType: '${ckEditorType}',
-    activityBody: `${activityBody}`
-  } """;
-
   jsManager.require("SHARED/jquery", "jq")
            .require("SHARED/bts_tooltip").addScripts("jq('*[rel=\"tooltip\"]').tooltip();")
-           .require("SHARED/social-ui-activity", "activity").addScripts("activity.onLoad($params);")
-           .require("SHARED/ActivityComposer", "activityComposer").addScripts("activityComposer.init($composerParams);");
+           .require("SHARED/social-ui-activity", "activity").addScripts("activity.onLoad($params);");
 
 
   //make sure commentFormFocused is set to false to prevent any refresh to focus, only focus after post a comment
@@ -147,7 +138,7 @@
 					<span class="arrowLeft"></span>
                <div class="activityHeader">
                 <% _ctx.includeTemplates("UIActivityHeading") %>
-                <div id="activityComposer"></div>
+                <div id="activityComposer${activity.id}"></div>
                 <!-- three dots activity menu -->
                     <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink">
                         <div class="dropdown-toggle" data-toggle="dropdown">
@@ -163,7 +154,7 @@
                         </li>
               <% if(activityEditable) {%>
                             <li class="actLink-item">
-                                <a id="EditActivitylink${activity.id}" class="" data-edit-activity="${activity.id}" data-placement="bottom" href="javascript:void(0)">
+                                <a id="EditActivitylink${activity.id}" class="EditActivitylink" data-edit-activity="${activity.id}" data-placement="bottom" href="javascript:void(0)">
                                     <i class="uiIcon uiIconEdit actLink-icon"></i>
                                     <span class="actLink-label">${labelEdit}</span>
                                 </a>

--- a/webapp/portlet/src/main/webapp/activity-composer-app/main.js
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/main.js
@@ -26,27 +26,37 @@ if (extensionRegistry) {
 
 // getting locale resources
 export function init(params) {
-  getActivityComposerActionExtensions().forEach(extension => {
-    if(extension.resourceBundle) {
-      urls.push(`/portal/rest/i18n/bundle/${extension.resourceBundle}-${lang}.json`);
+  if ($('.activityComposerApp').length) {
+    if (params && params.activityId) {
+      document.dispatchEvent(new CustomEvent('activity-composer-edit-activity', {detail : params}));
     }
-  });
-  params = params ? params : '';
-  exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
-    // init Vue app when locale resources are ready
-    new Vue({
-      el: '#activityComposer',
-      data: function() {
-        return {
-          composerAction: params.composerAction || 'post',
-          activityBody: params.activityBody || '',
-          ckEditorType: params.ckEditorType || 'activityContent',
-          activityId: params.activityId || '',
-        };
-      },
-      template: '<exo-activity-composer :activityBody="activityBody" :activity-id="activityId" :composer-action="composerAction" :ck-editor-type="ckEditorType"></exo-activity-composer>',
-      i18n,
-      vuetify
+  } else {
+    getActivityComposerActionExtensions().forEach(extension => {
+      if(extension.resourceBundle) {
+        urls.push(`/portal/rest/i18n/bundle/${extension.resourceBundle}-${lang}.json`);
+      }
     });
-  });
+    params = params ? params : '';
+    exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
+      let elementId = '#activityComposer';
+      if (!$('#activityComposer').length && params && params.activityId) {
+        elementId = `#activityComposer${params.activityId}`;
+      }
+
+      // init Vue app when locale resources are ready
+      new Vue({
+        el: elementId,
+        data: () => ({
+          composerAction: params && params.composerAction || 'post',
+          activityBody: params && params.activityBody || '',
+          activityId: params && params.activityId || '',
+          standalone: !!(params && params.activityId),
+        }),
+        template: '<exo-activity-composer :activityBody="activityBody" :activity-id="activityId" :composer-action="composerAction" :standalone="standalone"></exo-activity-composer>',
+        i18n,
+        vuetify
+      });
+    });
+    window.activityComposerInitialized = true;
+  }
 }

--- a/webapp/portlet/src/main/webapp/space-infos-app/spaceInfosServices.js
+++ b/webapp/portlet/src/main/webapp/space-infos-app/spaceInfosServices.js
@@ -5,6 +5,6 @@ export function getSpaceDescriptionByPrettyName(){
 }
 
 export function getSpaceManagersByPrettyName(){
-  return fetch(`${spacesConstants.SOCIAL_SPACE_API}${spacesConstants.SPACE_ID}${spacesConstants.MANAGERS_ROLE}`, {credentials: 'include'}).then(resp => resp.json()).catch(e => {console.log(e);});
+  return fetch(`${spacesConstants.SOCIAL_SPACE_API}${spacesConstants.SPACE_ID}${spacesConstants.MANAGERS_ROLE}`, {credentials: 'include'}).then(resp => resp.json());
 }
 

--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
@@ -32,6 +32,7 @@
     },
     configure: function(params) {
       UIActivity.activityId = params.activityId || null;
+      UIActivity.activityBody = params.activityBody || '';
       UIActivity.inputWriteAComment = params.inputWriteAComment || "";
       UIActivity.commentMinCharactersAllowed = params.commentMinCharactersAllowed || 0;
       UIActivity.commentMaxCharactersAllowed = params.commentMaxCharactersAllowed || 0;
@@ -44,7 +45,7 @@
       UIActivity.labels = params.labels;
 
       if (UIActivity.activityId == null) {
-        alert('err: activityId is null!');
+        console.error('err: activityId is null!');
         return;
       }
       UIActivity.commentLinkId = 'CommentLink' + UIActivity.activityId;
@@ -79,6 +80,18 @@
         } catch (e) {
           console.log(e);
         }
+      });
+
+      var editActivityButton = $("#EditActivitylink" + UIActivity.activityId);
+      editActivityButton.on('mouseup', () => {
+        window.require(['SHARED/ActivityComposer'], activityComposerApp => {
+          activityComposerApp.init({
+            activityId: params.activityId,
+            composerAction: 'update',
+            ckEditorType: `editActivity${params.activityId}`,
+            activityBody: params.activityBody
+          });
+        });
       });
     },
 


### PR DESCRIPTION
Activity Composer is instanciated multiple times in Activity Stream: one for the activity composer to post new activities and other instances, one per Activity present in Stream to allow editing activity in composer. this strategy is very heavy on browser especially when posting new activity, in fact the AS gets updated and the Composer gets instantiated again each time there is an update in the AS (like, comment...)
To avoid this performance regression, a single instance of Activity composer will be used, and events through document.dispatchEvent will be used to open composer with editing activity details.