### PR TITLE
MAINT-28235 : use userName as value for users suggested from a space

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -539,11 +539,11 @@ public class PeopleRestService implements ResourceContainer{
     SpaceService spaceSrv = getSpaceService(); 
     for (Identity identity : identities) {
       String fullName = identity.getProfile().getFullName();
-      String userName = (String) identity.getProfile().getProperty(Profile.USERNAME); 
+      String userName = identity.getRemoteId();
       Option opt = new Option();
       if (SPACE_MEMBER.equals(typeOfRelation) && spaceSrv.isMember(space, userName)) {
         opt.setType("user");
-        opt.setValue(fullName);
+        opt.setValue(userName);
         opt.setText(fullName);
         opt.setAvatarUrl(identity.getProfile() == null ? null : identity.getProfile().getAvatarUrl());
       } else if (USER_TO_INVITE.equals(typeOfRelation) && (space == null || (!spaceSrv.isInvitedUser(space, userName)


### PR DESCRIPTION
When suggesting users who are members of a space, the list of items provides the fullname of the user as value and this does not allow using it with other APIs
The fix sets the username as the value for each suggested item. 