### PR TITLE
Fix/38543 : fixed sent Comment notification for activityLikers 

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
@@ -58,6 +58,7 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
         Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
         Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
         Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
+        Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId());
         receivers.remove(parentCommentUserPosterId);
       }
     } else {
@@ -65,6 +66,7 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
       Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
       Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
       Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
+      Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId());
     }
     //
     return NotificationInfo.instance()


### PR DESCRIPTION
When you like an activity you don't receive notifications when someone comments it
Added sendToLikers method on ActivityCommentPlugin