### PR TITLE
41534 : Fix URLs for invitation and refuse invitation to connect

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/LinkProviderUtils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/LinkProviderUtils.java
@@ -62,7 +62,7 @@ public static final String RESOURCE_URL = "social/notifications";
    * @return
    */
   public static String getConfirmInvitationToConnectUrl(String senderId, String receiverId) {
-    return getPrivateRestUrl(CONFIRM_INVITATION_TO_CONNECT, senderId, receiverId);
+    return getPortalRestUrl(CONFIRM_INVITATION_TO_CONNECT, senderId, receiverId);
   }
   
   /**
@@ -73,7 +73,7 @@ public static final String RESOURCE_URL = "social/notifications";
    * @return
    */
   public static String getIgnoreInvitationToConnectUrl(String senderId, String receiverId) {
-    return getPrivateRestUrl(IGNORE_INVITATION_TO_CONNECT, senderId, receiverId);
+    return getPortalRestUrl(IGNORE_INVITATION_TO_CONNECT, senderId, receiverId);
   }
   
   /**
@@ -213,6 +213,7 @@ public static final String RESOURCE_URL = "social/notifications";
    * @param objectId2
    * @return
    */
+  @Deprecated
   public static String getPrivateRestUrl(String type, String objectId1, String objectId2) {
     String baseUrl = getBasePrivateRestUrl();
     return new StringBuffer(baseUrl).append("/").append(type).append("/").append(objectId1)

--- a/component/notification/src/test/java/org/exoplatform/social/notification/LinkProviderUtilsTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/LinkProviderUtilsTest.java
@@ -41,13 +41,13 @@ public class LinkProviderUtilsTest extends AbstractCoreTest {
 
   public void testGetConfirmInvitationToConnectUrl() {
     String receiverId = "demo", senderId = "root";
-    String expected = "http://exoplatform.com/rest/private/social/notifications/confirmInvitationToConnect/root/demo";
+    String expected = "http://exoplatform.com/portal/login?initialURI=/portal/rest/social/notifications/confirmInvitationToConnect/root/demo";
     assertEquals(expected, LinkProviderUtils.getConfirmInvitationToConnectUrl(senderId, receiverId));
   }
 
   public void testGetIgnoreInvitationToConnectUrl() {
     String receiverId = "demo", senderId = "root";
-    String expected = "http://exoplatform.com/rest/private/social/notifications/ignoreInvitationToConnect/root/demo";
+    String expected = "http://exoplatform.com/portal/login?initialURI=/portal/rest/social/notifications/ignoreInvitationToConnect/root/demo";
     assertEquals(expected, LinkProviderUtils.getIgnoreInvitationToConnectUrl(senderId, receiverId));
   }
 


### PR DESCRIPTION
We should not use the /rest/private in Rest Calls as it redirects to basic authentication, which does not work when we use SSO mechanism. 
The fix will use the login redirection call to make sure that the user will be authenticated on SSO before confirming or refusing the invitation request.