### PR TITLE
TASK-39378: Enable adding params to custom suggester url

### DIFF
--- a/webapp/portlet/src/main/webapp/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/common/js/SuggesterService.js
@@ -47,7 +47,13 @@ function searchUsers(filter, items, typeOfRelation, searchOptions) {
     params = $.param(options);
     url = '/portal/rest/social/people/suggest.json?'.concat(params);
   } else {
-    url = searchOptions.searchUrl.concat(filter);
+    if (searchOptions.options) {
+      params = $.param(searchOptions.options);
+      url = searchOptions.searchUrl.concat(`${filter}?${params}`);
+    } else {
+      url = searchOptions.searchUrl.concat(filter);
+    }
+
   }
 
   return fetch(url, {credentials: 'include'})


### PR DESCRIPTION
When adding a custom rest url for the suggester, we need to enable adding **`parmas`** to our rest api too.