### PR TITLE
Task-50262 : Performance problem when displaying space member page

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -40,7 +40,6 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.GroupHandler;
-import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.security.IdentityConstants;

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.social.core.space.impl;
 
-import java.io.InputStream;
 import java.util.*;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -53,7 +52,6 @@ import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.model.BannerAttachment;
 import org.exoplatform.social.core.model.SpaceExternalInvitation;
 import org.exoplatform.social.core.space.SpaceApplicationConfigPlugin;
 import org.exoplatform.social.core.space.SpaceException;
@@ -71,7 +69,6 @@ import org.exoplatform.social.core.space.spi.SpaceApplicationHandler;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleListener;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.space.spi.SpaceTemplateService;
-import org.exoplatform.social.core.storage.api.IdentityStorage;
 import org.exoplatform.social.core.storage.api.SpaceStorage;
 import org.exoplatform.web.security.security.RemindPasswordTokenService;
 
@@ -1751,26 +1748,25 @@ public class SpaceServiceImpl implements SpaceService {
       return true;
     }
     org.exoplatform.services.security.Identity identity = identityRegistry.getIdentity(userId);
-    if (identity == null) {
-      Collection<Membership> memberships;
-      try {
-        memberships = getOrgService().getMembershipHandler().findMembershipsByUser(userId);
-      } catch (Exception e) {
-        throw new RuntimeException("Can't get user '" + userId + "' memberships", e);
-      }
-      List<MembershipEntry> entries = new ArrayList<>();
-      for (Membership membership : memberships) {
-        entries.add(new MembershipEntry(membership.getGroupId(), membership.getMembershipType()));
-      }
-      identity = new org.exoplatform.services.security.Identity(userId, entries);
-    }
     List<MembershipEntry> superManagersMemberships = spacesAdministrationService.getSpacesAdministratorsMemberships();
-    if (superManagersMemberships != null && !superManagersMemberships.isEmpty()) {
-      for (MembershipEntry superManagerMembership : superManagersMemberships) {
-        if (identity.isMemberOf(superManagerMembership)) {
-          return true;
-        }
-      }
+    if (identity == null) {
+      //user is not already loggued, and identity not present in identityRegistry
+      //so we dont load it, and check only concerned membershipEntry
+      return superManagersMemberships.parallelStream()
+                                         .anyMatch(membershipEntry -> isUserInGroup(userId, membershipEntry));
+    } else {
+      return superManagersMemberships.parallelStream()
+                                     .anyMatch(identity::isMemberOf);
+    }
+  }
+
+  private boolean isUserInGroup(String userId, MembershipEntry membershipEntry) {
+    try {
+      return getOrgService().getMembershipHandler().findMembershipByUserGroupAndType(userId, membershipEntry.getGroup(),
+                                                                              membershipEntry.getMembershipType()) != null;
+    } catch (Exception e) {
+      LOG.error("Error when check {} have membershipType {} in group {}", userId, membershipEntry.getMembershipType(),
+                membershipEntry.getGroup());
     }
     return false;
   }

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -3182,75 +3182,56 @@ public class SpaceServiceTest extends AbstractCoreTest {
 
   }
 
