### PR TITLE
Task-48190 : The switch to an article button shouldn't be displayed when exceed 1300 chars in stream main page

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
@@ -185,7 +185,7 @@ export default {
       return this.attachments.length * this.percent !== this.uploadingProgress;
     },
     displayHintMessage() {
-      return this.activityComposerHintAction && this.messageLength > this.MESSAGE_MAX_LENGTH;
+      return this.activityComposerHintAction && this.activityComposerHintAction.enabled && this.messageLength > this.MESSAGE_MAX_LENGTH;
     },
     uploadingProgress() {
       return this.attachments.map(attachment => {


### PR DESCRIPTION
Issue: When adding a post with exceeding 1300 chars, the switch to an article button is displayed on mainstream and space stream.
Solution: I have added a check to verify if is mainstream or space stream, and I display the switch to an article button only on space stream.