### PR TITLE
MAINT-21066: Make sure that news activities notifications aren't duplicated.

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -16,15 +16,10 @@
  */
 package org.exoplatform.social.notification;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.service.storage.MailNotificationStorage;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -35,6 +30,10 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.manager.RelationshipManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Utils {
   
@@ -63,6 +62,11 @@ public class Utils {
       "(?:[\\/|\\?|\\#].*)?$");                                                               // path and query
   
   private static final String styleCSS = " style=\"color: #2f5e92; text-decoration: none;\"";
+
+  /**
+   * Exo property name used for disable news activity notifications
+   */
+  private static final String DISABLED_ACTIVITY_TYPE_NOTIFICATIONS_PROPERTY_NAME = "exo.notifications.activity-type.disabled";
   
   @SuppressWarnings("unchecked")
   public static <T> T getService(Class<T> clazz) {
@@ -290,5 +294,20 @@ public class Utils {
 
   public static RelationshipManager getRelationshipManager() {
     return getService(RelationshipManager.class);
+  }
+
+  /**
+   * Checks if the notification is enabled for activities of type activityType
+   *
+   * @param activityType type of activity to check if their notification is enabled
+   * @return true if the notification is enabled for this Activity Type
+   */
+  public static boolean isActivityNotificationsEnabled(String activityType) {
+    String disabledNotifications = PropertyManager.getProperty(DISABLED_ACTIVITY_TYPE_NOTIFICATIONS_PROPERTY_NAME);
+    if (StringUtils.isNotBlank(disabledNotifications)) {
+      String[] activityTypes = disabledNotifications.split(",");
+      return !Arrays.asList(activityTypes).contains(activityType);
+    }
+    return true;
   }
 }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
@@ -16,12 +16,7 @@
  */
 package org.exoplatform.social.notification.plugin;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
-
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
@@ -30,6 +25,10 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.notification.Utils;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ActivityCommentPlugin extends BaseNotificationPlugin {
 
@@ -87,7 +86,11 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
     ExoSocialActivity comment = ctx.value(SocialNotificationUtils.ACTIVITY);
     ExoSocialActivity activity = Utils.getActivityManager().getParentActivity(comment);
 
-    if(isSubComment && comment.getParentCommentId() == null) {
+    if (!Utils.isActivityNotificationsEnabled(activity.getType())) {
+      return false;
+    }
+
+    if (isSubComment && comment.getParentCommentId() == null) {
       return false;
     }
 

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikePlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikePlugin.java
@@ -16,15 +16,16 @@
  */
 package org.exoplatform.social.notification.plugin;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.notification.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class LikePlugin extends BaseNotificationPlugin {
   
@@ -62,8 +63,13 @@ public class LikePlugin extends BaseNotificationPlugin {
   @Override
   public boolean isValid(NotificationContext ctx) {
     ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
+
+    if (!Utils.isActivityNotificationsEnabled(activity.getType())) {
+      return false;
+    }
+
     String[] likersId = activity.getLikeIdentityIds();
-    if (activity.getPosterId().equals(likersId[likersId.length-1])) {
+    if (activity.getPosterId().equals(likersId[likersId.length - 1])) {
       return false;
     }
     return true;

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/PostActivitySpaceStreamPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/PostActivitySpaceStreamPlugin.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.social.notification.plugin;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
@@ -62,12 +63,17 @@ public class PostActivitySpaceStreamPlugin extends BaseNotificationPlugin {
   @Override
   public boolean isValid(NotificationContext ctx) {
     ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
+
+    if (!Utils.isActivityNotificationsEnabled(activity.getType())) {
+      return false;
+    }
+
     Identity spaceIdentity = Utils.getIdentityManager().getOrCreateIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner(), false);
     //if the space is not null and it's not the default activity of space, then it's valid to make notification 
     if (spaceIdentity != null && activity.getPosterId().equals(spaceIdentity.getId()) == false) {
       return true;
     }
-    
+
     return false;
   }
 }


### PR DESCRIPTION
We added a new java property in order to set the disabled notifications according to the activity type and we set by default the 'news' and 'shared_news' notifications as disabled.