### PR TITLE
TASK-45845 Fix Who is online caching switch displayed space

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/whoIsOnline.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/whoIsOnline.jsp
@@ -1,8 +1,14 @@
+<%@page import="org.exoplatform.social.core.space.model.Space"%>
+<%@page import="org.exoplatform.social.core.space.SpaceUtils"%>
+<%
+  Space space = SpaceUtils.getSpaceByContext();
+  String spaceId = space == null ? "" : space.getId();
+%>
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application v-application--is-ltr hiddenable-widget theme--light"
     id="OnlinePortlet">
-    <v-cacheable-dom-app cache-id="OnlinePortlet"></v-cacheable-dom-app>
+    <v-cacheable-dom-app cache-id="OnlinePortlet_<%=spaceId%>"></v-cacheable-dom-app>
     <script>
       eXo.env.portal.addOnLoadCallback(() => {
         require([ 'PORTLET/social-portlet/WhoIsOnLinePortlet' ], function(whoIsOnlineApp) {

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -166,7 +166,7 @@
     <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
-      <value>/html/whoIsOnline.html</value>
+      <value>/WEB-INF/jsp/whoIsOnline.jsp</value>
     </init-param>
     <init-param>
       <name>prefetch.resources</name>

--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/main.js
@@ -20,6 +20,7 @@ if (extensionRegistry) {
 }
 
 const appId = 'OnlinePortlet';
+const cacheId = `${appId}_${eXo.env.portal.spaceId || ''}`;
 
 // getting locale ressources
 export function init() {
@@ -28,7 +29,7 @@ export function init() {
     appElement.id = appId;
 
     new Vue({
-      template: `<exo-who-is-online v-cacheable id="${appId}"></exo-who-is-online>`,
+      template: `<exo-who-is-online v-cacheable="{cacheId: '${cacheId}'}" id="${appId}"></exo-who-is-online>`,
       i18n,
       vuetify
     }).$mount(appElement);


### PR DESCRIPTION
Prior to this change, the Who Is Online Widget uses a common cache independently from the page where it's displayed. Thus, the list of displayed users in a space, for this widget, will come from the last display made of it (it can be displayed last time in a stream of another space in the same browser, or from stream page). This will ensure to use the Skeleton V3 cache key to introduce spaceId into it, so that the display of the widget will depends on current page's space identifier (as made for all other widgets)