### PR TITLE
Task-43957 Make passowrd file disabled in edit user drawer when user is sync

### DIFF
--- a/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementUserFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementUserFormDrawer.vue
@@ -83,7 +83,7 @@
           <input
             ref="newPasswordInput"
             v-model="user.password"
-            :disabled="saving"
+            :disabled="saving || !user.isInternal"
             :required="newUser"
             :minlength="newUser && 8 || 0"
             type="password"
@@ -99,7 +99,7 @@
           <input
             ref="confirmNewPassword"
             v-model="confirmNewPassword"
-            :disabled="saving"
+            :disabled="saving || !user.isInternal"
             :required="newUser"
             :minlength="newUser && 8 || 0"
             type="password"

--- a/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementUserFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/idm-users-management/components/UsersManagementUserFormDrawer.vue
@@ -83,7 +83,7 @@
           <input
             ref="newPasswordInput"
             v-model="user.password"
-            :disabled="saving || !user.isInternal"
+            :disabled="saving || (!user.isInternal && !newUser)"
             :required="newUser"
             :minlength="newUser && 8 || 0"
             type="password"
@@ -99,7 +99,7 @@
           <input
             ref="confirmNewPassword"
             v-model="confirmNewPassword"
-            :disabled="saving || !user.isInternal"
+            :disabled="saving || (!user.isInternal && !newUser)"
             :required="newUser"
             :minlength="newUser && 8 || 0"
             type="password"


### PR DESCRIPTION
When the addon write-in-ldap is installed, the administrator can edit the user, but Picketlink do not let us edit the password
So, when the administrator can open the edit user drawer, we disable passwords fields if the user is sync