### PR TITLE
Task-44094 : User Type on UserManegement search is not updated when a…

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/ExternalUsersListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/ExternalUsersListenerImpl.java
@@ -1,0 +1,59 @@
+package org.exoplatform.social.core.listeners;
+
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.MembershipEventListener;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.webui.exception.MessageException;
+
+public class ExternalUsersListenerImpl extends MembershipEventListener {
+  private static final Log LOG = ExoLogger.getLogger(ExternalUsersListenerImpl.class);
+
+  private static final String PLATFORM_EXTERNALS_GROUP  = "/platform/externals";
+
+  private IdentityManager identityManager;
+
+  @Override
+  public void postSave(Membership m, boolean isNew) {
+    if (m.getGroupId().equals(PLATFORM_EXTERNALS_GROUP)) {
+      Identity userIdentity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, m.getUserName());
+      Profile profile = userIdentity.getProfile();
+      if (profile != null) {
+        profile.setProperty(Profile.EXTERNAL, String.valueOf(true));
+        try {
+          getIdentityManager().updateProfile(profile, true);
+        } catch (MessageException e) {
+          LOG.error("Error while saving the external property for user profile {}", m.getUserName(), e);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void postDelete(Membership m) {
+    if (m.getGroupId().equals(PLATFORM_EXTERNALS_GROUP)) {
+      Identity userIdentity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, m.getUserName());
+      Profile profile = userIdentity.getProfile();
+      if (profile != null) {
+        profile.setProperty(Profile.EXTERNAL, String.valueOf(false));
+        try {
+          getIdentityManager().updateProfile(profile, true);
+        } catch (MessageException e) {
+          LOG.error("Error while saving the external property for user profile {}", m.getUserName(), e);
+        }
+      }
+    }
+  }
+
+  private IdentityManager getIdentityManager() {
+    if (identityManager == null) {
+      identityManager = CommonsUtils.getService(IdentityManager.class);
+    }
+    return identityManager;
+  }
+}

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
@@ -78,17 +78,6 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
 
         SpaceUtils.refreshNavigation();
       }
-    } 
-    //only trigger when the Organization service removes membership from Externals group
-    else if (m.getGroupId().equals(PLATFORM_EXTERNALS_GROUP)) {
-      // Set "external" social profile property to "false"
-      IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-      Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, m.getUserName());
-      Profile profile = identity.getProfile();
-      if (profile != null) {
-        profile.setProperty(Profile.EXTERNAL, "false");
-        identityManager.updateProfile(profile, true);
-      }
     }
     else if (m.getGroupId().startsWith(SpaceUtils.PLATFORM_USERS_GROUP)) {
       clearIdentityCaching();
@@ -138,14 +127,6 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
     }
     //only trigger when the Organization service adds new membership to Externals group
     else if (m.getGroupId().equals(PLATFORM_EXTERNALS_GROUP)) {
-      // Set "external" social profile property to "true"
-      IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-      Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, m.getUserName());
-      Profile profile = identity.getProfile();
-      if (profile != null) {
-        profile.setProperty(Profile.EXTERNAL, "true");
-        identityManager.updateProfile(profile);
-      }
       OrganizationService orgService = CommonsUtils.getService(OrganizationService.class);
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
       User user = orgService.getUserHandler().findUserByName(m.getUserName());

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
@@ -97,6 +97,12 @@
       <set-method>addListenerPlugin</set-method>
       <type>org.exoplatform.social.core.listeners.SocialUserProfileEventListenerImpl</type>
     </component-plugin>
+    <component-plugin>
+      <name>esocial.update.membership.event.listener</name>
+      <set-method>addListenerPlugin</set-method>
+      <type>org.exoplatform.social.core.listeners.ExternalUsersListenerImpl</type>
+      <description>Update external profile property.</description>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION
…n internal user become external (#705)

Before this fix, when we add an internal user to an external group, the profile property external isn't updated.
This fix will ensure that when we add users to an external group, the profile external property is changed to true.