### PR TITLE
MAINT-28720: Make sure that when redirecting to people page for received invitations the concerned drawer is opened.

### DIFF
--- a/webapp/portlet/src/main/webapp/people-overview/components/PeopleOverview.vue
+++ b/webapp/portlet/src/main/webapp/people-overview/components/PeopleOverview.vue
@@ -46,6 +46,9 @@ export default {
             this.skeleton = false;
             document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
           }
+          if (window.location.pathname.includes('receivedInvitations')) {
+            this.$refs.peopleDrawer.open('invitations', this.$t('peopleOverview.label.invitations'));
+          }
         });
       this.$userService.getPending()
         .then(data => {


### PR DESCRIPTION
After clicking on the See all requested connections from the snapshot page the people page should be loaded with the requested connections drawer opened.