### PR TITLE
Task-46145 Fix jacoco execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
               <exo.profiles>hsqldb</exo.profiles>
               <exo.files.storage.dir>${project.build.directory}/exo-files</exo.files.storage.dir>
               <com.arjuna.ats.arjuna.objectstore.objectStoreDir>${project.build.directory}/com.arjuna.ats.arjuna.objectstore.objectStoreDir</com.arjuna.ats.arjuna.objectstore.objectStoreDir>
-              <argLine>${argLine} -Xmx1024m -XX:MaxPermSize=512m</argLine>
+              <argLine>@{argLine} -Xmx1024m -XX:MaxPermSize=512m</argLine>
             </systemPropertyVariables>
           </configuration>
         </plugin>


### PR DESCRIPTION
Before this fix, when the argLine is not set (when 'coverage' profile is not used), the build failed
This fix define an empty property argLine, and change how maven should evaluate this property thanks to :
https://maven.apache.org/surefire/maven-surefire-plugin/faq.html#late-property-evaluation
By using @ instead of $, maven evaluate the property when the plugin execute, instead of evaluate it at the begining of the execution.