### PR TITLE
Task-21244: platform/dlp members should not be able to enable/disable dlp notifications

### DIFF
--- a/webapp/portlet/src/main/webapp/user-setting-notifications/components/UserSettingNotificationGroup.vue
+++ b/webapp/portlet/src/main/webapp/user-setting-notifications/components/UserSettingNotificationGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="group && group.pluginInfos && group.pluginInfos.length" class="border-radius border-color ma-4">
+  <div v-if="manageNotification" class="border-radius border-color ma-4">
     <v-list-item dense>
       <v-list-item-content>
         <v-list-item-title class="text-color font-weight-bold subtitle-1">
@@ -32,6 +32,9 @@ export default {
   computed: {
     label() {
       return this.settings && this.settings.groupsLabels && this.settings.groupsLabels[this.group.groupId];
+    },
+    manageNotification() {
+      return this.group && this.group.pluginInfos && this.group.pluginInfos.length && this.group.groupId !== 'quarantine';
     },
   },
   methods: {


### PR DESCRIPTION
- Before this fix, all users and members of platform/dlp can edit notifications settings of dlp feature.
- This fix will make sure that no one can edit dlp notifications it will be enabled by default.