### PR TITLE
TASK-48336 : Problems about indication(External) when hovering a mentioned external user in a comment

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -170,7 +170,7 @@ public class LinkProvider {
                 .append(buildProfileUri(identity.getRemoteId(), null, portalOwner)).append("\" target=\"_parent\">")
                 .append(StringEscapeUtils.escapeHtml(identity.getProfile().getFullName()));
     if(identity.getProfile().getProperty("external") != null && identity.getProfile().getProperty("external").equals("true")){
-      profileLink = profileLink.append("<span \" class=\"externalTagClass\">").append(" (").append(getResourceBundleLabel(new Locale(lang), "external.label.tag")).append(")").append("</span>");
+      profileLink = profileLink.append("<span \" class=\"externalFlagClass\">").append(" (").append(getResourceBundleLabel(new Locale(lang), "external.label.tag")).append(")").append("</span>");
     }
     return profileLink.append("</a>").toString();
   }


### PR DESCRIPTION
Before this fix , when mentioning an external user in a comment the indication external appears in blue color instead of grey color . This was fixed by applying the correct class and style to every mentioned user when processing the comment  message . 