### PR TITLE
Task-38140: Fix When searching a user and clicking on i the about me field is empty

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -160,6 +160,7 @@ public class ProfileSearchConnector {
       p.setProperty(Profile.POSITION, position);
       p.setProperty(Profile.EMAIL, email);
       p.setProperty(Profile.USERNAME, userName);
+      p.setProperty(Profile.ABOUT_ME, profile.getAboutMe());
       if (external != null) {
         p.setProperty(Profile.EXTERNAL, external);
       }


### PR DESCRIPTION
Problem: The about me property is not displayed when searching user from the unified search after clicking on the "i" icon.
How it was solved: by setting the about me property in the user object from the search result returned by the Elastic Search engine.