### PR TITLE
MAINT-27867 : fix search users by fullname in Membership form

### DIFF
--- a/webapp/portlet/src/main/webapp/idm-groups-management/components/GroupsManagementMembershipFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/idm-groups-management/components/GroupsManagementMembershipFormDrawer.vue
@@ -151,7 +151,7 @@ export default {
             this.users = [];
 
             this.loadingSuggestions++;
-            this.$userService.getUsersByStatus(value, 0, 20, 'ANY')
+            this.$userService.getUsersByStatus(value, 0, 20, 'ENABLED')
               .then(data => this.users = data && data.entities || [])
               .finally(() => this.loadingSuggestions--);
           }


### PR DESCRIPTION
Using ANY status for searching users, does not allow searching with fullname (not stored in IDM). Thus to be able to get users by fullname we switched to search ENABLED users only based on their social identities (Disabled users are not indexed in social identities).