### PR TITLE
MAINT-39075 : Newly created users avatar isn't displayed in people when filtering

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
@@ -16,18 +16,16 @@
  */
 package org.exoplatform.social.core.manager;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
-
 import org.apache.commons.lang3.StringUtils;
-
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.social.core.identity.*;
+import org.exoplatform.social.core.identity.IdentityProvider;
+import org.exoplatform.social.core.identity.IdentityProviderPlugin;
+import org.exoplatform.social.core.identity.ProfileFilterListAccess;
+import org.exoplatform.social.core.identity.SpaceMemberFilterListAccess;
 import org.exoplatform.social.core.identity.SpaceMemberFilterListAccess.Type;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
@@ -38,6 +36,10 @@ import org.exoplatform.social.core.search.Sorting;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
 import org.exoplatform.webui.exception.MessageException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
 
 /**
  * Class IdentityManagerImpl implements IdentityManager without caching.
@@ -263,6 +265,7 @@ public class IdentityManagerImpl implements IdentityManager {
                                            Profile.CONTACT_PHONES,
                                            Profile.CONTACT_IMS,
                                            Profile.CONTACT_URLS,
+                                           Profile.AVATAR,
                                            Profile.EXTERNAL)) {
         list.add(Profile.UpdateType.CONTACT);
       }

--- a/component/core/src/main/java/org/exoplatform/social/core/profile/UserProfileComparator.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profile/UserProfileComparator.java
@@ -49,7 +49,7 @@ public class UserProfileComparator {
     if (oldValue == null) {
       return newValue != null
           && (((newValue instanceof String) && StringUtils.isNotBlank(newValue.toString()))
-              || ((newValue instanceof List) && !((List<?>) newValue).isEmpty()));
+              || ((newValue instanceof List) && !((List<?>) newValue).isEmpty())) || profileToUpdate.getProperty(Profile.AVATAR) != null;
     } else if (oldValue instanceof String) {
       newValue = newValue == null ? StringUtils.EMPTY : String.valueOf(newValue);
       return !StringUtils.equals((String) oldValue, (String) newValue);


### PR DESCRIPTION
**Problem :** when updating avatar of user `Elasticsearch`  don't  indexing avatar so the **solution** is when update avatar we re-index it .