### PR TITLE
Task-36581: Add/Remove external social profile property flag when adding/removing to/from platform/externals

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/identity/model/Profile.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/model/Profile.java
@@ -119,6 +119,9 @@ public class Profile {
 
   /** CITY. */
   public static final String CITY                     = "city";
+  
+  /** EXTERNAL. */
+  public static final String EXTERNAL                 = "external";
 
   /**
    * An optional url for this profile

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -197,6 +197,9 @@ public class EntityBuilder {
     buildExperienceEntities(profile, userEntity);
     userEntity.setDeleted(profile.getIdentity().isDeleted());
     userEntity.setEnabled(profile.getIdentity().isEnable());
+    if (profile.getProperty(Profile.EXTERNAL) != null) {
+      userEntity.setIsExternal((String) profile.getProperty(Profile.EXTERNAL));
+    }
     userEntity.setCompany((String) profile.getProperty(Profile.COMPANY));
     userEntity.setLocation((String) profile.getProperty(profile.LOCATION));
     userEntity.setDepartment((String) profile.getProperty(profile.DEPARTMENT));

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
@@ -79,6 +79,8 @@ public class ProfileEntity extends BaseEntity {
   public static final String COUNTRY          = "country";
 
   public static final String CITY             = "city";
+  
+  public static final String EXTERNAL         = "external";
 
   public ProfileEntity() {
   }
@@ -457,6 +459,15 @@ public class ProfileEntity extends BaseEntity {
 
   public String isEnabled() {
     return getString(ENABLED);
+  }
+  
+  public ProfileEntity setIsExternal(String isExternal) {
+    setProperty(EXTERNAL, isExternal);
+    return this;
+  }
+
+  public String isExternal() {
+    return getString(EXTERNAL);
   }
 
   public static String getFieldName(String name) {


### PR DESCRIPTION
In this PR, when I add or remove a user to/from /platform/externals, I add/remove automatically using the socialMembershipListener "external" social property, this property will be injected on the userEntity and will be accessible from identity rest services