### PR TITLE
Task-50154 : Swallowed error in SpaceUtils

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -1871,7 +1871,7 @@ public class SpaceUtils {
       computeNavigationLabels(navigations, locale);
       computeNavigationIcons(navigations);
     } catch (Exception e) {
-      LOG.warn("Get UserNode of Space failed.");
+      LOG.error("Get UserNode of Space failed.",e);
     }
     return navigations;
   }


### PR DESCRIPTION
Before this fix, there is a swallowed error in SpaceUtils
This fix change the log level from warn to error, and add the complete error in the log. This will help to analyze the problem when it occurs.