### PR TITLE
TASK-40949: fixed unchanging space description value in space stream

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -272,7 +272,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
                                @Context Request request,
                                @ApiParam(value = "Space id", required = true) @PathParam("id") String id,
                                @ApiParam(value = "Asking for a full representation of a specific subresource, ex: members or managers", required = false) @QueryParam("expand") String expand) throws Exception {
-    
+    CacheControl cc = new CacheControl();
     String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
     Space space = spaceService.getSpaceById(id);
     if (space == null || (Space.HIDDEN.equals(space.getVisibility()) && ! spaceService.isMember(space, authenticatedUser) && ! spaceService.isSuperManager(authenticatedUser))) {
@@ -285,15 +285,9 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
     if (builder == null) {
       builder = EntityBuilder.getResponseBuilder(EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), expand), uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);
-      builder.tag(eTag);
     }
 
-    builder.cacheControl(CACHE_CONTROL);
-    builder.lastModified(space.getLastUpdatedTime() > 0 ? new Date(space.getLastUpdatedTime()) : new Date());
-    if (lastUpdateDate > 0) {
-      builder.expires(new Date(System.currentTimeMillis() + CACHE_IN_MILLI_SECONDS));
-    }
-    return builder.build();
+    return builder.cacheControl(cc).tag(eTag).build();
   }
 
   /**


### PR DESCRIPTION
Before this fix , when changing a space description in space settings , this value remains the same in the space bloc description in space stream which is caused by the fact that the browser is always rendering a stale cache value . So i made few changes in the method getspacebyID in SpaceRestResourcesV1 so that the browser demands a new fresh version of the resource in case it changed based on the value of the etag related to the resource.