### PR TITLE
MAINT-44337: fix edit short message activity when it contains a link with preview plus an attached file

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
@@ -18,6 +18,7 @@ package org.exoplatform.social.rest.impl.activity;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.*;
@@ -193,9 +194,18 @@ public class ActivityRestResourcesV1 implements ActivityRestResources {
       activity.setBody(model.getBody());
     }
     if(model.getTemplateParams() != null) {
-      Map<String, String> templateParams = new HashMap<>();
-      model.getTemplateParams().forEach((name, value) -> templateParams.put(name, (String) value));
-      activity.setTemplateParams(templateParams);
+      Map<String, String> newTemplateParams = new HashMap<>();
+      Map<String, String> currentTemplateParams = activity.getTemplateParams();
+      model.getTemplateParams().forEach((name, value) -> newTemplateParams.put(name, (String) value));
+      // merge the new updated template params with the old params
+      Map<String, String> updatedTemplateParams = newTemplateParams.entrySet().stream()
+              .filter(param -> currentTemplateParams.containsKey(param.getKey()))
+              .collect(Collectors.toMap(
+                      Map.Entry::getKey,
+                      Map.Entry::getValue,
+                      (oldParamValue, newParamValue) -> newParamValue,
+                      () -> new HashMap<>(currentTemplateParams)));
+      activity.setTemplateParams(updatedTemplateParams);
     }
     if (model.getUpdateDate() != null) {
       activity.setUpdated(Long.parseLong(model.getUpdateDate()));

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
@@ -1,7 +1,9 @@
 package org.exoplatform.social.rest.impl.activity;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.gatein.common.logging.Logger;
 import org.gatein.common.logging.LoggerFactory;
@@ -24,6 +26,7 @@ import org.exoplatform.social.rest.entity.CommentEntity;
 import org.exoplatform.social.rest.entity.DataEntity;
 import org.exoplatform.social.service.rest.api.VersionResources;
 import org.exoplatform.social.service.test.AbstractResourceTest;
+import org.junit.Test;
 
 public class ActivityRestResourcesTest extends AbstractResourceTest {
 
@@ -239,6 +242,38 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     activitiesTitle.add(entity.getTitle());
     assertTrue(activitiesTitle.contains("root activity"));
     assertTrue(activitiesTitle.contains("demo activity"));
+  }
+
+  public void testUpdateActivityById() throws Exception {
+    startSessionAs("root");
+
+    ExoSocialActivity rootActivity = new ExoSocialActivityImpl();
+    rootActivity.setTitle("test activity");
+    Map<String, String> templateParams = new HashMap<String, String>();
+    templateParams.put("WORKSPACE", "collaboration");
+    templateParams.put("MESSAGE", "old message");
+    templateParams.put("description", "description of the activity");
+    templateParams.put("DOCPATH", "path to a document");
+    rootActivity.setTemplateParams(templateParams);
+    activityManager.saveActivityNoReturn(rootIdentity, rootActivity);
+    ContainerResponse response = service("GET",
+            "/" + VersionResources.VERSION_ONE + "/social/activities/" + rootActivity.getId(), "", null, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    ActivityEntity result = getBaseEntity(response.getEntity(), ActivityEntity.class);
+    assertEquals("test activity", result.getTitle());
+
+    String input = "{\"title\":\"updated title\",\"templateParams\":{\"MESSAGE\":\"updated message\",\"NOT_EXIST_KEY\":\"any value\"}}";
+    ActivityEntity model = new ActivityEntity();
+
+    response = getResponse("PUT", "/" + VersionResources.VERSION_ONE + "/social/activities/" + rootActivity.getId(), input);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    result = getBaseEntity(response.getEntity(), ActivityEntity.class);
+    assertEquals( "updated title", result.getTitle());
+    assertEquals( "updated message", result.getTemplateParams().get("MESSAGE"));
+    assertFalse(result.getTemplateParams().containsKey("NOT_EXIST_KEY"));
+    assertEquals( 4, result.getTemplateParams().size());
   }
 
   public void testGetUpdatedDeletedActivityById() throws Exception {

--- a/component/webui/src/main/java/org/exoplatform/social/webui/activity/UILinkActivity.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/activity/UILinkActivity.java
@@ -18,6 +18,7 @@ package org.exoplatform.social.webui.activity;
 
 import java.util.Date;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.service.rest.Util;
 import org.exoplatform.social.webui.Utils;
@@ -53,6 +54,7 @@ public class UILinkActivity extends BaseUIActivity {
   public static final String COMMENT_PARAM = "comment";
   public static final String HTML_PARAM = "html";
   public static final String DEFAULT_TITLE = "default_title";
+  public static final String MESSAGE = "MESSAGE";
 
   private String linkSource = "";
   private String linkTitle = "";
@@ -61,7 +63,7 @@ public class UILinkActivity extends BaseUIActivity {
   private String linkComment = "";
   private String embedHtml = "";
   private String defaultTitle = "";
-
+  private String message = "";
   public String getLinkComment() {
     return linkComment;
   }
@@ -99,6 +101,19 @@ public class UILinkActivity extends BaseUIActivity {
     this.embedHtml = embedHtml;
   }
 
+  public String getMessage() {
+    if (StringUtils.isNotBlank(message)) {
+      return message;
+    } else {
+      return getLinkComment();
+    }
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+
   public String getDefaultTitle() {
     return defaultTitle;
   }
@@ -115,7 +130,8 @@ public class UILinkActivity extends BaseUIActivity {
     this.setLinkComment(message);
     Utils.getActivityManager().updateActivity(getActivity());
   }
-  
+
+
   public boolean isActivityShareable() {
     return true;
   }

--- a/component/webui/src/main/java/org/exoplatform/social/webui/activity/UILinkActivityBuilder.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/activity/UILinkActivityBuilder.java
@@ -41,6 +41,9 @@ public class UILinkActivityBuilder extends BaseUIActivityBuilder {
     }
     
     Map<String, String> templateParams = activity.getTemplateParams();
+    if (activity.getTemplateParams().get(UILinkActivity.MESSAGE) != null) {
+      uiLinkActivity.setMessage(templateParams.get(UILinkActivity.MESSAGE));
+    }
     uiLinkActivity.setDefaultTitle(templateParams.get(UILinkActivity.DEFAULT_TITLE));
     uiLinkActivity.setLinkSource(templateParams.get(UILinkActivity.LINK_PARAM));
     uiLinkActivity.setLinkTitle(templateParams.get(UILinkActivity.TITLE_PARAM));

--- a/component/webui/src/test/java/org/exoplatform/social/webui/activity/UILinkActivityTest.java
+++ b/component/webui/src/test/java/org/exoplatform/social/webui/activity/UILinkActivityTest.java
@@ -1,0 +1,36 @@
+package org.exoplatform.social.webui.activity;
+
+import junit.framework.TestCase;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
+import org.junit.Test;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class UILinkActivityTest extends TestCase {
+
+    @Test
+    public void testGetMessage() {
+        String linkComment = "test test";
+        String message = "test message";
+        UILinkActivityBuilder activityBuilder = new UILinkActivityBuilder();
+        ExoSocialActivity activity = new ExoSocialActivityImpl();
+        UILinkActivity linkUIActivity = new UILinkActivity();
+
+        Map<String, String> activityParameters = new HashMap<>();
+        activityParameters.put(UILinkActivity.COMMENT_PARAM, linkComment);
+        activity.setTemplateParams(activityParameters);
+
+        activityBuilder.extendUIActivity(linkUIActivity, activity);
+        assertEquals(linkComment, linkUIActivity.getMessage());
+
+        activityParameters.put(UILinkActivity.MESSAGE, message);
+        activityBuilder.extendUIActivity(linkUIActivity, activity);
+
+        assertEquals(message, linkUIActivity.getMessage());
+
+
+
+    }
+}

--- a/extension/war/src/main/webapp/groovy/social/webui/activity/UILinkActivity.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/activity/UILinkActivity.gtmpl
@@ -36,6 +36,7 @@
   def jsManager = pcontext.getJavascriptManager().require("SHARED/uiForm");
   def labelActivityHasBeenDeleted = _ctx.appRes("UIActivity.label.Activity_Has_Been_Deleted");
   def activity = uicomponent.getActivity();
+  def activityMessage = uicomponent.getMessage();
   def activityDeletable = uicomponent.isActivityDeletable();
   def activityEditable = uicomponent.isActivityEditable(activity);
   def activityCommentAndLikable = uicomponent.isActivityCommentAndLikable();
@@ -80,7 +81,7 @@
   String activityLink = new StringBuilder("<p><a id='editActivityLinkPreview' href='").append(uicomponent.getLinkSource())
                         .append("'>").append(uicomponent.getLinkSource()).append("</a></p>");
   def activityTitle = uicomponent.getDefaultTitle();
-  String activityBody = new StringBuilder(activityTitle.split('<oembed>')[0]).append(activityLink);
+  String activityBody = new StringBuilder(activityTitle.split('<oembed>')[0]);
 
   //params for init UIActivity javascript object
   def params = """ {
@@ -204,8 +205,8 @@
 					    linkClass = "embedBox";
 					  }
 					%>
-				<% if (linkComment != null && linkComment.length() > 0) { %>
-				<div class="description">$linkComment</div>
+				<% if (activityMessage != null && activityMessage.length() > 0) { %>
+				<div class="description">$activityMessage</div>
 				<% } %>
                 <div class="desktop-input clearfix">
                     <div class="blastInputPeople hideEffect">

--- a/webapp/portlet/src/main/webapp/activity-composer-app/composerServices.js
+++ b/webapp/portlet/src/main/webapp/activity-composer-app/composerServices.js
@@ -43,6 +43,9 @@ export function updateActivityInUserStream(message, activityId, activityType, at
     body: JSON.stringify({
       'updateDate': Date.now(),
       'title': message,
+      'templateParams': {
+        'MESSAGE': message
+      },
       'type': activityType,
       'files': attachments
     })


### PR DESCRIPTION
**FIX** edit short message activity when it contains a link with preview plus an attached file by using adapting the `UIlinkActivtyBuilder` to use the **MESSAGE** param as it will be available when the activity contains an attached file and it's extended in the same time by the `LinkActivity` params, also updating the rest service to be able to update the **MESSAGE** param when editing the activity as the old implementation will **never** update and only updating the title. 