### PR TITLE
Fix Activity Reactions JS error

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-reactions/components/ActivityReactionsApp.vue
+++ b/webapp/portlet/src/main/webapp/activity-reactions/components/ActivityReactionsApp.vue
@@ -6,6 +6,7 @@
           <exo-user-avatar
             v-for="liker in likersToDisplay"
             :key="liker.id"
+            :username="liker.likerId"
             :title="liker.personLikeFullName"
             :avatar-url="liker.personLikeAvatarImageSource"
             :url="liker.personLikeProfileUri"


### PR DESCRIPTION
When attempting to retrieve user details for tiptip in activity reactions, the username isn't passed for exo-user-avatar component, thus a REST call is made with null  username