### PR TITLE
Task-49264: Space members shouldn't be able to create projects (#1016)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -279,7 +279,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     }
 
     long cacheTime = space.getCacheTime();
-    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(expand.hashCode() + cacheTime);
+    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(authenticatedUser.hashCode() + expand.hashCode() + cacheTime);
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);


### PR DESCRIPTION
Prior this change, every login/logout with a user we need to empty the browser cache to display or hide Add project button, The problem is that when the authenticated User has been changed, the cache does not updated.
We should integrate the authenticated user into the cache calculation to get the correct result.