### PR TITLE
When a user was synchronized before M12 release, the synchronized dat…

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -352,6 +352,7 @@ UsersManagement.confirmPassword=Confirm password
 UsersManagement.status=Status
 UsersManagement.source=Source
 UsersManagement.source.synchronized=Synchronized on {0}
+UsersManagement.source.synchronized.notProvided=Not provided
 UsersManagement.source.createdUser=Created on {0}
 UsersManagement.type=Type
 UsersManagement.type.internal=Internal

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_fr.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_fr.properties
@@ -352,6 +352,7 @@ UsersManagement.confirmPassword=Confirmer le mot de passe
 UsersManagement.status=Statut
 UsersManagement.source=Source
 UsersManagement.source.synchronized=Synchronis\u00E9 le {0}
+UsersManagement.source.synchronized.notProvided=Non renseign\u00E9
 UsersManagement.source.createdUser=Cr\u00E9\u00E9 le {0}
 UsersManagement.type=Nom
 UsersManagement.type.internal=Interne

--- a/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementList.vue
@@ -338,7 +338,11 @@ export default {
       }
     },
     synchronizedTitle(synchronizedDate) {
-      return this.$t('UsersManagement.source.synchronized', {0: this.formatDate(synchronizedDate)});
+      if (synchronizedDate) {
+        return this.$t('UsersManagement.source.synchronized', {0: this.formatDate(synchronizedDate)});
+      } else {
+        return this.$t('UsersManagement.source.synchronized.notProvided');
+      }
     },
     createdTitle(createdDate) {
       return this.$t('UsersManagement.source.createdUser', {0: this.formatDate(createdDate)});


### PR DESCRIPTION
…e is not filled

Before this fix, the userManagement application fails to load if the synchronized date is not filled, with js error in console
This commit add a check and display a message if the sync date is not provided