### PR TITLE
MAINT-26764: Reaction labels (Reply and kudos) not colored in blue in comment section

### DIFF
--- a/extension/war/src/main/webapp/groovy/social/webui/activity/UIActivityCommentActions.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/activity/UIActivityCommentActions.gtmpl
@@ -64,7 +64,7 @@
         <li class="separator">-</li>
         <li class="reply">
             <a id="CommentLink${comment.id}" data-activity="$comment.parentId" data-comment="$parentCommentId" data-sub-comment="$subCommentId" data-author-name="$authorName" data-author-fullname="$authorFullName" href="javascript:void(0);">
-                $labelReply
+                <span class="replyComment">$labelReply</span>
             </a> 
         </li>
         <% _ctx.includeTemplates("UIActivityCommentActionBar-actions-after") %>


### PR DESCRIPTION
Backport [commit](https://github.com/Meeds-io/social/commit/c998ec46cd5533809e658eddd62e9aab067e1054)