### PR TITLE
MAINT-26972 Fix saving about Me user information using correct encoding

### DIFF
--- a/webapp/portlet/src/main/webapp/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/common/js/UserService.js
@@ -181,13 +181,17 @@ export function deleteRelationship(userId) {
 }
 
 export function updateProfileField(username, name, value) {
+  const formData = new FormData();
+  formData.append('name', name);
+  formData.append('value', value);
+
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${username}`, {
     method: 'PATCH',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: `name=${name}&value=${value}`
+    body: new URLSearchParams(formData).toString(),
   }).then(resp => {
     if (!resp || !resp.ok) {
       return resp.text();


### PR DESCRIPTION
When appending manually Query string of POST Form data, the characters encoding of the sent request will be ignored, thus the server will decode the form data using bad Character encoding. By using javascript FormData object to simulate sending a form, the data is correctly encoded and thus correctly saved in Server side using the correct Character encoding