### PR TITLE
TASK-48563 Fix High Memory Consumption when reindexing User Profile

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/manager/RelationshipManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/RelationshipManager.java
@@ -17,6 +17,7 @@
 package org.exoplatform.social.core.manager;
 
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.deprecation.DeprecatedAPI;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.profile.ProfileFilter;
 import org.exoplatform.social.core.relationship.model.Relationship;
@@ -624,6 +625,8 @@ public interface RelationshipManager {
    * @LevelAPI Platform
    * @since  1.2.3
    */
+  @DeprecatedAPI("Must use getIncoming method instead, ES doesn't index incomings")
+  @Deprecated
   ListAccess<Identity> getIncomingByFilter(Identity existingIdentity, ProfileFilter profileFilter);
   
   /**
@@ -636,6 +639,8 @@ public interface RelationshipManager {
    * @LevelAPI Platform
    * @since  1.2.3
    */
+  @DeprecatedAPI("Must use getIncoming method instead, ES doesn't index outgoings")
+  @Deprecated
   ListAccess<Identity> getOutgoingByFilter(Identity existingIdentity, ProfileFilter profileFilter);
   
   /**

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexDocument.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexDocument.java
@@ -1,0 +1,18 @@
+package org.exoplatform.social.core.jpa.search;
+
+import java.util.*;
+
+import org.exoplatform.commons.search.domain.Document;
+
+public class ProfileIndexDocument extends Document {
+
+  public ProfileIndexDocument(String id, String url, Date lastUpdatedDate, Set<String> permissions, Map<String, String> fields) {
+    super(id, url, lastUpdatedDate, permissions, fields);
+  }
+
+  @Override
+  public String toJSON() {
+    String json = super.toJSON();
+    return json.replace("\"@@@[", "[").replace("]@@@\"", "]");
+  }
+}


### PR DESCRIPTION
Due to recent change made in https://github.com/Meeds-io/social/commit/c146347542fbc4f9519b0166df65a5d59be45969, a high memory consumption has been observed on production. In fact, assuming that a user can have tens of thousands of users as 'relationship', retrieving a list of connection IDs in a list of String will consume much more Memory than appending the list of Ids in one single String. Thus this fix will revert to compute the IDs inside a String instead (Old behavior). In addition two methods has been deprecated knowing that it's not used, in order to avoid indexing & searching to/from ES the pending (incoming & outgoing) relationships.