### PR TITLE
43332 : avoid loading space members in spaces administration page (#7…

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -372,7 +372,16 @@ public class EntityBuilder {
         spaceEntity.setHref(RestUtils.getRestUrl(SPACES_TYPE, space.getId(), restPath));
         Identity spaceIdentity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName(), true);
         LinkEntity identity;
-        if(RestProperties.IDENTITY.equals(expand)) {
+
+        List<String> expandFields;
+        if (StringUtils.isBlank(expand)) {
+          expandFields = Collections.emptyList();
+        } else {
+          expandFields = Arrays.asList(expand.split(","));
+        }
+
+
+        if(expandFields.contains(RestProperties.IDENTITY)) {
           identity = new LinkEntity(buildEntityIdentity(spaceIdentity, restPath, null));
         } else {
           identity = new LinkEntity(RestUtils.getRestUrl(IDENTITIES_TYPE, spaceIdentity.getId(), restPath));
@@ -383,7 +392,7 @@ public class EntityBuilder {
         spaceEntity.setApplications(getSpaceApplications(space));
   
         LinkEntity managers;
-        if(RestProperties.MANAGERS.equals(expand)) {
+        if(expandFields.contains(RestProperties.MANAGERS)) {
           managers = new LinkEntity(buildEntityProfiles(space.getManagers(), restPath, expand));
         } else {
           managers = new LinkEntity(getMembersSpaceRestUrl(space.getId(), true, restPath));
@@ -391,14 +400,18 @@ public class EntityBuilder {
         spaceEntity.setManagers(managers);
   
         LinkEntity members;
-        if(RestProperties.MEMBERS.equals(expand)) {
+        if(expandFields.contains(RestProperties.MEMBERS)) {
           members = new LinkEntity(buildEntityProfiles(space.getMembers(), restPath, expand));
         } else {
           members = new LinkEntity(getMembersSpaceRestUrl(space.getId(), false, restPath));
         }
         spaceEntity.setMembers(members);
+
+        if(expandFields.contains(RestProperties.MEMBERS_COUNT)) {
+          spaceEntity.setMembersCount(space.getMembers().length);
+        }
   
-        if(RestProperties.PENDING.equals(expand)) {
+        if (expandFields.contains(RestProperties.PENDING)) {
           LinkEntity pending = new LinkEntity(buildEntityProfiles(space.getPendingUsers(), restPath, expand));
           spaceEntity.setPending(pending);
         }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/RestProperties.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/RestProperties.java
@@ -34,5 +34,6 @@ public class RestProperties {
   public static final String TYPE          = "type";
   public static final String UPDATE_DATE   = "updateDate";
   public static final String LIKES         = "likes";
-  public static final String SUB_COMMENTS      = "subComments";
+  public static final String SUB_COMMENTS  = "subComments";
+  public static final String MEMBERS_COUNT = "membersCount";
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/binding/GroupSpaceBindingRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/binding/GroupSpaceBindingRestResourcesV1.java
@@ -327,7 +327,7 @@ public class GroupSpaceBindingRestResourcesV1 implements GroupSpaceBindingRestRe
 
       // Set the space entity to the operation report entity.
       Space space = spaceService.getSpaceById(Long.toString(bindingOperationReport.getSpaceId()));
-      SpaceEntity spaceEntity = EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), "members");
+      SpaceEntity spaceEntity = EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), null);
       operationReportEntity.setSpace(spaceEntity.getDataEntity());
       bindingOperationReportsDataEntities.add(operationReportEntity.getDataEntity());
     }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -120,7 +120,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
   @ApiOperation(value = "Gets spaces of user",
                 httpMethod = "GET",
                 response = Response.class,
-                notes = "This returns a list of spaces switch request paramters")
+                notes = "This returns a list of spaces switch request parameters")
   @ApiResponses(value = {
     @ApiResponse (code = 200, message = "Request fulfilled"),
     @ApiResponse (code = 500, message = "Internal server error"),

--- a/webapp/portlet/src/main/webapp/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
+++ b/webapp/portlet/src/main/webapp/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
@@ -37,9 +37,13 @@
         <td v-html="space.description"></td>
         <td class="center"> {{ $t('social.spaces.administration.manageSpaces.visibility.'+space.visibility) }} </td>
         <td class="center"> {{ $t('social.spaces.administration.manageSpaces.registration.'+space.subscription) }} </td>
-        <td class="center"> {{ space.totalBoundUsers }}/{{ space.members.length }} </td>
-        <td class="center actionContainer" >
-          <a v-exo-tooltip.bottom.body="$t('social.spaces.administration.manageSpaces.actions.bind')" v-if="canBindGroupsAndSpaces" class="actionIcon" @click="openSpaceBindingDrawer(space, index)">
+        <td class="center"> {{ space.totalBoundUsers }}/{{ space.membersCount }} </td>
+        <td class="center actionContainer">
+          <a
+            v-exo-tooltip.bottom.body="$t('social.spaces.administration.manageSpaces.actions.bind')"
+            v-if="canBindGroupsAndSpaces"
+            class="actionIcon"
+            @click="openSpaceBindingDrawer(space, index)">
             <i :class="{'bound': space.hasBindings}" class="uiIconSpaceBinding uiIconGroup"></i>
           </a>
           <a v-exo-tooltip.bottom.body="$t('social.spaces.administration.manageSpaces.actions.edit')" :href="getSpaceLinkSetting(space.displayName,space.groupId)" class="actionIcon" target="_blank">

--- a/webapp/portlet/src/main/webapp/spaces-administration/spacesAdministrationServices.js
+++ b/webapp/portlet/src/main/webapp/spaces-administration/spacesAdministrationServices.js
@@ -1,15 +1,15 @@
 import { spacesConstants } from '../js/spacesConstants.js';
 
 export function getSpaces() {
-  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=members`, {credentials: 'include'}).then(resp => resp.json());
+  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=membersCount`, {credentials: 'include'}).then(resp => resp.json());
 }
 
 export function searchSpaces(search) {
-  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?q=${search}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=members`, {credentials: 'include'}).then(resp => resp.json());
+  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?q=${search}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=membersCount`, {credentials: 'include'}).then(resp => resp.json());
 }
 
 export function getSpacesPerPage(offset) {
-  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?offset=${offset}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=members`, {credentials: 'include'}).then(resp => resp.json());
+  return fetch(`${spacesConstants.SOCIAL_SPACE_API}?offset=${offset}&sort=date&order=desc&limit=${spacesConstants.SPACES_PER_PAGE}&returnSize=true&expand=membersCount`, {credentials: 'include'}).then(resp => resp.json());
 }
 
 export function deleteSpaceById(id) {


### PR DESCRIPTION
…82) (#830)

To display members count in sapce administration page, all users are loaded ands sent in the JSON response.
The fix added a new expand value membersCount to retrieve just the members count and add it to the JSON response .

(cherry picked from commit 8cae874a8be6d7cd02ac2f647f1489e063b332e6)