### PR TITLE
TASK-27712: Fix can't mention user when edit a post

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -53,7 +53,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
   private static final Log                       LOG                         =
                                                      ExoLogger.getLogger(RDBMSActivityStorageImpl.class);
 
-  public static final Pattern                    MENTION_PATTERN             = Pattern.compile("@([^\\s]+)|@([^\\s]+)$");
+  public static final Pattern                    MENTION_PATTERN             = Pattern.compile("@([^\\s<]+)|@([^\\s<]+)$");
 
   public static final String                     COMMENT_PREFIX              = "comment";
 


### PR DESCRIPTION
**-Problem:** we can't mention user when edit post because we have  CKEditor instance already initialized,
the mention users not well displayed in edit.
**Solution:** To resolve the problem, we must destroy the ck-Editor instance, remove `setData` to ensure that suggester find its configuration, we add a method `initCKEditorData` to keep the style of mentioning users.