### PR TITLE
TASK-39994-39972-39971: Make sure to be able to mention external users from the activity composer in the activity stream.

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -99,15 +99,15 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
       do {
         list.addAll(connectionDAO.getSenderIds(id, type, offset, limit).stream().map(senderId -> senderId.toString()).collect(Collectors.toList()));
         offset += limit;
-      } while (list != null && list.size() >= limit);
+      } while (list.size() >= limit);
     }
 
     if (inReceiver) {
       int offset = 0;
       do {
-        list.addAll(connectionDAO.getReceiverIds(id, type, offset, limit).stream().map(receierId -> receierId.toString()).collect(Collectors.toList()));
+        list.addAll(connectionDAO.getReceiverIds(id, type, offset, limit).stream().map(receiverId -> receiverId.toString()).collect(Collectors.toList()));
         offset += limit;
-      } while (list != null && list.size() >= limit);
+      } while (list.size() >= limit);
     }
 
     return list;
@@ -218,17 +218,17 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     Map<String, Collection<String>> listFields = new HashMap<>();
     // confirmed connections
     List<String> connectionsStr = buildConnectionString(identity, Relationship.Type.CONFIRMED);
-    if (connectionsStr.size() > 0) {
+    if (!connectionsStr.isEmpty()) {
       listFields.put("connections", connectionsStr);
     }
     // outgoing connections
     connectionsStr = buildConnectionString(identity, Relationship.Type.OUTGOING);
-    if (connectionsStr.size() > 0) {
+    if (!connectionsStr.isEmpty()) {
       listFields.put("outgoings", connectionsStr);
     }
     // incoming connections
     connectionsStr = buildConnectionString(identity, Relationship.Type.INCOMING);
-    if (connectionsStr.size() > 0) {
+    if (!connectionsStr.isEmpty()) {
       listFields.put("incomings", connectionsStr);
     }
 


### PR DESCRIPTION
The field "connections" was mapped as a string (separated ids by a comma) in the ES user profile indexes which makes the ES query not returning the right connections due to the type of the field.
`Query: {
  "from": 0,
  "size": 10,
  "sort": {
    "lastName.raw": {
      "order": "ASC"
    }
  },
  "query": {
    "constant_score": {
      "filter": {
        "bool": {
          "must": {
            "query_string": {
              "query": "userId",
              "fields": [
                "connections"
              ]
            }
          },
          "filter": [
            {
              "query_string": {
                "query": "( name.whitespace:*searchText* OR userName:*searchText*)"
              }
            }
          ]
        }
      }
    }
  }
}`
**Fix**: i updated the "connections" field type to array which is the right type for such entries, and made same for the fields "outgoings" and "incomings".