### PR TITLE
MAINT-26764: Like label should be blue colored as like icon when the post is liked

### DIFF
--- a/extension/war/src/main/webapp/groovy/social/webui/activity/commons/UIActivityActionBar.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/activity/commons/UIActivityActionBar.gtmpl
@@ -16,7 +16,7 @@
     <li>
       <a onclick="$unlikeActivityAction" rel="tooltip" data-placement="bottom" title="<%=_ctx.appRes("UIActivity.msg.UnlikeActivity"); %>" id="UnLikeLink${activity.id}" href="javascript:void(0);">
         <i class="uiIconThumbUp uiIconBlue"></i>
-        <span class="LikeLabel reactionLabel">$labelLike</span>
+        <span class="LikeLabel reactionLabel uiIconBlue">$labelLike</span>
       </a>
     </li>
   <% } else { %>


### PR DESCRIPTION
Backport [commit](https://github.com/Meeds-io/social/commit/ed43494429616ea89687d736f15b983bf9a34ec4)