### PR TITLE
TASK-47891 Improve Users & spaces suggesters loading

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/suggestions.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/suggestions.jsp
@@ -8,23 +8,15 @@
   } else {
     suggestionsType = ((String[])suggestionsType)[0];
   }
-  List<String> preloadURLs = new ArrayList<>();
-  if (suggestionsType == "user") {
-    preloadURLs.add("/portal/rest/homepage/intranet/people/contacts/suggestions");
-  } else if (suggestionsType == "space") {
-    preloadURLs.add("/portal/rest/homepage/intranet/spaces/suggestions");
-  } else {
-    preloadURLs.add("/portal/rest/homepage/intranet/people/contacts/suggestions");
-    preloadURLs.add("/portal/rest/homepage/intranet/spaces/suggestions");
-  }
 %>
 <div class="VuetifyApp">
-  <% for (String preloadURL : preloadURLs) { %>
-  <link rel="prefetch" href="<%=preloadURL%>" as="fetch" crossorigin="use-credentials">
-  <% } %>
   <div data-app="true"
     class="v-application hiddenable-widget transparent v-application--is-ltr theme--light"
-    id="SuggestionsPeopleAndSpace" flat="" data-suggestion-type="<%=suggestionsType%>">
-    <v-cacheable-dom-app cache-id="SuggestionsPeopleAndSpace_<%=suggestionsType%>"></v-cacheable-dom-app>
+    id="SuggestionsPeopleAndSpace" flat="">
+    <script type="text/javascript">
+      require(['PORTLET/social-portlet/SuggestionsPeopleAndSpace'],
+        app => app.init('<%=suggestionsType%>')
+      );
+    </script>
   </div>
 </div>

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -719,14 +719,6 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/suggestions.jsp</value>
     </init-param>
-    <init-param>
-      <name>use-js-manager</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
-      <name>js-manager-javascript-content</name>
-      <value><![CDATA[SuggestionsPeopleAndSpace.init(document.querySelector('#SuggestionsPeopleAndSpace').getAttribute('data-suggestion-type'))]]></value>
-    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SpaceService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SpaceService.js
@@ -228,6 +228,9 @@ export function getSpaces(query, offset, limit, filter, expand) {
 }
 
 export function removeSpace(spaceId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/${spaceId}`, {
     method: 'DELETE',
     credentials: 'include',
@@ -239,6 +242,9 @@ export function removeSpace(spaceId) {
 }
 
 export function updateSpace(space) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/${space.id}`, {
     method: 'PUT',
     credentials: 'include',
@@ -277,6 +283,9 @@ export function createSpace(space) {
 }
 
 export function leave(spaceId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/spaces/leave/${spaceId}`, {
     method: 'DELETE',
     credentials: 'include',
@@ -288,6 +297,9 @@ export function leave(spaceId) {
 }
 
 export function cancel(spaceId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/spaces/cancel/${spaceId}`, {
     method: 'DELETE',
     credentials: 'include',
@@ -299,6 +311,9 @@ export function cancel(spaceId) {
 }
 
 export function join(spaceId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/spaces/join/${spaceId}`, {
     method: 'GET',
     credentials: 'include',
@@ -310,6 +325,9 @@ export function join(spaceId) {
 }
 
 export function requestJoin(spaceId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/spaces/request/${spaceId}`, {
     method: 'GET',
     credentials: 'include',
@@ -321,6 +339,9 @@ export function requestJoin(spaceId) {
 }
 
 export function accept(spaceId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/spaces/accept/${spaceId}`, {
     method: 'GET',
     credentials: 'include',
@@ -332,6 +353,9 @@ export function accept(spaceId) {
 }
 
 export function deny(spaceId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/spaces/deny/${spaceId}`, {
     method: 'GET',
     credentials: 'include',
@@ -531,6 +555,10 @@ export function removeMember(spacePrettyName, username) {
 }
 
 export function getSuggestionsSpace(){
+  const cachedSuggestions = sessionStorage && sessionStorage.getItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  if (cachedSuggestions) {
+    return Promise.resolve(JSON.parse(cachedSuggestions));
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/spaces/suggestions`, {
     credentials: 'include'
   }).then(resp => {
@@ -541,10 +569,22 @@ export function getSuggestionsSpace(){
     } else {
       return resp.json();
     }
+  }).then(data => {
+    if (sessionStorage && data) {
+      try {
+        sessionStorage.setItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`, JSON.stringify(data));
+      } catch (e) {
+        // Expected when Quota Error is thrown 
+      }
+    }
+    return data;
   });
 }
 
 export function ignoreSuggestion(item) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Spaces_${eXo.env.server.sessionId}`);
+  }
   const data = {'user': item.username,'space': item.displayName, 'status': 'IGNORED'};
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spacesMemberships/`, {
     method: 'POST',

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -1,3 +1,4 @@
+
 export function getUser(username, expand) {
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${username}?expand=${expand || ''}`, {
     method: 'GET',
@@ -129,6 +130,10 @@ export function getPending(offset, limit, expand) {
 }
 
 export function getSuggestionsUsers() {
+  const cachedSuggestions = sessionStorage && sessionStorage.getItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+  if (cachedSuggestions) {
+    return Promise.resolve(JSON.parse(cachedSuggestions));
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/people/contacts/suggestions`,{
     credentials: 'include'
   }).then(resp => {
@@ -139,10 +144,22 @@ export function getSuggestionsUsers() {
     } else {
       return resp.json();
     }
+  }).then(data => {
+    if (sessionStorage && data) {
+      try {
+        sessionStorage.setItem(`Suggestions_Users_${eXo.env.server.sessionId}`, JSON.stringify(data));
+      } catch (e) {
+        // Expected when Quota Error is thrown 
+      }
+    }
+    return data;
   });
 }
 
 export function sendConnectionRequest(userID) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/homepage/intranet/people/contacts/connect/${userID}`,{
     method: 'GET',
     credentials: 'include',
@@ -154,6 +171,9 @@ export function sendConnectionRequest(userID) {
 }
 
 export function ignoreSuggestion(receiver) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+  }
   const sender = eXo.env.portal.userName;
   const data = {'sender': sender ,'receiver': receiver,'status': 'IGNORED'};
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/usersRelationships/`, {
@@ -176,6 +196,9 @@ export function ignoreSuggestion(receiver) {
 }
 
 export function connect(userId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/usersRelationships`, {
     method: 'POST',
     credentials: 'include',
@@ -198,6 +221,9 @@ export function connect(userId) {
 }
 
 export function confirm(userId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/usersRelationships`, {
     method: 'PUT',
     credentials: 'include',
@@ -220,6 +246,9 @@ export function confirm(userId) {
 }
 
 export function deleteRelationship(userId) {
+  if (sessionStorage) {
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+  }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/usersRelationships/${eXo.env.portal.userName}/${userId}`, {
     method: 'DELETE',
     credentials: 'include',


### PR DESCRIPTION
Prior to this change, the suggested users & spaces are retrieved from server side on each page display. This change will allow to cache the suggester Widget items during the lifetime of Server Session of the user. The cached items will be stored in sessionStorage (that uses LRU algorithm for eviction) to purge it when the browser is closed.