### PR TITLE
Task-36441: Conserve the attached files to the posted message from activity composer when switching to the article mode

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
@@ -68,7 +68,7 @@
               v-for="action in activityComposerActions"
               :key="action.key"
               :class="`${action.appClass}Action`">
-              <div class="actionItem" @click="executeAction(action)">
+              <div class="actionItem" @click="executeAction(action, attachments)">
                 <div class="actionItemIcon"><div :class="action.iconClass"></div></div>
                 <div class="actionItemDescription">
                   <div class="actionLabel">{{ getLabel(action.labelKey) }}</div>
@@ -346,8 +346,8 @@ export default {
       this.showMessageComposer = false;
       this.$refs[this.ckEditorId].unload();
     },
-    executeAction(action) {
-      executeExtensionAction(action, this.$refs[action.key]);
+    executeAction(action, attachments) {
+      executeExtensionAction(action, this.$refs[action.key], attachments);
     },
     updateAttachments(attachments) {
       this.attachments = attachments;

--- a/webapp/portlet/src/main/webapp/activity-composer-app/extension.js
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/extension.js
@@ -20,12 +20,12 @@ export function getActivityComposerHintActionExtensions() {
   return activityComposerHintAction;
 }
 
-export function executeExtensionAction(extension, component) {
+export function executeExtensionAction(extension, component, attachments) {
   if (extension.hasOwnProperty('onExecute') && isFunction(extension.onExecute)) {
     if (component) {
       extension.onExecute(component[0]);
     } else {
-      extension.onExecute();
+      extension.onExecute(attachments);
     }
   }
 }


### PR DESCRIPTION
Current behaviour:

- It is not possible to conserve the attachments uploaded from activity composer when switching to a news article

New behaviour:

- The attachments uploaded from activity composer are conserved when switching to a news article