### PR TITLE
TASK-46251: fix initializing space pretty name in building popup

### DIFF
--- a/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
+++ b/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
@@ -299,7 +299,7 @@
                     var isManager = false;
                     var isMember = false;
                     var labels = opts.labels;
-                    var spaceName = spaceUrl.substring(spaceUrl.lastIndexOf('/')+1);
+                    var spaceName = json.prettyName;
                     if(json.membership.roles.indexOf('manager')>=0) {
                         isManager = true;
                     }


### PR DESCRIPTION
The initializing of the space popup was made with an empty space pretty name as the trimmed string contains` / `at the end. For more consistency, I replaced it with the pretty name coming from the space json object.