### PR TITLE
Fix-MAINT-37615: Make sure to display the enable/disable sapce chat setting.

### DIFF
--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettings.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettings.vue
@@ -29,6 +29,11 @@ export default {
     document.addEventListener('hideSettingsApps', () => this.displaySpaceExternalSettings = false);
     document.addEventListener('showSettingsApps', () => this.displaySpaceExternalSettings = true);
   },
+  destroyed() {
+    document.removeEventListener('chat-external-updated');
+    document.removeEventListener('hideSettingsApps');
+    document.removeEventListener('showSettingsApps');
+  },
   mounted() {
     this.$nextTick().then(() => this.$root.$emit('application-loaded'));
   },


### PR DESCRIPTION
At space setting's instance Vue creation the chat Vue instance is not already created, i made sure to dispatch the event of chat-external-updated after the creation of chat's Vue instance.