### PR TITLE
Task-41416_4117: Implement MalwareDetection feature

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -58,7 +58,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.social.notification.Utils;
 import org.exoplatform.social.notification.plugin.*;
-import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionItemConnector;
 
 /**
  * Created by The eXo Platform SAS
@@ -1215,7 +1215,7 @@ public class MailTemplateProvider extends TemplateProvider {
       String language = getLanguage(notification);
       TemplateContext templateContext = new TemplateContext(notification.getKey().getId(), language);
       SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
-      templateContext.put("INFECTED_ITEM_NAME", notification.getValueOwnerParameter(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME));
+      templateContext.put("INFECTED_ITEM_NAME", notification.getValueOwnerParameter(MalwareDetectionItemConnector.INFECTED_ITEM_NAME));
 
       String subject = TemplateUtils.processSubject(templateContext);
       String body = TemplateUtils.processGroovy(templateContext);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -58,6 +58,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.social.notification.Utils;
 import org.exoplatform.social.notification.plugin.*;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
 
 /**
  * Created by The eXo Platform SAS
@@ -81,7 +82,9 @@ import org.exoplatform.social.notification.plugin.*;
     @TemplateConfig(pluginId = SpaceInvitationPlugin.ID, template = "war:/notification/templates/SpaceInvitationPlugin.gtmpl"),
     @TemplateConfig(pluginId = DlpAdminDetectedItemPlugin.ID, template = "war:/notification/templates/DlpAdminDetectedItemPlugin.gtmpl"),
     @TemplateConfig(pluginId = DlpUserDetectedItemPlugin.ID, template = "war:/notification/templates/DlpUserDetectedItemPlugin.gtmpl"),
-    @TemplateConfig(pluginId = DlpUserRestoredItemPlugin.ID, template = "war:/notification/templates/DlpUserRestoredItemPlugin.gtmpl")})
+    @TemplateConfig(pluginId = DlpUserRestoredItemPlugin.ID, template = "war:/notification/templates/DlpUserRestoredItemPlugin.gtmpl"),
+    @TemplateConfig(pluginId = MalwareDetectionPlugin.ID, template = "war:/notification/templates/MalwareDetectionPlugin.gtmpl")})
+
 public class MailTemplateProvider extends TemplateProvider {
 
   private static final Log LOG = ExoLogger.getLogger(MailTemplateProvider.class);
@@ -1200,6 +1203,34 @@ public class MailTemplateProvider extends TemplateProvider {
         }
 
     };
+    
+  /** Defines the template builder for MalwareDetectionPlugin*/
+  private AbstractTemplateBuilder malwareDetection = new AbstractTemplateBuilder() {
+    @Override
+    protected MessageInfo makeMessage(NotificationContext ctx) {
+      MessageInfo messageInfo = new MessageInfo();
+
+      NotificationInfo notification = ctx.getNotificationInfo();
+
+      String language = getLanguage(notification);
+      TemplateContext templateContext = new TemplateContext(notification.getKey().getId(), language);
+      SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
+      templateContext.put("INFECTED_ITEM_NAME", notification.getValueOwnerParameter(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME));
+
+      String subject = TemplateUtils.processSubject(templateContext);
+      String body = TemplateUtils.processGroovy(templateContext);
+      //binding the exception throws by processing template
+      ctx.setException(templateContext.getException());
+
+      return messageInfo.subject(subject).body(body).end();
+    }
+
+    @Override
+    protected boolean makeDigest(NotificationContext ctx, Writer writer) {
+      return false;
+    }
+  };
+  
   protected ExoSocialActivity getI18N(ExoSocialActivity activity,Locale locale) {
 
     I18NActivityProcessor i18NActivityProcessor =(I18NActivityProcessor) PortalContainer.getInstance().getComponentInstanceOfType(I18NActivityProcessor.class);
@@ -1227,6 +1258,7 @@ public class MailTemplateProvider extends TemplateProvider {
     this.templateBuilders.put(PluginKey.key(DlpAdminDetectedItemPlugin.ID), dlpAdminDetectedItem);
     this.templateBuilders.put(PluginKey.key(DlpUserDetectedItemPlugin.ID), dlpUserDetectedItem);
     this.templateBuilders.put(PluginKey.key(DlpUserRestoredItemPlugin.ID), dlpUserRestoredItem);
+    this.templateBuilders.put(PluginKey.key(MalwareDetectionPlugin.ID), malwareDetection);
   }
 
 }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
