### PR TITLE
Task-50744: Don't allow admins to post on redactional space activity stream

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -1781,9 +1781,6 @@ public class SpaceServiceImpl implements SpaceService {
 
   private boolean isManagerOrSpaceManager(org.exoplatform.services.security.Identity viewer, Space space) {
     String username = viewer.getUserId();
-    if (viewer.isMemberOf(userACL.getAdminGroups()) || StringUtils.equals(userACL.getSuperUser(), username)) {
-      return true;
-    }
     if (isSuperManager(username)) {
       return true;
     }


### PR DESCRIPTION
Prior to this change, administrators can post on redactional space activity stream. After this change, we remove the possibility to access to composer for administrators when they are a simple space members. 