### PR TITLE
Maint-27955 : Fix problem with URL after renaming a space

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -422,7 +422,6 @@ public class SpaceUtils {
    * Rename label group
    *
    * @param space
-   * @return
    */
   public static void renameGroupLabel(Space space) {
     try {
@@ -443,7 +442,7 @@ public class SpaceUtils {
    * Rename page node.
    *
    * @param space
-   * @return
+   * @return UserNode
    */
   public static UserNode renamePageNode(Space space) {
 

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.web.url.navigation.NodeURL;
 import org.gatein.common.i18n.LocalizedString;
 import org.gatein.common.util.Tools;
 import org.gatein.pc.api.Portlet;
@@ -1888,92 +1887,6 @@ public class SpaceUtils {
       LOG.warn("Get UserNode of Space failed.");
     }
     return navigations;
-  }
-
-  /**
-   * Get the space url.
-   *
-   * @param node
-   * @return
-   */
-  public static String getSpaceURL(UserNode node) {
-    RequestContext ctx = RequestContext.getCurrentInstance();
-    NodeURL nodeURL =  ctx.createURL(NodeURL.TYPE);
-    return nodeURL.setNode(node).toString();
-  }
-
-  /**
-   * Rename navigation and group
-   *
-   * @param space
-   * @return
-   */
-  public static void renameNavigationAndGroup(Space space) {
-    try {
-
-      String oldSpaceName = space.getGroupId().split(SPACE_GROUP + "/")[1];
-      if (!oldSpaceName.equals(space.getDisplayName())) {
-        String cleanedString = SpaceUtils.cleanString(space.getDisplayName());
-        UserNode node = renamePageNode(cleanedString, space);
-        OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
-        GroupHandler groupHandler = organizationService.getGroupHandler();
-        Group group = groupHandler.findGroupById(space.getGroupId());
-        group.setLabel(space.getDisplayName());
-        groupHandler.saveGroup(group, true);
-        if (node != null) {
-          PortalRequestContext prContext = Util.getPortalRequestContext();
-          prContext.createURL(NodeURL.TYPE).setNode(node);
-          space.setUrl(getSpaceURL(node));
-        }
-      }
-    } catch (Exception e) {
-      LOG.warn(e.getMessage(), e);
-    } finally {
-      RequestLifeCycle.end();
-    }
-  }
-
-  /**
-   * Rename page node.
-   *
-   * @param newNodeLabel
-   * @param space
-   * @return
-   */
-  public static UserNode renamePageNode(String newNodeLabel, Space space) {
-
-    try {
-
-      DataStorage dataService = CommonsUtils.getService(DataStorage.class);
-      UserNode renamedNode = SpaceUtils.getSpaceUserNode(space);
-      UserNode parentNode = renamedNode.getParent();
-      String newNodeName = SpaceUtils.cleanString(newNodeLabel);
-      //
-      renamedNode.setLabel(newNodeLabel);
-      renamedNode.setName(newNodeName);
-
-      Page page = dataService.getPage(renamedNode.getPageRef().format());
-      if (page != null) {
-        page.setTitle(newNodeLabel);
-        dataService.save(page);
-      }
-
-      SpaceUtils.getUserPortal().saveNode(parentNode, null);
-
-      space.setUrl(newNodeName);
-      SpaceUtils.changeSpaceUrlPreference(renamedNode, space, newNodeLabel);
-      SpaceUtils.changeAppPageTitle(renamedNode, newNodeLabel);
-
-      List<UserNode> userNodes =  new ArrayList<UserNode>(renamedNode.getChildren());
-      for (UserNode childNode : userNodes) {
-        SpaceUtils.changeSpaceUrlPreference(childNode, space, newNodeLabel);
-        SpaceUtils.changeAppPageTitle(childNode, newNodeLabel);
-      }
-      return renamedNode;
-    } catch (Exception e) {
-      LOG.warn(e.getMessage() , e);
-      return null;
-    }
   }
 
   public static String getUri(UserNode userNode) {

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.web.url.navigation.NodeURL;
 import org.gatein.common.i18n.LocalizedString;
 import org.gatein.common.util.Tools;
 import org.gatein.pc.api.Portlet;
@@ -415,6 +416,68 @@ public class SpaceUtils {
       }
     }
     return cleanedStr.toString().toLowerCase();
+  }
+
+  /**
+   * Rename label group
+   *
+   * @param space
+   * @return
+   */
+  public static void renameGroupLabel(Space space) {
+    try {
+      RequestLifeCycle.begin(PortalContainer.getInstance());
+      OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+      GroupHandler groupHandler = organizationService.getGroupHandler();
+      Group group = groupHandler.findGroupById(space.getGroupId());
+      group.setLabel(space.getDisplayName());
+      groupHandler.saveGroup(group, true);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    } finally {
+      RequestLifeCycle.end();
+    }
+  }
+
+  /**
+   * Rename page node.
+   *
+   * @param space
+   * @return
+   */
+  public static UserNode renamePageNode(Space space) {
+
+    try {
+
+      DataStorage dataService = CommonsUtils.getService(DataStorage.class);
+      UserNode renamedNode = SpaceUtils.getSpaceUserNode(space);
+      UserNode parentNode = renamedNode.getParent();
+      String newNodeLabel = space.getDisplayName();
+      String newNodeName = SpaceUtils.cleanString(newNodeLabel);
+      renamedNode.setLabel(newNodeLabel);
+      renamedNode.setName(newNodeName);
+
+      Page page = dataService.getPage(renamedNode.getPageRef().format());
+      if (page != null) {
+        page.setTitle(newNodeLabel);
+        dataService.save(page);
+      }
+
+      SpaceUtils.getUserPortal().saveNode(parentNode, null);
+
+      space.setUrl(newNodeName);
+      SpaceUtils.changeAppPageTitle(renamedNode, newNodeLabel);
+
+      List<UserNode> userNodes = new ArrayList<>(renamedNode.getChildren());
+      for (UserNode childNode : userNodes) {
+        SpaceUtils.changeSpaceUrlPreference(childNode, space, newNodeLabel);
+        SpaceUtils.changeAppPageTitle(childNode, newNodeLabel);
+      }
+      return renamedNode;
+    } catch (Exception e) {
+      LOG.warn(e.getMessage(), e);
+      return null;
+    }
   }
 
   /**

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -1895,35 +1895,41 @@ public class SpaceUtils {
    *
    * @param node
    * @return
-   * @since 1.2.1
    */
   public static String getSpaceURL(UserNode node) {
     RequestContext ctx = RequestContext.getCurrentInstance();
     NodeURL nodeURL =  ctx.createURL(NodeURL.TYPE);
     return nodeURL.setNode(node).toString();
   }
+
   /**
-   * Get the space url.
+   * Rename navigation and group
    *
    * @param space
    * @return
-   * @since 1.2.1
    */
-  public static void renameNavigationAndGroup(Space space) throws  Exception{
-    String oldSpaceName = space.getGroupId().split(SPACE_GROUP +"/")[1];
-    if (!oldSpaceName.equals(space.getDisplayName())) {
-      String cleanedString = SpaceUtils.cleanString(space.getDisplayName());
-      UserNode node = renamePageNode(cleanedString, space);
-      OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
-      GroupHandler groupHandler = organizationService.getGroupHandler();
-      Group group = groupHandler.findGroupById(space.getGroupId());
-      group.setLabel(space.getDisplayName());
-      groupHandler.saveGroup(group, true);
-      if (node != null) {
-        PortalRequestContext prContext = Util.getPortalRequestContext();
-        prContext.createURL(NodeURL.TYPE).setNode(node);
-        space.setUrl(getSpaceURL(node));
+  public static void renameNavigationAndGroup(Space space) {
+    try {
+
+      String oldSpaceName = space.getGroupId().split(SPACE_GROUP + "/")[1];
+      if (!oldSpaceName.equals(space.getDisplayName())) {
+        String cleanedString = SpaceUtils.cleanString(space.getDisplayName());
+        UserNode node = renamePageNode(cleanedString, space);
+        OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+        GroupHandler groupHandler = organizationService.getGroupHandler();
+        Group group = groupHandler.findGroupById(space.getGroupId());
+        group.setLabel(space.getDisplayName());
+        groupHandler.saveGroup(group, true);
+        if (node != null) {
+          PortalRequestContext prContext = Util.getPortalRequestContext();
+          prContext.createURL(NodeURL.TYPE).setNode(node);
+          space.setUrl(getSpaceURL(node));
+        }
       }
+    } catch (Exception e) {
+      LOG.warn(e.getMessage(), e);
+    } finally {
+      RequestLifeCycle.end();
     }
   }
 
@@ -1933,7 +1939,6 @@ public class SpaceUtils {
    * @param newNodeLabel
    * @param space
    * @return
-   * @since 1.2.8
    */
   public static UserNode renamePageNode(String newNodeLabel, Space space) {
 

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
@@ -18,6 +18,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
 import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.web.url.navigation.NodeURL;
+import org.exoplatform.container.PortalContainer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -92,7 +93,8 @@ public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
   @Override
   public void spaceRenamed(SpaceLifeCycleEvent event) {
     Space space = event.getSpace();
-    renameNavigationAndGroup(space);
+    SpaceUtils.renamePageNode(space);
+    SpaceUtils.renameGroupLabel(space);
   }
 
   @Override
@@ -113,92 +115,6 @@ public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
   @Override
   public void addPendingUser(SpaceLifeCycleEvent event) {
 
-  }
-
-  /**
-   * Rename navigation and group
-   *
-   * @param space
-   * @return
-   */
-  public static void renameNavigationAndGroup(Space space) {
-    try {
-
-      String oldSpaceName = space.getGroupId().split("/spaces/")[1];
-      if (!oldSpaceName.equals(space.getDisplayName())) {
-        String cleanedString = SpaceUtils.cleanString(space.getDisplayName());
-        UserNode node = renamePageNode(cleanedString, space);
-        OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
-        GroupHandler groupHandler = organizationService.getGroupHandler();
-        Group group = groupHandler.findGroupById(space.getGroupId());
-        group.setLabel(space.getDisplayName());
-        groupHandler.saveGroup(group, true);
-        if (node != null) {
-          PortalRequestContext prContext = Util.getPortalRequestContext();
-          prContext.createURL(NodeURL.TYPE).setNode(node);
-          space.setUrl(getSpaceURL(node));
-        }
-      }
-    } catch (Exception e) {
-      LOG.warn(e.getMessage(), e);
-    } finally {
-      RequestLifeCycle.end();
-    }
-  }
-
-  /**
-   * Rename page node.
-   *
-   * @param newNodeLabel
-   * @param space
-   * @return
-   */
-  public static UserNode renamePageNode(String newNodeLabel, Space space) {
-
-    try {
-
-      DataStorage dataService = CommonsUtils.getService(DataStorage.class);
-      UserNode renamedNode = SpaceUtils.getSpaceUserNode(space);
-      UserNode parentNode = renamedNode.getParent();
-      String newNodeName = SpaceUtils.cleanString(newNodeLabel);
-      //
-      renamedNode.setLabel(newNodeLabel);
-      renamedNode.setName(newNodeName);
-
-      Page page = dataService.getPage(renamedNode.getPageRef().format());
-      if (page != null) {
-        page.setTitle(newNodeLabel);
-        dataService.save(page);
-      }
-
-      SpaceUtils.getUserPortal().saveNode(parentNode, null);
-
-      space.setUrl(newNodeName);
-      SpaceUtils.changeSpaceUrlPreference(renamedNode, space, newNodeLabel);
-      SpaceUtils.changeAppPageTitle(renamedNode, newNodeLabel);
-
-      List<UserNode> userNodes = new ArrayList<>(renamedNode.getChildren());
-      for (UserNode childNode : userNodes) {
-        SpaceUtils.changeSpaceUrlPreference(childNode, space, newNodeLabel);
-        SpaceUtils.changeAppPageTitle(childNode, newNodeLabel);
-      }
-      return renamedNode;
-    } catch (Exception e) {
-      LOG.warn(e.getMessage(), e);
-      return null;
-    }
-  }
-
-  /**
-   * Get the space url.
-   *
-   * @param node
-   * @return
-   */
-  public static String getSpaceURL(UserNode node) {
-    RequestContext ctx = RequestContext.getCurrentInstance();
-    NodeURL nodeURL = ctx.createURL(NodeURL.TYPE);
-    return nodeURL.setNode(node).toString();
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
@@ -1,0 +1,204 @@
+package org.exoplatform.social.core.space.impl;
+
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.config.DataStorage;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.user.UserNode;
+import org.exoplatform.portal.webui.util.Util;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.GroupHandler;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.social.core.space.SpaceListenerPlugin;
+import org.exoplatform.social.core.space.SpaceUtils;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
+import org.exoplatform.web.application.RequestContext;
+import org.exoplatform.web.url.navigation.NodeURL;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
+
+  private static final Log LOG = ExoLogger.getExoLogger(SpaceRenamedListenerImpl.class);
+
+  @Override
+  public void spaceAccessEdited(SpaceLifeCycleEvent event) {
+  }
+
+  @Override
+  public void spaceRegistrationEdited(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void spaceBannerEdited(SpaceLifeCycleEvent event) {
+  }
+
+  @Override
+  public void spaceCreated(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void spaceRemoved(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void applicationActivated(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void applicationAdded(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void applicationDeactivated(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void applicationRemoved(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void grantedLead(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void joined(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void left(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void revokedLead(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void spaceRenamed(SpaceLifeCycleEvent event) {
+    Space space = event.getSpace();
+    renameNavigationAndGroup(space);
+  }
+
+  @Override
+  public void spaceDescriptionEdited(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void spaceAvatarEdited(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void addInvitedUser(SpaceLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void addPendingUser(SpaceLifeCycleEvent event) {
+
+  }
+
+  /**
+   * Rename navigation and group
+   *
+   * @param space
+   * @return
+   */
+  public static void renameNavigationAndGroup(Space space) {
+    try {
+
+      String oldSpaceName = space.getGroupId().split("/spaces/")[1];
+      if (!oldSpaceName.equals(space.getDisplayName())) {
+        String cleanedString = SpaceUtils.cleanString(space.getDisplayName());
+        UserNode node = renamePageNode(cleanedString, space);
+        OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+        GroupHandler groupHandler = organizationService.getGroupHandler();
+        Group group = groupHandler.findGroupById(space.getGroupId());
+        group.setLabel(space.getDisplayName());
+        groupHandler.saveGroup(group, true);
+        if (node != null) {
+          PortalRequestContext prContext = Util.getPortalRequestContext();
+          prContext.createURL(NodeURL.TYPE).setNode(node);
+          space.setUrl(getSpaceURL(node));
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn(e.getMessage(), e);
+    } finally {
+      RequestLifeCycle.end();
+    }
+  }
+
+  /**
+   * Rename page node.
+   *
+   * @param newNodeLabel
+   * @param space
+   * @return
+   */
+  public static UserNode renamePageNode(String newNodeLabel, Space space) {
+
+    try {
+
+      DataStorage dataService = CommonsUtils.getService(DataStorage.class);
+      UserNode renamedNode = SpaceUtils.getSpaceUserNode(space);
+      UserNode parentNode = renamedNode.getParent();
+      String newNodeName = SpaceUtils.cleanString(newNodeLabel);
+      //
+      renamedNode.setLabel(newNodeLabel);
+      renamedNode.setName(newNodeName);
+
+      Page page = dataService.getPage(renamedNode.getPageRef().format());
+      if (page != null) {
+        page.setTitle(newNodeLabel);
+        dataService.save(page);
+      }
+
+      SpaceUtils.getUserPortal().saveNode(parentNode, null);
+
+      space.setUrl(newNodeName);
+      SpaceUtils.changeSpaceUrlPreference(renamedNode, space, newNodeLabel);
+      SpaceUtils.changeAppPageTitle(renamedNode, newNodeLabel);
+
+      List<UserNode> userNodes = new ArrayList<>(renamedNode.getChildren());
+      for (UserNode childNode : userNodes) {
+        SpaceUtils.changeSpaceUrlPreference(childNode, space, newNodeLabel);
+        SpaceUtils.changeAppPageTitle(childNode, newNodeLabel);
+      }
+      return renamedNode;
+    } catch (Exception e) {
+      LOG.warn(e.getMessage(), e);
+      return null;
+    }
+  }
+
+  /**
+   * Get the space url.
+   *
+   * @param node
+   * @return
+   */
+  public static String getSpaceURL(UserNode node) {
+    RequestContext ctx = RequestContext.getCurrentInstance();
+    NodeURL nodeURL = ctx.createURL(NodeURL.TYPE);
+    return nodeURL.setNode(node).toString();
+  }
+
+}

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -783,6 +783,15 @@
     </external-component-plugins>
 
     <external-component-plugins>
+        <target-component>org.exoplatform.social.core.space.spi.SpaceService</target-component>
+        <component-plugin>
+            <name>SpaceRenamedListenerImpl</name>
+            <set-method>addSpaceListener</set-method>
+            <type>org.exoplatform.social.core.space.impl.SpaceRenamedListenerImpl</type>
+        </component-plugin>
+    </external-component-plugins>
+
+    <external-component-plugins>
         <target-component>org.exoplatform.services.organization.OrganizationService</target-component>
         <component-plugin>
             <name>space.binding.group.event.listener</name>

--- a/webapp/portlet/src/main/java/org/exoplatform/social/portlet/SpaceMenuPortlet.java
+++ b/webapp/portlet/src/main/java/org/exoplatform/social/portlet/SpaceMenuPortlet.java
@@ -44,6 +44,7 @@ public class SpaceMenuPortlet extends GenericPortlet {
     Locale locale = request.getLocale();
     String currentUser = request.getRemoteUser();
     try {
+      SpaceUtils.renameNavigationAndGroup(space);
       List<UserNode> navigations = SpaceUtils.getSpaceNavigations(space,
                                                                   locale,
                                                                   currentUser);

--- a/webapp/portlet/src/main/java/org/exoplatform/social/portlet/SpaceMenuPortlet.java
+++ b/webapp/portlet/src/main/java/org/exoplatform/social/portlet/SpaceMenuPortlet.java
@@ -44,7 +44,6 @@ public class SpaceMenuPortlet extends GenericPortlet {
     Locale locale = request.getLocale();
     String currentUser = request.getRemoteUser();
     try {
-      SpaceUtils.renameNavigationAndGroup(space);
       List<UserNode> navigations = SpaceUtils.getSpaceNavigations(space,
                                                                   locale,
                                                                   currentUser);

--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
@@ -243,6 +243,7 @@ export default {
           window.setTimeout(() => {
             this.$refs.spaceFormDrawer.close();
           }, 200);
+          location.reload();
         })
         .catch(e => {
           // eslint-disable-next-line no-console

--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
@@ -243,7 +243,8 @@ export default {
           window.setTimeout(() => {
             this.$refs.spaceFormDrawer.close();
           }, 200);
-          window.location.href = `${eXo.env.portal.context}/g/${space.groupId.replace(/\//g, ':')}`;
+
+          window.location.href = `${eXo.env.portal.context}/g/${space.groupId.replace(/\//g, ':')}/${space.displayName}/settings`;
         })
         .catch(e => {
           // eslint-disable-next-line no-console

--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
@@ -243,7 +243,7 @@ export default {
           window.setTimeout(() => {
             this.$refs.spaceFormDrawer.close();
           }, 200);
-          location.reload();
+          window.location.href = `${eXo.env.portal.context}/g/${space.groupId.replace(/\//g, ':')}`;
         })
         .catch(e => {
           // eslint-disable-next-line no-console

--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingFormDrawer.vue
@@ -244,7 +244,7 @@ export default {
             this.$refs.spaceFormDrawer.close();
           }, 200);
 
-          window.location.href = `${eXo.env.portal.context}/g/${space.groupId.replace(/\//g, ':')}/${space.displayName}/settings`;
+          window.location.href = `${eXo.env.portal.context}/g/${space.groupId.replace(/\//g, ':')}/${space.prettyName}/settings`;
         })
         .catch(e => {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
This PR will fix the problem of the current URL witch not update when the user updates the space name, this bug is due to the migration JCR to RDBMS.
Solution: Rename space navigation and space group after editing space name and reload the page the have the new space context.