### PR TITLE
TASK-41277:fixed searching inside the administration users doesn't work when user's email is missing

### DIFF
--- a/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementList.vue
@@ -221,6 +221,7 @@ export default {
           user.userName = user.userName || user.username || '';
           user.firstName = user.firstName || user.firstname || '';
           user.lastName = user.lastName || user.lastname || '';
+          user.email = user.email || user.email || '';
         });
         this.users = entities;
         this.totalSize = data && data.size || 0;


### PR DESCRIPTION
when the user's email is missing the search is not working
added user.email that takes empty string when the email field is missing while retrieving user while searching