### PR TITLE
MAINT-37594 : Clear cache for portlet getting started when a user close this portlet and fix css

### DIFF
--- a/webapp/portlet/src/main/webapp/getting-started/components/ExoGettingStarted.vue
+++ b/webapp/portlet/src/main/webapp/getting-started/components/ExoGettingStarted.vue
@@ -110,16 +110,10 @@ export default {
       });
     },
     clearCache(){
-      caches.keys().then(function(cacheNames) {
-        return Promise.all(
-          cacheNames.filter(function(cacheName) {
-            return cacheName === 'portal-pwa-resources-dom';
-          }).map((cacheName) => {
-            caches.open(cacheName).then(function(cache) {
-              return cache.delete('/dom-cache?id=GettingStartedPortlet');
-            });
-          })
-        );
+      caches.open('portal-pwa-resources-dom').then(function(cache) {
+        cache.delete('/dom-cache?id=GettingStartedPortlet').then(function() {
+          console.debug('cache deleted');
+        });
       });
     }
   }

--- a/webapp/portlet/src/main/webapp/getting-started/components/ExoGettingStarted.vue
+++ b/webapp/portlet/src/main/webapp/getting-started/components/ExoGettingStarted.vue
@@ -15,8 +15,8 @@
               <v-card-title class="getting-started-title subtitle-1 text-uppercase pb-0">
                 <span class="title">
                   {{ $t('locale.portlet.gettingStarted.title') }}
+                  <a v-show="showButtonClose" :title="$t('locale.portlet.gettingStarted.button.close')" class="btClose" href="#" rel="tooltip" data-placement="bottom" @click="hideGettingStarted">x</a>
                 </span>
-                <a v-if="showButtonClose" :title="$t('locale.portlet.gettingStarted.button.close')" href="#" rel="tooltip" data-placement="bottom" @click="hideGettingStarted">x</a>
               </v-card-title>
               <v-list dense class="getting-started-list">
                 <v-list-item v-for="(step, index) in gettingStratedSteps" :key="index" class="getting-started-list-item">
@@ -63,6 +63,7 @@ export default {
       if (localStorage.getItem('gettingStarted') && this.showButtonClose){
         const data = JSON.parse(localStorage.getItem('gettingStarted') || {});
         if (data.user === eXo.env.portal.userName && data.gettingStartedStatus === true){
+          this.clearCache();
           this.showGettingStrated = false;
           return;
         }else {
@@ -72,6 +73,7 @@ export default {
       }else if (this.showButtonClose){
         gettingStartedService.getGettingStartedSettings().then((resp) =>{
           if (resp && resp.value){
+            this.clearCache();
             this.showGettingStrated = false;
             return;
           }else {
@@ -97,6 +99,7 @@ export default {
     hideGettingStarted(){
       gettingStartedService.saveGettingStartedSettings().then((response) => {
         if (response){
+          this.clearCache();
           const gettingStarted = {
             user : eXo.env.portal.userName,
             gettingStartedStatus: true
@@ -104,6 +107,19 @@ export default {
           localStorage.setItem('gettingStarted',JSON.stringify(gettingStarted));
           this.showGettingStrated = false;
         }
+      });
+    },
+    clearCache(){
+      caches.keys().then(function(cacheNames) {
+        return Promise.all(
+          cacheNames.filter(function(cacheName) {
+            return cacheName === 'portal-pwa-resources-dom';
+          }).map((cacheName) => {
+            caches.open(cacheName).then(function(cache) {
+              return cache.delete('/dom-cache?id=GettingStartedPortlet');
+            });
+          })
+        );
       });
     }
   }


### PR DESCRIPTION
when user closed portlet `getting started`, the portlet is always displayed because the portlet is saved in the cache so the solution is to delete the cache when the user close the portlet.