### PR TITLE
MAINT-25906: Make sure that after liking a comment, Smileys doesn't get displayed as an encoded text in activity comments.

### DIFF
--- a/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/XMLBalancerFilterPlugin.java
+++ b/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/XMLBalancerFilterPlugin.java
@@ -19,7 +19,7 @@ package org.exoplatform.social.common.xmlprocessor.filters;
 import java.util.List;
 import java.util.regex.Matcher;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.exoplatform.social.common.xmlprocessor.BaseXMLFilterPlugin;
 import org.exoplatform.social.common.xmlprocessor.DOMParser;
 import org.exoplatform.social.common.xmlprocessor.Tokenizer;
@@ -93,7 +93,7 @@ public class XMLBalancerFilterPlugin extends BaseXMLFilterPlugin {
         }
         if (searchOpenedNode.getParentNode() == null) {
           Node invalidNode = new Node();
-          invalidNode.setContent(StringEscapeUtils.escapeHtml(token));
+          invalidNode.setContent(StringEscapeUtils.escapeHtml4(token));
           currentNode.addChildNode(invalidNode);
         } else if (searchOpenedNode.getTitle().equals(currentNode.getTitle())) {
           currentNode = currentNode.getParentNode();
@@ -105,8 +105,8 @@ public class XMLBalancerFilterPlugin extends BaseXMLFilterPlugin {
         parsingNode = new Node();
         parsingNode.setParentNode(currentNode);
         // make sure the content part which was escaped before don't be escaped again
-        String content = StringEscapeUtils.unescapeHtml(token);
-        parsingNode.setContent(StringEscapeUtils.escapeHtml(content));
+        String content = StringEscapeUtils.unescapeHtml4(token);
+        parsingNode.setContent(StringEscapeUtils.escapeHtml4(content));
 
         currentNode.addChildNode(parsingNode);
       }

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -402,6 +402,10 @@ public class ActivityManagerImpl implements ActivityManager {
    * {@inheritDoc}
    */
   public void saveLike(ExoSocialActivity existingActivity, Identity identity) {
+    // in order to avoid updating unnecessarily activity title, body and template params 
+    existingActivity.setTitle(null);
+    existingActivity.setBody(null);
+    existingActivity.setTemplateParams(null);
     String[] identityIds = existingActivity.getLikeIdentityIds();
     if (ArrayUtils.contains(identityIds, identity.getId())) {
       LOG.warn("activity is already liked by identity: " + identity);
@@ -422,6 +426,7 @@ public class ActivityManagerImpl implements ActivityManager {
    * {@inheritDoc}
    */
   public void deleteLike(ExoSocialActivity activity, Identity identity) {
+    // in order to avoid updating unnecessarily activity title, body and template params
     activity.setTitle(null);
     activity.setBody(null);
     activity.setTemplateParams(null);

--- a/component/service/src/test/java/org/exoplatform/social/service/rest/api/ActivityStreamResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/rest/api/ActivityStreamResourcesTest.java
@@ -1761,13 +1761,15 @@ public class ActivityStreamResourcesTest extends AbstractResourceTest {
       // Demo creates 5 activities to space activity stream
       createActivities(demoIdentity, spaceIdentity, 5);
       List<ExoSocialActivity> demoActivities = activityManager.getActivitiesOfUserSpacesWithListAccess(demoIdentity)
-                                                              .loadAsList(0, 20);
+                                                              .loadAsList(0, 1);
 
       ExoSocialActivity likeActivity = demoActivities.get(0);
       activityManager.saveLike(likeActivity, demoIdentity);
       activityManager.saveLike(likeActivity, johnIdentity);
       activityManager.saveLike(likeActivity, maryIdentity);
 
+      demoActivities = activityManager.getActivitiesOfUserSpacesWithListAccess(demoIdentity)
+              .loadAsList(0, 20);
       ContainerResponse containerResponse2 = service("GET", resourceUrl, "", null, null);
       assertEquals("containerResponse2.getStatus() must return 200", 200,
                    containerResponse2.getStatus());


### PR DESCRIPTION
Avoid encoding emoji in comments when liked and avoid the unnecessary update of comment title, body and template params for the like/dislike comment action.