### PR TITLE
46374: Make sure that returned users profiles contains accentueted characters if present.

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
@@ -683,7 +683,11 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
       identity = profileFilter.getViewerIdentity();
     }
     if (OrganizationIdentityProvider.NAME.equals(providerId)) {
-      return getProfileSearchConnector().search(identity, profileFilter, type, offset, limit);
+      List<Identity> identities = getProfileSearchConnector().search(identity, profileFilter, type, offset, limit);
+      identities.stream().forEach(identity1 -> {
+        identity1.setProfile(loadProfile(identity1.getProfile()));
+      });
+      return identities;
     } else {
       throw new IllegalStateException("Can't search identities with provider id = " + providerId);
     }


### PR DESCRIPTION
When searching for users identities via the elastic search connector the user's name, last name and full name aren't accentueted.
These changes make sure to return the correct user's name, last name and full name with accentueted characters if present by loadig user's profiles from the identity manager.