### PR TITLE
TASK-36623: fix managers popup in space info section.

### DIFF
--- a/webapp/portlet/src/main/webapp/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/space-infos-app/components/ExoSpaceInfos.vue
@@ -39,8 +39,8 @@ export default {
             return this.$nextTick();
           })
           .then(() => {
-            this.initPopup();
             this.$root.$emit('application-loaded');
+            this.initPopup();
           });
       }
     },


### PR DESCRIPTION
 While initializing the component, the div with id `spaceManagers` was not found because it wasn't loaded (event  "application-loaded" sent after trying to initialize the popup. It should be before so the dom will be updated).