### PR TITLE
Task-49602: Fix the problem of hidden datepicker when implement stepper

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/DatePicker.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/DatePicker.vue
@@ -12,7 +12,7 @@
       :left="left"
       class="datePickerMenu"
       transition="scale-transition"
-      attach
+      :attach="attach"
       allow-overflow
       offset-y
       eager>
@@ -124,6 +124,12 @@ export default {
       type: Boolean,
       default: function() {
         return false;
+      },
+    },
+    attach: {
+      type: Boolean,
+      default: function() {
+        return true;
       },
     },
     format: {


### PR DESCRIPTION
Prior to this fix, when implementing stepper in `ExoScheduleNewsDrawer.vue`, we noticed that the datepicker is not well displayed. After this change, the problem is fixed by disabling attach property.