### PR TITLE
Task 35529 : Space template names and description are not i18n (#348)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceTemplateServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceTemplateServiceImpl.java
@@ -141,7 +141,7 @@ public class SpaceTemplateServiceImpl implements SpaceTemplateService, Startable
       ResourceBundle resourceBundle = resourceBundleService.getResourceBundle(
                                                                               new String[] { "locale.portal.webui",
                                                                                   "locale.portlet.social.SpacesAdministrationPortlet" },
-                                                                              new Locale("en"));
+                                                                              new Locale(lang));
       if (resourceBundle != null) {
         try {
           spaceTemplate.setResolvedLabel(resourceBundle.getString("social.spaces.templates.name." + spaceTemplate.getName()));


### PR DESCRIPTION
Before this fix, space templates names and descriptions are always in english.
This fix use the user locale to resolve name label, instead of en locale hardcoded