### PR TITLE
Task-48992: Allow publisher on content management to the publish and schedule news

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -44,6 +44,7 @@ import org.exoplatform.services.organization.GroupHandler;
 import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.security.MembershipEntry;
@@ -89,6 +90,8 @@ public class SpaceServiceImpl implements SpaceService {
   public static final String                   MANAGER                  = "manager";
 
   public static final String                   DEFAULT_APP_CATEGORY     = "spacesApplications";
+
+  private final static String                  PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
 
   private IdentityRegistry                     identityRegistry;
 
@@ -1439,7 +1442,7 @@ public class SpaceServiceImpl implements SpaceService {
   @Override
   public boolean canRedactOnSpace(Space space, org.exoplatform.services.security.Identity viewer) {
     String username = viewer.getUserId();
-    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username)))
+    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username) || isPublisherOrAdministratorOnContentManegementGroup()))
         || isManagerOrSpaceManager(viewer, space);
   }
 
@@ -1791,6 +1794,12 @@ public class SpaceServiceImpl implements SpaceService {
       return true;
     }
     return isManager(space, username);
+  }
+
+  private boolean isPublisherOrAdministratorOnContentManegementGroup() {
+    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
+    return currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "publisher") ||
+            currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "*");
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -44,7 +44,6 @@ import org.exoplatform.services.organization.GroupHandler;
 import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
-import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.security.MembershipEntry;
@@ -1442,7 +1441,7 @@ public class SpaceServiceImpl implements SpaceService {
   @Override
   public boolean canRedactOnSpace(Space space, org.exoplatform.services.security.Identity viewer) {
     String username = viewer.getUserId();
-    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username) || isPublisherOrAdministratorOnContentManegementGroup()))
+    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username) || viewer.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "publisher")))
         || isManagerOrSpaceManager(viewer, space);
   }
 
@@ -1794,12 +1793,6 @@ public class SpaceServiceImpl implements SpaceService {
       return true;
     }
     return isManager(space, username);
-  }
-
-  private boolean isPublisherOrAdministratorOnContentManegementGroup() {
-    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
-    return currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "publisher") ||
-            currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "*");
   }
 
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -26,6 +26,7 @@ import org.exoplatform.container.xml.*;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.activity.ActivitySystemTypePlugin;
@@ -302,6 +303,8 @@ public class ActivityManagerTest extends AbstractCoreTest {
     org.exoplatform.services.security.Identity demoACLIdentity = new org.exoplatform.services.security.Identity("demo");
     org.exoplatform.services.security.Identity jamesACLIdentity = new org.exoplatform.services.security.Identity("james");
     org.exoplatform.services.security.Identity maryACLIdentity = new org.exoplatform.services.security.Identity("mary");
+
+    ConversationState.setCurrent(new ConversationState(demoACLIdentity));
 
     InitParams params = new InitParams();
     ValueParam param = new ValueParam();

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -34,6 +34,7 @@ import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.MembershipType;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -541,6 +542,8 @@ public class SpaceServiceTest extends AbstractCoreTest {
     org.exoplatform.services.security.Identity demoACLIdentity = new org.exoplatform.services.security.Identity("demo");
     org.exoplatform.services.security.Identity jamesACLIdentity = new org.exoplatform.services.security.Identity("james");
     org.exoplatform.services.security.Identity maryACLIdentity = new org.exoplatform.services.security.Identity("mary");
+
+    ConversationState.setCurrent(new ConversationState(demoACLIdentity));
 
     Space space = createSpace("spaceTest", "demo");
     space.setMembers(new String[]{"demo", "james"});


### PR DESCRIPTION
Prior to this change, publishers on the content management group are not able to publish or schedule news since the scheduling/edit scheduling drawers are not displayed.
After this change, publishers on the content management group will have the scheduling/edit scheduling drawers in order to publish and schedule news