### PR TITLE
TASK-40887 Avoid destroying CKEditor of Activity form on edit

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
@@ -310,7 +310,6 @@ export default {
     },
     closeMessageComposer: function() {
       this.showMessageComposer = false;
-      this.message = '';
     },
     executeAction(action) {
       executeExtensionAction(action, this.$refs[action.key]);

--- a/webapp/portlet/src/main/webapp/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/common/components/ExoActivityRichEditor.vue
@@ -46,32 +46,37 @@ export default {
       this.$emit('input', val);
     },
     value(val) {
-      // watch value to reset the editor value if the value has been updated by the component parent
-      const editorData = CKEDITOR.instances[this.ckEditorType].getData();
-      if (editorData != null && val !== editorData) {
-        if (val === '') {
-          this.initCKEditor();
-        } else {
-          //Knowing that using CKEDITOR.setData will rewrite a new CKEditor Body,
-          // the suggester (which writes its settings in body attribute) doesn't
-          // find its settings anymore when using '.setData' after initializing.
-          // Thus, we destroy the ckEditor instance before setting new data.
-          CKEDITOR.instances[this.ckEditorType].destroy(true);
-          this.initCKEditor();
-          this.initCKEditorData(val);
-        }
+      if (!CKEDITOR.instances[this.ckEditorType]) {
+        this.initCKEditor();
+      }
+      let editorData = null;
+      try {
+        editorData = CKEDITOR.instances[this.ckEditorType].getData();
+      } catch (e) {
+        // When CKEditor not initialized yet
+      }
+      if (val !== editorData) {
+        //Knowing that using CKEDITOR.setData will rewrite a new CKEditor Body,
+        // the suggester (which writes its settings in body attribute) doesn't
+        // find its settings anymore when using '.setData' after initializing.
+        // Thus, we destroy the ckEditor instance before setting new data.
+        this.initCKEditorData(val || '');
       }
     }
   },
   mounted() {
-    this.initCKEditor();
+    this.initCKEditor(true);
   },
   methods: {
-    initCKEditor: function () {
-      CKEDITOR.plugins.addExternal('embedsemantic', '/commons-extension/eXoPlugins/embedsemantic/', 'plugin.js');
+    initCKEditor: function (reset) {
       if (CKEDITOR.instances[this.ckEditorType] && CKEDITOR.instances[this.ckEditorType].destroy && !this.ckEditorType.includes('editActivity')) {
-        CKEDITOR.instances[this.ckEditorType].destroy(true);
+        if (reset) {
+          CKEDITOR.instances[this.ckEditorType].destroy(true);
+        } else {
+          return;
+        }
       }
+      CKEDITOR.plugins.addExternal('embedsemantic', '/commons-extension/eXoPlugins/embedsemantic/', 'plugin.js');
       CKEDITOR.dtd.$removeEmpty['i'] = false;
       let extraPlugins = 'simpleLink,suggester,widget,embedsemantic';
       const windowWidth = $(window).width();
@@ -130,17 +135,25 @@ export default {
               return $('<span/>', {
                 class:'atwho-inserted',
                 html: `<span class="exo-mention">${$(this).text()}<a data-cke-survive href="#" class="remove"><i data-cke-survive class="uiIconClose uiIconLightGray"></i></a></span>`
-              }).attr('data-atwho-at-query',`@${  $(this).attr('href').substring($(this).attr('href').lastIndexOf('/')+1)}`)
+              }).attr('data-atwho-at-query',`@${$(this).attr('href').substring($(this).attr('href').lastIndexOf('/')+1)}`)
                 .attr('data-atwho-at-value',$(this).attr('href').substring($(this).attr('href').lastIndexOf('/')+1))
                 .attr('contenteditable','false');
             });
           });
-        message = `${tempdiv.html()  }&nbsp;`;
+        message = tempdiv.html();
       }
-      CKEDITOR.instances[this.ckEditorType].setData(message);
+      try {
+        if (CKEDITOR.instances[this.ckEditorType]) {
+          CKEDITOR.instances[this.ckEditorType].setData(message);
+        }
+      } catch (e) {
+        // When CKEditor not initialized or is detroying
+      }
     },
     setFocus: function() {
-      CKEDITOR.instances[this.ckEditorType].focus();
+      if (CKEDITOR.instances[this.ckEditorType]) {
+        CKEDITOR.instances[this.ckEditorType].focus();
+      }
     },
     getMessage: function() {
       const newData = CKEDITOR.instances[this.ckEditorType].getData();


### PR DESCRIPTION
When editing an activity, the CKEditor is reused and thus, destroying it will cause to re-initialize a new CKEditor.
This PR will improve managing CKEditor instance in Activity Drawer editor