### PR TITLE
Task-48341 : Externals users are displayed on the unified search

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -71,7 +71,8 @@ public class ProfileSearchConnector {
                                      long offset,
                                      long limit) {
     if(identity == null && filter.getViewerIdentity() != null) {
-      identity = filter.getViewerIdentity();}
+      identity = filter.getViewerIdentity();
+    }
     String esQuery = buildQueryStatement(identity, filter, type, offset, limit);
     String jsonResponse = this.client.sendRequest(esQuery, this.index);
     return buildResult(jsonResponse);

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -71,8 +71,7 @@ public class ProfileSearchConnector {
                                      long offset,
                                      long limit) {
     if(identity == null && filter.getViewerIdentity() != null) {
-      identity = filter.getViewerIdentity();
-    }
+      identity = filter.getViewerIdentity();}
     String esQuery = buildQueryStatement(identity, filter, type, offset, limit);
     String jsonResponse = this.client.sendRequest(esQuery, this.index);
     return buildResult(jsonResponse);
@@ -250,25 +249,28 @@ public class ProfileSearchConnector {
         subQueryEmpty = false;
         appendCommar = true;
       }
+      esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
+
     }
     if (filter.isConnected() != null) {
-        esSubQuery.append("    \"should\": [\n");
-        esSubQuery.append("                  {\n");
-        esSubQuery.append("                    \"bool\": {\n");
-        if (filter.isConnected()) {
-          esSubQuery.append("                      \"must\": {\n");
-        } else {
-          esSubQuery.append("                      \"must_not\": {\n");
-        }
-        esSubQuery.append("                        \"exists\": {\n");
-        esSubQuery.append("                          \"field\": \"lastLoginTime\"\n");
-        esSubQuery.append("                        }\n");
-        esSubQuery.append("                      }\n");
-        esSubQuery.append("                    }\n");
-        esSubQuery.append("                  }\n");
-        esSubQuery.append("                  ]\n");
-        subQueryEmpty = false;
-        appendCommar = true;
+      esSubQuery.append("    \"should\": [\n");
+      esSubQuery.append("                  {\n");
+      esSubQuery.append("                    \"bool\": {\n");
+      if (filter.isConnected()) {
+        esSubQuery.append("                      \"must\": {\n");
+      } else {
+        esSubQuery.append("                      \"must_not\": {\n");
+      }
+      esSubQuery.append("                        \"exists\": {\n");
+      esSubQuery.append("                          \"field\": \"lastLoginTime\"\n");
+      esSubQuery.append("                        }\n");
+      esSubQuery.append("                      }\n");
+      esSubQuery.append("                    }\n");
+      esSubQuery.append("                  }\n");
+      esSubQuery.append("                  ]\n");
+      esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
+      subQueryEmpty = false;
+      appendCommar = true;
     }
     if(filter.getEnrollmentStatus() != null && !filter.getEnrollmentStatus().isEmpty()) {
       switch (filter.getEnrollmentStatus()) {
@@ -284,6 +286,7 @@ public class ProfileSearchConnector {
           esSubQuery.append("                    }\n");
           esSubQuery.append("                  }\n");
           esSubQuery.append("                  ]\n");
+          esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
           subQueryEmpty = false;
           appendCommar = true;
           break;
@@ -293,24 +296,25 @@ public class ProfileSearchConnector {
           esSubQuery.append("    \"should\": [\n");
           esSubQuery.append("                  {\n");
           esSubQuery.append("                    \"bool\": {\n");
-          esSubQuery.append("                      \"must_not\": {\n");
+          esSubQuery.append("                      \"must_not\": [{\n");
           esSubQuery.append("                        \"exists\": {\n");
           esSubQuery.append("                          \"field\": \"enrollmentDate\"\n");
           esSubQuery.append("                          }\n");
           esSubQuery.append("                        },\n");
+          esSubQuery.append("                      {\n");
+          esSubQuery.append("                        \"exists\": {\n");
+          esSubQuery.append("                          \"field\": \"lastLoginTime\"\n");
+          esSubQuery.append("                        }\n");
+          esSubQuery.append("                      }],\n");
           esSubQuery.append("                      \"must\": {\n");
           esSubQuery.append("                       \"term\": {\n");
           esSubQuery.append("                         \"external\": false\n");
           esSubQuery.append("                         }\n");
-          esSubQuery.append("                      },\n");
-          esSubQuery.append("                      \"must_not\": {\n");
-          esSubQuery.append("                        \"exists\": {\n");
-          esSubQuery.append("                          \"field\": \"lastLoginTime\"\n");
-          esSubQuery.append("                        }\n");
           esSubQuery.append("                      }\n");
           esSubQuery.append("                    }\n");
           esSubQuery.append("                  }\n");
           esSubQuery.append("                  ]\n");
+          esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
           subQueryEmpty = false;
           appendCommar = true;
           break;
@@ -339,6 +343,7 @@ public class ProfileSearchConnector {
           esSubQuery.append("                    }\n");
           esSubQuery.append("                  }\n");
           esSubQuery.append("                  ]\n");
+          esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
           subQueryEmpty = false;
           appendCommar = true;
           break;


### PR DESCRIPTION
This commit should also fix
Task-47922 : External users are displayed in people list
Task-47770 : Wrong behaviors when search with an advanced filter applied

Before this fix, when doing an es request containing a should option, if none of should option match, the condition stay true.
This fix add the option minimum_should_match to 1, so that, at least one should option is true.
This modification applies on requests about external/internal users, connected/not connected users, and request about enrollment status

In addition the request to get notEnrolled users have a syntax error because of multiple must_not part.
This change reworks this request to make a correct one