### PR TITLE
Task-44606: Write an article button is not shown until an explicit refresh of the space activity stream

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/components/ExoActivityComposer.vue
@@ -236,7 +236,7 @@ export default {
       const urls = [];
       this.activityComposerActions = getActivityComposerActionExtensions();
       this.activityComposerActions.forEach(action => {
-        this.checkEnabled(action);
+        this.setExtensionEnabled(action);
         if (action.component) {
           this.actionsData[action.key] = action.component.model.value;
           this.actionsEvents[action.key] = action.component.events;
@@ -247,15 +247,19 @@ export default {
       });
       exoi18n.loadLanguageAsync(eXo.env.portal.language, urls);
     },
-    checkEnabled(action) {
+    setExtensionEnabled(action) {
       if (action.hasOwnProperty('enabled')) {
         if (typeof action.enabled === 'boolean') {
           action.isEnabled = action.enabled;
         } else if (this.isFunction(action.enabled)) {
-          action.enabled().then(enabled => {
-            action.isEnabled = enabled;
-            this.forceRecomputeCounter++;
-          });
+          if (action.enabled() === '') {
+            action.isEnabled = false;
+          } else {
+            action.enabled().then(enabled => {
+              action.isEnabled = enabled;
+              this.forceRecomputeCounter++;
+            });
+          }
         }
       } else {
         action.isEnabled = true;

--- a/webapp/portlet/src/main/webapp/activity-composer-app/extension.js
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/extension.js
@@ -1,10 +1,6 @@
-let activityComposerActions = null;
 let activityComposerHintAction = null;
 export function getActivityComposerActionExtensions() {
-  const allExtensions = getExtensionsByType('activity-composer-action');
-  activityComposerActions = allExtensions.filter(extension => isExtensionEnabled(extension));
-
-  return activityComposerActions;
+  return getExtensionsByType('activity-composer-action');
 }
 
 export function getActivityComposerHintActionExtensions() {
@@ -32,18 +28,6 @@ export function executeExtensionAction(extension, component, attachments) {
 
 function getExtensionsByType(type) {
   return extensionRegistry.loadExtensions('ActivityComposer', type);
-}
-
-function isExtensionEnabled(extension) {
-  if (extension.hasOwnProperty('enabled')) {
-    if (typeof extension.enabled === 'boolean') {
-      return extension.enabled;
-    } else if (isFunction(extension.enabled)) {
-      return extension.enabled.call();
-    }
-  }
-
-  return true;
 }
 
 function isFunction(object) {


### PR DESCRIPTION
The problem is that the newsComposerPlugin is loaded only at the first site page access and not when switching from one page to another, so the "enabled" parameter will keep the initial value.
To fix this problem, we have to call the "enabled" method each time the component loads.