### PR TITLE
TASK-47234 Add Tooling to intercept globally Vue applications creation and full display 

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -387,6 +387,48 @@
       <depends>
         <module>ActivityStream</module>
       </depends>
+      <depends>
+        <module>social-ui-profile</module>
+        <as>socialUIProfile</as>
+      </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
+      <depends>
+        <module>ActivityComposer</module>
+        <as>activityComposer</as>
+      </depends>
+      <depends>
+        <module>ActivityReactions</module>
+        <as>activityReactions</as>
+      </depends>
+      <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>jquery</module>
+        <as>$</as>
+      </depends>
+      <depends>
+        <module>extensionRegistry</module>
+      </depends>
+      <depends>
+        <module>suggester</module>
+      </depends>
+      <depends>
+        <module>commons-editor</module>
+        <as>editor</as>
+      </depends>
+      <depends>
+        <module>commons-cometd3</module>
+        <as>cCometd</as>
+      </depends>
     </module>
   </portlet>
 
@@ -395,6 +437,48 @@
     <module>
       <depends>
         <module>ActivityStream</module>
+      </depends>
+      <depends>
+        <module>social-ui-profile</module>
+        <as>socialUIProfile</as>
+      </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
+      <depends>
+        <module>ActivityComposer</module>
+        <as>activityComposer</as>
+      </depends>
+      <depends>
+        <module>ActivityReactions</module>
+        <as>activityReactions</as>
+      </depends>
+      <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>jquery</module>
+        <as>$</as>
+      </depends>
+      <depends>
+        <module>extensionRegistry</module>
+      </depends>
+      <depends>
+        <module>suggester</module>
+      </depends>
+      <depends>
+        <module>commons-editor</module>
+        <as>editor</as>
+      </depends>
+      <depends>
+        <module>commons-cometd3</module>
+        <as>cCometd</as>
       </depends>
     </module>
   </portlet>

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
@@ -47,6 +47,7 @@
       </div>
     </div>
     <script type="text/javascript">
+      document.dispatchEvent(new CustomEvent('vue-app-loading-start', {detail: 'Stream'}));
       fetch('<%=activitiesLoadingURL%>', {
         method: 'GET',
         credentials: 'include',

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/search.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/search.jsp
@@ -34,12 +34,19 @@
   <div data-app="true"
     class="v-application v-application--is-ltr theme--light"
     id="SearchApplication">
-    <v-cacheable-dom-app cache-id="SearchApplication"></v-cacheable-dom-app>
+    <div class="v-application--wrap">
+      <button
+        type="button"
+        disabled="disabled"
+        class="transparent v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default">
+        <span class="v-btn__content">
+          <i class="uiIconPLF24x24Search"></i>
+        </span>
+      </button>
+    </div>
     <textarea id="searchConnectorsDefaultValue" class="hidden"><%= jsonSearchConnectors%></textarea>
-    <script type="text/javascript" defer="defer">
-      eXo.env.portal.addOnLoadCallback(() => {
-        require(['PORTLET/social-portlet/Search'], app => app.init(JSON.parse(document.getElementById('searchConnectorsDefaultValue').value)));
-      });
+    <script type="text/javascript">
+      require(['PORTLET/social-portlet/Search'], app => app.init(JSON.parse(document.getElementById('searchConnectorsDefaultValue').value)));
     </script>
   </div>
 </div>

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/suggestions.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/suggestions.jsp
@@ -24,14 +24,7 @@
   <% } %>
   <div data-app="true"
     class="v-application hiddenable-widget transparent v-application--is-ltr theme--light"
-    id="SuggestionsPeopleAndSpace" flat="">
+    id="SuggestionsPeopleAndSpace" flat="" data-suggestion-type="<%=suggestionsType%>">
     <v-cacheable-dom-app cache-id="SuggestionsPeopleAndSpace_<%=suggestionsType%>"></v-cacheable-dom-app>
-    <script type="text/javascript" defer="defer">
-      eXo.env.portal.addOnLoadCallback(() =>
-        require(['PORTLET/social-portlet/SuggestionsPeopleAndSpace'],
-          app => app.init('<%=suggestionsType%>')
-        )
-      );
-    </script>
   </div>
 </div>

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/whoIsOnline.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/whoIsOnline.jsp
@@ -9,12 +9,5 @@
     class="v-application v-application--is-ltr hiddenable-widget theme--light"
     id="OnlinePortlet">
     <v-cacheable-dom-app cache-id="OnlinePortlet_<%=spaceId%>"></v-cacheable-dom-app>
-    <script>
-      eXo.env.portal.addOnLoadCallback(() => {
-        require([ 'PORTLET/social-portlet/WhoIsOnLinePortlet' ], function(whoIsOnlineApp) {
-          whoIsOnlineApp.init();
-        });
-      });
-    </script>
   </div>
 </div>

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -718,19 +718,7 @@
       <value>/html/topbarNotification.html</value>
     </init-param>
     <init-param>
-      <name>use-js-manager</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>js-manager-jsModule</name>
-      <value>PORTLET/social-portlet/TopBarNotification</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resource.bundles</name>
+      <name>preload.resource.bundles</name>
       <value>locale.portlet.Portlets</value>
     </init-param>
     <init-param>
@@ -936,8 +924,12 @@
       <value>/WEB-INF/jsp/suggestions.jsp</value>
     </init-param>
     <init-param>
-      <name>prefetch.resources</name>
+      <name>use-js-manager</name>
       <value>true</value>
+    </init-param>
+    <init-param>
+      <name>js-manager-javascript-content</name>
+      <value><![CDATA[SuggestionsPeopleAndSpace.init(document.querySelector('#SuggestionsPeopleAndSpace').getAttribute('data-suggestion-type'))]]></value>
     </init-param>
     <init-param>
       <name>prefetch.resource.bundles</name>
@@ -961,12 +953,8 @@
       <value>/WEB-INF/jsp/search.jsp</value>
     </init-param>
     <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resource.bundles</name>
-      <value>locale.portlet.Portlets,locale.commons.Commons,locale.portlet.social.PeopleListApplication,locale.portlet.social.SpacesListApplication</value>
+      <name>preload.resource.bundles</name>
+      <value>locale.portlet.Portlets</value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>

--- a/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -36,6 +36,7 @@
      eXo.env.portal.cometdContext = "<%=cometdContext%>";
      eXo.env.portal.vuetifyPreset = {
        dark: true,
+       silent: !eXo.developing,
        iconfont: 'mdi',
        rtl: eXo.env.portal.orientation === 'rtl',
      };

--- a/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPreloadHead.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPreloadHead.gtmpl
@@ -19,7 +19,7 @@
   def jsConfig = uicomponent.getJSConfig();
   def jsConfigPaths = jsConfig.get("paths");
 
-  def i18nPaths = new HashSet();
+  def searchConnectorsI18nPaths = new HashSet();
   def skinPaths = new HashSet();
   for (connector in connectors) {
     def skinConfig = null;
@@ -32,7 +32,7 @@
       }
     }
     if (connector.getI18nBundle() != null) {
-      i18nPaths.add(connector.getI18nBundle());
+      searchConnectorsI18nPaths.add(connector.getI18nBundle());
     }
   }
 
