### PR TITLE
Task-48965: A deleted user still displayed

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
@@ -389,7 +389,9 @@ export default {
     },
     deleteUserConfirm() {
       this.loading = true;
-      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/users/${this.selectedUser.userName}`, {
+      const self = this;
+      const userNameDeleted = this.selectedUser.userName ;
+      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/users/${userNameDeleted}`, {
         method: 'DELETE',
         credentials: 'include',
       }).then(resp => {
@@ -401,8 +403,9 @@ export default {
           } else {
             throw new Error(this.$t('IDMManagement.error.UnknownServerError'));
           }
+        } else {
+          self.users = self.users.filter(u => u.userName !== userNameDeleted);
         }
-        return this.searchUsers();
       }).catch(error => {
         error = error.message || String(error);
         const errorI18NKey = `UsersManagement.error.${error}`;


### PR DESCRIPTION
when you delete a user you have to synchronize between API delete and API get so to avoid this problem if the delete is done correctly just filter the user object and delete the user from the list