### PR TITLE
Task-45373: Fix Applications' name and description are not displayed by their value in space settings interface

### DIFF
--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingApplicationCard.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingApplicationCard.vue
@@ -13,12 +13,12 @@
         <div
           :title="applicationName"
           class="text-truncate subtitle-1 px-1 pt-4 text-color SpaceApplicationCardTitle">
-          {{ applicationName }}
+          {{ application.displayName }}
         </div>
         <v-card-subtitle
           :title="applicationDescription"
           class="text-truncate subtitle-2 px-1 pt-0 text-sub-title SpaceApplicationCardDescription">
-          {{ applicationDescription || applicationName }}
+          {{ application.description || application.applicationName }}
         </v-card-subtitle>
       </div>
       <div class="SpaceApplicationCardAction">
@@ -136,6 +136,7 @@ export default {
         }
       });
     }
+    this.$root.$on('last-updates', data => {this.application = data;});
   },
 };
 </script>


### PR DESCRIPTION
Problem: the display name and description of an application wasn't displayed correctly in space settings application.
How it was solved: by replacing the static values read from the .properties files by dynamic values read in the SpaceSettingApplicationCard component. 