### PR TITLE
Fix SuggesterService identity retrieval and conversion in JS

### DIFF
--- a/webapp/portlet/src/main/webapp/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/common/js/SuggesterService.js
@@ -112,13 +112,6 @@ export function getSuggesterItemByIdentityId(identityId) {
   }
 
   return getIdentityById(identityId)
-    .then(resp => {
-      if (!resp || !resp.ok) {
-        throw new Error('Response code indicates a server error', resp);
-      } else {
-        return resp.json();
-      }
-    })
     .then(convertIdentityToSuggesterItem);
 }
 


### PR DESCRIPTION
The response from IdentityService.getIdentityById method is already interpreted, thus, no need to interpret it again in SuggesterService methods