@@ -70,7 +70,14 @@
     language += "_" + country;
   }
 
-  i18nPaths.addAll(uicomponent.getPortletBundles());
-  for (i18nPath in i18nPaths) {%>
+  def i18NPaths = uicomponent.getPortletBundles();
+  for (i18nPath in uicomponent.getPortletBundles()) { %>
     <link rel="preload" href="<%="/portal/rest/i18n/bundle/" + i18nPath + "-" + language + ".json?v=" + ResourceRequestHandler.VERSION%>" as="fetch" crossorigin="anonymous">
-  <% } %>
+  <% }
+  for (i18nPath in searchConnectorsI18nPaths) {
+    if (!i18NPaths.contains(i18nPath)) { %>
+      <link rel="preload" href="<%="/portal/rest/i18n/bundle/" + i18nPath + "-" + language + ".json?v=" + ResourceRequestHandler.VERSION%>" as="fetch" crossorigin="anonymous">
+  <%
+     }
+    }
+  %>

--- a/webapp/portlet/src/main/webapp/html/topbarLogo.html
+++ b/webapp/portlet/src/main/webapp/html/topbarLogo.html
@@ -4,9 +4,7 @@
     id="TopBarLogo">
     <v-cacheable-dom-app cache-id="TopBarLogo"></v-cacheable-dom-app>
     <script type="text/javascript">
-      eXo.env.portal.addOnLoadCallback(() => {
-        require(['PORTLET/social-portlet/TopBarLogo'], app => app.init());
-      });
+      require(['PORTLET/social-portlet/TopBarLogo'], app => app.init());
     </script>
   </div>
 </div>

--- a/webapp/portlet/src/main/webapp/html/topbarNotification.html
+++ b/webapp/portlet/src/main/webapp/html/topbarNotification.html
@@ -2,11 +2,27 @@
   <div data-app="true"
     class="v-application v-application--is-ltr theme--light"
     id="NotificationPopoverPortlet">
-    <v-cacheable-dom-app cache-id="NotificationPopoverPortlet"></v-cacheable-dom-app>
+    <div class="v-application--wrap">
+      <div class="flex">
+        <div class="layout">
+          <button type="button"
+            disabled="disabled"
+            class="text-xs-center v-btn v-btn--flat v-btn--disabled v-btn--icon v-btn--round theme--light v-size--default">
+            <span class="v-btn__content"><span flat=""
+              class="v-badge v-badge--overlap theme--light"><i
+                aria-hidden="true"
+                class="v-icon notranslate grey-color mdi mdi-bell theme--light"
+                style="font-size: 21px;"></i><span
+                class="v-badge__wrapper"><span aria-atomic="true"
+                  aria-label="Badge" aria-live="polite" role="status"
+                  class="v-badge__badge"
+                  style="inset: auto auto calc(100% - 12px) calc(100% - 12px); background-color: var(- -allPagesBadgePrimaryColor, #ff5335); border-color: var(- -allPagesBadgePrimaryColor, #ff5335); display: none;"></span></span></span></span>
+          </button>
+        </div>
+      </div>
+    </div>
     <script type="text/javascript">
-      eXo.env.portal.addOnLoadCallback(() => {
-        require(['PORTLET/social-portlet/TopBarNotification'], app => app.init());
-      });
+      require(['PORTLET/social-portlet/TopBarNotification'], app => app.init());
     </script>
   </div>
 </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/main.js
@@ -1,16 +1,4 @@
 import './components/initComponents.js';
-import { getActivityComposerActionExtensions } from './extension.js';
-
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
-// getting language of the PLF
-const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
-
-const urls = [
-  `/portal/rest/i18n/bundle/locale.portlet.Portlets-${lang}.json`
-];
 
 // get overridden components if exists
 if (extensionRegistry) {
@@ -19,57 +7,5 @@ if (extensionRegistry) {
     components.forEach(cmp => {
       Vue.component(cmp.componentName, cmp.componentOptions);
     });
-  }
-}
-
-// getting locale resources
-export function init(params) {
-  if ($('.activityComposerApp').length && params && params.activityId) {
-    document.dispatchEvent(new CustomEvent('activity-composer-edit-activity', {detail: params}));
-  } else {
-    getActivityComposerActionExtensions().forEach(extension => {
-      if (extension.resourceBundle) {
-        urls.push(`/portal/rest/i18n/bundle/${extension.resourceBundle}-${lang}.json`);
-      }
-    });
-    params = params ? params : '';
-    exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
-      const appId = 'activityComposer';
-      let appElement = null;
-      let cacheAttribute = null;
-
-      if ($(`${appId}`).length) {
-        appElement = document.createElement('div');
-        appElement.id = appId;
-        const cacheId = `${appId}_${eXo.env.portal.spaceId}_${params && params.activityId || ''}`;
-        cacheAttribute = `v-cacheable="{cacheId: '${cacheId}'}"`;
-      } else {
-        $(`<div id="${appId}"></div>`).appendTo($('#UIPortalApplication'));
-        appElement = `#${appId}`;
-        cacheAttribute = '';
-      }
-
-      new Vue({
-        data: () => ({
-          composerAction: params && params.composerAction || 'post',
-          activityBody: params && params.activityBody || '',
-          activityId: params && params.activityId || '',
-          activityParams: params && params.activityParams || '',
-          standalone: !!(params && params.activityId),
-        }),
-        template: `<exo-activity-composer
-                     ${cacheAttribute}
-                     id="${appId}"
-                     :activityBody="activityBody"
-                     :activity-id="activityId"
-                     :composer-action="composerAction"
-                     :standalone="standalone">
-                   </exo-activity-composer>`,
-        i18n,
-        vuetify,
-      }).$mount(appElement);
-    });
-
-    window.activityComposerInitialized = true;
   }
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
@@ -23,7 +23,7 @@
             <img
               :src="seeMoreLikerToDisplay.avatar"
               :title="seeMoreLikerToDisplay.fullname"
-              :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}">
+              class="object-fit-cover">
             <span class="seeMoreLikersDetails">+{{ showMoreLikersNumber }}</span>
           </v-avatar>
         </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
@@ -1,12 +1,5 @@
 import './initComponents.js';
 
