### PR TITLE
Task 28722 : the close search button does not respect a9n criteria 1.1.1 Non Text Content

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -448,6 +448,7 @@ GroupsManagement.error.invalidField=The "{0}" field must start with a character 
 Search.label.inputPlaceHolder=Search for content...
 Search.button.tooltip.open=You can use {0} to open or close search
 Search.button.loadMore=Load more
+Search.button.close.label=Close search
 Search.activity.inComment=In comments
 search.connector.label.activity=Activity
 search.connector.label.all=All

--- a/webapp/portlet/src/main/webapp/search/components/SearchToolbar.vue
+++ b/webapp/portlet/src/main/webapp/search/components/SearchToolbar.vue
@@ -15,7 +15,7 @@
       <v-btn v-if="term" text color="error" @click="clearSearchTerm">
         {{ $t('search.connector.label.clear') }}
       </v-btn>
-      <v-btn v-if="!standalone" icon class="searchCloseIcon transparent" @click="$emit('close-search')">
+      <v-btn v-if="!standalone" icon class="searchCloseIcon transparent" aria-label="Close search" @click="$emit('close-search')">
         <v-icon>mdi-close</v-icon>
       </v-btn>
     </v-list-item-action>

--- a/webapp/portlet/src/main/webapp/search/components/SearchToolbar.vue
+++ b/webapp/portlet/src/main/webapp/search/components/SearchToolbar.vue
@@ -15,7 +15,8 @@
       <v-btn v-if="term" text color="error" @click="clearSearchTerm">
         {{ $t('search.connector.label.clear') }}
       </v-btn>
-      <v-btn v-if="!standalone" icon class="searchCloseIcon transparent" aria-label="Close search" @click="$emit('close-search')">
+      <v-btn v-if="!standalone" :aria-label="$t('Search.button.close.label')" icon class="searchCloseIcon transparent"
+             @click="$emit('close-search')">
         <v-icon>mdi-close</v-icon>
       </v-btn>
     </v-list-item-action>


### PR DESCRIPTION
Prior to this change, the button is empty (has no text), so reading tools are not able to read it.
This fix add an aria-label on the button, then reading tools can read the button
In addition, after the fix, the wave plugin does not mark this as an error.