### PR TITLE
TASK-50322 Improve Activity Stream Owner and likers computing

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -67,6 +67,8 @@ import org.exoplatform.ws.frameworks.json.impl.*;
 
 public class EntityBuilder {
 
+  private static final int                DEFAULT_LIKERS_LIMIT                       = 4;
+
   private static final String             GROUP_BINDING_DATE_FORMAT                  = "dd/MM/yyyy HH:mm:ss";
 
   private static final Log                LOG                                        = ExoLogger.getLogger(EntityBuilder.class);
@@ -634,7 +636,7 @@ public class EntityBuilder {
                                                                        restPath,
                                                                        "",
                                                                        RestUtils.DEFAULT_OFFSET,
-                                                                       RestUtils.HARD_LIMIT);
+                                                                       DEFAULT_LIKERS_LIMIT);
       activityEntity.setLikes(new LinkEntity(likesEntity));
     } else {
       activityEntity.setLikes(new LinkEntity(getLikesActivityRestUrl(activity.getId(), restPath)));

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -994,19 +994,19 @@ public class EntityBuilder {
 
     DataEntity as = new DataEntity();
     IdentityManager identityManager = getIdentityManager();
-    Identity owner = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, activity.getStreamOwner());
+    Identity owner = identityManager.getIdentity(activity.getStreamId());
     SpaceService spaceService = getSpaceService();
-    if (owner != null) { // case of user activity
-      as.put(RestProperties.TYPE, USER_ACTIVITY_TYPE);
-    } else { // case of space activity
-      owner = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner());
-      as.put(RestProperties.TYPE, SPACE_ACTIVITY_TYPE);
-
-      Space space = spaceService.getSpaceByPrettyName(owner.getRemoteId());
-      as.put(RestProperties.SPACE, buildEntityFromSpace(space, authentiatedUser.getRemoteId(), restPath, null));
+    if (owner != null) {
+      if (owner.isUser()) { // case of user activity
+        as.put(RestProperties.TYPE, USER_ACTIVITY_TYPE);
+      } else { // case of space activity
+        as.put(RestProperties.TYPE, SPACE_ACTIVITY_TYPE);
+  
+        Space space = spaceService.getSpaceByPrettyName(owner.getRemoteId());
+        as.put(RestProperties.SPACE, buildEntityFromSpace(space, authentiatedUser.getRemoteId(), restPath, null));
+      }
+      as.put(RestProperties.ID, owner.getRemoteId());
     }
-    //
-    as.put(RestProperties.ID, owner.getRemoteId());
     return as;
   }
 

--- a/component/service/src/main/java/org/exoplatform/social/websocket/ActivityStreamWebSocketService.java
+++ b/component/service/src/main/java/org/exoplatform/social/websocket/ActivityStreamWebSocketService.java
@@ -16,6 +16,27 @@
 */
 package org.exoplatform.social.websocket;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.mortbay.cometd.continuation.EXoContinuationBayeux;
+import org.picocontainer.Startable;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.activity.model.ActivityStream.Type;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.*;
+import org.exoplatform.social.core.relationship.model.Relationship;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.websocket.entity.ActivityStreamModification;
 import org.exoplatform.ws.frameworks.cometd.ContinuationService;
 
@@ -23,14 +44,52 @@ import org.exoplatform.ws.frameworks.cometd.ContinuationService;
  * A websocket service that will send information about modified Activity. This
  * will allow to have dynamic UI and fresh updates without refreshing page.
  */