-// getting language of the PLF
-const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
-
-// should expose the locale ressources as REST API
-const url = `${Vue.prototype.$spacesConstants.PORTAL}/${Vue.prototype.$spacesConstants.PORTAL_REST}/i18n/bundle/locale.social.Webui-${lang}.json`;
-
-
 // get overrided components if exists
 if (extensionRegistry) {
   const components = extensionRegistry.loadComponents('ActivityReactions');
@@ -16,35 +9,3 @@ if (extensionRegistry) {
     });
   }
 }
-
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
-export function init(params) {
-  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    // init Vue app when locale ressources are ready
-    new Vue({
-      data: () => ({
-        activityId: params.activityId,
-        likers: params.likers,
-        likersNumber: params.likersNum,
-        commentNumber: params.commentNum
-      }),
-      template: `<activity-reactions-app
-                   id="activityReactions-${params.activityId}"
-                   :data-id="activityId"
-                   :activity-id="activityId"
-                   :likers="likers"
-                   :likers-number="likersNumber"
-                   :comment-number="commentNumber" />`,
-      i18n,
-      vuetify,
-    }).$mount(`#activityReactions-${params.activityId}`);
-  });
-  document.dispatchEvent(
-    new CustomEvent('display-activity-details', {detail: {
-      id: params.activityId,
-      type: 'ACTIVITY',
-    }}));
-}
-

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -22,8 +22,7 @@
             v-if="thumbnail"
             :src="thumbnail"
             :alt="title"
-            :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-            class="my-auto">
+            class="object-fit-cover my-auto">
           <v-icon
             v-else
             :size="defaultIconSize"
@@ -61,8 +60,7 @@
           v-if="thumbnail"
           :src="thumbnail"
           :alt="title"
-          :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-          class="my-auto">
+          class="object-fit-cover my-auto">
         <v-icon
           v-else
           :size="defaultIconSize"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
@@ -9,8 +9,7 @@
       class="ma-0">
       <img
         :src="avatarUrl"
-        :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-        class="my-auto">
+        class="object-fit-cover my-auto">
     </v-avatar>
     {{ displayName }}
   </a>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadUser.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadUser.vue
@@ -7,8 +7,7 @@
     <v-list-item-avatar :size="size" class="ma-0">
       <img
         :src="avatarUrl"
