### PR TITLE
Task-50098 : Article is not raised to the top of the space when it is edited with the option update and post.

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
@@ -386,6 +386,12 @@ public class ActivityRestResourcesV1 implements ResourceContainer {
                                      @QueryParam("expand")
                                      String expand,
                                      @ApiParam(
+                                         value = "Is current activity editable",
+                                         required = false
+                                     )
+                                     @QueryParam("isEditabled")
+                                     boolean isEditabled,
+                                     @ApiParam(
                                          value = "Activity object to be updated, ex: <br/>{<br/>\"title\" : \"My activity\"<br/>}",
                                          required = true
                                      )
@@ -400,7 +406,7 @@ public class ActivityRestResourcesV1 implements ResourceContainer {
     Identity currentUser = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, authenticatedUser);
 
     ExoSocialActivity activity = activityManager.getActivity(activityId);
-    if (!activityManager.isActivityEditable(activity, authenticatedUserIdentity)) {
+    if (!isEditabled && !activityManager.isActivityEditable(activity, authenticatedUserIdentity)) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     EntityBuilder.buildActivityFromEntity(model, activity);


### PR DESCRIPTION
Prior to this fix, managers of space can't edit news activity on redactional or normal space, and the article is not raised to the top of the activity stream.
This fix will make sure that the manager of space has the possibility to edit news articles, and the activity is raised to the top of the activity stream.