### PR TITLE
Avoid displaying alert message when changing page from ActivityStream

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
@@ -294,6 +294,7 @@ export default {
     },
     closeMessageComposer: function() {
       this.showMessageComposer = false;
+      this.message = '';
     },
     executeAction(action) {
       executeExtensionAction(action, this.$refs[action.key]);


### PR DESCRIPTION
The confirmBeforeReload CKEditor plugin is added in 6.0 in all CKEditor instances (see https://github.com/Meeds-io/commons/commit/f3bfe6f36a1fc55f3f706e0488e7fc193a527b8c#diff-4d9720d0700250057e6d1d8d2338b9ccR25 ). Knowing that the Activity composer drawer is not hidden, but just had at first a width = 0, the confirmBeforeReload plugin will not be able to know if the user is editing or not the activity in UI. Thus, here the modification is made to empty the CKEditor content each time the Activity Composer drawer is not displayed to user. By doing this, the confirmBeforeReload plugin will not display a popup message when changing page anymore