### PR TITLE
Task-40653 : People & spaces connectors for external users and internal

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/search/impl/SearchServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/search/impl/SearchServiceImpl.java
@@ -20,6 +20,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.portal.config.UserACL;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.api.settings.SettingService;
@@ -38,6 +40,8 @@ public class SearchServiceImpl implements SearchService, Startable {
   private static final Scope   SEARCH_CONNECTORS_SCOPE        = Scope.APPLICATION.id("connectors");
 
   private static final String  SEARCH_CONNECTORS_STATUS_PARAM = "enabledSearchConnectors";
+
+  private static final String  PLATFORM_EXTERNALS_GROUP  = "/platform/externals";
 
   private SettingService       settingService;
 
@@ -76,6 +80,9 @@ public class SearchServiceImpl implements SearchService, Startable {
 
   @Override
   public Set<SearchConnector> getEnabledConnectors() {
+    UserACL userACL = CommonsUtils.getService(UserACL.class);
+    boolean isExternalUser = userACL.isUserInGroup(PLATFORM_EXTERNALS_GROUP);
+    connectors.stream().filter(connector -> connector.getName().equals("space") || connector.getName().equals("people")).forEach(connector -> connector.setEnabled(!isExternalUser));
     return Collections.unmodifiableSet(connectors.stream()
                                                  .filter(SearchConnector::isEnabled)
                                                  .map(SearchConnector::clone)

--- a/component/core/src/main/java/org/exoplatform/social/core/search/impl/SearchServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/search/impl/SearchServiceImpl.java
@@ -82,9 +82,8 @@ public class SearchServiceImpl implements SearchService, Startable {
   public Set<SearchConnector> getEnabledConnectors() {
     UserACL userACL = CommonsUtils.getService(UserACL.class);
     boolean isExternalUser = userACL.isUserInGroup(PLATFORM_EXTERNALS_GROUP);
-    connectors.stream().filter(connector -> connector.getName().equals("space") || connector.getName().equals("people")).forEach(connector -> connector.setEnabled(!isExternalUser));
     return Collections.unmodifiableSet(connectors.stream()
-                                                 .filter(SearchConnector::isEnabled)
+                                                 .filter(c -> c.isEnabled() && !((c.getName().equals("people") || c.getName().equals("space")) && isExternalUser))
                                                  .map(SearchConnector::clone)
                                                  .collect(Collectors.toSet()));
   }

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
@@ -60,7 +60,7 @@
               <string>people</string>
             </field>
             <field name="uri">
-              <string><![CDATA[/portal/rest/v1/social/users?q={keyword}&limit={limit}&expand=all,spacesCount,relationshipStatus,connectionsCount]]></string>
+              <string><![CDATA[/portal/rest/v1/social/users?excludeExternal=true&q={keyword}&limit={limit}&expand=all,spacesCount,relationshipStatus,connectionsCount]]></string>
             </field>
             <field name="enabled">
               <boolean>${exo.search.people.enabled:true}</boolean>


### PR DESCRIPTION
improvement :

1. As internal user, When I go to the unified search

Then I don't display external users (whether I am connected or not to the external user I don't see him)

2. As PLF external user, When I go to the unified search

Then I cannot search by people and spaces  (I don't see the tag)