### PR TITLE
TASK-46403 Fix Link activity display

### DIFF
--- a/webapp/portlet/src/main/webapp/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/activity-stream/components/activity/content/ActivityLink.vue
@@ -186,7 +186,7 @@ export default {
       return this.activityTypeExtension && this.activityTypeExtension.getTooltip;
     },
     defaultIcon() {
-      return this.activityTypeExtension && (this.activityTypeExtension.defaultIcon || this.activityTypeExtension.getDefaultIcon(this.comment || this.activity));
+      return this.activityTypeExtension && (this.activityTypeExtension.defaultIcon || (this.activityTypeExtension.getDefaultIcon && this.activityTypeExtension.getDefaultIcon(this.comment || this.activity)));
     },
     defaultIconClass() {
       return this.defaultIcon && this.defaultIcon.icon || 'far fa-image';


### PR DESCRIPTION
The link activities aren't displayed anymore due to a regression. This fix ensures to make an additional test on existance of method getDefaultIcon in Activity Extensions before proceeding to display the activity.