### PR TITLE
TASK-47890 Load Hamburger Manu on user click

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/siteHamburgerMenuItem.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/siteHamburgerMenuItem.jsp
@@ -5,5 +5,5 @@
   String homeLink = portalConfigService.getUserHomePage(request.getRemoteUser());
 %>
 <script type="text/javascript">
-eXo.env.portal.homeLink = '<%=homeLink%>';
+  eXo.env.portal.homeLink = "<%=homeLink%>";
 </script>

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -383,22 +383,6 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/siteHamburgerMenuItem.jsp</value>
     </init-param>
-    <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>use-js-manager</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>js-manager-jsModule</name>
-      <value>PORTLET/social-portlet/SiteHamburgerMenu</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resource.rest</name>
-      <value><![CDATA[/portal/rest/v1/navigations/portal/?siteName=dw&scope=children&visibility=displayed]]></value>
-    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -414,18 +398,6 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/blank.html</value>
     </init-param>
-    <init-param>
-      <name>use-js-manager</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>js-manager-jsModule</name>
-      <value>PORTLET/social-portlet/ProfileHamburgerMenu</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
-    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -440,18 +412,6 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/siteHamburgerMenuItem.jsp</value>
-    </init-param>
-    <init-param>
-      <name>use-js-manager</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>js-manager-jsModule</name>
-      <value>PORTLET/social-portlet/SpacesHamburgerMenu</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
     </init-param>
     <init-param>
       <name>prefetch.resource.rest</name>
@@ -828,22 +788,6 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/blank.html</value>
     </init-param>
-    <init-param>
-      <name>use-js-manager</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>js-manager-jsModule</name>
-      <value>PORTLET/social-portlet/AdministrationHamburgerMenu</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resource.rest</name>
-      <value><![CDATA[/portal/rest/v1/navigations/group?exclude=/spaces.*&visibility=displayed]]></value>
-    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -858,18 +802,6 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/blank.html</value>
-    </init-param>
-    <init-param>
-      <name>use-js-manager</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>js-manager-jsModule</name>
-      <value>PORTLET/social-portlet/UserHamburgerMenu</value>
-    </init-param>
-    <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>

--- a/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -34,6 +34,7 @@
      eXo.env.portal.timezoneDSTSavings = <%=Utils.getViewerTimezoneDSTSavings()%> ;
      eXo.env.portal.cometdToken = "<%=cometdToken%>";
      eXo.env.portal.cometdContext = "<%=cometdContext%>";
+     eXo.env.server.sessionId = "<%=rcontext.getRequest().getSession(true).getId()%>";
      eXo.env.portal.vuetifyPreset = {
        dark: true,
        silent: !eXo.developing,

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
@@ -35,9 +35,6 @@ window.disableSwipeOnPage = true;
 //getting language of the PLF
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const appId = 'ActivityStream';
 
 // Attention!!! when changing this, the list of preloaded
@@ -57,7 +54,7 @@ export function init(initialData, initialLimit) {
         activityBaseLink: activityBaseLink,
       },
       template: `<activity-stream id="${appId}" :initial-limit="initialLimit" :initial-data="initialData" />`,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n,
     }, `#${appId}`, 'Stream');
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationNavigations.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationNavigations.vue
@@ -4,7 +4,11 @@
     px-0
     py-0
     class="white">
-    <v-row v-if="navigations && navigations.length" class="mx-0">
+    <v-progress-linear
+      v-if="loading"
+      color="primary"
+      height="2" />
+    <v-row v-else-if="navigations && navigations.length" class="mx-0">
       <v-list 
         shaped 
         dense 
