### PR TITLE
Task-50281 : [A11N - Navigation - 12.6] Add roles on main page part

### DIFF
--- a/extension/war/src/main/resources/locale/portal/HamburgerMenu_en.properties
+++ b/extension/war/src/main/resources/locale/portal/HamburgerMenu_en.properties
@@ -7,3 +7,5 @@ menu.confirmation.message.changeHome=Would you like to change home link of curre
 menu.confirmation.ok=OK
 menu.confirmation.cancel=Cancel
 menu.profile.external=(External)
+menu.role.navigation.first.level=First Level Navigation
+menu.role.navigation.second.level=Second Level Navigation

--- a/extension/war/src/main/resources/locale/portal/HamburgerMenu_fr.properties
+++ b/extension/war/src/main/resources/locale/portal/HamburgerMenu_fr.properties
@@ -7,3 +7,5 @@ menu.confirmation.message.changeHome=Voulez-vous changer votre page d'accueil en
 menu.confirmation.ok=OK
 menu.confirmation.cancel=Annuler
 menu.profile.external=Externe
+menu.role.navigation.first.level=Navigation principale
+menu.role.navigation.second.level=Navigation secondaire

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app v-if="loaded">
+  <v-app v-if="loaded" role="main">
     <activity-notification-alerts />
     <activity-stream-list
       :activity-id="activityId"

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
@@ -21,7 +21,10 @@
           class="HamburgerMenuLevelsParent fill-height"
           no-gutters
           @mouseleave="hideSecondLevel()">
-          <div :class="secondLevel && 'd-none d-sm-block'" class="HamburgerMenuFirstLevelParent border-box-sizing">
+          <div :class="secondLevel && 'd-none d-sm-block'"
+            class="HamburgerMenuFirstLevelParent border-box-sizing"
+            role="navigation"
+            :aria-label="$t('menu.role.navigation.first.level')">
             <v-flex v-for="contentDetail in contents" :key="contentDetail.id">
               <div :id="contentDetail.id"></div>
             </v-flex>
@@ -29,7 +32,9 @@
           <div
             v-show="secondLevel"
             :class="secondLevel && 'open'"
-            class="HamburgerMenuSecondLevelParent border-box-sizing">
+            class="HamburgerMenuSecondLevelParent border-box-sizing"
+            role="navigation"
+            :aria-label="$t('menu.role.navigation.second.level')">
             <div id="HamburgerMenuSecondLevel"></div>
           </div>
           <span id="HamburgerMenuVisibility" class="d-none d-sm-block"></span>

--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchApplication.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchApplication.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app role="search">
     <v-btn
       :title="buttonTooltip"
       icon


### PR DESCRIPTION
Before this fix, there war no role on main pages.
This commit add role="main" on the application ActivityStream, and role="navigation" on left navigations (first level and second level). In addition to separate the 2 navigation level, we add i18n aria-label on navigations