### PR TITLE
MAINT-27291 : fix special characters encoding in reaction drawer (#234)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -446,7 +446,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     if (space == null || (! spaceService.isManager(space, authenticatedUser) && ! spaceService.isSuperManager(authenticatedUser))) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
-    if ( StringUtils.isBlank(model.getDisplayName()) || model.getDisplayName().length() > 200 || !SpaceUtils.isValidSpaceName(model.getDisplayName())) {
+    if ( model.getDisplayName() != null && ( model.getDisplayName().length() > 200 || !SpaceUtils.isValidSpaceName(model.getDisplayName()))) {
       throw new SpaceException(SpaceException.Code.INVALID_SPACE_NAME);
     }
 

--- a/webapp/portlet/src/main/webapp/activity-reactions/components/ActivityReactionsListItems.vue
+++ b/webapp/portlet/src/main/webapp/activity-reactions/components/ActivityReactionsListItems.vue
@@ -9,8 +9,8 @@
           :id="cmpId"
           :href="profileUrl"
           rel="nofollow"
-          class="text-color">
-          {{ name }}
+          class="text-color"
+          v-html="name">
         </a>
       </v-list-item-title>
       <v-list-item-subtitle v-if="attributesLoaded && !sameUser" class="caption text-bold">


### PR DESCRIPTION
Special/Accentued characters are encoded wrongly in the reaction drawer.
The fix uses v-html to display the fullname. This PR also fixes a problem when adding a member to a space.
(cherry picked from commit cd55863e287549389978984da4a835e1a1af3b71)