### PR TITLE
TASK-41618: fixed password overwrite when importing csv file containing user data 

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1341,7 +1341,12 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     boolean onboardUser = !userObject.isNull("onboardUser") && userObject.getString("onboardUser").equals("true");
 
     User existingUser = organizationService.getUserHandler().findUserByName(userName, UserStatus.ANY);
-    if (existingUser != null) {
+    if (existingUser != null ) {
+      if(LOG.isDebugEnabled()){
+        LOG.debug("Skipping password update for: {}",userName);
+      }
+      // skipping password overwrite from csvLine
+      user.setPassword(null);
       organizationService.getUserHandler().saveUser(user, true);
       onboardUser = onboardUser && existingUser.isEnabled() && (existingUser.getLastLoginTime().getTime() == existingUser.getCreatedDate().getTime());
     }

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -1,5 +1,7 @@
 package org.exoplatform.social.rest.impl.users;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.*;
@@ -15,6 +17,7 @@ import org.exoplatform.services.rest.impl.ContainerResponse;
 import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
 import org.exoplatform.services.user.UserStateModel;
 import org.exoplatform.services.user.UserStateService;
+import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -46,6 +49,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
   private SpaceService        spaceService;
 
+  private OrganizationService organizationService;
+
   private UserStateService    userStateService;
 
   private MockUploadService   uploadService;
@@ -70,7 +75,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
     userStateService = getContainer().getComponentInstanceOfType(UserStateService.class);
     uploadService = (MockUploadService) getContainer().getComponentInstanceOfType(UploadService.class);
-
+    organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
     rootIdentity = new Identity(OrganizationIdentityProvider.NAME, "root");
     johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
     maryIdentity = new Identity(OrganizationIdentityProvider.NAME, "mary");
@@ -571,6 +576,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertEquals(content, storedContent);
   }
 
+
   public void testImportUsers() throws Exception {
     startSessionAs("root");
 
@@ -600,6 +606,15 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertNull(response.getEntity());
     assertEquals(204, response.getStatus());
 
+    uploadId = "users-update.csv";
+    resource = getClass().getClassLoader().getResource("users-update.csv");
+    uploadService.createUploadResource(uploadId, resource.getFile(), "users-update.csv", "text/csv");
+    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&sync=true").getBytes());
+    assertNotNull(response);
+    assertNull(response.getEntity());
+    assertEquals(204, response.getStatus());
+
+    uploadId = "users.csv";
     response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&progress=true").getBytes());
     assertNotNull(response);
     assertNotNull(response.getEntity());
@@ -608,10 +623,44 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     UserImportResultEntity importResultEntity = (UserImportResultEntity) response.getEntity();
     assertEquals(4, importResultEntity.getCount());
     assertEquals(importResultEntity.getCount(), importResultEntity.getProcessedCount());
+    UploadResource uploadResource = uploadService.getUploadResource(uploadId);
+
+    BufferedReader reader = new BufferedReader(new FileReader(uploadResource.getStoreLocation()));
+    reader.readLine();
+    String User = reader.readLine();
+    List<String> userNames = new ArrayList<>();
+    List<String> passWords = new ArrayList<>();
+
+    while (User!= null){
+    List<String> userProperties = Arrays.asList(User.split(","));
+     userNames.add(userProperties.get(0));
+     passWords.add(userProperties.get(3));
+     User = reader.readLine();
+    }
+
     assertNull(importResultEntity.getErrorMessages());
     assertNull(importResultEntity.getWarnMessages());
 
-    UploadResource uploadResource = uploadService.getUploadResource(uploadId);
+    uploadId = "users-update.csv";
+    response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&progress=true").getBytes());
+    assertNotNull(response);
+    assertNotNull(response.getEntity());
+    assertEquals(200, response.getStatus());
+    assertEquals(response.getEntity().getClass(), UserImportResultEntity.class);
+    importResultEntity = (UserImportResultEntity) response.getEntity();
+    assertEquals(4, importResultEntity.getCount());
+    assertEquals(importResultEntity.getCount(), importResultEntity.getProcessedCount());
+
+    assertNull(importResultEntity.getErrorMessages());
+    assertNull(importResultEntity.getWarnMessages());
+
+    for(int i=0;i<(userNames.size());i++) {
+    boolean result = organizationService.getUserHandler().authenticate(userNames.get(i), passWords.get(i));
+    assertTrue(result);
+    }
+
+    uploadId = "users.csv";
+    uploadResource = uploadService.getUploadResource(uploadId);
     assertNotNull(uploadResource);
     response = service("POST", getURLResource("users/csv"), "", headers, ("uploadId=" + uploadId + "&clean=true").getBytes());
     assertNotNull(response);
@@ -899,6 +948,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertEquals(String.valueOf(response.getEntity()), 204, response.getStatus());
     endSession();
   }
+
 
   private void uploadUserAvatar(String user) throws Exception {
     startSessionAs(user);

--- a/component/service/src/test/resources/users-update.csv
+++ b/component/service/src/test/resources/users-update.csv
@@ -1,0 +1,5 @@
+userName,firstName,lastName,password,email,groups,aboutMe,timeZone,company,position
+successuser1,user1,user1,newsuccessuser1,user1@example.com,*:/platform/users;member:/platform/administrators,aboutMe1,timeZone1,company1,position1
+successuser2,user2,user2,successuser2,user2@example.com,*:/platform/users;member:/platform/administrators,aboutMe2,timeZone2,company2,position2
+successuser3,user3,user3,successuser3,user3@example.com,*:/platform/users;member:/platform/administrators,aboutMe3,timeZone3,company3,position3
+successuser4,user4,user4,successuser4,user4@example.com,*:/platform/users;member:/platform/administrators,aboutMe4,timeZone4,company4,position4


### PR DESCRIPTION
when importing a csv file containing users , the password is overwritten which causes many conflicts and must lead to additional operations in order to inform the user about the changes happening to his password. in order to get rid of this not recommended behavior dealing with user password ,i refactored importuser method in UserRestResourcesV1 to prevent password overwrite.