### PR TITLE
Task-47412: Allow all space members to see space redactors by the redactors filter of space members application

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
@@ -132,6 +132,9 @@ export default {
           text: this.$t('peopleList.label.filter.member'),
           value: 'member',
         },{
+          text: this.$t('peopleList.label.filter.redactor'),
+          value: 'redactor',
+        },{
           text: this.$t('peopleList.label.filter.manager'),
           value: 'manager',
         }];


### PR DESCRIPTION

Prior to this change, only space managers can see space redactors using the redactors filter of space members application.
After this change, any space member have access to the redactors filter of space members application in order to see space redactors.