+  public void testIsSuperManager() throws Exception {
+    Space space = createSpace("spacename1", "root");
+    space.setVisibility(Space.PUBLIC);
+    space.setRegistration(Space.OPEN);
+    spaceService.updateSpace(space);
 
-//FIXME regression JCR to RDBMS migration
-//  public void testSpacesSuperManager() throws Exception {
-//    Space space = createSpace("spacename1", "root");
-//    space.setVisibility(Space.PUBLIC);
-//    space.setRegistration(Space.OPEN);
-//    spaceService.updateSpace(space);
-//
-//    space = createSpace("spacename2", "root");
-//    space.setVisibility(Space.PUBLIC);
-//    space.setRegistration(Space.CLOSE);
-//    spaceService.updateSpace(space);
-//
-//    space = createSpace("spacename3", "root");
-//    space.setVisibility(Space.PRIVATE);
-//    space.setRegistration(Space.OPEN);
-//    spaceService.updateSpace(space);
-//
-//    space = createSpace("spacename4", "root");
-//    space.setVisibility(Space.PRIVATE);
-//    space.setRegistration(Space.CLOSE);
-//    spaceService.updateSpace(space);
-//
-//    space = createSpace("spacename5", "root");
-//    space.setVisibility(Space.HIDDEN);
-//    space.setRegistration(Space.OPEN);
-//    spaceService.updateSpace(space);
-//
-//    space = createSpace("spacename6", "root");
-//    space.setVisibility(Space.HIDDEN);
-//    space.setRegistration(Space.CLOSE);
-//    spaceService.updateSpace(space);
-//
-//    User user = organizationService.getUserHandler().createUserInstance("user-super-1");
-//    organizationService.getUserHandler().createUser(user, false);
-//    Group group = organizationService.getGroupHandler().createGroupInstance();
-//    group.setGroupName("testgroup");
-//    organizationService.getGroupHandler().addChild(null, group, true);
-//    MembershipType mstype = organizationService.getMembershipTypeHandler().createMembershipTypeInstance();
-//    mstype.setName("mstypetest");
-//    organizationService.getMembershipTypeHandler().createMembershipType(mstype, true);
-//
-//    organizationService.getMembershipHandler().linkMembership(user, group, mstype, true);
-//
-//    String userName = user.getUserName();
-//
-//    assertEquals(6, spaceService.getAllSpacesWithListAccess().getSize());
-//
-//    assertFalse(spaceService.isSuperManager(userName));
-//    assertFalse(spaceService.hasAccessPermission(space, userName));
-//    assertFalse(spaceService.hasSettingPermission(space, userName));
-//    assertEquals(2, spaceService.getVisibleSpacesWithListAccess(userName, null).getSize());
-//    assertEquals(0, spaceService.getPublicSpacesByFilter(userName, null).getSize());
-//    assertEquals(0, spaceService.getAccessibleSpacesByFilter(userName, null).getSize());
-//    assertEquals(0, spaceService.getSettingableSpaces(userName).getSize());
-//
-//    spacesAdministrationService.updateSpacesAdministratorsMemberships(Arrays.asList(new MembershipEntry("/testgroup",
-//                                                                                                        "mstypetest")));
-//    assertTrue(spaceService.isSuperManager(userName));
-//    assertTrue(spaceService.hasAccessPermission(space, userName));
-//    assertTrue(spaceService.hasSettingPermission(space, userName));
-//    assertEquals(6, spaceService.getVisibleSpacesWithListAccess(userName, null).getSize());
-//
-//    // number fixed to 0 for super users in SpaceListAccess.getSize()
-//    assertEquals(0, spaceService.getPublicSpacesByFilter(userName, null).getSize());
-//
-//    assertEquals(6, spaceService.getAccessibleSpacesByFilter(userName, null).getSize());
-//    assertEquals(6, spaceService.getSettingableSpaces(userName).getSize());
-//  }
+    space = createSpace("spacename2", "root");
+    space.setVisibility(Space.PUBLIC);
+    space.setRegistration(Space.CLOSE);
+    spaceService.updateSpace(space);
+
+    space = createSpace("spacename3", "root");
+    space.setVisibility(Space.PRIVATE);
+    space.setRegistration(Space.OPEN);
+    spaceService.updateSpace(space);
+
+    space = createSpace("spacename4", "root");
+    space.setVisibility(Space.PRIVATE);
+    space.setRegistration(Space.CLOSE);
+    spaceService.updateSpace(space);
+
+    space = createSpace("spacename5", "root");
+    space.setVisibility(Space.HIDDEN);
+    space.setRegistration(Space.OPEN);
+    spaceService.updateSpace(space);
+
+    space = createSpace("spacename6", "root");
+    space.setVisibility(Space.HIDDEN);
+    space.setRegistration(Space.CLOSE);
+    spaceService.updateSpace(space);
+
+    User user = organizationService.getUserHandler().createUserInstance("user-space-admin");
+    organizationService.getUserHandler().createUser(user, false);
+    Group group = organizationService.getGroupHandler().createGroupInstance();
+    group.setGroupName("testgroup");
+    organizationService.getGroupHandler().addChild(null, group, true);
+    MembershipType mstype = organizationService.getMembershipTypeHandler().createMembershipTypeInstance();
+    mstype.setName("mstypetest");
+    organizationService.getMembershipTypeHandler().createMembershipType(mstype, true);
+
+    organizationService.getMembershipHandler().linkMembership(user, group, mstype, true);
+
+    String userName = user.getUserName();
+
+    assertEquals(6, spaceService.getAllSpacesWithListAccess().getSize());
+    assertFalse(spaceService.isSuperManager(userName));
+    spacesAdministrationService.updateSpacesAdministratorsMemberships(Arrays.asList(new MembershipEntry("/testgroup",
+                                                                                                                "mstypetest")));
+    assertTrue(spaceService.isSuperManager(userName));
+  }
 
   private Space populateData() throws Exception {
     String spaceDisplayName = "Space1";


### PR DESCRIPTION
Before this fix, when a user is present in a lot of space, but not in space super manager group, when another user access to a space member page, the request to get users is long, due to the compute of SpaceService.isSuperManager()
This is due to the fact that, if the owner of all space is not connected, the identity is not present in identityRegistry, so that, we load it, with all group membership, and as there is a lot of groups, it is long to load
This fix improves that point, by checking only the user is present in groups configured as superManager group (generaly, there is only few ones).
In case of user already log (so identity is present in identityRegistry), we keep to original way of check (identity.isMemberOf), but the loop is rewrited with a stream to improve code lisibility.