@@ -51,6 +51,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.social.notification.Utils;
 import org.exoplatform.social.notification.plugin.*;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
 import org.exoplatform.webui.utils.TimeConvertUtils;
 
 /**
@@ -78,7 +79,8 @@ import org.exoplatform.webui.utils.TimeConvertUtils;
        @TemplateConfig( pluginId=SpaceInvitationPlugin.ID, template="war:/intranet-notification/templates/SpaceInvitationPlugin.gtmpl"),
        @TemplateConfig( pluginId= DlpUserDetectedItemPlugin.ID, template="war:/intranet-notification/templates/DlpUserDetectedItemPlugin.gtmpl"),
        @TemplateConfig( pluginId= DlpAdminDetectedItemPlugin.ID, template="war:/intranet-notification/templates/DlpAdminDetectedItemPlugin.gtmpl"),
-       @TemplateConfig( pluginId = DlpUserRestoredItemPlugin.ID, template = "war:/intranet-notification/templates/DlpUserRestoredItemPlugin.gtmpl")
+       @TemplateConfig( pluginId = DlpUserRestoredItemPlugin.ID, template = "war:/intranet-notification/templates/DlpUserRestoredItemPlugin.gtmpl"),
+       @TemplateConfig( pluginId = MalwareDetectionPlugin.ID, template = "war:/intranet-notification/templates/MalwareDetectionPlugin.gtmpl")
    }
 )
 public class WebTemplateProvider extends TemplateProvider {
@@ -986,6 +988,43 @@ public class WebTemplateProvider extends TemplateProvider {
       return false;
     }
   };
+  
+  /**
+   * Defines the template builder for MalwareDetectionPlugin
+   */
+  private AbstractTemplateBuilder malwareDetection = new AbstractTemplateBuilder() {
+
+    @Override
+    protected MessageInfo makeMessage(NotificationContext ctx) {
+      NotificationInfo notification = ctx.getNotificationInfo();
+
+      String language = getLanguage(notification);
+
+      TemplateContext templateContext = TemplateContext.newChannelInstance(getChannelKey(), notification.getKey().getId(), language);
+
+      templateContext.put("isIntranet", "true");
+      Calendar cal = Calendar.getInstance();
+      cal.setTimeInMillis(notification.getLastModifiedDate());
+      templateContext.put("READ", Boolean.valueOf(notification.getValueOwnerParameter(NotificationMessageUtils.READ_PORPERTY.getKey())) ? "read" : "unread");
+      templateContext.put("NOTIFICATION_ID", notification.getId());
+      templateContext.put("LAST_UPDATED_TIME", TimeConvertUtils.convertXTimeAgoByTimeServer(cal.getTime(), "EE, dd yyyy", new Locale(language), TimeConvertUtils.YEAR));
+      templateContext.put("INFECTED_ITEM_NAME", notification.getValueOwnerParameter(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME));
+      
+      //
+      String body = TemplateUtils.processGroovy(templateContext);
+      //binding the exception throws by processing template
+      ctx.setException(templateContext.getException());
+      MessageInfo messageInfo = new MessageInfo();
+      return messageInfo.body(body).end();
+    }
+
+    @Override
+    protected boolean makeDigest(NotificationContext ctx, Writer writer) {
+      return false;
+    }
+
+
+  };
     
   public WebTemplateProvider(InitParams initParams) {
     super(initParams);
@@ -1005,6 +1044,7 @@ public class WebTemplateProvider extends TemplateProvider {
     this.templateBuilders.put(PluginKey.key(DlpUserDetectedItemPlugin.ID), dlpUserDetectedItem);
     this.templateBuilders.put(PluginKey.key(DlpAdminDetectedItemPlugin.ID), dlpAdminDetectedItem);
     this.templateBuilders.put(PluginKey.key(DlpUserRestoredItemPlugin.ID), dlpUserRestoredItem);
+    this.templateBuilders.put(PluginKey.key(MalwareDetectionPlugin.ID), malwareDetection);
   }
 
   /**

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
@@ -51,7 +51,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.social.notification.Utils;
 import org.exoplatform.social.notification.plugin.*;
-import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionItemConnector;
 import org.exoplatform.webui.utils.TimeConvertUtils;
 
 /**
@@ -1008,7 +1008,7 @@ public class WebTemplateProvider extends TemplateProvider {
       templateContext.put("READ", Boolean.valueOf(notification.getValueOwnerParameter(NotificationMessageUtils.READ_PORPERTY.getKey())) ? "read" : "unread");
       templateContext.put("NOTIFICATION_ID", notification.getId());
       templateContext.put("LAST_UPDATED_TIME", TimeConvertUtils.convertXTimeAgoByTimeServer(cal.getTime(), "EE, dd yyyy", new Locale(language), TimeConvertUtils.YEAR));
-      templateContext.put("INFECTED_ITEM_NAME", notification.getValueOwnerParameter(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME));
+      templateContext.put("INFECTED_ITEM_NAME", notification.getValueOwnerParameter(MalwareDetectionItemConnector.INFECTED_ITEM_NAME));
       
       //
       String body = TemplateUtils.processGroovy(templateContext);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/MalwareDetectionPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/MalwareDetectionPlugin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.social.notification.plugin;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+
+public class MalwareDetectionPlugin extends BaseNotificationPlugin {
+
+  public static final String ID = "MalwareDetectionPlugin";
+
+  public MalwareDetectionPlugin(InitParams initParams) {
+    super(initParams);
+  }
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public NotificationInfo makeNotification(NotificationContext ctx) {
+    String infectedItemName = ctx.value(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME_ARGUMENT);
+    String infectedItemLastModifier = ctx.value(MalwareDetectionServiceConnector.INFECTED_ITEM_LAST_MODIFIER_ARGUMENT);
+    NotificationInfo notificationInfo = NotificationInfo.instance().key(getId());
+    notificationInfo.with(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME, infectedItemName);
+    notificationInfo.to(infectedItemLastModifier);
+    return notificationInfo;
+  }
+
+  @Override
+  public boolean isValid(NotificationContext ctx) {
+    return true;
+  }
+}

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/MalwareDetectionPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/MalwareDetectionPlugin.java
@@ -20,7 +20,7 @@ import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionItemConnector;
 
 public class MalwareDetectionPlugin extends BaseNotificationPlugin {
 
@@ -37,10 +37,10 @@ public class MalwareDetectionPlugin extends BaseNotificationPlugin {
 
   @Override
   public NotificationInfo makeNotification(NotificationContext ctx) {
-    String infectedItemName = ctx.value(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME_ARGUMENT);
-    String infectedItemLastModifier = ctx.value(MalwareDetectionServiceConnector.INFECTED_ITEM_LAST_MODIFIER_ARGUMENT);
+    String infectedItemName = ctx.value(MalwareDetectionItemConnector.INFECTED_ITEM_NAME_ARGUMENT);
+    String infectedItemLastModifier = ctx.value(MalwareDetectionItemConnector.INFECTED_ITEM_LAST_MODIFIER_ARGUMENT);
     NotificationInfo notificationInfo = NotificationInfo.instance().key(getId());
-    notificationInfo.with(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME, infectedItemName);
+    notificationInfo.with(MalwareDetectionItemConnector.INFECTED_ITEM_NAME, infectedItemName);
     notificationInfo.to(infectedItemLastModifier);
     return notificationInfo;
   }

--- a/component/notification/src/test/java/org/exoplatform/social/notification/AbstractPluginTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/AbstractPluginTest.java
@@ -374,6 +374,7 @@ public abstract class AbstractPluginTest extends AbstractCoreTest {
     instantly.add(DlpUserDetectedItemPlugin.ID);
     instantly.add(DlpAdminDetectedItemPlugin.ID);
     instantly.add(DlpUserRestoredItemPlugin.ID);
+    instantly.add(MalwareDetectionPlugin.ID);
 
     List<String> daily = new ArrayList<String>();
     daily.add(PostActivityPlugin.ID);
@@ -419,6 +420,7 @@ public abstract class AbstractPluginTest extends AbstractCoreTest {
     webNotifs.add(DlpUserDetectedItemPlugin.ID);
     webNotifs.add(DlpAdminDetectedItemPlugin.ID);
     webNotifs.add(DlpUserRestoredItemPlugin.ID);
+    webNotifs.add(MalwareDetectionPlugin.ID);
     
     // root
     saveSetting(instantly, daily, weekly, webNotifs, rootIdentity.getRemoteId());

--- a/component/notification/src/test/java/org/exoplatform/social/notification/InitContainerTestSuite.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/InitContainerTestSuite.java
@@ -41,7 +41,9 @@ import org.junit.runners.Suite.SuiteClasses;
   DlpAdminDetectedItemWebBuilderTest.class,
   DlpAdminDetectedItemMailBuilderTest.class,
   DlpUserRestoredItemWebBuilderTest.class,
-  DlpUserRestoredItemMailBuilderTest.class
+  DlpUserRestoredItemMailBuilderTest.class,
+  MalwareDetectionWebBuilderTest.class,
+  MalwareDetectionMailBuilderTest.class
 })
 @ConfigTestCase(AbstractCoreTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/MailTemplateProviderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/MailTemplateProviderTest.java
@@ -147,6 +147,10 @@ public class MailTemplateProviderTest extends AbstractCoreTest {
     actual = channel.getTemplateFilePath(PluginKey.key(DlpUserRestoredItemPlugin.ID));
     expected = "war:/notification/templates/DlpUserRestoredItemPlugin.gtmpl";
     assertEquals(expected, actual);
+    
+    actual = channel.getTemplateFilePath(PluginKey.key(MalwareDetectionPlugin.ID));
+    expected = "war:/notification/templates/MalwareDetectionPlugin.gtmpl";
+    assertEquals(expected, actual);
   }
   
   public void testMailTemplateBuilder() throws Exception {
@@ -167,6 +171,7 @@ public class MailTemplateProviderTest extends AbstractCoreTest {
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(DlpUserDetectedItemPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(DlpAdminDetectedItemPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(DlpUserRestoredItemPlugin.ID)));
+    assertTrue(channel.hasTemplateBuilder(PluginKey.key(MalwareDetectionPlugin.ID)));
   }
     
 }

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/WebTemplateProviderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/WebTemplateProviderTest.java
@@ -130,6 +130,10 @@ public class WebTemplateProviderTest extends AbstractCoreTest {
     actual = channel.getTemplateFilePath(PluginKey.key(DlpUserRestoredItemPlugin.ID));
     expected = "war:/intranet-notification/templates/DlpUserRestoredItemPlugin.gtmpl";
     assertEquals(expected, actual);
+    
+    actual = channel.getTemplateFilePath(PluginKey.key(MalwareDetectionPlugin.ID));
+    expected = "war:/intranet-notification/templates/MalwareDetectionPlugin.gtmpl";
+    assertEquals(expected, actual);
   }
   
   public void testWebTemplateBuilder() throws Exception {
@@ -150,6 +154,7 @@ public class WebTemplateProviderTest extends AbstractCoreTest {
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(DlpUserDetectedItemPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(DlpAdminDetectedItemPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(DlpUserRestoredItemPlugin.ID)));
+    assertTrue(channel.hasTemplateBuilder(PluginKey.key(MalwareDetectionPlugin.ID)));
   }
     
 }

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/MalwareDetectionMailBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/MalwareDetectionMailBuilderTest.java
@@ -1,0 +1,70 @@
+package org.exoplatform.social.notification.channel.template;
+
+import java.util.List;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.channel.AbstractChannel;
+import org.exoplatform.commons.api.notification.channel.ChannelManager;
+import org.exoplatform.commons.api.notification.channel.template.AbstractTemplateBuilder;
+import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
+import org.exoplatform.commons.api.notification.model.ChannelKey;
+import org.exoplatform.commons.api.notification.model.MessageInfo;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
+import org.exoplatform.commons.notification.channel.MailChannel;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.social.notification.AbstractPluginTest;
+import org.exoplatform.social.notification.plugin.MalwareDetectionPlugin;
+
+public class MalwareDetectionMailBuilderTest extends AbstractPluginTest {
+  public static final String INFECTED_ITEM_NAME = "infectedItemName";
+  public static final ArgumentLiteral<String> INFECTED_ITEM_NAME_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_NAME);
+  public static final String INFECTED_ITEM_LAST_MODIFIER = "infectedItemLastModifier";
+  public static final ArgumentLiteral<String> INFECTED_ITEM_LAST_MODIFIER_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_LAST_MODIFIER);
+  
+  private ChannelManager manager;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    manager = getService(ChannelManager.class);
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  @Override
+  public AbstractTemplateBuilder getTemplateBuilder() {
+    AbstractChannel channel = manager.getChannel(ChannelKey.key(MailChannel.ID));
+    assertNotNull(channel);
+    assertTrue(channel.hasTemplateBuilder(PluginKey.key(MalwareDetectionPlugin.ID)));
+    return channel.getTemplateBuilder(PluginKey.key(MalwareDetectionPlugin.ID));
+  }
+
+  @Override
+  public BaseNotificationPlugin getPlugin() {
+    return pluginService.getPlugin(PluginKey.key(MalwareDetectionPlugin.ID));
+  }
+
+  public void testSimpleCase() {
+    // When
+    
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.append(INFECTED_ITEM_NAME_ARGUMENT, "test.docx");
+    ctx.append(INFECTED_ITEM_LAST_MODIFIER_ARGUMENT, maryIdentity.getRemoteId());
+    ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(MalwareDetectionPlugin.ID))).execute(ctx);
+
+    // assert Message Info
+    List<NotificationInfo> list = assertMadeMailDigestNotifications(maryIdentity.getRemoteId(), 1);
+    ctx = NotificationContextImpl.cloneInstance();
+    ctx.setNotificationInfo(list.get(0).setTo(rootIdentity.getRemoteId()));
+    MessageInfo message = buildMessageInfo(ctx);
+
+    assertSubject(message, "File is infected");
+    assertBody(message, "has been detected as a malware. So the file is no longer available.");
+    notificationService.clearAll();
+  }
+}

--- a/component/notification/src/test/java/org/exoplatform/social/notification/mock/MockMailTemplateProvider.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/mock/MockMailTemplateProvider.java
@@ -22,7 +22,8 @@ import org.exoplatform.social.notification.plugin.*;
     @TemplateConfig(pluginId = SpaceInvitationPlugin.ID, template = "classpath:/notification/templates/SpaceInvitationPlugin.gtmpl"),
     @TemplateConfig(pluginId = DlpUserDetectedItemPlugin.ID, template = "classpath:/notification/templates/DlpUserDetectedItemPlugin.gtmpl"),
     @TemplateConfig(pluginId = DlpAdminDetectedItemPlugin.ID, template = "classpath:/notification/templates/DlpAdminDetectedItemPlugin.gtmpl"), 
-    @TemplateConfig(pluginId = DlpUserRestoredItemPlugin.ID, template = "classpath:/notification/templates/DlpUserRestoredItemPlugin.gtmpl")})
+    @TemplateConfig(pluginId = DlpUserRestoredItemPlugin.ID, template = "classpath:/notification/templates/DlpUserRestoredItemPlugin.gtmpl"),
+    @TemplateConfig(pluginId = MalwareDetectionPlugin.ID, template = "classpath:/notification/templates/MalwareDetectionPlugin.gtmpl")})
 public class MockMailTemplateProvider extends MailTemplateProvider {
 
   public MockMailTemplateProvider(InitParams initParams) {

--- a/component/notification/src/test/java/org/exoplatform/social/notification/mock/MockWebTemplateProvider.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/mock/MockWebTemplateProvider.java
@@ -22,7 +22,8 @@ import org.exoplatform.social.notification.plugin.*;
     @TemplateConfig(pluginId = SpaceInvitationPlugin.ID, template = "classpath:/notification/web/templates/SpaceInvitationPlugin.gtmpl"),
     @TemplateConfig(pluginId = DlpUserDetectedItemPlugin.ID, template = "classpath:/notification/web/templates/DlpUserDetectedItemPlugin.gtmpl"),
     @TemplateConfig(pluginId = DlpAdminDetectedItemPlugin.ID, template = "classpath:/notification/web/templates/DlpAdminDetectedItemPlugin.gtmpl"),    
-    @TemplateConfig(pluginId = DlpUserRestoredItemPlugin.ID, template = "classpath:/notification/web/templates/DlpUserRestoredItemPlugin.gtmpl")})
+    @TemplateConfig(pluginId = DlpUserRestoredItemPlugin.ID, template = "classpath:/notification/web/templates/DlpUserRestoredItemPlugin.gtmpl"),
+    @TemplateConfig(pluginId = MalwareDetectionPlugin.ID, template = "classpath:/notification/web/templates/MalwareDetectionPlugin.gtmpl")})
 public class MockWebTemplateProvider extends WebTemplateProvider {
 
   public MockWebTemplateProvider(InitParams initParams) {

--- a/component/notification/src/test/java/org/exoplatform/social/notification/web/template/MalwareDetectionWebBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/web/template/MalwareDetectionWebBuilderTest.java
@@ -1,0 +1,70 @@
+package org.exoplatform.social.notification.web.template;
+
+import java.util.List;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.channel.AbstractChannel;
+import org.exoplatform.commons.api.notification.channel.ChannelManager;
+import org.exoplatform.commons.api.notification.channel.template.AbstractTemplateBuilder;
+import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
+import org.exoplatform.commons.api.notification.model.ChannelKey;
+import org.exoplatform.commons.api.notification.model.MessageInfo;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
+import org.exoplatform.commons.notification.channel.WebChannel;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.social.notification.AbstractPluginTest;
+import org.exoplatform.social.notification.plugin.MalwareDetectionPlugin;
+
+public class MalwareDetectionWebBuilderTest extends AbstractPluginTest {
+  public static final String INFECTED_ITEM_NAME = "infectedItemName";
+  public static final ArgumentLiteral<String> INFECTED_ITEM_NAME_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_NAME);
+  public static final String INFECTED_ITEM_LAST_MODIFIER = "infectedItemLastModifier";
+  public static final ArgumentLiteral<String> INFECTED_ITEM_LAST_MODIFIER_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_LAST_MODIFIER);
+
+  private ChannelManager manager;
+  
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    manager = getService(ChannelManager.class);
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  @Override
+  public AbstractTemplateBuilder getTemplateBuilder() {
+    AbstractChannel channel = manager.getChannel(ChannelKey.key(WebChannel.ID));
+    assertNotNull(channel);
+    assertTrue(channel.hasTemplateBuilder(PluginKey.key(MalwareDetectionPlugin.ID)));
+    return channel.getTemplateBuilder(PluginKey.key(MalwareDetectionPlugin.ID));
+  }
+
+  @Override
+  public BaseNotificationPlugin getPlugin() {
+    return pluginService.getPlugin(PluginKey.key(MalwareDetectionPlugin.ID));
+  }
+
+  public void testSimpleCase() {
+    // When
+
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.append(INFECTED_ITEM_NAME_ARGUMENT, "test.docx");
+    ctx.append(INFECTED_ITEM_LAST_MODIFIER_ARGUMENT, maryIdentity.getRemoteId());
+    ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(MalwareDetectionPlugin.ID))).execute(ctx);
+
+    // then
+    List<NotificationInfo> list = assertMadeWebNotifications(maryIdentity.getRemoteId(), 1);
+
+    // assert Message Info
+    ctx.setNotificationInfo(list.get(0).setTo(rootIdentity.getRemoteId()));
+    MessageInfo message = buildMessageInfo(ctx);
+
+    assertBody(message, "has been detected as a malware. So the file is no longer available.");
+    notificationService.clearAll();
+  }
+}

--- a/component/notification/src/test/resources/conf/exo.social.component.notification-configuration.xml
+++ b/component/notification/src/test/resources/conf/exo.social.component.notification-configuration.xml
@@ -774,6 +774,43 @@
         </object-param>
       </init-params>
     </component-plugin>
+    
+    <component-plugin>
+      <name>notification.plugins</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.social.notification.plugin.MalwareDetectionPlugin</type>
+      <description>Initial information for plugin.</description>
+      <init-params>
+        <object-param>
+          <name>template.MalwareDetectionPlugin</name>
+          <description>The template of MalwareDetectionPlugin</description>
+          <object type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+            <field name="pluginId">
+              <string>MalwareDetectionPlugin</string>
+            </field>
+            <field name="resourceBundleKey">
+              <string>UINotification.label.MalwareDetectionPlugin</string>
+            </field>
+            <field name="order">
+              <string>4</string>
+            </field>
+            <field name="defaultConfig">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>Instantly</string>
+                </value>
+              </collection>
+            </field>
+            <field name="groupId">
+              <string>malwareDetection</string>
+            </field>
+            <field name="bundlePath">
+              <string>locale.notification.template.Notification</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
   
 </configuration>

--- a/component/notification/src/test/resources/locale/notification/template/Notification_en.properties
+++ b/component/notification/src/test/resources/locale/notification/template/Notification_en.properties
@@ -238,3 +238,12 @@ Notification.intranet.message.DlpAdminDetectedItemPlugin=The item named <strong>
 Notification.title.DlpUserRestoredItemPlugin=Item has been validated
 Notification.subject.DlpUserRestoredItemPlugin=Item has been validated
 Notification.intranet.message.DlpUserRestoredItemPlugin=The item named <strong>{0}</strong> has been analyzed during a quarantine phase. It has been validated and restored in his initial location.
+
+#############################################################################
+#                         MalwareDetectionPlugin                         #
+#############################################################################
+Notification.subject.MalwareDetectionPlugin=File is infected
+Notification.mail.MalwareDetectionPlugin.Hello=Hello
+Notification.title.MalwareDetectionPlugin=File is infected
+Notification.intranet.message.MalwareDetectionPlugin=The file named <strong>{0}</strong> has been detected as a malware. So the file is no longer available.
+Notification.mail.MalwareDetectionPlugin.footer=eXo Platform

--- a/component/notification/src/test/resources/notification/templates/MalwareDetectionPlugin.gtmpl
+++ b/component/notification/src/test/resources/notification/templates/MalwareDetectionPlugin.gtmpl
@@ -1,0 +1,40 @@
+<table width="80%" align="center" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+        <td>
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                <!-- begin top-->
+                <tr bgcolor="#f5f5f5" >
+                    <td height="44" valign="middle" align="center" bgcolor="#d6d6d6" style="color: #476a98; border-bottom: 1px solid #ccc;">
+                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;"><%=_ctx.appRes("Notification.title.MalwareDetectionPlugin")%></h2>
+                    </td>
+                </tr>
+                <!--end top-->
+
+                <!--begin body-->
+                <tr align="center">
+                    <td align="center" style="padding: 25px 0 25px">
+                        <table width="90%" cellpadding="0" cellspacing="0" >
+                            <tr>
+                                <td align="left" style="line-height: 18px;font-size: 14px;color:#333;font-family: 'Helvetica', 'Arial', sans-serif;">
+                                    <p style="margin: 0 0 10px 0;line-height: 40px;font-size: 17px;text-transform: capitalize"><%=_ctx.appRes("Notification.mail.MalwareDetectionPlugin.Hello")%>,</p>
+                                    <p style="margin: 0 0 30px 0;line-height:22px"><%=_ctx.appRes("Notification.intranet.message.MalwareDetectionPlugin", INFECTED_ITEM_NAME)%></p>
+                                    
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <!--end body-->
+
+                <!-- begin footer-->
+                <tr>
+                    <td height="38" valign="middle" align="center" bgcolor="#578dc9" style="color:#fff;font-family: 'Helvetica', 'Arial', sans-serif;border-radius: 4px;">
+                        <h2 style="color: #fff;margin: 0;padding: 0; font-size: 16px;"><%=_ctx.appRes("Notification.mail.MalwareDetectionPlugin.footer")%></h2>
+                    </td>
+                </tr>
+                <!--end footer-->
+
+            </table>
+        </td>
+    </tr>
+</table>

--- a/component/notification/src/test/resources/notification/web/templates/MalwareDetectionPlugin.gtmpl
+++ b/component/notification/src/test/resources/notification/web/templates/MalwareDetectionPlugin.gtmpl
@@ -1,0 +1,17 @@
+<li class="$READ clearfix" data-id="$NOTIFICATION_ID">
+  <div class="media">
+    <div class="pull-left">
+      <i class="uiIconFolderPrivate" style="font-size: 30px;"></i>
+    </div> 
+    <div class="media-body">
+        <div class="contentSmall">
+        <%
+        String message = _ctx.appRes("Notification.intranet.message.MalwareDetectionPlugin", INFECTED_ITEM_NAME);
+        %>
+          <div class="status"><%= message %></div>
+          <div class="lastUpdatedTime">$LAST_UPDATED_TIME</div>
+        </div>
+    </div>
+  </div>
+  <span class="remove-item" data-rest=""><i class="uiIconClose uiIconLightGray"></i></span>
+</li>

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
@@ -1,0 +1,71 @@
+/**
+ * 
+ */
+package org.exoplatform.social.service.malwareDetection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+
+/**
+ * Is extended by all MalwareDetectionService connectors, and allows to build configuration needed by a list of connectors that is used for Malware detection.
+ * 
+ */
+public class MalwareDetectionService {
+  
+  private Map<String, MalwareDetectionServiceConnector> connectors = new HashMap<String, MalwareDetectionServiceConnector>();
+  private static final Log LOGGER = ExoLogger.getExoLogger(MalwareDetectionService.class);
+  
+  /**
+   * Add Malware detection Connector to the service
+   * @param malwareDetectionServiceConnector the Malware detection Connector to add
+   * @LevelAPI Experimental
+   */
+  public void addConnector (MalwareDetectionServiceConnector malwareDetectionServiceConnector) {
+    addConnector(malwareDetectionServiceConnector, false);
+  }
+  
+  /**
+   * Add malware detection Connector to the service
+   * @param malwareDetectionServiceConnector the malware detection connector to add
+   * @param override equal true if we can override an existing connector, false otherwise
+   * @LevelAPI Experimental
+   */
+  public void addConnector (MalwareDetectionServiceConnector malwareDetectionServiceConnector, Boolean override) {
+    if (connectors.containsKey(malwareDetectionServiceConnector.getType()) && override.equals(false)) {
+      LOGGER.error("Impossible to add connector {}. A connector with the same name has already been registered.", malwareDetectionServiceConnector.getType());
+    } else {
+      connectors.put(malwareDetectionServiceConnector.getType(), malwareDetectionServiceConnector);
+      LOGGER.info("A Malware detection Connector has been added: {}", malwareDetectionServiceConnector.getType());
+    }
+  }
+  
+  /**
+   * Gets all current connectors
+   * @return Connectors
+   * @LevelAPI Experimental
+   */
+  public Map<String, MalwareDetectionServiceConnector> getConnectors() {
+    return connectors;
+  }
+  
+  public void processInfectedItem(String infectedItemPath) {
+    if (infectedItemPath.contains(MalwareDetectionServiceConnector.FILES_CONNECTOR)) {
+      MalwareDetectionServiceConnector fileMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(MalwareDetectionServiceConnector.FILES_CONNECTOR);
+      if(fileMalwareDetectionServiceConnector != null && fileMalwareDetectionServiceConnector.isEnable()) {
+        fileMalwareDetectionServiceConnector.sendInfectedItemNotification(infectedItemPath);
+        fileMalwareDetectionServiceConnector.cleanInfectedItem(infectedItemPath);
+      }
+    }
+    else if (infectedItemPath.contains(MalwareDetectionServiceConnector.JCR_CONNECTOR)) {
+      MalwareDetectionServiceConnector jcrMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(MalwareDetectionServiceConnector.JCR_CONNECTOR);
+      if(jcrMalwareDetectionServiceConnector != null && jcrMalwareDetectionServiceConnector.isEnable()) {
+        jcrMalwareDetectionServiceConnector.sendInfectedItemNotification(infectedItemPath);
+        jcrMalwareDetectionServiceConnector.cleanInfectedItem(infectedItemPath);
+      }
+    }
+  }
+}

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
@@ -8,74 +8,63 @@ import java.util.Map;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionItemConnector;
 
 /**
- * Is extended by all MalwareDetectionService connectors, and allows to build configuration needed by a list of connectors that is used for Malware detection.
+ * Is extended by all MalwareDetectionItemConnector connectors, and allows to build configuration needed by a list of connectors that is used for Malware detection.
  * 
  */
 public class MalwareDetectionService {
   
-  private Map<String, MalwareDetectionServiceConnector> connectors = new HashMap<String, MalwareDetectionServiceConnector>();
+  private Map<String, MalwareDetectionItemConnector> itemConnectors = new HashMap<String, MalwareDetectionItemConnector>();
   private static final Log LOGGER = ExoLogger.getExoLogger(MalwareDetectionService.class);
   private static final String SLASH_SEPARATOR = "/";
   private static final String BACK_SLASH_SEPARATOR = "\\";
   
-  public static final String FILES_CONNECTOR = "files";
-  public static final String JCR_CONNECTOR = "jcr";
-  public static final String VALUES = "values";
-  
   /**
-   * Add Malware detection Connector to the service
-   * @param malwareDetectionServiceConnector the Malware detection Connector to add
+   * Add Malware detection item connector to the service
+   * @param malwareDetectionItemConnector the Malware detection item connector to add
    * @LevelAPI Experimental
    */
-  public void addConnector (MalwareDetectionServiceConnector malwareDetectionServiceConnector) {
-    addConnector(malwareDetectionServiceConnector, false);
+  public void addConnector (MalwareDetectionItemConnector malwareDetectionItemConnector) {
+    addConnector(malwareDetectionItemConnector, false);
   }
   
   /**
-   * Add malware detection Connector to the service
-   * @param malwareDetectionServiceConnector the malware detection connector to add
+   * Add malware detection item connector to the service
+   * @param malwareDetectionItemConnector the malware detection item connector to add
    * @param override equal true if we can override an existing connector, false otherwise
    * @LevelAPI Experimental
    */
-  public void addConnector (MalwareDetectionServiceConnector malwareDetectionServiceConnector, Boolean override) {
-    if (connectors.containsKey(malwareDetectionServiceConnector.getType()) && override.equals(false)) {
-      LOGGER.error("Impossible to add connector {}. A connector with the same name has already been registered.", malwareDetectionServiceConnector.getType());
+  public void addConnector (MalwareDetectionItemConnector malwareDetectionItemConnector, Boolean override) {
+    if (itemConnectors.containsKey(malwareDetectionItemConnector.getType()) && override.equals(false)) {
+      LOGGER.error("Impossible to add malware detection item {}. A malware detection item with the same type has already been registered.", malwareDetectionItemConnector.getType());
     } else {
-      connectors.put(malwareDetectionServiceConnector.getType(), malwareDetectionServiceConnector);
-      LOGGER.info("A Malware detection Connector has been added: {}", malwareDetectionServiceConnector.getType());
+      itemConnectors.put(malwareDetectionItemConnector.getType(), malwareDetectionItemConnector);
+      LOGGER.info("A Malware detection item connector has been added: {}", malwareDetectionItemConnector.getType());
     }
   }
   
   /**
-   * Gets all current connectors
-   * @return Connectors
+   * Gets all current item connectors
+   * @return Item connectors
    * @LevelAPI Experimental
    */
-  public Map<String, MalwareDetectionServiceConnector> getConnectors() {
-    return connectors;
+  public Map<String, MalwareDetectionItemConnector> getItemConnectors() {
+    return itemConnectors;
   }
   
   public void processInfectedItem(String infectedItemPath) {
-    if (infectedItemPath.contains(getJcrNodePathSeparator(infectedItemPath) + FILES_CONNECTOR + getJcrNodePathSeparator(infectedItemPath))) {
-      MalwareDetectionServiceConnector fileMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(FILES_CONNECTOR);
-      if(fileMalwareDetectionServiceConnector != null && fileMalwareDetectionServiceConnector.isEnable()) {
-        fileMalwareDetectionServiceConnector.sendInfectedItemNotification(infectedItemPath);
-        fileMalwareDetectionServiceConnector.cleanInfectedItem(infectedItemPath);
-      }
-    }
-    else if (infectedItemPath.contains(getJcrNodePathSeparator(infectedItemPath) + JCR_CONNECTOR + getJcrNodePathSeparator(infectedItemPath) + VALUES + getJcrNodePathSeparator(infectedItemPath))) {
-      MalwareDetectionServiceConnector jcrMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(JCR_CONNECTOR);
-      if(jcrMalwareDetectionServiceConnector != null && jcrMalwareDetectionServiceConnector.isEnable()) {
-        jcrMalwareDetectionServiceConnector.sendInfectedItemNotification(infectedItemPath);
-        jcrMalwareDetectionServiceConnector.cleanInfectedItem(infectedItemPath);
+    for (Map.Entry mapentry : itemConnectors.entrySet()) {
+      MalwareDetectionItemConnector malwareDetectionItemConnector = (MalwareDetectionItemConnector) mapentry.getValue();
+      if (malwareDetectionItemConnector.canProcessInfectedItem(infectedItemPath)) {
+        malwareDetectionItemConnector.sendInfectedItemNotification(infectedItemPath);
+        malwareDetectionItemConnector.cleanInfectedItem(infectedItemPath);
       }
     }
   }
   
-  public static String getJcrNodePathSeparator(String infectedFilePath) {
+  public static String getPathSeparator(String infectedFilePath) {
     String separator = "";
     if (infectedFilePath.contains(SLASH_SEPARATOR)) {
       separator = SLASH_SEPARATOR;
@@ -85,5 +74,4 @@ public class MalwareDetectionService {
     }
     return separator;
   }
-  
 }

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
@@ -18,6 +18,11 @@ public class MalwareDetectionService {
   
   private Map<String, MalwareDetectionServiceConnector> connectors = new HashMap<String, MalwareDetectionServiceConnector>();
   private static final Log LOGGER = ExoLogger.getExoLogger(MalwareDetectionService.class);
+  private static final String SLASH_SEPARATOR = "/";
+  private static final String BACK_SLASH_SEPARATOR = "\\";
+  
+  public static final String FILES_CONNECTOR = "files";
+  public static final String JCR_CONNECTOR = "jcr";
   
   /**
    * Add Malware detection Connector to the service
@@ -53,19 +58,31 @@ public class MalwareDetectionService {
   }
   
   public void processInfectedItem(String infectedItemPath) {
-    if (infectedItemPath.contains(MalwareDetectionServiceConnector.FILES_CONNECTOR)) {
-      MalwareDetectionServiceConnector fileMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(MalwareDetectionServiceConnector.FILES_CONNECTOR);
+    if (infectedItemPath.contains(getJcrNodePathSeparator(infectedItemPath) + FILES_CONNECTOR + getJcrNodePathSeparator(infectedItemPath))) {
+      MalwareDetectionServiceConnector fileMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(FILES_CONNECTOR);
       if(fileMalwareDetectionServiceConnector != null && fileMalwareDetectionServiceConnector.isEnable()) {
         fileMalwareDetectionServiceConnector.sendInfectedItemNotification(infectedItemPath);
         fileMalwareDetectionServiceConnector.cleanInfectedItem(infectedItemPath);
       }
     }
-    else if (infectedItemPath.contains(MalwareDetectionServiceConnector.JCR_CONNECTOR)) {
-      MalwareDetectionServiceConnector jcrMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(MalwareDetectionServiceConnector.JCR_CONNECTOR);
+    else if (infectedItemPath.contains(getJcrNodePathSeparator(infectedItemPath) + JCR_CONNECTOR + getJcrNodePathSeparator(infectedItemPath) + "values" + getJcrNodePathSeparator(infectedItemPath))) {
+      MalwareDetectionServiceConnector jcrMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(JCR_CONNECTOR);
       if(jcrMalwareDetectionServiceConnector != null && jcrMalwareDetectionServiceConnector.isEnable()) {
         jcrMalwareDetectionServiceConnector.sendInfectedItemNotification(infectedItemPath);
         jcrMalwareDetectionServiceConnector.cleanInfectedItem(infectedItemPath);
       }
     }
   }
+  
+  public static String getJcrNodePathSeparator(String infectedFilePath) {
+    String separator = "";
+    if (infectedFilePath.contains(SLASH_SEPARATOR)) {
+      separator = SLASH_SEPARATOR;
+    }
+    else if (infectedFilePath.contains(BACK_SLASH_SEPARATOR)) {
+      separator = BACK_SLASH_SEPARATOR;
+    }
+    return separator;
+  }
+  
 }

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionService.java
@@ -23,6 +23,7 @@ public class MalwareDetectionService {
   
   public static final String FILES_CONNECTOR = "files";
   public static final String JCR_CONNECTOR = "jcr";
+  public static final String VALUES = "values";
   
   /**
    * Add Malware detection Connector to the service
@@ -65,7 +66,7 @@ public class MalwareDetectionService {
         fileMalwareDetectionServiceConnector.cleanInfectedItem(infectedItemPath);
       }
     }
-    else if (infectedItemPath.contains(getJcrNodePathSeparator(infectedItemPath) + JCR_CONNECTOR + getJcrNodePathSeparator(infectedItemPath) + "values" + getJcrNodePathSeparator(infectedItemPath))) {
+    else if (infectedItemPath.contains(getJcrNodePathSeparator(infectedItemPath) + JCR_CONNECTOR + getJcrNodePathSeparator(infectedItemPath) + VALUES + getJcrNodePathSeparator(infectedItemPath))) {
       MalwareDetectionServiceConnector jcrMalwareDetectionServiceConnector = (MalwareDetectionServiceConnector) getConnectors().get(JCR_CONNECTOR);
       if(jcrMalwareDetectionServiceConnector != null && jcrMalwareDetectionServiceConnector.isEnable()) {
         jcrMalwareDetectionServiceConnector.sendInfectedItemNotification(infectedItemPath);

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
@@ -1,0 +1,77 @@
+package org.exoplatform.social.service.malwareDetection.connector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+public class FileMalwareDetectionServiceConnector extends MalwareDetectionServiceConnector {
+  
+  private static final Log LOGGER = ExoLogger.getExoLogger(FileMalwareDetectionServiceConnector.class);
+  private FileService fileService;
+  
+  public FileMalwareDetectionServiceConnector(InitParams initParams, FileService fileService) {
+    super(initParams);
+    this.fileService = fileService;
+  }
+  
+  @Override
+  public List<Map<String, String>> getInfectedItems(String infectedFilePath) {
+    String fileChecksum = getInfectedFileChecksum(infectedFilePath);
+    List<Map<String, String>> infectedItems = new ArrayList<Map<String, String>>();
+    try {
+      List<FileItem> infectedFileItems = fileService.getFilesByChecksum(fileChecksum);
+      for (FileItem infectedFileItem : infectedFileItems) {
+        if (infectedFileItem != null && infectedFileItem.getFileInfo() != null) {
+          long startTime = System.currentTimeMillis();
+          Map<String, String> infectedItem = new HashMap<String, String>();
+          infectedItem.put(INFECTED_ITEM_NAME, infectedFileItem.getFileInfo().getName());
+          infectedItem.put(INFECTED_ITEM_LAST_MODIFIER, infectedFileItem.getFileInfo().getUpdater());
+          infectedItems.add(infectedItem);
+          long endTime = System.currentTimeMillis();
+          LOGGER.info("service={} operation={} parameters=\"fileId:{}\" \"fileName:{}\" \"lastModifier:{}\" status=ok " + "duration_ms={}",
+                      MALWARE_DETECTION_FEATURE,
+                      MALWARE_INFECTED_FILE_DETECTION,
+                      infectedFileItem.getFileInfo().getId(),
+                      infectedFileItem.getFileInfo().getName(),
+                      infectedFileItem.getFileInfo().getUpdater(),
+                      endTime - startTime);
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error when trying to get the infected item informations", e);
+    }
+    return infectedItems;
+  }
+  
+  public void cleanInfectedItem(String infectedFilePath) {
+    String fileChecksum = getInfectedFileChecksum(infectedFilePath);
+    try {
+      List<FileItem> infectedFileItems = fileService.getFilesByChecksum(fileChecksum);
+      for (FileItem infectedFileItem : infectedFileItems) {
+        if (infectedFileItem != null && infectedFileItem.getFileInfo() != null && infectedFileItem.getFileInfo().getId() != null) {
+          fileService.deleteFile(infectedFileItem.getFileInfo().getId());
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error when trying to clean the infected item", e);
+    }
+  }
+  
+  private String getInfectedFileChecksum(String infectedFilePath) {
+    String separator = "";
+    if (infectedFilePath.contains(SLASH_SEPARATOR)) {
+      separator = SLASH_SEPARATOR;
+    }
+    else if (infectedFilePath.contains(BACK_SLASH_SEPARATOR)) {
+      separator = BACK_SLASH_SEPARATOR;
+    }
+    return infectedFilePath.substring(infectedFilePath.lastIndexOf(separator) + 1);
+  }
+}

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
@@ -45,7 +45,7 @@ public class FileMalwareDetectionServiceConnector extends MalwareDetectionServic
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Error when trying to get the infected item informations", e);
+      LOGGER.error("Error when trying to get the infected item informations from fileChecksum={}", fileChecksum, e);
     }
     return infectedItems;
   }
@@ -60,7 +60,7 @@ public class FileMalwareDetectionServiceConnector extends MalwareDetectionServic
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Error when trying to clean the infected item", e);
+      LOGGER.error("Error when trying to clean the infected items from fileChecksum={}", fileChecksum, e);
     }
   }
   

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
@@ -5,11 +5,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.file.services.FileService;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.social.service.malwareDetection.MalwareDetectionService;
 
 public class FileMalwareDetectionServiceConnector extends MalwareDetectionServiceConnector {
   
@@ -65,13 +68,7 @@ public class FileMalwareDetectionServiceConnector extends MalwareDetectionServic
   }
   
   private String getInfectedFileChecksum(String infectedFilePath) {
-    String separator = "";
-    if (infectedFilePath.contains(SLASH_SEPARATOR)) {
-      separator = SLASH_SEPARATOR;
-    }
-    else if (infectedFilePath.contains(BACK_SLASH_SEPARATOR)) {
-      separator = BACK_SLASH_SEPARATOR;
-    }
-    return infectedFilePath.substring(infectedFilePath.lastIndexOf(separator) + 1);
+    String separator = MalwareDetectionService.getJcrNodePathSeparator(infectedFilePath);
+    return StringUtils.substringAfterLast(infectedFilePath, separator);
   }
 }

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/FileMalwareDetectionServiceConnector.java
@@ -54,17 +54,7 @@ public class FileMalwareDetectionServiceConnector extends MalwareDetectionServic
   }
   
   public void cleanInfectedItem(String infectedFilePath) {
-    String fileChecksum = getInfectedFileChecksum(infectedFilePath);
-    try {
-      List<FileItem> infectedFileItems = fileService.getFilesByChecksum(fileChecksum);
-      for (FileItem infectedFileItem : infectedFileItems) {
-        if (infectedFileItem != null && infectedFileItem.getFileInfo() != null && infectedFileItem.getFileInfo().getId() != null) {
-          fileService.deleteFile(infectedFileItem.getFileInfo().getId());
-        }
-      }
-    } catch (Exception e) {
-      LOGGER.error("Error when trying to clean the infected items from fileChecksum={}", fileChecksum, e);
-    }
+    //TODO
   }
   
   private String getInfectedFileChecksum(String infectedFilePath) {

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionFilesConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionFilesConnector.java
@@ -14,12 +14,14 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.service.malwareDetection.MalwareDetectionService;
 
-public class FileMalwareDetectionServiceConnector extends MalwareDetectionServiceConnector {
+public class MalwareDetectionFilesConnector extends MalwareDetectionItemConnector {
   
-  private static final Log LOGGER = ExoLogger.getExoLogger(FileMalwareDetectionServiceConnector.class);
+  private static final Log LOGGER = ExoLogger.getExoLogger(MalwareDetectionFilesConnector.class);
   private FileService fileService;
+  private static final String FILES = "files";
+  private static final String MALWARE_INFECTED_FILE_DETECTION = "MalwareInfectedFileDetection";
   
-  public FileMalwareDetectionServiceConnector(InitParams initParams, FileService fileService) {
+  public MalwareDetectionFilesConnector(InitParams initParams, FileService fileService) {
     super(initParams);
     this.fileService = fileService;
   }
@@ -27,18 +29,18 @@ public class FileMalwareDetectionServiceConnector extends MalwareDetectionServic
   @Override
   public List<Map<String, String>> getInfectedItems(String infectedFilePath) {
     String fileChecksum = getInfectedFileChecksum(infectedFilePath);
-    List<Map<String, String>> infectedItems = new ArrayList<Map<String, String>>();
+    List<Map<String, String>> infectedFiles = new ArrayList<Map<String, String>>();
     try {
       List<FileItem> infectedFileItems = fileService.getFilesByChecksum(fileChecksum);
       for (FileItem infectedFileItem : infectedFileItems) {
         if (infectedFileItem != null && infectedFileItem.getFileInfo() != null) {
           long startTime = System.currentTimeMillis();
-          Map<String, String> infectedItem = new HashMap<String, String>();
-          infectedItem.put(INFECTED_ITEM_NAME, infectedFileItem.getFileInfo().getName());
-          infectedItem.put(INFECTED_ITEM_LAST_MODIFIER, infectedFileItem.getFileInfo().getUpdater());
-          infectedItems.add(infectedItem);
+          Map<String, String> infectedFile = new HashMap<String, String>();
+          infectedFile.put(INFECTED_ITEM_NAME, infectedFileItem.getFileInfo().getName());
+          infectedFile.put(INFECTED_ITEM_LAST_MODIFIER, infectedFileItem.getFileInfo().getUpdater());
+          infectedFiles.add(infectedFile);
           long endTime = System.currentTimeMillis();
-          LOGGER.info("service={} operation={} parameters=\"fileId:{}\" \"fileName:{}\" \"lastModifier:{}\" status=ok " + "duration_ms={}",
+          LOGGER.info("service={} operation={} parameters=\"fileId:{}\" \"fileName:{}\" \"fileLastModifier:{}\" status=ok " + "duration_ms={}",
                       MALWARE_DETECTION_FEATURE,
                       MALWARE_INFECTED_FILE_DETECTION,
                       infectedFileItem.getFileInfo().getId(),
@@ -50,15 +52,22 @@ public class FileMalwareDetectionServiceConnector extends MalwareDetectionServic
     } catch (Exception e) {
       LOGGER.error("Error when trying to get the infected item informations from fileChecksum={}", fileChecksum, e);
     }
-    return infectedItems;
+    return infectedFiles;
   }
   
+  @Override
   public void cleanInfectedItem(String infectedFilePath) {
     //TODO
   }
   
+  @Override
+  public boolean canProcessInfectedItem(String infectedFilePath) {
+    String infectedFilePathSeparator = MalwareDetectionService.getPathSeparator(infectedFilePath);
+    return infectedFilePath.contains(infectedFilePathSeparator + FILES + infectedFilePathSeparator);
+  }
+  
   private String getInfectedFileChecksum(String infectedFilePath) {
-    String separator = MalwareDetectionService.getJcrNodePathSeparator(infectedFilePath);
-    return StringUtils.substringAfterLast(infectedFilePath, separator);
+    String infectedItemPathSeparator = MalwareDetectionService.getPathSeparator(infectedFilePath);
+    return StringUtils.substringAfterLast(infectedFilePath, infectedItemPathSeparator);
   }
 }

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionItemConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionItemConnector.java
@@ -17,17 +17,16 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PropertiesParam;
 
 /**
- * Is extended by all MalwareDetectionService connectors, and allows to build configuration needed by a list of connectors that is used for Malware detection.
+ * Is extended by all MalwareDetectionItem connectors, and allows to build configuration needed by a list of connectors that is used for Malware detection.
  * 
  */
-public abstract class MalwareDetectionServiceConnector extends BaseComponentPlugin {
+public abstract class MalwareDetectionItemConnector extends BaseComponentPlugin {
   
   private String type;
   private boolean enable = true;
   private static final String MALWARE_DETECTION_PLUGIN_ID = "MalwareDetectionPlugin";
   
   protected static final String MALWARE_DETECTION_FEATURE = "MalwareDetection";
-  protected static final String MALWARE_INFECTED_FILE_DETECTION = "MalwareInfectedFileDetection";
   
   public static final String INFECTED_ITEM_NAME = "infectedItemName";
   public static final ArgumentLiteral<String> INFECTED_ITEM_NAME_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_NAME);
@@ -35,11 +34,11 @@ public abstract class MalwareDetectionServiceConnector extends BaseComponentPlug
   public static final ArgumentLiteral<String> INFECTED_ITEM_LAST_MODIFIER_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_LAST_MODIFIER);
 
   /**
-   * Initializes a malware detection service connector. The constructor is default that connectors must implement.
-   * @param initParams The parameters which are used for initializing the malware detection service connector from configuration.
+   * Initializes a malware detection item connector. The constructor is default that connectors must implement.
+   * @param initParams The parameters which are used for initializing the malware detection item connector from configuration.
    * @LevelAPI Experimental
    */
-  public MalwareDetectionServiceConnector(InitParams initParams) {
+  public MalwareDetectionItemConnector(InitParams initParams) {
     PropertiesParam param = initParams.getPropertiesParam("constructor.params");
     this.type = param.getProperty("type");
     if (StringUtils.isNotBlank(param.getProperty("enable"))) {
@@ -83,6 +82,8 @@ public abstract class MalwareDetectionServiceConnector extends BaseComponentPlug
       ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(MALWARE_DETECTION_PLUGIN_ID))).execute(ctx);
     }
   }
+  
+  public abstract boolean canProcessInfectedItem(String infectedItemPath);
   
   public abstract List<Map<String, String>> getInfectedItems(String infectedItemPath);
   

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionServiceConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionServiceConnector.java
@@ -1,0 +1,94 @@
+/**
+ * 
+ */
+package org.exoplatform.social.service.malwareDetection.connector;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.container.component.BaseComponentPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.PropertiesParam;
+
+/**
+ * Is extended by all MalwareDetectionService connectors, and allows to build configuration needed by a list of connectors that is used for Malware detection.
+ * 
+ */
+public abstract class MalwareDetectionServiceConnector extends BaseComponentPlugin {
+  
+  private String type;
+  private boolean enable = true;
+  private static final String MALWARE_DETECTION_PLUGIN_ID = "MalwareDetectionPlugin";
+  protected static final String MALWARE_DETECTION_FEATURE = "MalwareDetection";
+  protected static final String MALWARE_INFECTED_FILE_DETECTION = "MalwareInfectedFileDetection";
+  protected static final String SLASH_SEPARATOR = "/";
+  protected static final String BACK_SLASH_SEPARATOR = "\\";
+  
+  public static final String FILES_CONNECTOR = "files";
+  public static final String JCR_CONNECTOR = "jcr";
+  public static final String INFECTED_ITEM_NAME = "infectedItemName";
+  public static final ArgumentLiteral<String> INFECTED_ITEM_NAME_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_NAME);
+  public static final String INFECTED_ITEM_LAST_MODIFIER = "infectedItemLastModifier";
+  public static final ArgumentLiteral<String> INFECTED_ITEM_LAST_MODIFIER_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_LAST_MODIFIER);
+
+  /**
+   * Initializes a malware detection service connector. The constructor is default that connectors must implement.
+   * @param initParams The parameters which are used for initializing the malware detection service connector from configuration.
+   * @LevelAPI Experimental
+   */
+  public MalwareDetectionServiceConnector(InitParams initParams) {
+    PropertiesParam param = initParams.getPropertiesParam("constructor.params");
+    this.type = param.getProperty("type");
+    if (StringUtils.isNotBlank(param.getProperty("enable"))) {
+      this.setEnable(Boolean.parseBoolean(param.getProperty("enable")));
+    }
+  }
+  
+  /**
+   * @return the type
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * @param type the type to set
+   */
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  /**
+   * @return the enable
+   */
+  public boolean isEnable() {
+    return enable;
+  }
+
+  /**
+   * @param enable the enable to set
+   */
+  public void setEnable(boolean enable) {
+    this.enable = enable;
+  }
+  
+  public void sendInfectedItemNotification(String infectedItemPath) {
+    for (Map<String, String> infectedItem : getInfectedItems(infectedItemPath)) {
+      NotificationContext ctx = NotificationContextImpl.cloneInstance();
+      ctx.append(INFECTED_ITEM_NAME_ARGUMENT, infectedItem.get(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME));
+      ctx.append(INFECTED_ITEM_LAST_MODIFIER_ARGUMENT, infectedItem.get(MalwareDetectionServiceConnector.INFECTED_ITEM_LAST_MODIFIER));
+      ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(MALWARE_DETECTION_PLUGIN_ID))).execute(ctx);
+    }
+  }
+  
+  public abstract List<Map<String, String>> getInfectedItems(String infectedItemPath);
+  
+  public abstract void cleanInfectedItem(String infectedItem);
+}

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionServiceConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionServiceConnector.java
@@ -25,13 +25,10 @@ public abstract class MalwareDetectionServiceConnector extends BaseComponentPlug
   private String type;
   private boolean enable = true;
   private static final String MALWARE_DETECTION_PLUGIN_ID = "MalwareDetectionPlugin";
+  
   protected static final String MALWARE_DETECTION_FEATURE = "MalwareDetection";
   protected static final String MALWARE_INFECTED_FILE_DETECTION = "MalwareInfectedFileDetection";
-  protected static final String SLASH_SEPARATOR = "/";
-  protected static final String BACK_SLASH_SEPARATOR = "\\";
   
-  public static final String FILES_CONNECTOR = "files";
-  public static final String JCR_CONNECTOR = "jcr";
   public static final String INFECTED_ITEM_NAME = "infectedItemName";
   public static final ArgumentLiteral<String> INFECTED_ITEM_NAME_ARGUMENT = new ArgumentLiteral<String>(String.class, INFECTED_ITEM_NAME);
   public static final String INFECTED_ITEM_LAST_MODIFIER = "infectedItemLastModifier";
@@ -81,8 +78,8 @@ public abstract class MalwareDetectionServiceConnector extends BaseComponentPlug
   public void sendInfectedItemNotification(String infectedItemPath) {
     for (Map<String, String> infectedItem : getInfectedItems(infectedItemPath)) {
       NotificationContext ctx = NotificationContextImpl.cloneInstance();
-      ctx.append(INFECTED_ITEM_NAME_ARGUMENT, infectedItem.get(MalwareDetectionServiceConnector.INFECTED_ITEM_NAME));
-      ctx.append(INFECTED_ITEM_LAST_MODIFIER_ARGUMENT, infectedItem.get(MalwareDetectionServiceConnector.INFECTED_ITEM_LAST_MODIFIER));
+      ctx.append(INFECTED_ITEM_NAME_ARGUMENT, infectedItem.get(INFECTED_ITEM_NAME));
+      ctx.append(INFECTED_ITEM_LAST_MODIFIER_ARGUMENT, infectedItem.get(INFECTED_ITEM_LAST_MODIFIER));
       ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(MALWARE_DETECTION_PLUGIN_ID))).execute(ctx);
     }
   }
@@ -90,4 +87,5 @@ public abstract class MalwareDetectionServiceConnector extends BaseComponentPlug
   public abstract List<Map<String, String>> getInfectedItems(String infectedItemPath);
   
   public abstract void cleanInfectedItem(String infectedItem);
+  
 }

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionServiceConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/MalwareDetectionServiceConnector.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang.StringUtils;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
-import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.container.component.BaseComponentPlugin;

--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/rest/MalwareDetectionRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/rest/MalwareDetectionRestService.java
@@ -1,0 +1,51 @@
+/**
+ * 
+ */
+package org.exoplatform.social.service.malwareDetection.rest;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import java.util.List;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.exoplatform.services.rest.resource.ResourceContainer;
+import org.exoplatform.social.service.malwareDetection.MalwareDetectionService;
+
+/**
+ * @author Ayoub Zayati
+ */
+@Path("/malware/detection")
+@Api(tags = "/malware", value = "/malware", description = "Malware detection")
+public class MalwareDetectionRestService implements ResourceContainer {
+
+  private MalwareDetectionService malwareDetectionService;
+  
+  public MalwareDetectionRestService(MalwareDetectionService malwareDetectionService) {
+    this.malwareDetectionService = malwareDetectionService;
+  }
+
+  @POST
+  @RolesAllowed("administrators")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Process infected items",
+      httpMethod = "POST",
+      response = Response.class,
+      notes = "This processes infected items")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Request fulfilled") })
+  public Response processInfectedItems(List<String> infectedItemsPaths) throws Exception {
+    for (String infectedItemPath : infectedItemsPaths) {
+      malwareDetectionService.processInfectedItem(infectedItemPath);
+    }
+    return Response.ok().entity("{\"result\":\"" + infectedItemsPaths + "\"}").build();
+  }
+}

--- a/component/service/src/test/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionServiceTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionServiceTest.java
@@ -2,7 +2,7 @@ package org.exoplatform.social.service.malwareDetection;
 
 import org.mockito.Mockito;
 
-import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionItemConnector;
 import org.exoplatform.social.service.test.AbstractResourceTest;
 
 public class MalwareDetectionServiceTest extends AbstractResourceTest {
@@ -16,12 +16,12 @@ public class MalwareDetectionServiceTest extends AbstractResourceTest {
 
   public void testProcessInfectedItem() {
     String infectedItemPath = "/gatein/data/files/d/e/4/c/e/2/d/7/dedeerere673r777";
-    MalwareDetectionServiceConnector malwareDetectionServiceConnector = Mockito.mock(MalwareDetectionServiceConnector.class);
-    Mockito.when(malwareDetectionServiceConnector.getType()).thenReturn(MalwareDetectionService.FILES_CONNECTOR);
-    malwareDetectionService.addConnector(malwareDetectionServiceConnector);
-    Mockito.when(malwareDetectionServiceConnector.isEnable()).thenReturn(true);
+    MalwareDetectionItemConnector malwareDetectionItemConnector = Mockito.mock(MalwareDetectionItemConnector.class);
+    Mockito.when(malwareDetectionItemConnector.getType()).thenReturn("files");
+    malwareDetectionService.addConnector(malwareDetectionItemConnector);
+    Mockito.when(malwareDetectionItemConnector.canProcessInfectedItem(Mockito.anyString())).thenReturn(true);
     malwareDetectionService.processInfectedItem(infectedItemPath);
-    Mockito.verify(malwareDetectionServiceConnector, Mockito.times(1)).sendInfectedItemNotification(infectedItemPath);
-    Mockito.verify(malwareDetectionServiceConnector, Mockito.times(1)).cleanInfectedItem(infectedItemPath);
+    Mockito.verify(malwareDetectionItemConnector, Mockito.times(1)).sendInfectedItemNotification(infectedItemPath);
+    Mockito.verify(malwareDetectionItemConnector, Mockito.times(1)).cleanInfectedItem(infectedItemPath);
   }
 }

--- a/component/service/src/test/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionServiceTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionServiceTest.java
@@ -1,0 +1,27 @@
+package org.exoplatform.social.service.malwareDetection;
+
+import org.mockito.Mockito;
+
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+import org.exoplatform.social.service.test.AbstractResourceTest;
+
+public class MalwareDetectionServiceTest extends AbstractResourceTest {
+  
+  private MalwareDetectionService malwareDetectionService;
+
+  public void setUp() throws Exception {
+    super.setUp();
+    malwareDetectionService = getContainer().getComponentInstanceOfType(MalwareDetectionService.class);
+  }
+
+  public void testProcessInfectedItem() {
+    String infectedItemPath = "/gatein/data/files/d/e/4/c/e/2/d/7/dedeerere673r777";
+    MalwareDetectionServiceConnector malwareDetectionServiceConnector = Mockito.mock(MalwareDetectionServiceConnector.class);
+    Mockito.when(malwareDetectionServiceConnector.getType()).thenReturn(MalwareDetectionServiceConnector.FILES_CONNECTOR);
+    malwareDetectionService.addConnector(malwareDetectionServiceConnector);
+    Mockito.when(malwareDetectionServiceConnector.isEnable()).thenReturn(true);
+    malwareDetectionService.processInfectedItem(infectedItemPath);
+    Mockito.verify(malwareDetectionServiceConnector, Mockito.times(1)).sendInfectedItemNotification(infectedItemPath);
+    Mockito.verify(malwareDetectionServiceConnector, Mockito.times(1)).cleanInfectedItem(infectedItemPath);
+  }
+}

--- a/component/service/src/test/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionServiceTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/malwareDetection/MalwareDetectionServiceTest.java
@@ -17,7 +17,7 @@ public class MalwareDetectionServiceTest extends AbstractResourceTest {
   public void testProcessInfectedItem() {
     String infectedItemPath = "/gatein/data/files/d/e/4/c/e/2/d/7/dedeerere673r777";
     MalwareDetectionServiceConnector malwareDetectionServiceConnector = Mockito.mock(MalwareDetectionServiceConnector.class);
-    Mockito.when(malwareDetectionServiceConnector.getType()).thenReturn(MalwareDetectionServiceConnector.FILES_CONNECTOR);
+    Mockito.when(malwareDetectionServiceConnector.getType()).thenReturn(MalwareDetectionService.FILES_CONNECTOR);
     malwareDetectionService.addConnector(malwareDetectionServiceConnector);
     Mockito.when(malwareDetectionServiceConnector.isEnable()).thenReturn(true);
     malwareDetectionService.processInfectedItem(infectedItemPath);

--- a/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
@@ -27,6 +27,7 @@ import org.exoplatform.social.rest.impl.spacemembership.SpaceMembershipRestResou
 import org.exoplatform.social.rest.impl.spacesadministration.SpacesAdministrationRestResourcesTest;
 import org.exoplatform.social.rest.impl.userrelationship.UsersRelationshipsRestResourcesTest;
 import org.exoplatform.social.rest.impl.users.UserRestResourcesTest;
+import org.exoplatform.social.service.malwareDetection.MalwareDetectionServiceTest;
 import org.exoplatform.social.service.rest.ActivitiesRestServiceTest;
 import org.exoplatform.social.service.rest.GroupSpaceBindingRestServiceTest;
 import org.exoplatform.social.service.rest.IdentityRestServiceTest;
@@ -40,6 +41,7 @@ import org.exoplatform.social.service.rest.api.ActivityResourcesTest;
 import org.exoplatform.social.service.rest.api.ActivityStreamResourcesTest;
 import org.exoplatform.social.service.rest.api.IdentityResourcesTest;
 import org.exoplatform.social.service.rest.api.VersionResourcesTest;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -70,7 +72,8 @@ import org.junit.runners.Suite.SuiteClasses;
   SpacesAdministrationRestResourcesTest.class,
   UsersRelationshipsRestResourcesTest.class,
   UserRestResourcesTest.class,
-  GroupSpaceBindingRestServiceTest.class
+  GroupSpaceBindingRestServiceTest.class,
+  MalwareDetectionServiceTest.class
   })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/service/src/test/resources/conf/exo.social.component.service-configuration.xml
+++ b/component/service/src/test/resources/conf/exo.social.component.service-configuration.xml
@@ -42,6 +42,10 @@
   <component>
     <type>org.exoplatform.social.service.rest.NotificationsRestService</type>
   </component>
+  
+  <component>
+    <type>org.exoplatform.social.service.malwareDetection.MalwareDetectionService</type>
+  </component>
 
   <component>
     <type>org.exoplatform.services.rest.impl.ProvidersRegistry</type>

--- a/extension/notification/src/main/resources/locale/notification/template/Notification_en.properties
+++ b/extension/notification/src/main/resources/locale/notification/template/Notification_en.properties
@@ -278,3 +278,16 @@ UINotification.title.DlpUserRestoredItemPlugin=Item has been validated
 Notification.title.DlpUserRestoredItemPlugin=Item has been validated
 Notification.subject.DlpUserRestoredItemPlugin=Item has been validated
 Notification.intranet.message.DlpUserRestoredItemPlugin=The item named <strong>{0}</strong> has been analyzed during a quarantine phase. It has been validated and restored in his initial location.
+
+
+#############################################################################
+#                         MalwareDetectionPlugin                         #
+#############################################################################
+UINotification.label.group.MalwareDetection=Malware detection
+UINotification.label.MalwareDetectionPlugin=Malware detection
+UINotification.title.MalwareDetectionPlugin=File is infected
+Notification.subject.MalwareDetectionPlugin=File is infected
+Notification.mail.MalwareDetectionPlugin.Hello=Hello
+Notification.title.MalwareDetectionPlugin=File is infected
+Notification.intranet.message.MalwareDetectionPlugin=The file named <strong>{0}</strong> has been detected as a malware. So the file is no longer available.
+Notification.mail.MalwareDetectionPlugin.footer=eXo Platform

--- a/extension/notification/src/main/resources/locale/notification/template/Notification_fr.properties
+++ b/extension/notification/src/main/resources/locale/notification/template/Notification_fr.properties
@@ -278,3 +278,15 @@ UINotification.title.DlpUserRestoredItemPlugin=L'\u00E9l\u00E9ment a \u00E9t\u00
 Notification.title.DlpUserRestoredItemPlugin=L'\u00E9l\u00E9ment a \u00E9t\u00E9 valid\u00E9
 Notification.subject.DlpUserRestoredItemPlugin=L'\u00E9l\u00E9ment a \u00E9t\u00E9 valid\u00E9
 Notification.intranet.message.DlpUserRestoredItemPlugin=L'\u00E9l\u00E9ment nomm\u00E9 <strong>{0}</strong> a \u00E9t\u00E9 analys\u00E9 lors d'une mise en quarantaine. Il a \u00E9t\u00E9 valid\u00E9 et il est donc restaur\u00E9 dans son emplacement initial. 
+
+#############################################################################
+#                         MalwareDetectionPlugin                         #
+#############################################################################
+UINotification.label.group.MalwareDetection=D\u00E9tection de malware
+UINotification.label.MalwareDetectionPlugin=D\u00E9tection de malware
+UINotification.title.MalwareDetectionPlugin=Le fichier est infect\u00E9
+Notification.subject.MalwareDetectionPlugin=Le fichier est infect\u00E9
+Notification.mail.MalwareDetectionPlugin.Hello=Bonjour
+Notification.title.MalwareDetectionPlugin=Le fichier est infect\u00E9
+Notification.intranet.message.MalwareDetectionPlugin=Le fichier nomm\u00E9 <strong>{0}</strong> a \u00E9t\u00E9 d\u00E9tect\u00E9 comme potentiel virus. Ce fichier n'est donc plus disponible.
+Notification.mail.MalwareDetectionPlugin.footer=eXo Platform

--- a/extension/notification/src/main/webapp/WEB-INF/conf/social-notification-extension/social/notification-plugins-configuration.xml
+++ b/extension/notification/src/main/webapp/WEB-INF/conf/social-notification-extension/social/notification-plugins-configuration.xml
@@ -815,6 +815,47 @@
               </object-param>
           </init-params>
       </component-plugin>
-  </external-component-plugins>  
+  </external-component-plugins>
+  
+  <external-component-plugins>
+      <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
+      <component-plugin>
+          <name>notification.plugins</name>
+          <set-method>addPlugin</set-method>
+          <type>org.exoplatform.social.notification.plugin.MalwareDetectionPlugin</type>
+          <description>Initial information for plugin.</description>
+          <init-params>
+              <object-param>
+                  <name>template.MalwareDetectionPlugin</name>
+                  <description>The template of MalwareDetectionPlugin</description>
+                  <object
+                          type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+                      <field name="pluginId">
+                          <string>MalwareDetectionPlugin</string>
+                      </field>
+                      <field name="resourceBundleKey">
+                          <string>UINotification.label.MalwareDetectionPlugin</string>
+                      </field>
+                    <field name="order">
+                      <string>3</string>
+                    </field>
+                    <field name="defaultConfig">
+                          <collection type="java.util.ArrayList">
+                              <value>
+                                  <string>Instantly</string>
+                              </value>
+                          </collection>
+                      </field>
+                      <field name="groupId">
+                          <string>malwareDetection</string>
+                      </field>
+                      <field name="bundlePath">
+                          <string>locale.notification.template.Notification</string>
+                      </field>
+                  </object>
+              </object-param>
+          </init-params>
+      </component-plugin>
+  </external-component-plugins>
 
 </configuration>

--- a/extension/notification/src/main/webapp/WEB-INF/intranet-notification/templates/MalwareDetectionPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/intranet-notification/templates/MalwareDetectionPlugin.gtmpl
@@ -1,0 +1,17 @@
+<li class="$READ clearfix" data-id="$NOTIFICATION_ID">
+  <div class="media">
+    <div class="pull-left">
+      <i class="uiIconFolderPrivate" style="font-size: 30px;"></i>
+    </div> 
+    <div class="media-body">
+        <div class="contentSmall">
+        <%
+        String message = _ctx.appRes("Notification.intranet.message.MalwareDetectionPlugin", INFECTED_ITEM_NAME);
+        %>
+          <div class="status"><%= message %></div>
+          <div class="lastUpdatedTime">$LAST_UPDATED_TIME</div>
+        </div>
+    </div>
+  </div>
+  <span class="remove-item" data-rest=""><i class="uiIconClose uiIconLightGray"></i></span>
+</li>

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/MalwareDetectionPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/MalwareDetectionPlugin.gtmpl
@@ -1,0 +1,40 @@
+<table width="80%" align="center" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+        <td>
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                <!-- begin top-->
+                <tr bgcolor="#f5f5f5" >
+                    <td height="44" valign="middle" align="center" bgcolor="#d6d6d6" style="color: #476a98; border-bottom: 1px solid #ccc;">
+                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;"><%=_ctx.appRes("Notification.title.MalwareDetectionPlugin")%></h2>
+                    </td>
+                </tr>
+                <!--end top-->
+
+                <!--begin body-->
+                <tr align="center">
+                    <td align="center" style="padding: 25px 0 25px">
+                        <table width="90%" cellpadding="0" cellspacing="0" >
+                            <tr>
+                                <td align="left" style="line-height: 18px;font-size: 14px;color:#333;font-family: 'Helvetica', 'Arial', sans-serif;">
+                                    <p style="margin: 0 0 10px 0;line-height: 40px;font-size: 17px;text-transform: capitalize"><%=_ctx.appRes("Notification.mail.MalwareDetectionPlugin.Hello")%>,</p>
+                                    <p style="margin: 0 0 30px 0;line-height:22px"><%=_ctx.appRes("Notification.intranet.message.MalwareDetectionPlugin", INFECTED_ITEM_NAME)%></p>
+                                    
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <!--end body-->
+
+                <!-- begin footer-->
+                <tr>
+                    <td height="38" valign="middle" align="center" bgcolor="#578dc9" style="color:#fff;font-family: 'Helvetica', 'Arial', sans-serif;border-radius: 4px;">
+                        <h2 style="color: #fff;margin: 0;padding: 0; font-size: 16px;"><%=_ctx.appRes("Notification.mail.MalwareDetectionPlugin.footer")%></h2>
+                    </td>
+                </tr>
+                <!--end footer-->
+
+            </table>
+        </td>
+    </tr>
+</table>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/service-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/service-configuration.xml
@@ -161,14 +161,14 @@
   </external-component-plugins>
 <!-- Social request/response filter -->
 
-<!-- Malware Detection Service Connector -->
+<!-- Malware Detection Files Connector -->
   <external-component-plugins>
     <target-component>org.exoplatform.social.service.malwareDetection.MalwareDetectionService</target-component>
     <component-plugin>
-      <name>MalwareDetectionServiceConnector</name>
+      <name>MalwareDetectionFilesConnector</name>
       <set-method>addConnector</set-method>
-      <type>org.exoplatform.social.service.malwareDetection.connector.FileMalwareDetectionServiceConnector</type>
-      <description>File Malware Detection Service Connector</description>
+      <type>org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionFilesConnector</type>
+      <description>Malware Detection Files Connector</description>
       <init-params>
         <properties-param>
           <name>constructor.params</name>
@@ -178,5 +178,5 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
-<!-- Malware Detection Service Connector -->
+<!-- Malware Detection Files Connector -->
 </configuration>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/service-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/service-configuration.xml
@@ -135,6 +135,15 @@
   </component>
 <!-- Getting Started Services -->
 
+<!-- Malware Detection Services -->
+  <component>
+    <type>org.exoplatform.social.service.malwareDetection.MalwareDetectionService</type>
+  </component>
+  <component>
+    <type>org.exoplatform.social.service.malwareDetection.rest.MalwareDetectionRestService</type>
+  </component>
+<!-- Malware Detection Services -->
+
 <!-- Social request/response filter -->
   <external-component-plugins>
       <target-component>org.exoplatform.services.rest.impl.RequestHandlerImpl</target-component>
@@ -151,4 +160,23 @@
       </component-plugin>
   </external-component-plugins>
 <!-- Social request/response filter -->
+
+<!-- Malware Detection Service Connector -->
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.service.malwareDetection.MalwareDetectionService</target-component>
+    <component-plugin>
+      <name>MalwareDetectionServiceConnector</name>
+      <set-method>addConnector</set-method>
+      <type>org.exoplatform.social.service.malwareDetection.connector.FileMalwareDetectionServiceConnector</type>
+      <description>File Malware Detection Service Connector</description>
+      <init-params>
+        <properties-param>
+          <name>constructor.params</name>
+          <property name="enable" value="true"/>
+          <property name="type" value="files"/>
+        </properties-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+<!-- Malware Detection Service Connector -->
 </configuration>

--- a/webapp/portlet/src/main/webapp/user-setting-notifications/components/UserSettingNotificationGroup.vue
+++ b/webapp/portlet/src/main/webapp/user-setting-notifications/components/UserSettingNotificationGroup.vue
@@ -34,7 +34,7 @@ export default {
       return this.settings && this.settings.groupsLabels && this.settings.groupsLabels[this.group.groupId];
     },
     manageNotification() {
-      return this.group && this.group.pluginInfos && this.group.pluginInfos.length && this.group.groupId !== 'quarantine';
+      return this.group && this.group.pluginInfos && this.group.pluginInfos.length && this.group.groupId !== 'quarantine' && this.group.groupId !== 'malwareDetection';
     },
   },
   methods: {


### PR DESCRIPTION
This PR:
- Implements Malware detection rest service which allows to process "files" or "jcr nodes" detected as malware ,the process is right now only sending a notification to the last updater of the infected file. 
- Implements FileMalwareDetectionServiceConnector for the "files" detection case, for example after uploading a wiki attachment, a FS file example is generated into /gatein/data/files/2/2/d/b/1/2/3/3/22db1233ceb84833ac44cc36f630fb1c of the server,  the last part of the file path is the file checksum, the connector will detect this checksum, get the corresponding files using FileService then send the notification.