### PR TITLE
Task-45373: Fix Applications' name and description are not displayed by their value in space settings interface (#775)

### DIFF
--- a/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingAddApplicationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/space-settings/components/SpaceSettingAddApplicationDrawer.vue
@@ -56,16 +56,9 @@ export default {
   },
   created() {
     this.$spaceService.getSpaceApplicationsChoices()
-      .then(data => {
-        this.applications = data.map(app => ({
-          applicationName: app.applicationName,
-          contentId: app.contentId,
-          description: this.$t(`SpaceSettings.application.${/\s/.test(app.displayName) ? app.displayName.replace(/ /g,'.').toLowerCase() : app.displayName.toLowerCase()}.description`),
-          displayName: this.$t(`SpaceSettings.application.${/\s/.test(app.displayName) ? app.displayName.replace(/ /g,'.').toLowerCase() : app.displayName.toLowerCase()}.title`),
-          id: app.id,
-          removable: app.removable,
-        }));
-      });
+      .then(data =>
+        this.applications = data
+      );
   },
   methods: {
     open() {


### PR DESCRIPTION
Problem: the name and the description of apps were not displayed by their values in the addApplication drawer.
How it was solved: delete the duplicated values, already read from the SpaceSettingApplicationCard component, from the SpaceSettingAddApplicationDrawer component.