-        :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-        class="my-auto">
+        class="object-fit-cover my-auto">
     </v-list-item-avatar>
   </a>
   <a

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -135,6 +135,7 @@ export default {
     Promise.resolve(this.init())
       .finally(() => {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
+        this.$root.$applicationLoaded();
       });
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -4,8 +4,7 @@
       <v-list-item-avatar :size="avatarSize" class="mt-0 mb-auto me-2">
         <img
           :src="avatarUrl"
-          :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-          class="my-auto">
+          class="object-fit-cover my-auto">
       </v-list-item-avatar>
       <v-list-item-content class="flex px-0 py-0 mb-2 flex-shrink-1 border-box-sizing rich-editor-content">
         <exo-activity-rich-editor

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -105,13 +105,13 @@ extensionRegistry.registerExtension('activity', 'action', {
   },
   click: (activity, activityTypeExtension) => {
     const bodyToEdit = activityTypeExtension.getBodyToEdit && activityTypeExtension.getBodyToEdit(activity) || activityTypeExtension.getBody(activity);
-    activityComposer.init({
+    document.dispatchEvent(new CustomEvent('activity-composer-edit-activity', {detail: {
       activityId: activity.id,
       composerAction: 'update',
       ckEditorType: `editActivity${activity.id}`,
       activityBody: bodyToEdit,
       templateParams: activity.templateParams,
-    });
+    }}));
   },
 });
 

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
@@ -50,7 +50,7 @@ const urls = [
 
 export function init(initialData, initialLimit) {
   exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
-    new Vue({
+    Vue.createApp({
       data: {
         initialData,
         initialLimit,
@@ -59,6 +59,6 @@ export function init(initialData, initialLimit) {
       template: `<activity-stream id="${appId}" :initial-limit="initialLimit" :initial-data="initialData" />`,
       vuetify,
       i18n,
-    }).$mount(`#${appId}`);
+    }, `#${appId}`, 'Stream');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -111,9 +111,8 @@ export default {
     },
   },
   created() {
-    // Differ retrieving data from server
-    // eslint-disable-next-line no-magic-numbers
-    window.setTimeout(this.retrieveAdministrationMenu, 1000);
+    Promise.resolve(this.retrieveAdministrationMenu())
+      .finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     retrieveAdministrationMenu() {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
@@ -10,8 +10,7 @@
       <img
         :src="avatarUrl"
         :class="avatarClass"
-        :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-        class="ma-auto">
+        class="object-fit-cover ma-auto">
       <v-img
         :src="avatarUrl"
         :height="size"

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -10,8 +10,7 @@
         class="ma-0 pull-left">
         <img
           :src="avatarUrl"
-          :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-          class="ma-auto">
+          class="object-fit-cover ma-auto">
       </v-avatar>
       <div v-if="fullname || $slots.subTitle" class="pull-left ms-2 d-flex flex-column text-truncate">
         <p

--- a/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
@@ -48,6 +48,28 @@ for (const key in components) {
   Vue.component(key, components[key]);
 }
 
+Vue.prototype.$applicationLoaded = function() {
+  this.$root.$emit('application-loaded');
+  document.dispatchEvent(new CustomEvent('vue-app-loading-end', {detail: this.appName}));
+};
+
+Vue.createApp = function(params, el, appName) {
+  const element = typeof el === 'string' ? document.querySelector(el) : el;
+  if (element) {
+    if (!params.data) {
+      params.data = {};
+    }
+    params.data.appName = appName || element.id;
+    document.dispatchEvent(new CustomEvent('vue-app-loading-start', {detail: params.data.appName}));
+    const vueApp = new Vue(params);
+    vueApp.$mount(element);
+    return vueApp;
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(`Can't mount ${el} application because DOM element doesn't exist'`);
+  }
+};
+
 Vue.directive('cacheable', {
   bind(el, binding, vnode) {
     const appId = el.id;

--- a/webapp/portlet/src/main/webapp/vue-apps/company-branding-app/components/ExoCompanyBranding.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/company-branding-app/components/ExoCompanyBranding.vue
@@ -186,7 +186,8 @@ export default {
     }
   },
   created() {
-    this.initBrandingInformation();
+    this.initBrandingInformation()
+      .finally(() => this.$root.$applicationLoaded());
   },
   mounted() {
     // init top bar preview
@@ -287,9 +288,10 @@ export default {
       document.location.href = brandingConstants.PORTAL;
     },
     initBrandingInformation() {
-      brandingServices.getBrandingInformation().then(data => {
-        this.branding = data;
-      });
+      return brandingServices.getBrandingInformation()
+        .then(data => {
+          this.branding = data;
+        });
     },
     cleanMessage() {
       this.$el.querySelector('#savenotok').style.display = 'none';

--- a/webapp/portlet/src/main/webapp/vue-apps/company-branding-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/company-branding-app/main.js
@@ -27,11 +27,10 @@ if (extensionRegistry) {
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready
-    new Vue({
-      el: '#branding',
+    Vue.createApp({
       template: '<exo-company-branding id="branding"></exo-company-branding>',
       i18n,
       vuetify,
-    });
+    }, '#branding', 'Branding Administration');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/dlp-quarantine/components/DlpQuarantineApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/dlp-quarantine/components/DlpQuarantineApp.vue
@@ -171,8 +171,10 @@ export default {
     },
   },
   created() {
-    this.getDlpFeatureStatus();
-    this.retrieveDlpPositiveItems();
+    const dlpFeatureStatusPromise = this.getDlpFeatureStatus();
+    const dlpPositiveItemsPromise = this.retrieveDlpPositiveItems();
+    Promise.all([dlpFeatureStatusPromise, dlpPositiveItemsPromise])
+      .finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     saveDlpFeatureStatus(status) {
@@ -207,7 +209,7 @@ export default {
       this.selectedDeleteItem = itemId;
     },
     getDlpFeatureStatus() {
-      this.$featureService.isFeatureEnabled(this.featureName).then(status => {
+      return this.$featureService.isFeatureEnabled(this.featureName).then(status => {
         this.dlpFeatureEnabled = status;
         this.dlpFeatureStatusLoaded = true;
       });
@@ -248,7 +250,7 @@ export default {
       }
       const offset = (page - 1) * itemsPerPage;
       this.loading = true;
-      dlpAdministrationServices.getDlpPositiveItems(offset , itemsPerPage).then(data => {
+      return dlpAdministrationServices.getDlpPositiveItems(offset , itemsPerPage).then(data => {
         this.items = data.entities;
         this.totalSize = data.size;
       }).then(() =>{

--- a/webapp/portlet/src/main/webapp/vue-apps/dlp-quarantine/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/dlp-quarantine/main.js
@@ -29,13 +29,13 @@ export function init() {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<dlp-quarantine-app v-cacheable id="${appId}" />`,
       vuetify,
       i18n
-    }).$mount(appElement);
+    }, appElement, 'DLP Quarantine');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -56,7 +56,7 @@ export default {
     externalSpacesListService.getExternalSpacesRequests().then(
       (data) => {
         this.spacesRequestsSize = data.spacesMemberships.length;
-      }).then(() => this.$root.$emit('application-loaded'));
+      }).finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     getExternalSpacesList() {

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/main.js
@@ -32,13 +32,13 @@ export function init() {
       appElement.id = appId;
 
       // init Vue app when locale ressources are ready
-      new Vue({
+      Vue.createApp({
         mounted() {
           document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
         },
         template: `<external-spaces-list id="${appId}" v-cacheable />`,
         i18n,
         vuetify,
-      }).$mount(appElement);
+      }, appElement, 'External Spaces List');
     });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/getting-started/components/ExoGettingStarted.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/getting-started/components/ExoGettingStarted.vue
@@ -75,21 +75,16 @@ export default {
     }
   },
   created() {
-    this.initGettingStarted();
+    this.initGettingStarted()
+      .finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     initGettingStarted() {
-      gettingStartedService.getGettingStartedSteps()
-        .then(data => {
-          this.steps = data || [];
-          return this.$nextTick();
-        })
-        .then(() => {
-          this.$root.$emit('application-loaded');
-        });
+      return gettingStartedService.getGettingStartedSteps()
+        .then(data => this.steps = data || []);
     },
     hideGettingStarted(){
-      gettingStartedService.hideGettingStarted()
+      return gettingStartedService.hideGettingStarted()
         .then(() => {
           this.clearCache();
           this.steps = [];

--- a/webapp/portlet/src/main/webapp/vue-apps/getting-started/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/getting-started/main.js
@@ -27,10 +27,10 @@ export function init() {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       template: `<exo-getting-started v-cacheable id="${appId}"></exo-getting-started>`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Getting Started');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
@@ -100,6 +100,8 @@ export default {
       const contentsToLoad = this.contents.filter(contentDetail => !contentDetail.loaded);
       this.initializing = contentsToLoad.length;
       const vuetify = this.vuetify;
+      let contentsToLoadLength = contentsToLoad.length;
+      const self = this;
       contentsToLoad.forEach(contentDetail => {
         if (!contentDetail.loaded) {
           window.setTimeout(() => {
@@ -113,6 +115,14 @@ export default {
                       messages: this.$i18n.messages,
                     }),
                     vuetify,
+                    methods: {
+                      $applicationLoaded() {
+                        contentsToLoadLength--;
+                        if (!contentsToLoadLength) {
+                          self.$root.$applicationLoaded();
+                        }
+                      },
+                    },
                     el: `#${contentDetail.id}`,
                   });
                   this.vueChildInstances[contentDetail.id].$on('open-second-level', () => {

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/main.js
@@ -24,13 +24,13 @@ export function init() {
   exoi18n.loadLanguageAsync(lang, url)
     .then(i18n => {
       // init Vue app when locale ressources are ready
-      new Vue({
+      Vue.createApp({
         mounted() {
           document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
         },
         template: '<exo-hamburger-menu-navigation></exo-hamburger-menu-navigation>',
         i18n,
         vuetify,
-      }).$mount('#HamburgerNavigationMenu');
+      }, '#HamburgerNavigationMenu', 'Hamburger Menu');
     });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/components/GroupsManagementTree.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/components/GroupsManagementTree.vue
@@ -52,7 +52,8 @@ export default {
     this.$root.$on('retrieveGroupChildren', this.retrieveGroupTree);
     this.$root.$on('searchGroup', keyword => this.keyword = keyword);
 
-    this.retrieveGroupTree().finally(() => this.$root.$emit('application-loaded'));
+    this.retrieveGroupTree()
+      .finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     updateGroupItem(group, groups) {

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/main.js
@@ -29,13 +29,13 @@ export function init() {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<groups-management v-cacheable id="${appId}" />`,
       vuetify,
       i18n,
-    }).$mount(appElement);
+    }, appElement, 'Group Management');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/components/MembershipTypesManagementList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/components/MembershipTypesManagementList.vue
@@ -132,7 +132,8 @@ export default {
     this.$root.$on('searchMembershipType', this.updateSearchTerms);
     this.$root.$on('refreshMembershipTypes', this.searchMembershipTypes);
 
-    this.searchMembershipTypes().finally(() => this.$root.$emit('application-loaded'));
+    this.searchMembershipTypes()
+      .finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     updateSearchTerms(keyword) {

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/main.js
@@ -29,13 +29,13 @@ export function init() {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<membership-types-management v-cacheable id="${appId}" />`,
       vuetify,
       i18n
-    }).$mount(appElement);
+    }, appElement, 'Membership Type Management');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
@@ -358,7 +358,7 @@ export default {
           }
         }).finally(() => {
           if (!this.initialized) {
-            this.$root.$emit('application-loaded');
+            this.$root.$applicationLoaded();
           }
           this.searchUsers();
           this.loading = false;
@@ -480,7 +480,7 @@ export default {
       })
         .finally(() => {
           if (!this.initialized) {
-            this.$root.$emit('application-loaded');
+            this.$root.$applicationLoaded();
           }
           this.loading = false;
           this.initialized = true;
@@ -535,7 +535,7 @@ export default {
         }
       })        .finally(() => {
         if (!this.initialized) {
-          this.$root.$emit('application-loaded');
+          this.$root.$applicationLoaded();
         }
         this.searchUsers();
         this.loading = false;
@@ -558,7 +558,7 @@ export default {
         }
       }).finally(() => {
         if (!this.initialized) {
-          this.$root.$emit('application-loaded');
+          this.$root.$applicationLoaded();
         }
         this.searchUsers();
         this.loading = false;

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/main.js
@@ -29,13 +29,13 @@ export function init() {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<users-management v-cacheable id="${appId}" />`,
       vuetify,
       i18n
-    }).$mount(appElement);
+    }, appElement, 'Users Management');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/mfa-access/components/MfaAccess.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/mfa-access/components/MfaAccess.vue
@@ -21,7 +21,7 @@ export default {
     getSettings().then(settings => {
       this.extension = extensionRegistry.loadExtensions('mfa-extension', 'mfa-extension')
         .find(plugin => plugin.id === settings.mfaSystem);
-    });
+    }).finally(() => this.$root.$applicationLoaded());
   },
 };
 

--- a/webapp/portlet/src/main/webapp/vue-apps/mfa-access/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/mfa-access/main.js
@@ -29,13 +29,13 @@ export function init() {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<mfa-access v-cacheable id="${appId}" />`,
       vuetify,
       i18n
-    }).$mount(appElement);
+    }, appElement, 'MFA Access');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/multi-factor-authentication/components/MultifactorAuthenticationComponent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/multi-factor-authentication/components/MultifactorAuthenticationComponent.vue
@@ -255,11 +255,13 @@ export default {
       this.displayMessage(message);
     });
     this.$root.$on('protectedGroupsList', this.protectedGroupsList);
-    this.getRevocationRequest();
-    this.getMfaFeatureStatus();
-    this.getCurrentMfaSystem();
-    this.getAvailableMfaSystems();
-    this.getProtectedGroups();
+    Promise.all([
+      this.getRevocationRequest(),
+      this.getMfaFeatureStatus(),
+      this.getCurrentMfaSystem(),
+      this.getAvailableMfaSystems(),
+      this.getProtectedGroups()
+    ]).finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     switchAuthenticationStatus() {
@@ -270,12 +272,12 @@ export default {
       this.selectedGroups = selectedGroups;
     },
     getMfaFeatureStatus() {
-      this.$featureService.isFeatureEnabled('mfa').then(status => {
+      return this.$featureService.isFeatureEnabled('mfa').then(status => {
         this.isMultifacorAuthenticationEnabled = status;
       });
     },
     getProtectedGroups() {
-      getProtectedGroups().then(data => {
+      return getProtectedGroups().then(data => {
         for (const group of data.protectedGroups) {
           this.selectedGroups.push(group);
         }
@@ -287,21 +289,21 @@ export default {
       });
     },
     getCurrentMfaSystem() {
-      getCurrentMfaSystem().then(settings => {
+      return getCurrentMfaSystem().then(settings => {
         this.currentMfaSystem=settings.mfaSystem;
         this.currentMfaSystemHelpTitle=settings.helpTitle;
         this.currentMfaSystemHelpContent=settings.helpContent;
       });
     },
     getAvailableMfaSystems() {
-      getAvailableMfaSystem().then(data => {
+      return getAvailableMfaSystem().then(data => {
         for (const system of data.available) {
           this.items.push(system);
         }
       });
     },
     getRevocationRequest() {
-      getRevocationRequests().then(revocationRequests => {
+      return getRevocationRequests().then(revocationRequests => {
         const promiseArray = [];
         for (const [index, revocationRequest] of revocationRequests.requests.entries()) {
           const userPromise = this.$userService.getUser(revocationRequest.username).then(user => {

--- a/webapp/portlet/src/main/webapp/vue-apps/multi-factor-authentication/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/multi-factor-authentication/main.js
@@ -29,13 +29,13 @@ export function init() {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<multifactor-authentication-app v-cacheable id="${appId}" />`,
       vuetify,
       i18n
-    }).$mount(appElement);
+    }, appElement, 'MFA');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/ExoTopBarNotification.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/ExoTopBarNotification.vue
@@ -103,12 +103,12 @@ export default {
     },
   },
   created() {
-    this.getNotifications();
     notificationlAPI.initCometd();
     document.addEventListener('cometdNotifEvent', this.notificationUpdated);
+    eXo.env.portal.addOnLoadCallback(() => this.getNotifications());
   },
   mounted() {
-    this.$root.$emit('application-loaded');
+    this.$root.$applicationLoaded();
   },
   methods: {
     getNotifications() {

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/main.js
@@ -23,14 +23,11 @@ const appId = 'NotificationPopoverPortlet';
 //getting locale ressources
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    const appElement = document.createElement('div');
-    appElement.id = appId;
-
     // init Vue app when locale ressources are ready
-    new Vue({
-      template: `<exo-top-bar-notification v-cacheable id="${appId}"></exo-top-bar-notification>`,
+    Vue.createApp({
+      template: `<exo-top-bar-notification id="${appId}"></exo-top-bar-notification>`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, `#${appId}`, 'Topbar Notifications');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -197,7 +197,7 @@ export default {
         })
         .finally(() => {
           if (!this.initialized) {
-            this.$root.$emit('application-loaded');
+            this.$root.$applicationLoaded();
           }
           this.loadingPeople = false;
           this.initialized = true;

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/main.js
@@ -17,13 +17,13 @@ export function init(filter) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<people-list v-cacheable id="${appId}" filter="${filter || 'all'}"></people-list>`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'People List');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverview.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverview.vue
@@ -31,7 +31,7 @@ export default {
   watch: {
     initialized(newVal, oldVal) {
       if (newVal !== oldVal && newVal) {
-        this.$root.$emit('application-loaded');
+        this.$root.$applicationLoaded();
       }
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/people-overview/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-overview/main.js
@@ -27,10 +27,10 @@ export function init() {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       template: `<people-overview v-cacheable id="${appId}" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'People Overview');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
@@ -85,7 +85,8 @@ export default {
   },
   created() {
     this.$userService.getUser(eXo.env.portal.profileOwner)
-      .then(user => this.refresh(user && user.aboutMe || ''));
+      .then(user => this.refresh(user && user.aboutMe || ''))
+      .finally(() => this.$root.$applicationLoaded());
   },
   mounted() {
     if (this.aboutMe) {
@@ -98,7 +99,7 @@ export default {
       if (this.$refs.aboutMeDrawer) {
         this.$refs.aboutMeDrawer.close();
       }
-      this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+      return this.$nextTick().then(() => this.$root.$emit('application-loaded'));
     },
     editAboutMe() {
       this.modifyingAboutMe = this.aboutMe;

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/main.js
@@ -29,16 +29,16 @@ export function init(aboutMe) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
-      data: () => ({
+    Vue.createApp({
+      data: {
         aboutMe: aboutMe,
-      }),
+      },
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<profile-about-me v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :about-me="aboutMe" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Profile About Me');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -164,7 +164,8 @@ export default {
   }),
   created() {
     return this.$userService.getUser(eXo.env.portal.profileOwner, 'all')
-      .then(user => this.refresh(user));
+      .then(user => this.refresh(user))
+      .finally(() => this.$root.$applicationLoaded());
   },
   mounted() {
     document.addEventListener('userModified', event => {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/main.js
@@ -30,13 +30,13 @@ export function init(uploadLimit) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<profile-contact-information v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :upload-limit="${uploadLimit}" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Profile Contact Information');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -109,9 +109,7 @@ export default {
         .catch((e) => {
           console.warn('Error while retrieving user details', e); // eslint-disable-line no-console
         })
-        .finally(() => {
-          this.$nextTick().then(() => this.$root.$emit('application-loaded'));
-        });
+        .finally(() => this.$nextTick().then(() => this.$root.$applicationLoaded()));
     },
     handleError(error) {
       if (error) {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/main.js
@@ -30,13 +30,13 @@ export function init(maxUploadSize) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<profile-header v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" max-upload-size="${maxUploadSize}" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Profile Header');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-navigation/components/ExoProfileHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-navigation/components/ExoProfileHamburgerNavigation.vue
@@ -45,14 +45,16 @@ export default {
         Object.assign(this.profile, event.detail);
       }
     });
-    this.profile = this.$currentUserIdentity && this.$currentUserIdentity.profile;
-    if (!this.profile) {
-      this.retrieveUserInformation();
-    }
+    Promise.resolve(this.retrieveUserInformation())
+      .finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     retrieveUserInformation() {
-      this.$identityService.getIdentityById(eXo.env.portal.userIdentityId).then(data => this.profile = data && data.profile);
+      this.profile = this.$currentUserIdentity && this.$currentUserIdentity.profile;
+      if (!this.profile) {
+        return this.$identityService.getIdentityById(eXo.env.portal.userIdentityId)
+          .then(data => this.profile = data && data.profile);
+      }
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperiences.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperiences.vue
@@ -59,7 +59,8 @@ export default {
     },
   },
   created() {
-    this.refresh();
+    this.refresh()
+      .finally(() => this.$root.$applicationLoaded());
   },
   mounted() {
     if (this.experiences) {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/main.js
@@ -30,13 +30,13 @@ export function init() {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<profile-work-experiences v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Profile Work Experience');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchApplication.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchApplication.vue
@@ -104,6 +104,9 @@ export default {
       });
     }
   },
+  mounted() {
+    this.$root.$applicationLoaded();
+  },
   methods: {
     changeURI() {
       const term = window.encodeURIComponent(this.term || '');

--- a/webapp/portlet/src/main/webapp/vue-apps/search/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/initComponents.js
@@ -16,9 +16,9 @@ for (const key in components) {
 
 // get overrided components if exists
 if (extensionRegistry) {
-  const components = extensionRegistry.loadComponents('SearchApplication');
-  if (components && components.length > 0) {
-    components.forEach(cmp => {
+  const overrideComponents = extensionRegistry.loadComponents('SearchApplication');
+  if (overrideComponents && overrideComponents.length) {
+    overrideComponents.forEach(cmp => {
       Vue.component(cmp.componentName, cmp.componentOptions);
     });
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/search/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/main.js
@@ -4,6 +4,7 @@ Vue.use(Vuetify);
 const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
 const appId = 'SearchApplication';
+const appName = 'Search';
 
 //getting language of the PLF 
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
@@ -12,6 +13,7 @@ const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 const urls = [`${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Portlets-${lang}.json`];
 
 export function init(connectors) {
+  document.dispatchEvent(new CustomEvent('vue-app-loading-start', {detail: appName}));
   if (connectors && connectors.length) {
     connectors.forEach(connector => {
       if (connector.i18nBundle) {
@@ -20,17 +22,16 @@ export function init(connectors) {
     });
   }
 
-  exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
-    const appElement = document.createElement('div');
-    appElement.id = appId;
-
-    new Vue({
-      data: () => ({
-        connectors: connectors,
-      }),
-      template: `<search-application v-cacheable id="${appId}" :connectors="connectors" />`,
-      vuetify,
-      i18n
-    }).$mount(appElement);
-  });
+  exoi18n.loadLanguageAsync(lang, urls, 'defer')
+    .then(i18n => {
+  
+      Vue.createApp({
+        data: {
+          connectors: connectors,
+        },
+        template: `<search-application id="${appId}" :connectors="connectors" />`,
+        vuetify,
+        i18n
+      }, `#${appId}`, appName);
+    });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/site-navigation/components/ExoSiteHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/site-navigation/components/ExoSiteHamburgerNavigation.vue
@@ -92,7 +92,8 @@ export default {
         if (this.navigations && this.navigations.length && !this.homeLink) {
           this.homeLink = `${this.BASE_SITE_URI}${this.navigations[0].uri}`;
         }
-      });
+      })
+      .finally(() => this.$root.$applicationLoaded());
     document.addEventListener('homeLinkUpdated', () => {
       this.homeLink = eXo.env.portal.homeLink;
     });

--- a/webapp/portlet/src/main/webapp/vue-apps/space-header/components/SpaceHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-header/components/SpaceHeader.vue
@@ -121,7 +121,7 @@ export default {
     });
   },
   mounted() {
-    this.$root.$emit('application-loaded');
+    this.$root.$applicationLoaded();
   },
   methods: {
     refresh() {

--- a/webapp/portlet/src/main/webapp/vue-apps/space-header/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-header/main.js
@@ -29,18 +29,18 @@ export function init(settings, bannerUrl, maxUploadSize, isAdmin) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
-      data: () => ({
+    Vue.createApp({
+      data: {
         navigations: settings && settings.navigations,
         selectedNavigationUri: settings && settings.selectedNavigationUri,
         bannerUrl: bannerUrl,
-      }),
+      },
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<space-header v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :navigations="navigations" :selected-navigation-uri="selectedNavigationUri" :banner-url="bannerUrl" :max-upload-size="${maxUploadSize}" :admin="${isAdmin}" />`,
       vuetify,
       i18n,
-    }).$mount(appElement);
+    }, appElement, 'Space Header');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -13,9 +13,8 @@
             <v-avatar :size="30">
               <img
                 :src="manager.avatar"
-                :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
                 alt="avatar"
-                class="ma-auto">
+                class="object-fit-cover ma-auto">
             </v-avatar>
             {{ manager.fullname }}
           </a>
@@ -35,7 +34,8 @@ export default {
     };
   },
   created() {
-    this.init(eXo.env.portal.spaceId);
+    Promise.resolve(this.init(eXo.env.portal.spaceId))
+      .finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     init(spaceId) {

--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/main.js
@@ -28,10 +28,10 @@ export function init() {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       template: `<exo-space-infos v-cacheable="{cacheId: '${cacheId}'}" id="${appId}"></exo-space-infos>`,
       vuetify,
       i18n,
-    }).$mount(appElement);
+    }, appElement, 'Space Info');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
@@ -57,9 +57,11 @@ export default {
     space: {}
   }),
   created() {
-    this.$spaceService.getSpaceById(eXo.env.portal.spaceId).then( space => {
-      this.space = space;
-    });
+    this.$spaceService.getSpaceById(eXo.env.portal.spaceId)
+      .then( space => {
+        this.space = space;
+      })
+      .finally(() => this.$root.$applicationLoaded());
     if (this.isManager) {
       extensionRegistry.registerExtension('space-member-extension', 'action', {
         id: 'spaceMembers-removeMember',

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/main.js
@@ -30,7 +30,7 @@ export function init(filter, isManager, isExternalFeatureEnabled) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
@@ -44,6 +44,6 @@ export function init(filter, isManager, isExternalFeatureEnabled) {
                   class="singlePageApplication" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Space Members');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
@@ -94,7 +94,7 @@ export default {
     });
   },
   mounted() {
-    this.$root.$emit('application-loaded');
+    this.$root.$applicationLoaded();
     this.computedSiteBodyMargin();
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/main.js
@@ -23,14 +23,14 @@ export function init(settings) {
   const appElement = document.createElement('div');
   appElement.id = appId;
 
-  new Vue({
-    data: () => ({
+  Vue.createApp({
+    data: {
       navigations: settings && settings.navigations,
       selectedNavigationUri: settings && settings.selectedNavigationUri,
-    }),
+    },
     template: `<space-menu v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :navigations="navigations" :selected-navigation-uri="selectedNavigationUri" />`,
     vuetify,
-  }).$mount(appElement);
+  }, appElement, 'Space Menu');
 
   const actionsElement = document.createElement('div');
   actionsElement.id = appIdAction;

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
@@ -30,7 +30,7 @@ export default {
     document.addEventListener('showSettingsApps', () => this.displaySpaceExternalSettings = true);
   },
   mounted() {
-    this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+    this.$nextTick().then(() => this.$root.$applicationLoaded());
   },
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/main.js
@@ -30,7 +30,7 @@ export function init(maxUploadSize) {
     
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
@@ -41,6 +41,6 @@ export function init(maxUploadSize) {
                   class="singlePageApplication" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Space Settings');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
@@ -261,12 +261,12 @@ export default {
     },
   },
   created() {
-    this.initSpaces();
+    this.initSpaces()
+      .finally(() => this.$root.$applicationLoaded());
   },
-
   methods: {
     initSpaces() {
-      spacesAdministrationServices.getSpaces().then(data =>{
+      return spacesAdministrationServices.getSpaces().then(data =>{
         this.spaces = data.spaces;
         this.totalPages = Math.ceil(data.size / this.$spacesConstants.SPACES_PER_PAGE);
       });

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationSpaces.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationSpaces.vue
@@ -98,12 +98,12 @@ export default {
     }
   },
   created() {
-    spacesAdministrationServices.getUserPermissions(eXo.env.portal.userName).then(data => {
-      if (data && data.platformAdministrator) {
-        this.canChangePermissions = data.platformAdministrator;
-        this.$nextTick().then(() => this.$root.$emit('application-loaded'));
-      }
-    });
+    spacesAdministrationServices.getUserPermissions(eXo.env.portal.userName)
+      .then(data => {
+        if (data && data.platformAdministrator) {
+          this.canChangePermissions = data.platformAdministrator;
+        }
+      });
   },
   mounted() {
     const windowLocationHash = window.location.hash;

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
@@ -31,13 +31,13 @@ export function init(applicationsByCategory) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
-      data: () => ({
+    Vue.createApp({
+      data: {
         applicationsByCategory: applicationsByCategory,
-      }),
+      },
       template: `<exo-spaces-administration-spaces v-cacheable id="${appId}" :applications-by-category="applicationsByCategory"></exo-spaces-administration-spaces>`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Spaces Administration');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesList.vue
@@ -47,7 +47,7 @@ export default {
     spacesLoaded(spacesSize) {
       this.spacesSize = spacesSize;
       if (!this.initialized) {
-        this.$root.$emit('application-loaded');
+        this.$root.$applicationLoaded();
         this.initialized = true;
       }
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/main.js
@@ -18,13 +18,13 @@ export function init(filter, canCreateSpace) {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<exo-spaces-list v-cacheable id="${appId}" filter="${filter || 'all'}" :can-create-space="${canCreateSpace}"></exo-spaces-list>`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Spaces List');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
@@ -78,6 +78,7 @@ export default {
     endTypingKeywordTimeout: 50,
     startTypingKeywordTimeout: 0,
     spaces: [],
+    initialized: false,
     loadingSpaces: false,
     limitToFetch: 0,
     originalLimitToFetch: 0,
@@ -116,7 +117,13 @@ export default {
       });
     },
     limitToFetch() {
-      this.searchSpaces();
+      this.searchSpaces()
+        .finally(() => {
+          if (!this.initialized) {
+            this.initialized = true;
+            this.$root.$applicationLoaded();
+          }
+        });
     },
   }, 
   created() {
@@ -124,7 +131,7 @@ export default {
   },
   methods: {
     searchSpaces() {
-      fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/${eXo.env.portal.containerName}/social/spaces/lastVisitedSpace/list.json?offset=${this.offset}&limit=${this.limitToFetch}`, {
+      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/${eXo.env.portal.containerName}/social/spaces/lastVisitedSpace/list.json?offset=${this.offset}&limit=${this.limitToFetch}`, {
         method: 'GET',
         credentials: 'include',
       })

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/components/SpacesOverview.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/components/SpacesOverview.vue
@@ -49,7 +49,7 @@ export default {
   watch: {
     loading(newVal, oldVal) {
       if (oldVal && !newVal) {
-        this.$root.$emit('application-loaded');
+        this.$root.$applicationLoaded();
       }
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/main.js
@@ -28,10 +28,10 @@ export function init() {
     appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+    Vue.createApp({
       template: `<spaces-overview v-cacheable id="${appId}" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'Spaces Overview');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleAndSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleAndSpace.vue
@@ -78,7 +78,7 @@ export default {
   watch: {
     loading(newVal, oldVal) {
       if (newVal !== oldVal && !newVal) {
-        this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+        this.$nextTick().then(() => this.$root.$applicationLoaded());
       }
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/main.js
@@ -29,10 +29,10 @@ export function init(suggestionsType) {
 
     const cacheId = `${appId}_${suggestionsType || ''}`;
 
-    new Vue({
+    Vue.createApp({
       template: `<exo-suggestions-people-and-space v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" suggestionsType="${suggestionsType || 'all'}"></exo-suggestions-people-and-space>`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, `Suggestions ${suggestionsType}`);
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-navigation/components/ExoUserHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-navigation/components/ExoUserHamburgerNavigation.vue
@@ -24,6 +24,9 @@ export default {
   data: () => ({
     settingsUrl: `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings`,
   }),
+  mounted() {
+    this.$root.$applicationLoaded();
+  },
   methods: {
     logOut() {
       eXo.portal.logout();

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
@@ -58,7 +58,9 @@ export default {
       }
     });
     document.addEventListener('showSettingsApps', () => this.displayed = true);
-    this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+  },
+  mounted() {
+    this.$nextTick().then(() => this.$root.$applicationLoaded());
   },
   methods: {
     openDrawer() {

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/main.js
@@ -29,16 +29,16 @@ export function init(languages) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
-      data: () => ({
+    Vue.createApp({
+      data: {
         languages: languages,
-      }),
+      },
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<user-setting-language v-cacheable id="${appId}" :languages="languages" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'User Setting Language');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-mobile/components/MobileSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-mobile/components/MobileSettings.vue
@@ -56,7 +56,9 @@ export default {
       }
     });
     document.addEventListener('showSettingsApps', () => this.displayed = true);
-    this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+  },
+  mounted() {
+    this.$nextTick().then(() => this.$root.$applicationLoaded());
   },
   methods: {
     openDetail() {

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-mobile/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-mobile/main.js
@@ -29,13 +29,13 @@ export function init() {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<mobile-settings id="${appId}" v-cacheable />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'User Settings Mobile');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotifications.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotifications.vue
@@ -77,7 +77,7 @@ export default {
           return this.$nextTick();
         })
         .finally(() => {
-          this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+          this.$nextTick().then(() => this.$root.$applicationLoaded());
         });
     },
     openDetail() {

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/main.js
@@ -32,16 +32,16 @@ export function init(settings) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
-      data: () => ({
+    Vue.createApp({
+      data: {
         settings: settings,
-      }),
+      },
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<user-setting-notifications v-cacheable id="${appId}" :languages="settings && settings.languages" :timezones="settings && settings.timezones" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'User Settings Notifications');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
@@ -63,7 +63,7 @@ export default {
     document.addEventListener('showSettingsApps', () => this.displayed = true);
   },
   mounted() {
-    this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+    this.$nextTick().then(() => this.$root.$applicationLoaded());
   },
   methods: {
     openSecurityDetail() {

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/main.js
@@ -28,13 +28,13 @@ export function init() {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<user-setting-security id="${appId}" v-cacheable />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'User Settings Security');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-timezone/components/UserSettingTimezone.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-timezone/components/UserSettingTimezone.vue
@@ -58,7 +58,7 @@ export default {
       }
     });
     document.addEventListener('showSettingsApps', () => this.displayed = true);
-    this.$nextTick().then(() => this.$root.$emit('application-loaded'));
+    this.$nextTick().then(() => this.$root.$applicationLoaded());
   },
   methods: {
     openDrawer() {

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-timezone/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-timezone/main.js
@@ -29,16 +29,16 @@ export function init(timezones) {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
-      data: () => ({
+    Vue.createApp({
+      data: {
         timezones: timezones,
-      }),
+      },
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<user-setting-timezone v-cacheable id="${appId}" :timezones="timezones" />`,
       i18n,
       vuetify,
-    }).$mount(appElement);
+    }, appElement, 'User Settings TimeZone');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
@@ -56,7 +56,7 @@ export default {
   },
   methods: {
     initOnlineUsers() {
-      whoIsOnlineServices.getOnlineUsers(eXo.env.portal.spaceId)
+      return whoIsOnlineServices.getOnlineUsers(eXo.env.portal.spaceId)
         .then(response => {
           if (response) {
             const users = response.users || [];
@@ -70,8 +70,9 @@ export default {
           } else {
             this.users = [];
           }
-          window.setTimeout(() => this.$root.$emit('application-loaded'), 200);
-        });
+          return this.$nextTick();
+        })
+        .finally(() => this.$root.$applicationLoaded());
     },
     initPopup() {
       const restUrl = `//${this.$spacesConstants.HOST_NAME}${this.$spacesConstants.PORTAL}/${this.$spacesConstants.PORTAL_REST}/social/people/getPeopleInfo/{0}.json`;

--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/main.js
@@ -28,10 +28,10 @@ export function init() {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
-    new Vue({
+    Vue.createApp({
       template: `<exo-who-is-online v-cacheable="{cacheId: '${cacheId}'}" id="${appId}"></exo-who-is-online>`,
       i18n,
       vuetify
-    }).$mount(appElement);
+    }, appElement, 'Who is Online');
   });
 }


### PR DESCRIPTION
Prior to this change, we didn't have a way to intercept globally Vue applications lifecycle Management. Some methods are added in Vue prototype to allow trigger events when the applications starts and completely (including fetch of Data) finishes.
In addition, some structure modification has been added to TopBar Buttons to not use the same lifecycle as Widgets.