### PR TITLE
MAINT-27093: Make sure that bound users can not be removed from the space to which they are bound.

### DIFF
--- a/webapp/portlet/src/main/webapp/space-members/components/SpaceMembers.vue
+++ b/webapp/portlet/src/main/webapp/space-members/components/SpaceMembers.vue
@@ -65,7 +65,7 @@ export default {
         icon: 'uiIconTrash',
         order: 0,
         enabled: (user) => {
-          return (this.filter === 'member' || this.filter === 'manager') && user.isMember;
+          return (this.filter === 'member' || this.filter === 'manager') && user.isMember && !user.isGroupBound;
         },
         click: (user) => {
           this.$spaceService.removeMember(eXo.env.portal.spaceName, user.username)


### PR DESCRIPTION
According to the group space binding rules, bound user can not be removed from a space to which they are bound, i added a check to verify if a user is already bound to the space in concern before enabling the "Remove member" extension.