### PR TITLE
43332 : avoid adding the whole list of members when returning the binding report

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/binding/GroupSpaceBindingRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/binding/GroupSpaceBindingRestResourcesV1.java
@@ -327,7 +327,7 @@ public class GroupSpaceBindingRestResourcesV1 implements GroupSpaceBindingRestRe
 
       // Set the space entity to the operation report entity.
       Space space = spaceService.getSpaceById(Long.toString(bindingOperationReport.getSpaceId()));
-      SpaceEntity spaceEntity = EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), "members");
+      SpaceEntity spaceEntity = EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), null);
       operationReportEntity.setSpace(spaceEntity.getDataEntity());
       bindingOperationReportsDataEntities.add(operationReportEntity.getDataEntity());
     }


### PR DESCRIPTION
The binding report table takes time to render because the returned Binding operation reports contains the full list of space members.
this fix will avoid loading space members as they are not needed for the generated report 