### PR TITLE
Task-43991 Rework userHandler to simplify the user fetching when quer…

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -328,11 +328,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
                     .map(user -> identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, user.getUserName()))
                     .toArray(Identity[]::new);
         } else {
-          
+          identities = new Identity[0];
         }
-
-        
-
       } else if (isDisabled && q != null && !q.isEmpty()) {
         ListAccess<User> usersListAccess;
         User[] users;

--- a/search/service/src/test/java/org/exoplatform/commons/search/service/MockOrganizationService.java
+++ b/search/service/src/test/java/org/exoplatform/commons/search/service/MockOrganizationService.java
@@ -381,11 +381,6 @@ public class MockOrganizationService implements OrganizationService {
       return null;
     }
 
-    @Override
-    public ListAccess<User> findUsersByQuery(Query query, List<String> groupIds, UserStatus userStatus) throws Exception {
-      return null;
-    }
-
     public  ListAccess<User> findUsersByGroupId(String groupId, UserStatus status) throws Exception {
         return null;
     }


### PR DESCRIPTION
…ying with a group

Before this fix, when using UserHandler to query user, by providing one or more groups, we use different method and code duplication
This fix refactor user fetching, by adding the groups list in the query, and use it to fetch users, in only one central function : findUsersByQuery