### PR TITLE
TASK-50322 Fix Displayed Remaining Reactions Count

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -643,6 +643,7 @@ public class EntityBuilder {
     }
 
     activityEntity.setLikesCount(activity.getLikeIdentityIds() == null ? 0 : activity.getLikeIdentityIds().length);
+    activityEntity.setHasLiked(ArrayUtils.contains(activity.getLikeIdentityIds(), authentiatedUser.getId()));
     activityEntity.setHasCommented(ArrayUtils.contains(activity.getCommentedIds(), authentiatedUser.getId()));
 
     activityEntity.setCreateDate(RestUtils.formatISO8601(new Date(activity.getPostedTime())));
@@ -772,6 +773,7 @@ public class EntityBuilder {
     commentEntity.setLikesCount(comment.getLikeIdentityIds() == null ? 0 : comment.getLikeIdentityIds().length);
     commentEntity.setCommentsCount(comment.getCommentedIds() == null ? 0 : comment.getCommentedIds().length);
     commentEntity.setHasCommented(ArrayUtils.contains(comment.getCommentedIds(), authentiatedUser.getId()));
+    commentEntity.setHasLiked(ArrayUtils.contains(comment.getLikeIdentityIds(), authentiatedUser.getId()));
     //
     if (!isBuildList) {
       updateCachedLastModifiedValue(comment.getUpdated());

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ActivityEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ActivityEntity.java
@@ -191,6 +191,15 @@ public class ActivityEntity extends BaseEntity {
     return count == null ? 0 : Integer.parseInt(count.toString());
   }
 
+  public void setHasLiked(boolean hasLiked) {
+    setProperty("hasLiked", String.valueOf(hasLiked));
+  }
+
+  public boolean isHasLiked() {
+    Object hasLiked = getProperty("hasLiked");
+    return hasLiked != null && Boolean.parseBoolean(hasLiked.toString());
+  }
+
   public void setHasCommented(boolean hasCommented) {
     setProperty("hasCommented", String.valueOf(hasCommented));
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
@@ -98,7 +98,7 @@ export default {
       return this.likers.slice(0, this.maxLikersToShow-1);
     },
     showMoreLikersNumber() {
-      return this.likers.length - this.maxLikersToShow + 1;
+      return this.likersNumber - this.maxLikersToShow + 1;
     }
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
@@ -78,6 +78,7 @@ export default {
       this.changingLike = true;
       return this.$activityService.likeActivity(this.activityId)
         .then(data => {
+          this.activity.hasLiked = 'true';
           this.computeLikes(data);
           this.$root.$emit('activity-liked', this.activity);
         })
@@ -87,6 +88,7 @@ export default {
       this.changingLike = true;
       return this.$activityService.unlikeActivity(this.activityId)
         .then(data => {
+          this.activity.hasLiked = 'false';
           this.computeLikes(data);
           this.$root.$emit('activity-liked', this.activity);
         })
@@ -97,7 +99,7 @@ export default {
         this.$set(this.activity, 'likes', data && data.likes || []);
         this.$set(this.activity, 'likesCount', data && data.size || 0);
       }
-      this.hasLiked = this.activity && this.activity.likes && this.activity.likes.filter(like => like && like.id === eXo.env.portal.userIdentityId).length;
+      this.hasLiked = this.activity && this.activity.hasLiked === 'true';
     },
   },
 };


### PR DESCRIPTION
Prior to this change, the retrieved paginated likers count is different from real likers count, thus the displayed (+XY) likers to show isn't the same as the expected. This fix will ensure to use the likers count, independently from retrieved size of likers for an activity.