### PR TITLE
Task-48221 : Download option is still displayed after suspend temporarily download documents on transfer rules page.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
@@ -52,13 +52,14 @@ export default {
   data: () => ({
     menu: false,
     loading: false,
+    downloadAllowed: true,
   }),
   computed: {
     menuButtonStyle() {
       return this.$vuetify && this.$vuetify.rtl && 'top:8px;left:4px;' || 'top:8px;right:4px;';
     },
     enabledActions() {
-      return this.activityActions && Object.values(this.activityActions).filter(action => action.isEnabled && action.id && action.click && action.isEnabled(this.activity, this.activityTypeExtension));
+      return this.activityActions && Object.values(this.activityActions).filter(action => action.isEnabled && action.id && action.click && action.isEnabled(this.activity, this.activityTypeExtension)).filter(action => !(this.downloadAllowed  && (action.id === 'download'|| action.id === 'downloadAll'))) ;
     },
   },
   created() {
@@ -70,6 +71,10 @@ export default {
         }, 200);
       }
     });
+    this.$transferRulesService.getTransfertRulesDownloadDocumentStatus().then(
+      (data) => {
+        this.downloadAllowed = data.downloadDocumentStatus === 'true';
+      });
   },
   methods: {
     clickOnAction(action) {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/js/transferRulesService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/js/transferRulesService.js
@@ -1,0 +1,13 @@
+export function getTransfertRulesDownloadDocumentStatus() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/transferRules/getTransfertRulesDocumentStatus`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.json();
+    }
+    else {
+      throw new Error ('Error when getting transfer rules download documents status');
+    }
+  });
+}

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
@@ -15,6 +15,13 @@ if (!Vue.prototype.$activityConstants) {
   });
 }
 
+import * as transferRulesService from './js/transferRulesService.js';
+if (!Vue.prototype.$transferRulesService) {
+  window.Object.defineProperty(Vue.prototype, '$transferRulesService', {
+    value: transferRulesService,
+  });
+}
+
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
 const activityBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity`;


### PR DESCRIPTION
Issue: Before this fix, when suspending temporarily download documents on the transfer rules page, the download action (download or downloadAll)is still displayed on the activity stream (3 dots button).
Solution: Check the transfer rules download action status and filter enabled action according to this value, if suspend is enabled the download actions are displayed(download or downloadAll) otherwise isn't displayed.
