### PR TITLE
Fix default trendmicro list events delta default value

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/TrendMicroMalwareDetectionConnector.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/malwareDetection/connector/TrendMicroMalwareDetectionConnector.java
@@ -27,7 +27,7 @@ public class TrendMicroMalwareDetectionConnector extends MalwareDetectionConnect
   private static final String TRENDMICRO_USERNAME_PROPERTY = "exo.malwareDetection.connector.trendMicro.api.userName";
   private static final String TRENDMICRO_PASSWORD_PROPERTY = "exo.malwareDetection.connector.trendMicro.api.password";
   private static final String TRENDMICRO_LIST_EVENTS_DELTA_PROPERTY = "exo.malwareDetection.connector.trendMicro.api.listEvents.delta";
-  private static final String TRENDMICRO_LIST_EVENTS_DELTA_PROPERTY_DEFAULT = "90000";//In millisecondes, 15 minutes by default 
+  private static final String TRENDMICRO_LIST_EVENTS_DELTA_PROPERTY_DEFAULT = "900000";//In millisecondes, 15 minutes by default 
   private static final String MALWARE_DETECTION_JOB_PERIOD_PROPERTY = "exo.social.MalwareDetectionJob.period";
   private static final String MALWARE_DETECTION_JOB_PERIOD_PROPERTY_DEFAULT = "1800000";//In millisecondes, 30 minutes by default 
   private static final String TRENDMICRO_LOGIN_ENDPOINT = "/rest/authentication/login";


### PR DESCRIPTION
This fixes the default trendmicro list events delta default value (15 min by default)