### PR TITLE
TASK-47234 Allow to define extra processed object linked to activities

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/activity/model/ExoSocialActivity.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/activity/model/ExoSocialActivity.java
@@ -378,4 +378,8 @@ public interface ExoSocialActivity extends CacheEntry {
   Float getPriority();
 
   void setPriority(Float priority);
+
+  Map<String, Object> getLinkedProcessedEntities();
+
+  void setLinkedProcessedEntities(Map<String, Object> linkedProcessedEntities);
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/activity/model/ExoSocialActivityImpl.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/activity/model/ExoSocialActivityImpl.java
@@ -102,6 +102,8 @@ public class ExoSocialActivityImpl implements ExoSocialActivity {
 
   private Map<String, String> templateParams;
 
+  private Map<String, Object> linkedProcessedEntities;
+
   /**
    * The link to the activity object.
    */
@@ -681,6 +683,14 @@ public class ExoSocialActivityImpl implements ExoSocialActivity {
 
   public void setPriority(Float priority) {
     this.priority = priority;
+  }
+
+  public Map<String, Object> getLinkedProcessedEntities() {
+    return linkedProcessedEntities;
+  }
+
+  public void setLinkedProcessedEntities(Map<String, Object> linkedProcessedEntities) {
+    this.linkedProcessedEntities = linkedProcessedEntities;
   }
 
   public String toString() {

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/data/ActivityData.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/data/ActivityData.java
@@ -49,6 +49,7 @@ public class ActivityData implements CacheData<ExoSocialActivity> {
   private final String bodyId;
   private final String type;
   private final Map templateParams;
+  private final Map<String, Object> linkedProcessedEntities;
   private final String externalId;
   private final String url;
   private final String streamId;
@@ -102,9 +103,13 @@ public class ActivityData implements CacheData<ExoSocialActivity> {
 
     if (activity.getTemplateParams() != null) {
       this.templateParams = Collections.unmodifiableMap(activity.getTemplateParams());
-    }
-    else {
+    } else {
       this.templateParams = Collections.emptyMap();
+    }
+    if (activity.getLinkedProcessedEntities() != null) {
+      this.linkedProcessedEntities = Collections.unmodifiableMap(activity.getLinkedProcessedEntities());
+    } else {
+      this.linkedProcessedEntities = null;
     }
 
   }
@@ -135,6 +140,9 @@ public class ActivityData implements CacheData<ExoSocialActivity> {
     activity.setBodyId(bodyId);
     activity.setType(type);
     activity.setTemplateParams(new LinkedHashMap<>(templateParams));
+    if (linkedProcessedEntities != null) {
+      activity.setLinkedProcessedEntities(new LinkedHashMap<>(linkedProcessedEntities));
+    }
     activity.setExternalId(externalId);
     activity.setShareActions(shareActions == null ? null : Collections.unmodifiableSet(shareActions));
     activity.setFiles(files == null ? null : Collections.unmodifiableList(files));

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -654,6 +654,9 @@ public class EntityBuilder {
         }
       }
     }
+    if (activity.getLinkedProcessedEntities() != null) {
+      activityEntity.getDataEntity().putAll(activity.getLinkedProcessedEntities());
+    }
     return activityEntity;
   }
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/comment/CommentRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/comment/CommentRestResourcesV1.java
@@ -201,13 +201,15 @@ public class CommentRestResourcesV1 implements ResourceContainer {
   public Response addLikeOnComment(
                                    @Context
                                    UriInfo uriInfo,
+                                   @Context
+                                   Request request,
                                    @ApiParam(value = "Comment id", required = true)
                                    @PathParam("id")
                                    String id,
                                    @ApiParam(value = "Asking for a full representation of a subresource if any", required = false)
                                    @QueryParam("expand")
                                    String expand) {
-    return activityRestResourcesV1.addLike(uriInfo, id);
+    return activityRestResourcesV1.addLike(uriInfo, request, id);
   }
 
   @DELETE
@@ -229,6 +231,8 @@ public class CommentRestResourcesV1 implements ResourceContainer {
   public Response deleteLikeOnComment(
                                       @Context
                                       UriInfo uriInfo,
+                                      @Context
+                                      Request request,
                                       @ApiParam(value = "Comment id", required = true)
                                       @PathParam("id")
                                       String id,
@@ -241,7 +245,7 @@ public class CommentRestResourcesV1 implements ResourceContainer {
                                       )
                                       @QueryParam("expand")
                                       String expand) {
-    return activityRestResourcesV1.deleteLike(uriInfo, id);
+    return activityRestResourcesV1.deleteLike(uriInfo, request, id);
   }
 
 }

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
@@ -923,7 +923,34 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
                                          null,
                                          null);
     assertNotNull(response);
-    assertEquals(204, response.getStatus());
+    assertEquals(200, response.getStatus());
+    CollectionEntity collections = (CollectionEntity) response.getEntity();
+    assertEquals(0, collections.getEntities().size());
+    assertEquals(0, collections.getSize());
+
+    // clean data
+    activityManager.deleteActivity(demoActivity);
+  }
+
+  public void testAddLike() throws Exception {
+    startSessionAs("demo");
+
+    // root posts one activity
+    ExoSocialActivity demoActivity = new ExoSocialActivityImpl();
+    demoActivity.setTitle("demo activity");
+    activityManager.saveActivityNoReturn(demoIdentity, demoActivity);
+
+    ContainerResponse response = service("POST",
+                                         "/" + VersionResources.VERSION_ONE + "/social/activities/" + demoActivity.getId()
+                                         + "/likes",
+                                         "",
+                                         null,
+                                         null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    CollectionEntity collections = (CollectionEntity) response.getEntity();
+    assertEquals(1, collections.getEntities().size());
+    assertEquals(1, collections.getSize());
 
     // clean data
     activityManager.deleteActivity(demoActivity);

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
@@ -125,6 +125,8 @@ export function likeActivity(id) {
   }).then(resp => {
     if (!resp || !resp.ok) {
       throw new Error('Response code indicates a server error', resp);
+    } else {
+      return resp.json();
     }
   });
 }
@@ -136,6 +138,8 @@ export function unlikeActivity(id) {
   }).then(resp => {
     if (!resp || !resp.ok) {
       throw new Error('Response code indicates a server error', resp);
+    } else {
+      return resp.json();
     }
   });
 }


### PR DESCRIPTION
Prior to this change, retrieving kudos, news... all linked entities of the activity should be done using REST in async way independing from Cache lifecycle of Activity. This change will allow to cache and retrieve at the same time the linked entities to the activity when the addons defines a dedicated processor.