### PR TITLE
TASK-41376: fixed displaying user roles

### DIFF
--- a/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementUserMembershipDrawer.vue
+++ b/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementUserMembershipDrawer.vue
@@ -53,7 +53,7 @@ export default {
     drawer: false,
     loading: false,
     saving: false,
-    pageSize: 20,
+    pageSize: 10,
     page: 1,
     offset: 0,
     limit: 5,
@@ -62,7 +62,7 @@ export default {
   }),
   computed: {
     title() {
-      return this.$t('UsersManagement.button.membershipsOfUser', {0: this.user.fullName});
+      return this.$t('UsersManagement.button.membershipsOfUser', {0: this.user.fullname});
     },
     userName() {
       return this.user && this.user.userName;


### PR DESCRIPTION
- all rules are not displayed, it displays just 10 rules, because the "v-data-table items-per-page " is by default 10 
- changed the page size to 10 so it displays 10 roles per page so the rest of the roles will be displayed on the next page
- Also fixed display username : "this.user.fullName" is undefined changed to t"his.user.fullname"