### PR TITLE
Task-40603: Implement notifications for users who have access to quarantine feature

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 
 import org.apache.commons.lang.*;
 
+import org.exoplatform.commons.dlp.service.DlpPermissionsService;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
@@ -314,8 +315,9 @@ public class LinkProvider {
    *
    * @return
    */
-  public static String getQuarantinePageUri() {
-    return "/" + getPortalName(null) + "/g/:platform:administrators/dlp-quarantine";
+  public static String getQuarantinePageUri(String username) {
+    DlpPermissionsService dlpPermissionsService = CommonsUtils.getService(DlpPermissionsService.class);
+    return "/" + getPortalName(null) + dlpPermissionsService.getDlpQuarantinePageUrl(username);
   }
   
   /**

--- a/component/notification/src/main/java/org/exoplatform/social/notification/LinkProviderUtils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/LinkProviderUtils.java
@@ -1,5 +1,6 @@
 package org.exoplatform.social.notification;
 
+import org.exoplatform.commons.dlp.service.DlpPermissionsService;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.log.ExoLogger;
@@ -310,10 +311,11 @@ public static final String RESOURCE_URL = "social/notifications";
   /**
    * Get the Redirect quarantine page url
    *
-   * @return url http://localhost:8080/portal/g/:platform:administrators/dlp-quarantine
+   * @return the quarantine page url
    */
-  public static String getQuarantineRedirectURL() {
+  public static String getQuarantineRedirectURL(String username) {
+    DlpPermissionsService dlpPermissionsService = CommonsUtils.getService(DlpPermissionsService.class);
     String portal = PortalContainer.getCurrentPortalContainerName();
-    return new StringBuffer(CommonsUtils.getCurrentDomain()).append("/").append(portal).append("/").append("g/:platform:administrators/dlp-quarantine").toString();
+    return CommonsUtils.getCurrentDomain() + "/" + portal + dlpPermissionsService.getDlpQuarantinePageUrl(username);
   }
 }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -1128,7 +1128,7 @@ public class MailTemplateProvider extends TemplateProvider {
             SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
 
             templateContext.put("ITEM_TITLE", notification.getValueOwnerParameter("itemTitle"));
-            templateContext.put("DLP_PAGE_URL", LinkProviderUtils.getQuarantineRedirectURL());
+            templateContext.put("DLP_PAGE_URL", LinkProviderUtils.getQuarantineRedirectURL(notification.getTo()));
             String subject = TemplateUtils.processSubject(templateContext);
             String body = TemplateUtils.processGroovy(templateContext);
             //binding the exception throws by processing template

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
@@ -935,7 +935,7 @@ public class WebTemplateProvider extends TemplateProvider {
       templateContext.put("NOTIFICATION_ID", notification.getId());
       templateContext.put("LAST_UPDATED_TIME", TimeConvertUtils.convertXTimeAgoByTimeServer(cal.getTime(), "EE, dd yyyy", new Locale(language), TimeConvertUtils.YEAR));
       templateContext.put("ITEM_TITLE", notification.getValueOwnerParameter("itemTitle"));
-      templateContext.put("DLP_PAGE_URL", LinkProvider.getQuarantinePageUri());
+      templateContext.put("DLP_PAGE_URL", LinkProvider.getQuarantinePageUri(notification.getTo()));
       //
       String body = TemplateUtils.processGroovy(templateContext);
       //binding the exception throws by processing template

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/DlpAdminDetectedItemPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/DlpAdminDetectedItemPlugin.java
@@ -106,7 +106,6 @@ public class DlpAdminDetectedItemPlugin extends BaseNotificationPlugin {
             try {
                 ListAccess<User> membersAccess = organizationService.getUserHandler().findUsersByGroupId(permission);
                 int totalGroupMembersSize = adminMembersAccess.getSize();
-                if((permission.equals("/platform") || permission.equals("/organization")) && totalGroupMembersSize == 1) continue;
                 User[] membersUsers = membersAccess.load(0, totalGroupMembersSize);
                 List<String> members = Arrays.stream(membersUsers)
                                              .map(User::getUserName)


### PR DESCRIPTION
- Before this fix, only members of the group administrator and author of DLP action receive web and mail notifications.
- This fix will assure that all members of saved DLP permissions will receive notifications and if we delete permission from the group, the notification URL to the quarantine page will be not accessible.