### PR TITLE
MAINT-35910 : add title on user card for Open User Info and Open User Menu

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
@@ -43,3 +43,5 @@ peopleList.label.noDataLabel=No data
 peopleList.error.errorWhenSavingSpace=Error after saving a space
 search.connector.label.people=People
 peopleList.label.groupBound=Group bound
+peopleList.label.openUserMenu=Open User Menu
+peopleList.label.openUserInfo=Open User Information

--- a/webapp/portlet/src/main/webapp/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/people-list/components/PeopleCardFront.vue
@@ -10,6 +10,7 @@
       <v-btn
         :disabled="skeleton"
         :class="skeleton && 'skeleton-background skeleton-text'"
+        :title="$t('peopleList.label.openUserInfo')"
         icon
         small
         class="peopleInfoIcon d-flex"
@@ -41,6 +42,7 @@
         <v-btn
           :disabled="skeleton"
           :class="skeleton && 'skeleton-background skeleton-text'"
+          :title="$t('peopleList.label.openUserMenu')"
           icon
           text
           class="peopleMenuIcon d-block"


### PR DESCRIPTION
Before this fix, the 2 buttons are labelled as emtpy button by wave.
This implies that theses 2 buttons are not accessibles
This fix add titles on buttons to make them accessibles