-public class ActivityStreamWebSocketService {
+public class ActivityStreamWebSocketService implements Startable {
 
-  public static final String  COMETD_CHANNEL = "/eXo/Application/ActivityStream";
+  public static final String    COMETD_CHANNEL = "/eXo/Application/ActivityStream";
 
-  private ContinuationService continuationService;
+  private static final Log      LOG            = ExoLogger.getLogger(ActivityStreamWebSocketService.class);
 
-  public ActivityStreamWebSocketService(ContinuationService continuationService) {
+  private PortalContainer       portalContainer;
+
+  private ContinuationService   continuationService;
+
+  private EXoContinuationBayeux continuationBayeux;
+
+  private ActivityManager       activityManager;
+
+  private RelationshipManager   relationshipManager;
+
+  private IdentityManager       identityManager;
+
+  private SpaceService          spaceService;
+
+  private ExecutorService       executorService;
+
+  public ActivityStreamWebSocketService(PortalContainer portalContainer,
+                                        ActivityManager activityManager,
+                                        IdentityManager identityManager,
+                                        RelationshipManager relationshipManager,
+                                        SpaceService spaceService,
+                                        EXoContinuationBayeux continuationBayeux,
+                                        ContinuationService continuationService) {
+    this.portalContainer = portalContainer;
     this.continuationService = continuationService;
+    this.continuationBayeux = continuationBayeux;
+    this.activityManager = activityManager;
+    this.relationshipManager = relationshipManager;
+    this.spaceService = spaceService;
+    this.identityManager = identityManager;
+  }
+
+  @Override
+  public void start() {
+    executorService = Executors.newFixedThreadPool(1);
+  }
+
+  @Override
+  public void stop() {
+    executorService.shutdownNow();
   }
 
   /**
@@ -41,7 +100,70 @@ public class ActivityStreamWebSocketService {
    */
   public void sendMessage(ActivityStreamModification activityStreamModification) {
     String message = activityStreamModification.toString();
-    continuationService.sendBroadcastMessage(COMETD_CHANNEL, message);
+    String activityId = activityStreamModification.getActivityId();
+    ExoSocialActivity activity = activityManager.getActivity(activityId);
+    if (activity == null || activity.getActivityStream() == null) {
+      continuationService.sendBroadcastMessage(COMETD_CHANNEL, message);
+    } else if (activity.getActivityStream().getType() == Type.USER) {
+      executorService.execute(() -> {
+        RequestLifeCycle.begin(portalContainer);
+        ExoContainerContext.setCurrentContainer(portalContainer);
+        try {
+          // Send to stream owner
+          String userId = activity.getActivityStream().getPrettyId();
+          continuationService.sendMessage(userId, COMETD_CHANNEL, message);
+
+          // Send to stream owner connected users
+          Identity identity = this.identityManager.getIdentity(userId);
+          Set<String> connectedUserIds = new HashSet<>(continuationBayeux.getConnectedUserIds());
+          connectedUserIds.remove(userId);
+          connectedUserIds.forEach(connectedUserId -> {
+            Identity connectedIdentity = this.identityManager.getIdentity(connectedUserId);
+            if (relationshipManager.getStatus(identity, connectedIdentity) == Relationship.Type.CONFIRMED) {
+              try {
+                continuationService.sendMessage(connectedUserId, COMETD_CHANNEL, message);
+              } catch (Exception e) {
+                LOG.warn("Error sending WebSocket message for activity {} update",
+                         activityId,
+                         e);
+              }
+            }
+          });
+          relationshipManager.getAllWithListAccess(null);
+        } finally {
+          RequestLifeCycle.end();
+          ExoContainerContext.setCurrentContainer(null);
+        }
+      });
+    } else if (activity.getActivityStream().getType() == Type.SPACE) {
+      Space space = spaceService.getSpaceByPrettyName(activity.getActivityStream().getPrettyId());
+      if (space != null) {
+        // Send to space connected members only
+        Set<String> connectedUserIds = continuationBayeux.getConnectedUserIds();
+        if (CollectionUtils.isNotEmpty(connectedUserIds)) {
+          executorService.execute(() -> {
+            RequestLifeCycle.begin(portalContainer);
+            ExoContainerContext.setCurrentContainer(portalContainer);
+            try {
+              connectedUserIds.forEach(connectedUserId -> {
+                if (spaceService.isMember(space, connectedUserId)) {
+                  try {
+                    continuationService.sendMessage(connectedUserId, COMETD_CHANNEL, message);
+                  } catch (Exception e) {
+                    LOG.warn("Error sending WebSocket message for activity {} update",
+                             activityId,
+                             e);
+                  }
+                }
+              });
+            } finally {
+              RequestLifeCycle.end();
+              ExoContainerContext.setCurrentContainer(null);
+            }
+          });
+        }
+      }
+    }
   }
 
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
@@ -44,7 +44,6 @@
     </div>
     <activity-reactions-drawer
       ref="reactionsDrawer"
-      :likers="likers"
       :likers-number="likersNumber"
       :activity-id="activityId"
       :max-items-to-show="maxLikersToShow"

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
@@ -118,6 +118,19 @@ export function deleteActivity(id, hide) {
   });
 }
 
+export function getActivityLikers(id, offset, limit) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/activities/${id}/likes?offset=${offset || 0}&limit=${limit || 50}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error('Response code indicates a server error', resp);
+    } else {
+      return resp.json();
+    }
+  });
+}
+
 export function likeActivity(id) {
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/activities/${id}/likes`, {
     method: 'POST',

--- a/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverviewPeopleListItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverviewPeopleListItem.vue
@@ -23,7 +23,7 @@
         <a :href="url" class="text-color">
           {{ user.fullname }}
           <span v-if="user.external === 'true'" class="externalTagClass">{{ "(" + $t('UserProfilePopup.label.profile.external') +
-          ")"
+            ")"
           }}</span>
         </a>
       </v-list-item-title>


### PR DESCRIPTION
**First patch** :

Prior to this change, the identity of the Activity Stream Owner is computed by two operations (first to check if pretty name of stream owner is a user and a second for space identity). This change will rely on Identity#getId() property to get Stream Owner Identity by one single call.

**Second patch** :

Prior to this change, a lot of liker identities are retrieved when displaying the activity in Stream page, while we display only 4 at most in Activity Reactions section. This improvement will make likers loading made lazy when displaying Activity Reactions Drawer, and limit the retrieved list of likers to 4 when retrieving Activity Details to display on stream.

**Third patch**

Prior to this change, when a new activity is posted, the browser of connected users will retrieve in background the newer activities, all at the same time. This fix will make the activities retrieval only when the user clicks on button to display new activities to not let server treat a lot of 'Activity Refresh' at the same time.
