### PR TITLE
MAINT-28303 : Impossible to import users csv with SAML integration

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/RequestCsvFile.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/RequestCsvFile.java
@@ -1,0 +1,42 @@
+package org.exoplatform.social.rest.entity;
+
+public class RequestCsvFile {
+
+    private String uploadId;
+    private boolean progress;
+    private boolean clean;
+    private boolean sync;
+
+
+    public String getUploadId() {
+        return uploadId;
+    }
+
+    public void setUploadId(String uploadId) {
+        this.uploadId = uploadId;
+    }
+
+    public boolean getProgress() {
+        return progress;
+    }
+
+    public void setProgress(boolean progress) {
+        this.progress = progress;
+    }
+
+    public boolean getClean() {
+        return clean;
+    }
+
+    public void setClean(boolean clean) {
+        this.clean = clean;
+    }
+
+    public boolean getSync() {
+        return sync;
+    }
+
+    public void setSync(boolean sync) {
+        this.sync = sync;
+    }
+}

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -432,28 +432,26 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     startSessionAs("root");
 
     String uploadId = "users-empty.csv";
-    MultivaluedMap<String, String> headers = new MultivaluedMapImpl();
-    headers.putSingle("Content-Type", "application/x-www-form-urlencoded");
-    ContainerResponse response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&sync=true").getBytes());
+    ContainerResponse response = getResponse("POST", "/v1/social/users/csv", "{\"uploadId\":\"" + uploadId + "\", \"sync\":\"true\"}");
     assertNotNull(response);
 
     assertEquals(404, response.getStatus());
 
     URL resource = getClass().getClassLoader().getResource("users-empty.csv");
     uploadService.createUploadResource(uploadId, resource.getFile(), "users-empty.csv", "text/csv");
-    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&sync=true").getBytes());
+    response = getResponse("POST", "/v1/social/users/csv", "{\"uploadId\":\"" + uploadId + "\", \"sync\":\"true\"}");
     assertNotNull(response);
     assertEquals(400, response.getStatus());
 
     uploadId = "users.csv";
     resource = getClass().getClassLoader().getResource("users.csv");
     uploadService.createUploadResource(uploadId, resource.getFile(), "users.csv", "text/csv");
-    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&sync=true").getBytes());
+    response = getResponse("POST", "/v1/social/users/csv", "{\"uploadId\":\"" + uploadId + "\", \"sync\":\"true\"}");
     assertNotNull(response);
     assertNull(response.getEntity());
     assertEquals(204, response.getStatus());
 
-    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId+"&progress=true").getBytes());
+    response = getResponse("POST", "/v1/social/users/csv", "{\"uploadId\":\"" + uploadId + "\", \"progress\":\"true\"}");
     assertNotNull(response);
     assertNotNull(response.getEntity());
     assertEquals(200, response.getStatus());
@@ -466,7 +464,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
     UploadResource uploadResource = uploadService.getUploadResource(uploadId);
     assertNotNull(uploadResource);
-    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId+"&clean=true").getBytes());
+    response = getResponse("POST", "/v1/social/users/csv", "{\"uploadId\":\"" + uploadId + "\", \"clean\":\"true\"}");
     assertNotNull(response);
     assertNotNull(response.getEntity());
     assertEquals(200, response.getStatus());
@@ -481,12 +479,12 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     uploadId = "users-errors.csv";
     resource = getClass().getClassLoader().getResource("users-errors.csv");
     uploadService.createUploadResource(uploadId, resource.getFile(), "users-errors.csv", "text/csv");
-    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&sync=true").getBytes());
+    response = getResponse("POST", "/v1/social/users/csv", "{\"uploadId\":\"" + uploadId + "\", \"sync\":\"true\"}");
     assertNotNull(response);
     assertNull(response.getEntity());
     assertEquals(204, response.getStatus());
 
-    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId+"&progress=true").getBytes());
+    response = getResponse("POST", "/v1/social/users/csv", "{\"uploadId\":\"" + uploadId + "\", \"progress\":\"true\"}");
     assertNotNull(response);
     assertNotNull(response.getEntity());
     assertEquals(200, response.getStatus());

--- a/webapp/portlet/src/main/webapp/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/common/js/UserService.js
@@ -252,9 +252,11 @@ export function importUsers(uploadId) {
     method: 'POST',
     credentials: 'include',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Type': 'application/json',
     },
-    body: `uploadId=${uploadId}`,
+    body: JSON.stringify({
+      uploadId: `${uploadId}`,
+    })
   }).then(resp => {
     if (!resp || !resp.ok) {
       return resp.text();
@@ -271,9 +273,12 @@ export function checkImportUsersProgress(uploadId) {
     method: 'POST',
     credentials: 'include',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Type': 'application/json',
     },
-    body: `uploadId=${uploadId}&progress=true`,
+    body: JSON.stringify({
+      uploadId: `${uploadId}`,
+      progress: true,
+    })
   }).then(resp => {
     if (!resp || !resp.ok) {
       return resp.text();
@@ -293,9 +298,12 @@ export function cleanImportUsers(uploadId) {
     method: 'POST',
     credentials: 'include',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Type': 'application/json',
     },
-    body: `uploadId=${uploadId}&clean=true`,
+    body: JSON.stringify({
+      uploadId: `${uploadId}`,
+      clean: true,
+    })
   }).then(resp => {
     if (!resp || !resp.ok) {
       return resp.text();


### PR DESCRIPTION
The problem is due to SSO integration, which still somehow forces @FormParam to be null with these filters.
For that I propose to change the content type to application/json to get around this problem.