### PR TITLE
TASK-39856 Use sanitizeHTML on autolinker library to avoid XSS

### DIFF
--- a/webapp/resources/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/resources/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -430,7 +430,7 @@
       <adapter>
         (function() {
         <include>/javascript/autolinker.min.js</include>
-        Vue.directive('autolinker',(el, binding)=>el.innerHTML =  Autolinker.link(binding.value, binding.arg));
+        Vue.directive('autolinker',(el, binding)=>el.innerHTML =  Autolinker.link(binding.value, {sanitizeHtml: true}));
         })();
       </adapter>
     </script>


### PR DESCRIPTION
When adding a field that uses autolinker directive, the HTML gets interpreted.
(Use XSS attacks described here for example https://owasp.org/www-community/xss-filter-evasion-cheatsheet)
By using `sanitizeHTML` option, the HTML didn't get interpreted at all, as any Vue v-text directive.