### PR TITLE
MAINT-26920 : Make sure to use the right meta tag for link images (#312)

### DIFF
--- a/component/service/src/test/java/org/exoplatform/social/service/rest/LinkShareTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/rest/LinkShareTest.java
@@ -28,4 +28,28 @@ public class LinkShareTest {
       }
     }
   }
+
+  @Test
+  public void shouldFetchLinkPreviewWhenPreviewIsDisabled() throws Exception {
+    // Given
+    String previousPropertyValue = System.getProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY);
+    System.setProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY, "true");
+
+    try {
+      // When
+      LinkShare linkShare = LinkShare.getInstance("https://www.meeds.io/");
+
+      // Then
+      assertNotNull(linkShare);
+      assertEquals("https://www.meeds.io/", linkShare.getLink());
+      assertNotNull(linkShare.getDescription());
+      assertNotNull(linkShare.getImages());
+    } finally {
+      if (previousPropertyValue == null) {
+        System.clearProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY);
+      } else {
+        System.setProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY, previousPropertyValue);
+      }
+    }
+  }
 }


### PR DESCRIPTION
To generate an image for shared links, The LinkShare class was using just the Link tag with "image_src" as rel, then it looks for the images inside the body of the web page.
This fix changes the current behavior to make it similar to what is used in the Oembed plugin of CKEditor (https://github.com/nfl/jquery-oembed-all) :
    1- Look for Meta tag with property og:image -> the open Graph protocol https://ogp.me/
    2- Otherwise, look for the Link tag with "image_src" and get its content
    3- Finally look for images inside the web page

(cherry picked from commit 59ef0b89ea88764f22948507cd1212c4ba8e67df)