@@ -23,6 +27,10 @@
 <script>
 export default {
   props: {
+    loading: {
+      type: Boolean,
+      default: false
+    },
     navigations: {
       type: Object,
       default: null

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
@@ -13,6 +13,7 @@ export default {
   data: () => ({
     openedModals: 0,
     openedDrawers: 0,
+    uiPortalApplicationElement: null,
   }),
   computed: {
     overlay() {
@@ -27,6 +28,7 @@ export default {
 
     document.onkeydown = this.closeDisplayedDrawer;
     document.querySelector('#drawers-overlay').onclick = this.closeDisplayedDrawerNoEvent;
+    this.uiPortalApplicationElement = document.querySelector('#UIPortalApplication');
   },
   methods: {
     closeDisplayedDrawerNoEvent() {
@@ -38,17 +40,25 @@ export default {
       }
     },
     showOverlay() {
-      document.querySelector('#UIPortalApplication').classList.add('decrease-z-index');
+      this.uiPortalApplicationElement.classList.add('decrease-z-index');
       window.setTimeout(() => {
         this.openedDrawers += 1;
       }, 10);
+      const searchDialog = document.querySelector('#searchDialog');
+      if (searchDialog) {
+        searchDialog.style.zIndex = 'revert';
+      }
     },
     hideOverlay() {
       if (this.openedDrawers > 0) {
         this.openedDrawers -= 1;
       }
       if (this.openedDrawers === 0) {
-        document.querySelector('#UIPortalApplication').classList.remove('decrease-z-index');
+        this.uiPortalApplicationElement.classList.remove('decrease-z-index');
+      }
+      const searchDialog = document.querySelector('#searchDialog');
+      if (searchDialog) {
+        searchDialog.style.zIndex = '';
       }
     },
     modalOpened() {

--- a/webapp/portlet/src/main/webapp/vue-apps/company-branding-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/company-branding-app/main.js
@@ -9,9 +9,6 @@ const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 const url = `${brandingConstants.PORTAL}/${brandingConstants.PORTAL_REST}/i18n/bundle/locale.portlet.Branding-${lang}.json`;
 
 Vue.directive('exo-tooltip', companyBrandingDirectives.tooltip);
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
 // get overrided components if exists
 if (extensionRegistry) {
@@ -30,7 +27,7 @@ export function init() {
     Vue.createApp({
       template: '<exo-company-branding id="branding"></exo-company-branding>',
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, '#branding', 'Branding Administration');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/dlp-quarantine/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/dlp-quarantine/main.js
@@ -10,9 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
 const appId = 'dlpQuarantine';
@@ -34,7 +31,7 @@ export function init() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<dlp-quarantine-app v-cacheable id="${appId}" />`,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n
     }, appElement, 'DLP Quarantine');
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/main.js
@@ -19,9 +19,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const appId = 'ExternalSpacesListPortlet';
 
 export function init() {
@@ -38,7 +35,7 @@ export function init() {
         },
         template: `<external-spaces-list id="${appId}" v-cacheable />`,
         i18n,
-        vuetify,
+        vuetify: Vue.prototype.vuetifyOptions,
       }, appElement, 'External Spaces List');
     });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
@@ -16,7 +16,7 @@
       :style="hamburgerMenuStyle"
       left
       eager>
-      <template slot="content">
+      <template v-if="hamburgerMenuInitialized" slot="content">
         <v-row
           class="HamburgerMenuLevelsParent fill-height"
           no-gutters
@@ -52,7 +52,6 @@ export default {
       idleTime: 20,
       isMobile: false,
       idleTimeToDisplaySecondLevel: 20,
-      vuetify: new Vuetify(eXo.env.portal.vuetifyPreset),
     };
   },
   computed: {
@@ -88,6 +87,7 @@ export default {
     $(window).resize(() => {
       this.isMobile = !$('#HamburgerMenuVisibility').is(':visible');
     });
+    this.$root.$applicationLoaded();
   },
   methods: {
     refreshMenu() {
@@ -99,7 +99,6 @@ export default {
       this.contents = extensions;
       const contentsToLoad = this.contents.filter(contentDetail => !contentDetail.loaded);
       this.initializing = contentsToLoad.length;
-      const vuetify = this.vuetify;
       let contentsToLoadLength = contentsToLoad.length;
       const self = this;
       contentsToLoad.forEach(contentDetail => {
@@ -114,7 +113,7 @@ export default {
                       locale: this.$i18n.locale,
                       messages: this.$i18n.messages,
                     }),
-                    vuetify,
+                    vuetify: Vue.prototype.vuetifyOptions,
                     methods: {
                       $applicationLoaded() {
                         contentsToLoadLength--;

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/main.js
@@ -12,9 +12,6 @@ if (extensionRegistry) {
 
 Vuetify.prototype.preset = eXo.env.portal.vuetifyPreset;
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portal.HamburgerMenu-${lang}.json`;
 
@@ -30,7 +27,7 @@ export function init() {
         },
         template: '<exo-hamburger-menu-navigation></exo-hamburger-menu-navigation>',
         i18n,
-        vuetify,
+        vuetify: Vue.prototype.vuetifyOptions,
       }, '#HamburgerNavigationMenu', 'Hamburger Menu');
     });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/main.js
@@ -13,9 +13,6 @@ if (extensionRegistry) {
 //getting language of the PLF
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
 const appId = 'GroupsManagement';
@@ -34,7 +31,7 @@ export function init() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<groups-management v-cacheable id="${appId}" />`,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n,
     }, appElement, 'Group Management');
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/main.js
@@ -10,9 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
 const appId = 'MembershipTypesManagement';
@@ -34,7 +31,7 @@ export function init() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<membership-types-management v-cacheable id="${appId}" />`,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n
     }, appElement, 'Membership Type Management');
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/main.js
@@ -10,9 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
 const appId = 'UsersManagement';
@@ -34,7 +31,7 @@ export function init() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<users-management v-cacheable id="${appId}" />`,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n
     }, appElement, 'Users Management');
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/main.js
@@ -1,7 +1,3 @@
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -23,7 +19,7 @@ export function init(filter) {
       },
       template: `<people-list v-cacheable id="${appId}" filter="${filter || 'all'}"></people-list>`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'People List');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/people-overview/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-overview/main.js
@@ -10,10 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -30,7 +26,7 @@ export function init() {
     Vue.createApp({
       template: `<people-overview v-cacheable id="${appId}" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'People Overview');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/main.js
@@ -10,10 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -38,7 +34,7 @@ export function init(aboutMe) {
       },
       template: `<profile-about-me v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :about-me="aboutMe" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Profile About Me');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/main.js
@@ -12,10 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -36,7 +32,7 @@ export function init(uploadLimit) {
       },
       template: `<profile-contact-information v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :upload-limit="${uploadLimit}" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Profile Contact Information');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/main.js
@@ -12,10 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -36,7 +32,7 @@ export function init(maxUploadSize) {
       },
       template: `<profile-header v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" max-upload-size="${maxUploadSize}" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Profile Header');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-navigation/components/ExoProfileHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-navigation/components/ExoProfileHamburgerNavigation.vue
@@ -45,16 +45,17 @@ export default {
         Object.assign(this.profile, event.detail);
       }
     });
-    Promise.resolve(this.retrieveUserInformation())
-      .finally(() => this.$root.$applicationLoaded());
+    this.retrieveUserInformation();
   },
   methods: {
     retrieveUserInformation() {
       this.profile = this.$currentUserIdentity && this.$currentUserIdentity.profile;
       if (!this.profile) {
         return this.$identityService.getIdentityById(eXo.env.portal.userIdentityId)
-          .then(data => this.profile = data && data.profile);
+          .then(data => this.profile = data && data.profile)
+          .finally(() => this.$root.$applicationLoaded());
       }
+      this.$root.$applicationLoaded();
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/main.js
@@ -12,10 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -36,7 +32,7 @@ export function init() {
       },
       template: `<profile-work-experiences v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Profile Work Experience');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/search-space/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/search-space/main.js
@@ -10,14 +10,11 @@ const appId = 'SpaceSearchDrawers';
 
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const urls = [`${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Portlets-${lang}.json`];
 exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
   new Vue({
     template: '<space-search-drawers />',
-    vuetify,
-    i18n
+    vuetify: Vue.prototype.vuetifyOptions,
+    i18n,
   }).$mount(`#${appId}`);
 });

--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchResultCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchResultCard.vue
@@ -19,12 +19,6 @@ export default {
   }),
   mounted() {
     if (this.result && this.result.connector) {
-      const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-      const vueI18n = new VueI18n({
-        locale: this.$i18n.locale,
-        messages: this.$i18n.messages,
-      });
-
       const self = this;
       const SearchResultItem = Vue.extend({
         data: () => ({
@@ -43,8 +37,8 @@ export default {
       });
 
       new SearchResultItem({
-        i18n: vueI18n,
-        vuetify,
+        vuetify: Vue.prototype.vuetifyOptions,
+        i18n: exoi18n.i18n,
       }).$mount(`#${this.id}`);
       this.$forceUpdate();
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/space-header/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-header/main.js
@@ -10,9 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const appId = 'SpaceHeader';
 const cacheId = `${appId}_${eXo.env.portal.spaceId}`;
 
@@ -39,7 +36,7 @@ export function init(settings, bannerUrl, maxUploadSize, isAdmin) {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<space-header v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :navigations="navigations" :selected-navigation-uri="selectedNavigationUri" :banner-url="bannerUrl" :max-upload-size="${maxUploadSize}" :admin="${isAdmin}" />`,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n,
     }, appElement, 'Space Header');
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/main.js
@@ -16,9 +16,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const appId = 'spaceInfosApp';
 const cacheId = `${appId}_${eXo.env.portal.spaceId}`;
 
@@ -30,7 +27,7 @@ export function init() {
 
     Vue.createApp({
       template: `<exo-space-infos v-cacheable="{cacheId: '${cacheId}'}" id="${appId}"></exo-space-infos>`,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n,
     }, appElement, 'Space Info');
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/main.js
@@ -12,10 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -43,7 +39,7 @@ export function init(filter, isManager, isExternalFeatureEnabled) {
                   space-id="${eXo.env.portal.spaceId}"
                   class="singlePageApplication" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Space Members');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/main.js
@@ -10,9 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const appId = 'SpaceMenu';
 const cacheId = `${appId}_${eXo.env.portal.spaceId}`;
 
@@ -29,7 +26,7 @@ export function init(settings) {
       selectedNavigationUri: settings && settings.selectedNavigationUri,
     },
     template: `<space-menu v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" :navigations="navigations" :selected-navigation-uri="selectedNavigationUri" />`,
-    vuetify,
+    vuetify: Vue.prototype.vuetifyOptions,
   }, appElement, 'Space Menu');
 
   const actionsElement = document.createElement('div');
@@ -40,7 +37,7 @@ export function init(settings) {
       this.$root.$emit('application-loaded');
     },
     template: `<space-title-action-components v-cacheable="{cacheId: '${cachedIdActions}'}" id="${appIdAction}" />`,
-    vuetify,
+    vuetify: Vue.prototype.vuetifyOptions,
   }).$mount(actionsElement);
 
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/main.js
@@ -12,9 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -40,7 +37,7 @@ export function init(maxUploadSize) {
                   :max-upload-size="${maxUploadSize}"
                   class="singlePageApplication" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Space Settings');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
@@ -1,10 +1,6 @@
 import './components/initComponents.js';
 import * as spacesAdministrationDirectives from './spacesAdministrationDirectives.js';
 
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 // getting language of the PLF 
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
@@ -37,7 +33,7 @@ export function init(applicationsByCategory) {
       },
       template: `<exo-spaces-administration-spaces v-cacheable id="${appId}" :applications-by-category="applicationsByCategory"></exo-spaces-administration-spaces>`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Spaces Administration');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/main.js
@@ -1,9 +1,5 @@
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -24,7 +20,7 @@ export function init(filter, canCreateSpace) {
       },
       template: `<exo-spaces-list v-cacheable id="${appId}" filter="${filter || 'all'}" :can-create-space="${canCreateSpace}"></exo-spaces-list>`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Spaces List');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/main.js
@@ -10,10 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -31,7 +27,7 @@ export function init() {
     Vue.createApp({
       template: `<spaces-overview v-cacheable id="${appId}" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Spaces Overview');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/main.js
@@ -17,9 +17,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 const appId = 'SuggestionsPeopleAndSpace';
 
 export function init(suggestionsType) {
@@ -32,7 +29,7 @@ export function init(suggestionsType) {
     Vue.createApp({
       template: `<exo-suggestions-people-and-space v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" suggestionsType="${suggestionsType || 'all'}"></exo-suggestions-people-and-space>`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, `Suggestions ${suggestionsType}`);
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/main.js
@@ -12,10 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -38,7 +34,7 @@ export function init(languages) {
       },
       template: `<user-setting-language v-cacheable id="${appId}" :languages="languages" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'User Setting Language');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-mobile/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-mobile/main.js
@@ -10,10 +10,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -35,7 +31,7 @@ export function init() {
       },
       template: `<mobile-settings id="${appId}" v-cacheable />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'User Settings Mobile');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/main.js
@@ -12,10 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -41,7 +37,7 @@ export function init(settings) {
       },
       template: `<user-setting-notifications v-cacheable id="${appId}" :languages="settings && settings.languages" :timezones="settings && settings.timezones" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'User Settings Notifications');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/main.js
@@ -9,10 +9,6 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -34,7 +30,7 @@ export function init() {
       },
       template: `<user-setting-security id="${appId}" v-cacheable />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'User Settings Security');
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-timezone/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-timezone/main.js
@@ -12,10 +12,6 @@ if (extensionRegistry) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-Vue.use(Vuetify);
-Vue.use(VueEllipsis);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 //getting language of user
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -38,7 +34,7 @@ export function init(timezones) {
       },
       template: `<user-setting-timezone v-cacheable id="${appId}" :timezones="timezones" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'User Settings TimeZone');
   });
 }


### PR DESCRIPTION
Prior to this change, the Hamburder menu loading was made at the same time than the Page loading phase which can lead to a bad performance UX. This change will load lazily the Hamburger Menu items once the user clicks on it. To not have a bad UX of Hamburger menu display, a caching strategy based on sessionStorage will be used for Administration menu and sites Menu items. The cached items will use the Java session id in the key to ensure that a logout/login force the refresh of Menu items content. Besides, the Last Visited Spaces items are dynamic and changes a lot comparing to Sites Menu, thus the sessionStorage caching strategy will not be used for those items and instead, prefetching (not preloading) the list of last visted spaces list will allow to have an instant display of those items once the user clicks on Hamburger Menu items.