### PR TITLE
TASK-41618: fixed password overwrite when importing csv file containing user data 

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1341,8 +1341,12 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     boolean onboardUser = !userObject.isNull("onboardUser") && userObject.getString("onboardUser").equals("true");
 
     User existingUser = organizationService.getUserHandler().findUserByName(userName, UserStatus.ANY);
-    if (existingUser != null && !userObject.isNull("password")) {
-      user.setPassword(existingUser.getPassword());
+    if (existingUser != null ) {
+      if(LOG.isDebugEnabled()){
+        LOG.debug("Skipping password update for: {}",userName);
+      }
+      // skipping password overwrite from csvLine
+      user.setPassword(null);
       organizationService.getUserHandler().saveUser(user, true);
       onboardUser = onboardUser && existingUser.isEnabled() && (existingUser.getLastLoginTime().getTime() == existingUser.getCreatedDate().getTime());
     }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1341,7 +1341,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     boolean onboardUser = !userObject.isNull("onboardUser") && userObject.getString("onboardUser").equals("true");
 
     User existingUser = organizationService.getUserHandler().findUserByName(userName, UserStatus.ANY);
-    if (existingUser != null) {
+    if (existingUser != null && !userObject.isNull("password")) {
+      user.setPassword(existingUser.getPassword());
       organizationService.getUserHandler().saveUser(user, true);
       onboardUser = onboardUser && existingUser.isEnabled() && (existingUser.getLastLoginTime().getTime() == existingUser.getCreatedDate().getTime());
     }

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -63,8 +63,6 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
   private Identity            demoIdentity;
 
-  private UserRestResourcesV1 userRestResourcesV1;
-
   public void setUp() throws Exception {
     super.setUp();
 
@@ -77,7 +75,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
     userStateService = getContainer().getComponentInstanceOfType(UserStateService.class);
     uploadService = (MockUploadService) getContainer().getComponentInstanceOfType(UploadService.class);
-    organizationService= getContainer().getComponentInstanceOfType(OrganizationService.class);
+    organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
     rootIdentity = new Identity(OrganizationIdentityProvider.NAME, "root");
     johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
     maryIdentity = new Identity(OrganizationIdentityProvider.NAME, "mary");

--- a/component/service/src/test/resources/users-update.csv
+++ b/component/service/src/test/resources/users-update.csv
@@ -1,0 +1,5 @@
+userName,firstName,lastName,password,email,groups,aboutMe,timeZone,company,position
+successuser1,user1,user1,newsuccessuser1,user1@example.com,*:/platform/users;member:/platform/administrators,aboutMe1,timeZone1,company1,position1
+successuser2,user2,user2,successuser2,user2@example.com,*:/platform/users;member:/platform/administrators,aboutMe2,timeZone2,company2,position2
+successuser3,user3,user3,successuser3,user3@example.com,*:/platform/users;member:/platform/administrators,aboutMe3,timeZone3,company3,position3
+successuser4,user4,user4,successuser4,user4@example.com,*:/platform/users;member:/platform/administrators,aboutMe4,timeZone4,company4,position4


### PR DESCRIPTION
when importing a csv file containing users , the password is overwritten which causes many conflicts and must lead to additional operations in order to inform the user about the changes happening to his password. in order to get rid of this not recommended behavior dealing with user password ,i refactored importuser method in UserRestResourcesV1 to prevent password overwrite.