### PR TITLE
TASK-50322 Improve Activity Stream Owner computing

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -983,19 +983,19 @@ public class EntityBuilder {
 
     DataEntity as = new DataEntity();
     IdentityManager identityManager = getIdentityManager();
-    Identity owner = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, activity.getStreamOwner());
+    Identity owner = identityManager.getIdentity(activity.getStreamId());
     SpaceService spaceService = getSpaceService();
-    if (owner != null) { // case of user activity
-      as.put(RestProperties.TYPE, USER_ACTIVITY_TYPE);
-    } else { // case of space activity
-      owner = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner());
-      as.put(RestProperties.TYPE, SPACE_ACTIVITY_TYPE);
-
-      Space space = spaceService.getSpaceByPrettyName(owner.getRemoteId());
-      as.put(RestProperties.SPACE, buildEntityFromSpace(space, authentiatedUser.getRemoteId(), restPath, null));
+    if (owner != null) {
+      if (owner.isUser()) { // case of user activity
+        as.put(RestProperties.TYPE, USER_ACTIVITY_TYPE);
+      } else { // case of space activity
+        as.put(RestProperties.TYPE, SPACE_ACTIVITY_TYPE);
+  
+        Space space = spaceService.getSpaceByPrettyName(owner.getRemoteId());
+        as.put(RestProperties.SPACE, buildEntityFromSpace(space, authentiatedUser.getRemoteId(), restPath, null));
+      }
+      as.put(RestProperties.ID, owner.getRemoteId());
     }
-    //
-    as.put(RestProperties.ID, owner.getRemoteId());
     return as;
   }
 


### PR DESCRIPTION
Prior to this change, the identity of the Activity Stream Owner is computed by two operations (first to check if pretty name of stream owner is a user and a second for space identity). This change will rely on Identity#getId() property to get Stream Owner Identity by one single call.

(cherry picked from commit ff74e8e8ab494853a24ddcf2db9a1962a7adce4b)