### PR TITLE
Task 39157 : When an external user in invited, there is an error disp…

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -755,5 +755,9 @@
           </column>
         </addColumn>
   </changeSet>
+  
+  <changeSet author="task" id="1.0.0-77" dbms="oracle,postgresql">
+      <createSequence sequenceName="SEQ_INVITATION_ID" startValue="1"/>
+  </changeSet>
 
 </databaseChangeLog>

--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -756,7 +756,7 @@
         </addColumn>
   </changeSet>
   
-  <changeSet author="task" id="1.0.0-77" dbms="oracle,postgresql">
+  <changeSet author="social" id="1.0.0-77" dbms="oracle,postgresql">
       <createSequence sequenceName="SEQ_INVITATION_ID" startValue="1"/>
   </changeSet>
 


### PR DESCRIPTION
…layed with psql database

Prior to this change, when creating an external invitation, the line is not added in the corresponding table due to error in log.
With PSQL db, the sequence for this table is missing
This commit add the createSequence needed in liquibase