### PR TITLE
43332 : avoid loading space members in spaces administration page (#782)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -442,6 +442,10 @@ public class EntityBuilder {
         }
         spaceEntity.setMembers(members);
 
+        if(RestProperties.MEMBERS_COUNT.equals(expand)) {
+          spaceEntity.setMembersCount(space.getMembers().length);
+        }
+  
         if (expandFields.contains(RestProperties.PENDING)) {
           LinkEntity pending = new LinkEntity(buildEntityProfiles(space.getPendingUsers(), restPath, expand));
           spaceEntity.setPending(pending);

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/RestProperties.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/RestProperties.java
@@ -38,5 +38,5 @@ public class RestProperties {
   public static final String SUB_COMMENTS  = "subComments";
   public static final String CAN_EDIT      = "canEdit";
   public static final String CAN_DELETE    = "canDelete";
-
+  public static final String MEMBERS_COUNT = "membersCount";
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/binding/GroupSpaceBindingRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/binding/GroupSpaceBindingRestResourcesV1.java
@@ -327,7 +327,7 @@ public class GroupSpaceBindingRestResourcesV1 implements GroupSpaceBindingRestRe
 
       // Set the space entity to the operation report entity.
       Space space = spaceService.getSpaceById(Long.toString(bindingOperationReport.getSpaceId()));
-      SpaceEntity spaceEntity = EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), "members");
+      SpaceEntity spaceEntity = EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), null);
       operationReportEntity.setSpace(spaceEntity.getDataEntity());
       bindingOperationReportsDataEntities.add(operationReportEntity.getDataEntity());
     }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -121,7 +121,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
   @ApiOperation(value = "Gets spaces of user",
                 httpMethod = "GET",
                 response = Response.class,
-                notes = "This returns a list of spaces switch request paramters")
+                notes = "This returns a list of spaces switch request parameters")
   @ApiResponses(value = {
     @ApiResponse (code = 200, message = "Request fulfilled"),
     @ApiResponse (code = 500, message = "Internal server error"),

--- a/webapp/portlet/src/main/webapp/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
+++ b/webapp/portlet/src/main/webapp/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
@@ -53,7 +53,7 @@
         <td v-html="space.description"></td>
         <td class="center"> {{ $t('social.spaces.administration.manageSpaces.visibility.'+space.visibility) }} </td>
         <td class="center"> {{ $t('social.spaces.administration.manageSpaces.registration.'+space.subscription) }} </td>
-        <td class="center"> {{ space.totalBoundUsers }}/{{ space.members.length }} </td>
+        <td class="center"> {{ space.totalBoundUsers }}/{{ space.membersCount }} </td>
         <td class="center actionContainer">
           <a
             v-exo-tooltip.bottom.body="$t('social.spaces.administration.manageSpaces.actions.bind')"

--- a/webapp/portlet/src/main/webapp/spaces-administration/spacesAdministrationServices.js
+++ b/webapp/portlet/src/main/webapp/spaces-administration/spacesAdministrationServices.js
@@ -1,15 +1,15 @@
 import { spacesConstants } from '../js/spacesConstants.js';
 
 export function getSpaces() {
-  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=members`, {credentials: 'include'}).then(resp => resp.json());
+  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=membersCount`, {credentials: 'include'}).then(resp => resp.json());
 }
 
 export function searchSpaces(search) {
-  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?q=${search}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=members`, {credentials: 'include'}).then(resp => resp.json());
+  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?q=${search}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=membersCount`, {credentials: 'include'}).then(resp => resp.json());
 }
 
 export function getSpacesPerPage(offset) {
-  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?offset=${offset}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=members`, {credentials: 'include'}).then(resp => resp.json());
+  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?offset=${offset}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=membersCount`, {credentials: 'include'}).then(resp => resp.json());
 }
 
 export function deleteSpaceById(id) {


### PR DESCRIPTION
To display members count in sapce administration page, all users are loaded ands sent in the JSON response.
The fix added a new expand value membersCount to retrieve just the members count and add it to the JSON response .

(cherry picked from commit 8cae874a8be6d7cd02ac2f647f1489e063b332e6)