### PR TITLE
TASK-48719 Fix Space Stream Width

### DIFF
--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -841,7 +841,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertEquals(6, importResultEntity.getCount());
     assertEquals(importResultEntity.getCount(), importResultEntity.getProcessedCount());
     assertNotNull(importResultEntity.getErrorMessages());
-    assertEquals(3, importResultEntity.getErrorMessages().size());
+    assertEquals(2, importResultEntity.getErrorMessages().size());
     assertNotNull(importResultEntity.getWarnMessages());
     assertEquals(1, importResultEntity.getWarnMessages().size());
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
@@ -16,7 +16,7 @@
         :options="commentEditOptions" />
     </div>
     <template v-else>
-      <v-list-item :class="highlightClass" class="pa-0 mb-4 width-max-content">
+      <v-list-item :class="highlightClass" class="pa-0 mb-4 width-fit-content">
         <activity-head-user
           :identity="posterIdentity"
           :size="33"


### PR DESCRIPTION
Prior to this change, the stream width in Space page isn't all time fixed. In fact, when adding a long comment with a link in an activity, the Space Stream takes a large width in UI. This change ensures to make the comment fit the content box width of the Activity instead of taking the max content width of the comment.