### PR TITLE
MAINT-29059: Fix setAsRedactor and removeRedactor actions for the space manager

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesV1.java
@@ -374,11 +374,12 @@ public class SpaceMembershipRestResourcesV1 implements SpaceMembershipRestResour
     if (! authenticatedUser.equals(targetUser) && ! spaceService.isSuperManager(authenticatedUser) && ! spaceService.isManager(space, authenticatedUser)) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
-    if (spaceService.isOnlyManager(space, targetUser)) {
+    String role = idParams[2];
+    if (role != null && !role.equals("redactor") && spaceService.isOnlyManager(space, targetUser)) {
       throw new WebApplicationException(Response.Status.PRECONDITION_FAILED);
     }
     //
-    String role = idParams[2];
+    
     space.setEditor(authenticatedUser);
     if (role != null && role.equals("redactor")) {
       spaceService.removeRedactor(space, targetUser);

--- a/webapp/portlet/src/main/webapp/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/people-list/components/PeopleCardFront.vue
@@ -253,8 +253,8 @@ export default {
         return [];
       }
       if (this.isSameUser) {
-        return this.profileActionExtensions.slice().filter(extension => extension.title === this.$t('peopleList.button.setAsRedactor')
-            || extension.title === this.$t('peopleList.button.removeRedactor') && extension.enabled(this.user));
+        return this.profileActionExtensions.slice().filter(extension => (extension.title === this.$t('peopleList.button.setAsRedactor')
+            || extension.title === this.$t('peopleList.button.removeRedactor')) && extension.enabled(this.user));
       }
       return this.profileActionExtensions.slice().filter(extension => extension.enabled(this.user));
     },


### PR DESCRIPTION
This PR will fix two problems:
- Remove redactor not working for the space manager when it is the only one
- Set as redactor and remove redactor are both displayed for the manager