### PR TITLE
Enable user profile activity generation for avatar and banner

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -57,6 +57,7 @@ import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.activity.model.*;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.model.Profile.UpdateType;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.*;
 import org.exoplatform.social.core.model.*;
@@ -1336,12 +1337,14 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
                                             uploadResource.getMimeType(),
                                             inputStream,
                                             System.currentTimeMillis());
+          profile.setListUpdateTypes(Arrays.asList(UpdateType.AVATAR));
         } else {
           attachment = new BannerAttachment(null,
                                             uploadResource.getFileName(),
                                             uploadResource.getMimeType(),
                                             inputStream,
                                             System.currentTimeMillis());
+          profile.setListUpdateTypes(Arrays.asList(UpdateType.BANNER));
         }
         profile.setProperty(name, attachment);
         if (save) {


### PR DESCRIPTION
When a user changes his avatar or banner, the activity isn't populated anymore. In fact, the IdentityManager should detect automatically this change, but this wasn't possible to specify in Service layer, thus the update Type for Avatar and Banner attachments modifications are managed in REST layer by adding manually the update type to correctly dispatch Profile Update operation listeners.