### PR TITLE
Task-48597: Fix space popover without actions for managers

### DIFF
--- a/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
+++ b/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
@@ -307,7 +307,7 @@
 
                     tiptip_content.empty();
 
-                    if ((isManager && json.manager =>1)|| (!isManager && isMember)) {
+                    if ((isManager && json.manager => 1)|| (!isManager && isMember)) {
                         action = $('<div/>', {
                             "class": "btn-link leave-space",
                             "text": "" + labels.leave,

--- a/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
+++ b/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
@@ -307,7 +307,7 @@
 
                     tiptip_content.empty();
 
-                    if ((isManager && json.manager => 1)|| (!isManager && isMember)) {
+                    if ((isManager && json.manager >= 1)|| (!isManager && isMember)) {
                         action = $('<div/>', {
                             "class": "btn-link leave-space",
                             "text": "" + labels.leave,

--- a/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
+++ b/webapp/portlet/src/main/webapp/js/eXo/UISpaceInfoPopup.js
@@ -307,7 +307,7 @@
 
                     tiptip_content.empty();
 
-                    if ((isManager && json.manager >1)|| (!isManager && isMember)) {
+                    if ((isManager && json.manager =>1)|| (!isManager && isMember)) {
                         action = $('<div/>', {
                             "class": "btn-link leave-space",
                             "text": "" + labels.leave,


### PR DESCRIPTION
Problem: Space popover appears without actions only for managers.
How it was solved: by taking the "1" value in the condition json.manager >1 to build an action div because the build of the popup requires action different from null.