### PR TITLE
TASK-49958 : fix kudos mention not functional

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/processor/MentionsProcessor.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/processor/MentionsProcessor.java
@@ -62,6 +62,9 @@ public class MentionsProcessor extends BaseActivityProcessorPlugin {
       if (templateParams.containsKey("default_title")) {
         templateParams.put("default_title", MentionUtils.substituteUsernames(portalOwner, templateParams.get("default_title")));
       }
+      if (templateParams.containsKey("kudosMessage")) {
+        templateParams.put("kudosMessage", MentionUtils.substituteUsernames(portalOwner, templateParams.get("kudosMessage")));
+      }
     }
   }
 


### PR DESCRIPTION
Before this fix , kudos mention was not functional because the kudos message was not processed in order to add the mentions . This was fixed by processing the kudos message in addition to the kudos title .

