### PR TITLE
TASK-47663 Fix refreshing Replies Count in Comments Drawer

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityComments.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityComments.vue
@@ -176,6 +176,7 @@ export default {
             const commentToUpdate = this.comments[commentToUpdateIndex];
             if (!commentToUpdate.subComments.find(tmp => tmp.id === comment.id)) {
               commentToUpdate.subComments.push(comment);
+              commentToUpdate.subCommentsSize++;
             }
             this.$emit('comment-updated', commentToUpdate, commentToUpdateIndex);
           } else {


### PR DESCRIPTION
Prior to this change, the replies count aren't updated on drawer (in comments preview, it works). In addition, the highlight of a newly added comment wasn't made and the edit reply/comment option doesn't work when having more than one page of comments displayed in Drawer. This fix will ensure to refresh subCommentsSize property when a comment reply is added (in contrary to comments preview, the drawer doesn't retrieve again the comments from backend, thus we will have to manually increment the number of replies)