### PR TITLE
TASK-47589 : internal links opens in new tab

### DIFF
--- a/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/OpenLinkNewTabFilterPlugin.java
+++ b/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/OpenLinkNewTabFilterPlugin.java
@@ -19,6 +19,7 @@
 
 package org.exoplatform.social.common.xmlprocessor.filters;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.social.common.xmlprocessor.BaseXMLFilterPlugin;
 import org.exoplatform.social.common.xmlprocessor.DOMParser;
 import org.exoplatform.social.common.xmlprocessor.Tokenizer;
@@ -37,6 +38,8 @@ import java.util.List;
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
  */
 public class OpenLinkNewTabFilterPlugin extends BaseXMLFilterPlugin {
+
+  public static final String TARGET = "target";
   @Override
   public Object doFilter(Object input) {
     if (input instanceof String) {
@@ -54,9 +57,12 @@ public class OpenLinkNewTabFilterPlugin extends BaseXMLFilterPlugin {
 
   private void nodeFilter(Node currentNode) {
     if ("a".equalsIgnoreCase(currentNode.getTitle())) {
-      String target = currentNode.getAttributes().get("target");
-      if (target == null || !"_blank".equalsIgnoreCase(target)) {
-        currentNode.getAttributes().put("target", "_blank");
+      String currentDomain = CommonsUtils.getCurrentDomain();
+      String target = currentNode.getAttributes().get(TARGET);
+      if (target != null && currentNode.getAttributes().get("href").indexOf(currentDomain) == -1 ) {
+        currentNode.getAttributes().put(TARGET, "_blank");
+      } else {
+        currentNode.getAttributes().put(TARGET, "_self");
       }
       return;
     }

--- a/component/common/src/test/java/org/exoplatform/social/common/xmlprocessor/filters/OpenLinkNewTabFilterPluginTest.java
+++ b/component/common/src/test/java/org/exoplatform/social/common/xmlprocessor/filters/OpenLinkNewTabFilterPluginTest.java
@@ -27,16 +27,18 @@ import org.exoplatform.social.common.xmlprocessor.Filter;
  */
 public class OpenLinkNewTabFilterPluginTest extends TestCase {
   public void testFilterLinkTag() {
+    System.setProperty("gatein.email.domain.url", "exoplatform.com");
     Filter linkTagFilter = new OpenLinkNewTabFilterPlugin();
-    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_blank\">link</a>", linkTagFilter.doFilter("This is <a href=\"http://exoplatform.com\">link</a>"));
-    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_blank\">link</a> <a href=\"exoplatform.net\" target=\"_blank\">link2</a>",
+    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_self\">link</a>", linkTagFilter.doFilter("This is <a href=\"http://exoplatform.com\">link</a>"));
+    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_self\">link</a> <a href=\"exoplatform.net\" target=\"_blank\">link2</a>",
               linkTagFilter.doFilter("This is <a href=\"http://exoplatform.com\">link</a> <a href=\"exoplatform.net\">link2</a>"));
-    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_blank\">link</a>",
-            linkTagFilter.doFilter("This is <a href=\"http://exoplatform.com\" target=\"_self\">link</a>"));
-    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_blank\">link</a>",
+    assertEquals("This is <a href=\"http://exoplatform.net\" target=\"_blank\">link</a>",
+            linkTagFilter.doFilter("This is <a href=\"http://exoplatform.net\" target=\"_self\">link</a>"));
+    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_self\">link</a>",
             linkTagFilter.doFilter("This is <a href=\"http://exoplatform.com\" target=\"_parent\">link</a>"));
-    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_blank\">link</a>",
+    assertEquals("This is <a href=\"http://exoplatform.com\" target=\"_self\">link</a>",
             linkTagFilter.doFilter("This is <a href=\"http://exoplatform.com\" target=\"frame_name\">link</a>"));
+    System.clearProperty("gatein.email.domain.url");
   }
 
   public void testShouldReturnNullWhenFilteringNullInput() {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
@@ -32,6 +33,7 @@ import org.exoplatform.social.core.jpa.test.AbstractCoreTest;
 import org.exoplatform.social.core.jpa.test.MaxQueryNumber;
 import org.exoplatform.social.core.jpa.test.QueryNumberTest;
 import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.relationship.model.Relationship;
 import org.exoplatform.social.core.space.impl.DefaultSpaceApplicationHandler;
 import org.exoplatform.social.core.space.model.Space;
@@ -166,16 +168,17 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
 
   @MaxQueryNumber(123)
   public void testUpdateActivityMention() {
+    System.setProperty("gatein.email.domain.url", "exoplatform.com");
     ExoSocialActivity activity = createActivity(1);
     activityStorage.saveActivity(demoIdentity, activity);
     //
     activity = activityStorage.getActivity(activity.getId());
     assertEquals(0, activity.getMentionedIds().length);
 
+    String currentDomain = CommonsUtils.getCurrentDomain();
     //update
-    String processedTitle = "test <a href=\"/portal/classic/profile/root\" rel=\"nofollow\" target=\"_blank\">Root Root</a> " +
-        "<a href=\"/portal/classic/profile/john\" rel=\"nofollow\" target=\"_blank\">" + johnIdentity.getProfile().getFullName()
-        + "</a>";
+    String processedTitle ="test <a href=\""+ currentDomain +"/portal/classic/profile/root\" rel=\"nofollow\" target=\"_self\">Root Root</a> " +
+        "<a href=\""+ currentDomain +"/portal/classic/profile/john\" rel=\"nofollow\" target=\"_self\">John Anthony</a>";
     activity.setTitle("test @root @john");
     activityStorage.updateActivity(activity);
     //
@@ -212,6 +215,7 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
 
     //
     tearDownActivityList.add(activity);
+    System.clearProperty("gatein.email.domain.url");
   }
   
   @MaxQueryNumber(520)

--- a/component/core/src/test/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessorTest.java
@@ -50,6 +50,7 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
 
 
   public void testProcessActivity() throws Exception {
+    System.setProperty("gatein.email.domain.url", "exoplatform.com");
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     String sample = "this is a <strong> tag to keep</strong>";
     activity.setTitle(sample);
@@ -60,12 +61,12 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
     assertEquals(sample, activity.getBody());
 
     // tags with attributes
-    sample = "text <a href='#'>bar</a> zed";
+    sample = "text <a href='exoplatform.com'>bar</a> zed";
 
     activity.setTitle(sample);
     processor.processActivity(activity);
 
-    assertEquals("text <a href=\"#\" rel=\"nofollow\" target=\"_blank\">bar</a> zed", activity.getTitle());
+    assertEquals("text <a href=\"exoplatform.com\" rel=\"nofollow\" target=\"_self\">bar</a> zed", activity.getTitle());
 
     // only with open tag
     sample = "<strong> only open!!!";
@@ -90,9 +91,11 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
     activity.setTitle(sample);
     processor.processActivity(activity);
     assertEquals("<strong>foo</strong>bar", activity.getTitle());
+    System.clearProperty("gatein.email.domain.url");
   }
   
   public void testProcessActivityWithTemplateParam() throws Exception {
+    System.setProperty("gatein.email.domain.url", "exoplatform.com");
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     String sample = "this is a <strong> tag to keep</strong>";
     activity.setTitle(sample);
@@ -108,8 +111,9 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
     
     templateParams = activity.getTemplateParams();
     assertEquals("a\nb", templateParams.get("a"));
-    assertEquals("<a href=\"http://exoplatform.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">exoplatform.com</a>", templateParams.get("b"));
+    assertEquals("<a href=\"http://exoplatform.com\" target=\"_self\" rel=\"nofollow noopener noreferrer\">exoplatform.com</a>", templateParams.get("b"));
     assertEquals("exoplatform.com", templateParams.get("d"));
+    System.clearProperty("gatein.email.domain.url");
   }
   
 }


### PR DESCRIPTION
the internal link opens in a new tab due to the function nodeFilter in OpenLinkNewTabFilterPlugin always returns the target  '_blank' 
 fixed by comparing the link with the currentDomain