### PR TITLE
MAINT-40964: Fix process of canceling user invitation to a space.

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
@@ -456,8 +456,7 @@ public class RDBMSSpaceStorageImpl implements SpaceStorage {
       entity.setStatus(Status.IGNORED);
       spaceMemberDAO.create(entity);
     } else {
-      entity.setStatus(Status.IGNORED);
-      spaceMemberDAO.update(entity);
+      spaceMemberDAO.delete(entity);
     }
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -872,6 +872,7 @@ public class SpaceServiceImpl implements SpaceService {
    */
   public void setIgnored(String spaceId, String userId) {
     spaceStorage.ignoreSpace(spaceId, userId);
+    removeWebNotifications(spaceId, userId);
   }
 
   @Override


### PR DESCRIPTION
When canceling a user invitation to a space the method ignoreSpace() updates the status of the entry from 'invited' to 'ignored', since there is a composite key 'UK_SPACE_USER_STATUS_01' of the columns(SPACE_ID, USER_ID, STATUS) the update is not possible and an exception is thrown: javax.persistence.PersistenceException: org.hibernate.exception.ConstraintViolationException: could not execute statement

Fix: I made sure to delete the entry instead of updating it.