### PR TITLE
MAINT-7218: Searching for newly created users in order to invite them to a space is failing

### DIFF
--- a/webapp/portlet/src/main/webapp/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/common/components/ExoIdentitySuggester.vue
@@ -184,7 +184,7 @@ export default {
     searchTerm(value) {
       if (value && value.length) {
         window.setTimeout(() => {
-          if (this.previousSearchTerm === null || this.previousSearchTerm === this.searchTerm) {
+          if (!this.previousSearchTerm || this.previousSearchTerm === this.searchTerm) {
             this.loadingSuggestions = 0;
             this.items = [];
 

--- a/webapp/portlet/src/main/webapp/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/common/components/ExoIdentitySuggester.vue
@@ -184,7 +184,7 @@ export default {
     searchTerm(value) {
       if (value && value.length) {
         window.setTimeout(() => {
-          if (this.previousSearchTerm === this.searchTerm) {
+          if (this.previousSearchTerm === null || this.previousSearchTerm === this.searchTerm) {
             this.loadingSuggestions = 0;
             this.items = [];
 


### PR DESCRIPTION
This condition `if (this.previousSearchTerm === this.searchTerm)` is always invalid at the first letter typed, since `this.previousSearchTerm` is initialized to `null` , to fix this problem we should skip this first typed letter.