### PR TITLE
TASK-39856 Fix displaying current user About Me in profile page of other users

### DIFF
--- a/webapp/portlet/src/main/webapp/profile-about-me/components/ProfileAboutMe.vue
+++ b/webapp/portlet/src/main/webapp/profile-about-me/components/ProfileAboutMe.vue
@@ -75,7 +75,7 @@ export default {
     }
   },
   created() {
-    this.$userService.getUser(eXo.env.portal.userName)
+    this.$userService.getUser(eXo.env.portal.profileOwner)
       .then(user => this.refresh(user && user.aboutMe || ''));
   },
   mounted() {
@@ -97,7 +97,7 @@ export default {
       this.error = null;
       this.saving = true;
       this.$refs.aboutMeDrawer.startLoading();
-      return this.$userService.updateProfileField(eXo.env.portal.userName, 'aboutMe', this.modifyingAboutMe)
+      return this.$userService.updateProfileField(eXo.env.portal.profileOwner, 'aboutMe', this.modifyingAboutMe)
         .then(() => this.refresh(this.modifyingAboutMe))
         .catch(error => {
           console.warn('Error saving about me section', error); // eslint-disable-line no-console


### PR DESCRIPTION
When displaying the profile page of another user, to retrieve his profile, we will have to use `eXo.env.portal.profileOwner` variable instead of `eXo.env.portal.userName`. In addition, the variable `eXo.env.portal.profileOwner` will be equal to `eXo.env.portal.userName` the current user is displaying his own profile.