### PR TITLE
TASK-48986 : Add likes in reactions drawer

### DIFF
--- a/component/service/src/main/resources/locale/social/Webui_az.properties
+++ b/component/service/src/main/resources/locale/social/Webui_az.properties
@@ -119,6 +119,7 @@ UIActivity.label.Unlike=Unlike
 UIActivity.label.likesLabel=Likes
 UIActivity.label.single_likeLabel=Like
 UIActivity.label.Show_All_Likers=All
+UIActivity.label.reactions=Reactions
 UIActivity.label.Reactions_Number=Reactions
 UIActivity.label.single_Reaction_Number=Reaction
 UIActivity.label.Reactions_in_Common=connections in common

--- a/component/service/src/main/resources/locale/social/Webui_az.properties
+++ b/component/service/src/main/resources/locale/social/Webui_az.properties
@@ -119,7 +119,6 @@ UIActivity.label.Unlike=Unlike
 UIActivity.label.likesLabel=Likes
 UIActivity.label.single_likeLabel=Like
 UIActivity.label.Show_All_Likers=All
-UIActivity.label.reactions=Reactions
 UIActivity.label.Reactions_Number=Reactions
 UIActivity.label.single_Reaction_Number=Reaction
 UIActivity.label.Reactions_in_Common=connections in common

--- a/component/service/src/main/resources/locale/social/Webui_en.properties
+++ b/component/service/src/main/resources/locale/social/Webui_en.properties
@@ -119,6 +119,7 @@ UIActivity.label.Unlike=Unlike
 UIActivity.label.likesLabel=Likes
 UIActivity.label.single_likeLabel=Like
 UIActivity.label.Show_All_Likers=All
+UIActivity.label.reactions=Reactions
 UIActivity.label.Reactions_Number=Reactions
 UIActivity.label.single_Reaction_Number=Reaction
 UIActivity.label.Reactions_in_Common=connections in common

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
@@ -1,0 +1,93 @@
+<template>
+  <div v-if="liker">
+    <exo-user-avatar
+      :username="userName"
+      :fullname="fullName"
+      :avatar-url="avatar"
+      avatar-class="mr-5"
+      :url="profileUrl"
+      bold-title
+      size="42"
+      class="pl-3 pt-2 pb-1">
+      <template slot="subTitle">
+        <span v-if="!sameUser">
+          {{ inCommonConnections }} {{ $t('UIActivity.label.Reactions_in_Common') }}
+        </span>
+      </template>
+      <template slot="actions" v-if="notConnected">
+        <v-btn-toggle class="mr-5">
+          <a
+            text
+            icon
+            min-width="auto"
+            @click="connect()">
+            <i class="uiIconInviteUser"></i>
+          </a>
+        </v-btn-toggle>
+      </template>
+    </exo-user-avatar>
+    <v-divider />
+  </div>
+</template>
+
+<script>
+
+
+export default {
+  props: {
+    liker: {
+      type: Object,
+      default: null
+    }
+  },
+  data () {
+    return {
+      userInformations: null,
+    };
+  },
+  computed: {
+    inCommonConnections() {
+      return this.userInformations && this.userInformations.connectionsInCommonCount || 0;
+    },
+    sameUser() {
+      return this.userInformations && this.userInformations.username === eXo.env.portal.userName;
+    },
+    notConnected() {
+      return this.userInformations && !this.userInformations.relationshipStatus && !this.sameUser;
+    },
+    userName() {
+      return this.liker && this.liker.username;
+    },
+    fullName() {
+      return this.liker && this.liker.fullname;
+    },
+    avatar() {
+      return this.liker && this.liker.avatar;
+    },
+    profileUrl() {
+      return this.liker && this.liker.fullname && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.liker.fullname}`;
+    },
+  },
+  created() {
+    this.retrieveUserInformations();
+  },
+  methods: {
+    retrieveUserInformations() {
+      return this.$userService.getUser(this.liker.username, 'all,connectionsInCommonCount,relationshipStatus')
+        .then(item => this.userInformations = item)
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Error while getting user details', e);
+        });
+    },
+    connect() {
+      this.$userService.connect(this.liker.username)
+        .then(this.retrieveUserInformations())
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Error processing action', e);
+        });
+    },
+  },
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
@@ -5,25 +5,14 @@
       :fullname="fullName"
       :avatar-url="avatarUrl"
       :url="profileUrl"
-      avatar-class="mr-5"
+      avatar-class="me-2"
       size="42"
       class="pl-3 pt-2 pb-1"
       bold-title>
       <template slot="subTitle">
-        <span v-if="!sameUser">
+        <span v-if="!sameUser" class="caption text-bold">
           {{ inCommonConnections }} {{ $t('UIActivity.label.Reactions_in_Common') }}
         </span>
-      </template>
-      <template slot="actions" v-if="notConnected">
-        <v-btn-toggle class="mr-5">
-          <a
-            text
-            icon
-            min-width="auto"
-            @click="connect()">
-            <i class="uiIconInviteUser"></i>
-          </a>
-        </v-btn-toggle>
       </template>
     </exo-user-avatar>
     <v-divider />

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
@@ -1,14 +1,14 @@
 <template>
-  <div v-if="liker">
+  <div v-if="liker" class="activityLikerItem">
     <exo-user-avatar
       :username="userName"
       :fullname="fullName"
-      :avatar-url="avatar"
-      avatar-class="mr-5"
+      :avatar-url="avatarUrl"
       :url="profileUrl"
-      bold-title
+      avatar-class="mr-5"
       size="42"
-      class="pl-3 pt-2 pb-1">
+      class="pl-3 pt-2 pb-1"
+      bold-title>
       <template slot="subTitle">
         <span v-if="!sameUser">
           {{ inCommonConnections }} {{ $t('UIActivity.label.Reactions_in_Common') }}
@@ -29,9 +29,7 @@
     <v-divider />
   </div>
 </template>
-
 <script>
-
 
 export default {
   props: {
@@ -61,11 +59,11 @@ export default {
     fullName() {
       return this.liker && this.liker.fullname;
     },
-    avatar() {
+    avatarUrl() {
       return this.liker && this.liker.avatar;
     },
     profileUrl() {
-      return this.liker && this.liker.fullname && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.liker.fullname}`;
+      return this.liker && this.userName && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.userName}`;
     },
   },
   created() {
@@ -76,7 +74,6 @@ export default {
       return this.$userService.getUser(this.liker.username, 'all,connectionsInCommonCount,relationshipStatus')
         .then(item => this.userInformations = item)
         .catch((e) => {
-          // eslint-disable-next-line no-console
           console.error('Error while getting user details', e);
         });
     },
@@ -84,8 +81,7 @@ export default {
       this.$userService.connect(this.liker.username)
         .then(this.retrieveUserInformations())
         .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error('Error processing action', e);
+          console.error('Error while connecting to user', e);
         });
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -1,0 +1,120 @@
+<template>
+  <div>
+    <v-list-item
+      v-for="(like ,i) in numberOfLikes "
+      :key="i"
+      class="likerItem">
+      <v-list-item-avatar :size="like.avatarSize">
+        <v-img :src="like.avatar" class="likerAvatar" />
+      </v-list-item-avatar>
+      <v-list-item-content class="pb-3">
+        <v-list-item-title class="body-2 font-weight-bold text-color">
+          <a
+            :id="cmpId"
+            :href="like.profileUrl"
+            rel="nofollow"
+            class="text-color"
+            v-html="like.name">
+          </a>
+        </v-list-item-title>
+        <v-list-item-subtitle v-if="attributesLoaded && !sameUser" class="caption text-bold">
+          {{ inCommonConnections }} {{ $t('UIActivity.label.Reactions_in_Common') }}
+        </v-list-item-subtitle>
+      </v-list-item-content>
+      <v-list-item-action v-if="notConnected">
+        <v-btn-toggle class="transparent">
+          <a
+            text
+            icon
+            min-width="auto"
+            @click="connect()">
+            <i class="uiIconInviteUser"></i>
+          </a>
+        </v-btn-toggle>
+      </v-list-item-action>
+    </v-list-item>
+  </div>
+</template>
+<script>
+
+export default {
+  props: {
+    activityId: {
+      type: String,
+      default: () => ''
+    }
+  },
+  data () {
+    return {
+      cmpId: `react${parseInt(Math.random() * 10000)
+        .toString()}`,
+      user: null,
+      likes: null,
+      attributesLoaded: false,
+      limit: 10,
+    };
+  },
+  computed: {
+    inCommonConnections() {
+      return this.user && this.user.connectionsInCommonCount || 0;
+    },
+    sameUser() {
+      return this.user && this.user.username === eXo.env.portal.userName;
+    },
+    notConnected() {
+      return this.user && !this.user.relationshipStatus && !this.sameUser;
+    },
+    profileUrl() {
+      return this.user && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.user.username}`;
+    },
+    numberOfLikes() {
+      return this.likes && this.likes.length ;
+    }
+  },
+  created() {
+    this.retrieveLikers();
+    this.retrieveUserInformations();
+    this.initTiptip();
+  },
+  methods: {
+    retrieveUserInformations() {
+      return this.$userService.getUser(this.userId, 'all,connectionsInCommonCount,relationshipStatus')
+        .then(item => this.user = item)
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Error while getting user details', e);
+        })
+        .finally(() => this.attributesLoaded = true);
+    },
+    retrieveLikers() {
+      return this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
+        .then(data => {
+          this.likes = data;
+        })
+        .catch((e => {
+          console.error('error retrieving activity likers' , e) ;
+        }));
+    },
+    connect() {
+      this.$userService.connect(this.userId)
+        .then(this.retrieveUserInformations())
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Error processing action', e);
+        });
+    },
+    initTiptip() {
+      this.$nextTick(() => {
+        $(`#${this.cmpId}`).userPopup({
+          restURL: '/portal/rest/social/people/getPeopleInfo/{0}.json',
+          userId: this.id,
+          content: false,
+          keepAlive: true,
+          defaultPosition: 'top_left',
+          maxWidth: '240px',
+        });
+      });
+    },
+  },
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -65,6 +65,12 @@ export default {
       return this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
         .then(data => {
           this.likes = data.likes;
+          document.dispatchEvent(new CustomEvent('updateReaction', {
+            detail: {
+              numberOfReactions: this.numberOfReactions ,
+              type: 'like'
+            }
+          }));
         })
         .catch((e => {
           console.error('error retrieving activity likers' , e) ;

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -9,7 +9,6 @@
   </div>
 </template>
 <script>
-
 export default {
   props: {
     activityId: {
@@ -36,7 +35,7 @@ export default {
       return this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
         .then(data => {
           this.likers = data.likes;
-          document.dispatchEvent(new CustomEvent('updateReaction', {
+          document.dispatchEvent(new CustomEvent('update-reaction-extension', {
             detail: {
               numberOfReactions: this.numberOfReactions ,
               type: 'like'
@@ -46,14 +45,6 @@ export default {
         .catch((e => {
           console.error('error retrieving activity likers' , e) ;
         }));
-    },
-    connect() {
-      this.$userService.connect(this.userId)
-        .then(this.retrieveUserInformations())
-        .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error('Error processing action', e);
-        });
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -1,37 +1,25 @@
 <template>
-  <div>
+  <div v-if="likes">
     <v-list-item
-      v-for="(like ,i) in numberOfLikes "
+      v-for="(like ,i) in likes"
       :key="i"
       class="likerItem">
-      <v-list-item-avatar :size="like.avatarSize">
+      <v-list-item-avatar
+        v-if="like"
+        :size="15">
         <v-img :src="like.avatar" class="likerAvatar" />
       </v-list-item-avatar>
       <v-list-item-content class="pb-3">
         <v-list-item-title class="body-2 font-weight-bold text-color">
           <a
             :id="cmpId"
-            :href="like.profileUrl"
+            :href="like.href"
             rel="nofollow"
             class="text-color"
-            v-html="like.name">
+            v-html="like.fullname">
           </a>
         </v-list-item-title>
-        <v-list-item-subtitle v-if="attributesLoaded && !sameUser" class="caption text-bold">
-          {{ inCommonConnections }} {{ $t('UIActivity.label.Reactions_in_Common') }}
-        </v-list-item-subtitle>
       </v-list-item-content>
-      <v-list-item-action v-if="notConnected">
-        <v-btn-toggle class="transparent">
-          <a
-            text
-            icon
-            min-width="auto"
-            @click="connect()">
-            <i class="uiIconInviteUser"></i>
-          </a>
-        </v-btn-toggle>
-      </v-list-item-action>
     </v-list-item>
   </div>
 </template>
@@ -49,7 +37,7 @@ export default {
       cmpId: `react${parseInt(Math.random() * 10000)
         .toString()}`,
       user: null,
-      likes: null,
+      likes: [],
       attributesLoaded: false,
       limit: 10,
     };
@@ -70,10 +58,11 @@ export default {
     numberOfLikes() {
       return this.likes && this.likes.length ;
     }
+
   },
   created() {
     this.retrieveLikers();
-    this.retrieveUserInformations();
+    //this.retrieveUserInformations();
     this.initTiptip();
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -1,11 +1,9 @@
 <template>
-  <div v-if="likers">
-    <div
+  <div v-if="likers.length" class="likers-list">
+    <activity-liker-item
       v-for="(liker , i) in likers"
-      :key="i">
-      <activity-liker-item
-        :liker="liker" />
-    </div>
+      :key="i"
+      :liker="liker" />
   </div>
 </template>
 <script>
@@ -22,22 +20,17 @@ export default {
       limit: 10,
     };
   },
-  computed: {
-    numberOfReactions() {
-      return this.likers && this.likers.length;
-    },
-  },
   created() {
     this.retrieveLikers();
   },
   methods: {
     retrieveLikers() {
-      return this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
+      return this.$activityService.getActivityLikers(this.activityId, 0)
         .then(data => {
           this.likers = data.likes;
           document.dispatchEvent(new CustomEvent('update-reaction-extension', {
             detail: {
-              numberOfReactions: this.numberOfReactions ,
+              numberOfReactions: this.likers.length,
               type: 'like'
             }
           }));

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -1,17 +1,10 @@
 <template>
-  <div v-if="likes">
+  <div v-if="likers">
     <div
-      v-for="(like , i) in likes"
+      v-for="(liker , i) in likers"
       :key="i">
-      <exo-user-avatar
-        :username="like.username"
-        :fullname="like.fullname"
-        :avatar-url="like.avatar"
-        :url="profileUrl(like.fullname)"
-        bold-title
-        size="32"
-        class="pl-3 pt-2 pb-2" />
-      <v-divider dark />
+      <activity-liker-item
+        :liker="liker" />
     </div>
   </div>
 </template>
@@ -26,45 +19,23 @@ export default {
   },
   data () {
     return {
-      cmpId: `react${parseInt(Math.random() * 10000)
-        .toString()}`,
-      user: null,
-      likes: [],
-      attributesLoaded: false,
+      likers: [],
       limit: 10,
     };
   },
   computed: {
-    inCommonConnections() {
-      return this.user && this.user.connectionsInCommonCount || 0;
-    },
-    sameUser() {
-      return this.user && this.user.username === eXo.env.portal.userName;
-    },
-    notConnected() {
-      return this.user && !this.user.relationshipStatus && !this.sameUser;
-    },
     numberOfReactions() {
-      return this.likes && this.likes.length;
+      return this.likers && this.likers.length;
     },
   },
   created() {
     this.retrieveLikers();
   },
   methods: {
-    retrieveUserInformations() {
-      return this.$userService.getUser(this.userId, 'all,connectionsInCommonCount,relationshipStatus')
-        .then(item => this.user = item)
-        .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error('Error while getting user details', e);
-        })
-        .finally(() => this.attributesLoaded = true);
-    },
     retrieveLikers() {
       return this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
         .then(data => {
-          this.likes = data.likes;
+          this.likers = data.likes;
           document.dispatchEvent(new CustomEvent('updateReaction', {
             detail: {
               numberOfReactions: this.numberOfReactions ,
@@ -75,9 +46,6 @@ export default {
         .catch((e => {
           console.error('error retrieving activity likers' , e) ;
         }));
-    },
-    profileUrl(fullName) {
-      return fullName && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${fullName}`;
     },
     connect() {
       this.$userService.connect(this.userId)

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -1,26 +1,18 @@
 <template>
   <div v-if="likes">
-    <v-list-item
-      v-for="(like ,i) in likes"
-      :key="i"
-      class="likerItem">
-      <v-list-item-avatar
-        v-if="like"
-        :size="15">
-        <v-img :src="like.avatar" class="likerAvatar" />
-      </v-list-item-avatar>
-      <v-list-item-content class="pb-3">
-        <v-list-item-title class="body-2 font-weight-bold text-color">
-          <a
-            :id="cmpId"
-            :href="like.href"
-            rel="nofollow"
-            class="text-color"
-            v-html="like.fullname">
-          </a>
-        </v-list-item-title>
-      </v-list-item-content>
-    </v-list-item>
+    <div
+      v-for="(like , i) in likes"
+      :key="i">
+      <exo-user-avatar
+        :username="like.username"
+        :fullname="like.fullname"
+        :avatar-url="like.avatar"
+        :url="profileUrl(like.fullname)"
+        bold-title
+        size="32"
+        class="pl-3 pt-2 pb-2" />
+      <v-divider dark />
+    </div>
   </div>
 </template>
 <script>
@@ -52,18 +44,12 @@ export default {
     notConnected() {
       return this.user && !this.user.relationshipStatus && !this.sameUser;
     },
-    profileUrl() {
-      return this.user && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.user.username}`;
+    numberOfReactions() {
+      return this.likes && this.likes.length;
     },
-    numberOfLikes() {
-      return this.likes && this.likes.length ;
-    }
-
   },
   created() {
     this.retrieveLikers();
-    //this.retrieveUserInformations();
-    this.initTiptip();
   },
   methods: {
     retrieveUserInformations() {
@@ -78,11 +64,14 @@ export default {
     retrieveLikers() {
       return this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
         .then(data => {
-          this.likes = data;
+          this.likes = data.likes;
         })
         .catch((e => {
           console.error('error retrieving activity likers' , e) ;
         }));
+    },
+    profileUrl(fullName) {
+      return fullName && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${fullName}`;
     },
     connect() {
       this.$userService.connect(this.userId)
@@ -91,18 +80,6 @@ export default {
           // eslint-disable-next-line no-console
           console.error('Error processing action', e);
         });
-    },
-    initTiptip() {
-      this.$nextTick(() => {
-        $(`#${this.cmpId}`).userPopup({
-          restURL: '/portal/rest/social/people/getPeopleInfo/{0}.json',
-          userId: this.id,
-          content: false,
-          keepAlive: true,
-          defaultPosition: 'top_left',
-          maxWidth: '240px',
-        });
-      });
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -18,7 +18,7 @@
             :key="i"
             :href="`#tab-${tab.componentOptions.order}`"
             class="text-capitalize">
-            <span>{{ tab.componentOptions.reactionType }} ({{ numberOfReactions(tab) }})</span>
+            <span>{{ tab.componentOptions.reactionType }} ({{ tab.componentOptions.numberOfReactions }})</span>
           </v-tab>
         </v-tabs>
         <v-divider dark />
@@ -87,6 +87,9 @@ export default {
       };
     },
   },
+  created() {
+    document.addEventListener('updateReaction' , this.updateReaction );
+  },
   methods: {
     open() {
       this.refreshReactions();
@@ -103,15 +106,20 @@ export default {
     cancel() {
       this.$refs.activityReactionsDrawer.close();
     },
-    numberOfReactions(tab) {
-      return tab && tab.componentOptions.vueComponent.$options.computed.numberOfReactions();
-    },
     refreshReactions() {
       this.activityReactionsExtensions= [];
       const componentsToLoad = extensionRegistry.loadComponents('ActivityReactions') || [];
       // eslint-disable-next-line eqeqeq
       this.activityReactionsExtensions = componentsToLoad;
     },
+    updateReaction(event) {
+      if (event && event.detail) {
+        const extensionIndex = this.enabledReactionsTabsExtensions.findIndex(extension => extension.componentOptions.id === event.detail.type);
+        const extension = this.enabledReactionsTabsExtensions[extensionIndex];
+        extension.componentOptions.numberOfReactions = event.detail.numberOfReactions;
+        this.enabledReactionsTabsExtensions.splice(extensionIndex,1,extension);
+      }
+    }
   },
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -5,27 +5,26 @@
     right
     fixed>
     <template slot="title">
-      {{ $t('UIActivity.label.Reactions_Number') }}
+      {{ $t('UIActivity.label.reactions') }}
     </template>
     <template v-if="drawerOpened" slot="content">
       <div>
         <v-tabs
-          fixed-tabs
           slider-size="4"
           v-model="selectedTab">
           <v-tab
-            v-for="(tab, i) in enabledReactionsTabsExtensions"
+            v-for="(tab, i) in enabledReactionsTabsExtensionsToDisplay"
             :key="i"
             :href="`#tab-${tab.componentOptions.order}`"
             class="text-capitalize">
-            <span>{{ tab.componentOptions.reactionType }} ({{ tab.componentOptions.numberOfReactions }})</span>
+            <span>  {{ $t(`UIActivity.label.${tab.componentOptions.reactionLabel}`) }}({{ tab.componentOptions.numberOfReactions }})</span>
           </v-tab>
         </v-tabs>
         <v-divider dark />
       </div>
       <v-tabs-items v-model="selectedTab" class="pt-3">
         <v-tab-item
-          v-for="(tab, i) in enabledReactionsTabsExtensions"
+          v-for="(tab, i) in enabledReactionsTabsExtensionsToDisplay"
           :key="i"
           :eager="true"
           :value="`tab-${tab.componentOptions.order}`">
@@ -81,6 +80,9 @@ export default {
       }
       return this.activityReactionsExtensions;
     },
+    enabledReactionsTabsExtensionsToDisplay() {
+      return this.enabledReactionsTabsExtensions && this.enabledReactionsTabsExtensions.slice().filter(extension => extension.componentOptions.numberOfReactions > 0) || [];
+    },
     reactionParams() {
       return {
         activityId: this.activityId,
@@ -88,7 +90,10 @@ export default {
     },
   },
   created() {
-    document.addEventListener('updateReaction' , this.updateReaction );
+    document.addEventListener('update-reaction-extension' ,
+      (event) => {
+        this.updateReaction(event);
+      });
   },
   methods: {
     open() {
@@ -108,9 +113,7 @@ export default {
     },
     refreshReactions() {
       this.activityReactionsExtensions= [];
-      const componentsToLoad = extensionRegistry.loadComponents('ActivityReactions') || [];
-      // eslint-disable-next-line eqeqeq
-      this.activityReactionsExtensions = componentsToLoad;
+      this.activityReactionsExtensions = extensionRegistry.loadComponents('ActivityReactions') || [];
     },
     updateReaction(event) {
       if (event && event.detail) {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -13,10 +13,8 @@
             v-for="(tab, i) in enabledReactionsTabsExtensions"
             :key="i"
             :href="`#tab-${tab.order}`"
-            :class="`all${tab.class}`"
-            class="pe-3 ps-0">
-            <i :class="tab.icon"></i>
-            <span :class="`${tab.class}NumberLabel`">{{ tab.kudosNumber }}</span>
+            class="text-capitalize">
+            <span>{{ tab.componentOptions.reactionType }}</span>
           </v-tab>
         </v-tabs>
       </div>
@@ -58,15 +56,9 @@
           :key="i"
           :eager="true"
           :value="`tab-${tab.order}`">
-          <activity-reactions-list-items
-            v-for="(item, index) in tab.reactionListItems"
-            :key="index"
-            :user-id="item.senderId"
-            :avatar="item.senderAvatar"
-            :name="item.senderFullName"
-            :class="`${tab.class}List`"
-            :profile-url="item.senderURL"
-            class="px-3" />
+          <extension-registry-component
+            :component="tab"
+            :params="reactionParams" />
         </v-tab-item>
       </v-tabs-items>
     </template>
@@ -134,6 +126,11 @@ export default {
       }
       return this.activityReactionsExtensions;
     },
+    reactionParams() {
+      return {
+        activityId: this.activityId,
+      };
+    },
   },
   methods: {
     open() {
@@ -162,10 +159,9 @@ export default {
     },
     refreshReactions() {
       this.activityReactionsExtensions= [];
-      const contentsToLoad = extensionRegistry.loadExtensions('activity-reactions', 'activity-reactions') || [];
+      const componentsToLoad = extensionRegistry.loadComponents('ActivityReactions') || [];
       // eslint-disable-next-line eqeqeq
-      this.activityReactionsExtensions = contentsToLoad.filter(contentDetail => contentDetail.activityId == this.activityId );
-      this.$emit('reactions', this.kudosNumber);
+      this.activityReactionsExtensions = componentsToLoad;
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -5,22 +5,25 @@
     right
     fixed>
     <template slot="title">
+      {{ $t('UIActivity.label.Reactions_Number') }}
+    </template>
+    <template v-if="drawerOpened" slot="content">
       <div>
         <v-tabs
           fixed-tabs
+          slider-size="4"
           v-model="selectedTab">
           <v-tab
             v-for="(tab, i) in enabledReactionsTabsExtensions"
             :key="i"
             :href="`#tab-${tab.componentOptions.order}`"
             class="text-capitalize">
-            <span>{{ tab.componentOptions.reactionType }}</span>
+            <span>{{ tab.componentOptions.reactionType }} ({{ numberOfReactions(tab) }})</span>
           </v-tab>
         </v-tabs>
+        <v-divider dark />
       </div>
-    </template>
-    <template v-if="drawerOpened" slot="content">
-      <v-tabs-items v-model="selectedTab">
+      <v-tabs-items v-model="selectedTab" class="pt-3">
         <v-tab-item
           v-for="(tab, i) in enabledReactionsTabsExtensions"
           :key="i"
@@ -68,7 +71,6 @@ export default {
       selectedTab: null,
       drawerOpened: false,
       activityReactionsExtensions: [],
-      likers: [],
       user: {}
     };
   },
@@ -100,6 +102,9 @@ export default {
     },
     cancel() {
       this.$refs.activityReactionsDrawer.close();
+    },
+    numberOfReactions(tab) {
+      return tab && tab.componentOptions.vueComponent.$options.computed.numberOfReactions();
     },
     refreshReactions() {
       this.activityReactionsExtensions= [];

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -5,14 +5,14 @@
     right
     fixed>
     <template slot="title">
-      <div class="activityReactionsTitle">
-        <v-tabs v-model="selectedTab">
-          <v-tab class="allLikersAndKudos text-color pe-3 ps-0" href="#tab-1">{{ $t('UIActivity.label.Show_All_Likers') }} {{ reactionsNumber }}</v-tab>
-          <v-tab class="allLikers pe-3 ps-0" href="#tab-2"><i class="uiIconThumbUp"></i> <span class="primary--text">{{ likersNumber }}</span></v-tab>
+      <div>
+        <v-tabs
+          fixed-tabs
+          v-model="selectedTab">
           <v-tab
             v-for="(tab, i) in enabledReactionsTabsExtensions"
             :key="i"
-            :href="`#tab-${tab.order}`"
+            :href="`#tab-${tab.componentOptions.order}`"
             class="text-capitalize">
             <span>{{ tab.componentOptions.reactionType }}</span>
           </v-tab>
@@ -21,41 +21,11 @@
     </template>
     <template v-if="drawerOpened" slot="content">
       <v-tabs-items v-model="selectedTab">
-        <v-tab-item value="tab-1">
-          <activity-reactions-list-items
-            v-for="liker in likers"
-            :key="liker.id"
-            :user-id="liker.username"
-            :avatar="liker.avatar"
-            :name="liker.fullname"
-            class="px-3 likersList" />
-          <div v-for="(tab, i) in enabledReactionsTabsExtensions" :key="i">
-            <activity-reactions-list-items
-              v-for="(item, index) in tab.reactionListItems"
-              :key="index"
-              :user-id="item.senderId"
-              :avatar="item.senderAvatar"
-              :name="item.senderFullName"
-              :class="`${tab.class}List`"
-              :profile-url="item.senderURL"
-              class="px-3" />
-          </div>
-        </v-tab-item>
-        <v-tab-item value="tab-2">
-          <activity-reactions-list-items
-            v-for="liker in likers"
-            :key="liker.id"
-            :user-id="liker.username"
-            :avatar="liker.personLikeAvatarImageSource"
-            :name="liker.personLikeFullName"
-            :profile-url="liker.personLikeProfileUri"
-            class="px-3 likersList" />
-        </v-tab-item>
         <v-tab-item
           v-for="(tab, i) in enabledReactionsTabsExtensions"
           :key="i"
           :eager="true"
-          :value="`tab-${tab.order}`">
+          :value="`tab-${tab.componentOptions.order}`">
           <extension-registry-component
             :component="tab"
             :params="reactionParams" />
@@ -78,10 +48,6 @@
 <script>
 export default {
   props: {
-    likersNumber: {
-      type: Number,
-      default: 0
-    },
     extensionsReactions: {
       type: Array,
       default: null
@@ -107,19 +73,6 @@ export default {
     };
   },
   computed: {
-    reactionsNumber () {
-      let allReactionsNumber = this.likersNumber;
-      this.enabledReactionsTabsExtensions.forEach(item => {
-        allReactionsNumber += item.reactionListItems.length;
-      });
-      return allReactionsNumber;
-    },
-    hasMoreLikers() {
-      return this.likersNumber > this.limit;
-    },
-    kudosNumber() {
-      return this.reactionsNumber - this.likersNumber;
-    },
     enabledReactionsTabsExtensions() {
       if (!this.activityReactionsExtensions) {
         return [];
@@ -139,20 +92,11 @@ export default {
       this.drawerOpened = true;
       if (this.lastLoadedActivityId !== this.activityId) {
         this.limit = 10;
-        this.likers = [];
         this.lastLoadedActivityId = this.activityId;
-        this.retrieveLikers();
       }
     },
     loadMore() {
       this.limit += 10;
-      this.retrieveLikers();
-    },
-    retrieveLikers() {
-      this.$refs.activityReactionsDrawer.startLoading();
-      this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
-        .then(data => this.likers = data && data.likes || [])
-        .finally(() => this.$refs.activityReactionsDrawer.endLoading());
     },
     cancel() {
       this.$refs.activityReactionsDrawer.close();

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -11,23 +11,24 @@
       <div>
         <v-tabs
           slider-size="4"
+          fixed-tabs
           v-model="selectedTab">
           <v-tab
-            v-for="(tab, i) in enabledReactionsTabsExtensionsToDisplay"
+            v-for="(tab, i) in enabledReactionsTabsExtensions"
             :key="i"
-            :href="`#tab-${tab.componentOptions.order}`"
+            :href="`#tab-${tab.componentOptions.rank}`"
             class="text-capitalize">
-            <span>  {{ $t(`UIActivity.label.${tab.componentOptions.reactionLabel}`) }}({{ tab.componentOptions.numberOfReactions }})</span>
+            <span>{{ $t(`${tab.componentOptions.reactionLabel}`) }}({{ tab.componentOptions.numberOfReactions }})</span>
           </v-tab>
         </v-tabs>
         <v-divider dark />
       </div>
       <v-tabs-items v-model="selectedTab" class="pt-3">
         <v-tab-item
-          v-for="(tab, i) in enabledReactionsTabsExtensionsToDisplay"
+          v-for="(tab, i) in enabledReactionsTabsExtensions"
           :key="i"
           :eager="true"
-          :value="`tab-${tab.componentOptions.order}`">
+          :value="`tab-${tab.componentOptions.rank}`">
           <extension-registry-component
             :component="tab"
             :params="reactionParams" />
@@ -78,10 +79,9 @@ export default {
       if (!this.activityReactionsExtensions) {
         return [];
       }
-      return this.activityReactionsExtensions;
-    },
-    enabledReactionsTabsExtensionsToDisplay() {
-      return this.enabledReactionsTabsExtensions && this.enabledReactionsTabsExtensions.slice().filter(extension => extension.componentOptions.numberOfReactions > 0) || [];
+      return this.activityReactionsExtensions.slice().sort((extension1, extension2) => {
+        return extension1.componentOptions.rank - extension2.componentOptions.rank;
+      });
     },
     reactionParams() {
       return {
@@ -90,10 +90,7 @@ export default {
     },
   },
   created() {
-    document.addEventListener('update-reaction-extension' ,
-      (event) => {
-        this.updateReaction(event);
-      });
+    document.addEventListener('update-reaction-extension' , this.updateReaction);
   },
   methods: {
     open() {
@@ -118,9 +115,11 @@ export default {
     updateReaction(event) {
       if (event && event.detail) {
         const extensionIndex = this.enabledReactionsTabsExtensions.findIndex(extension => extension.componentOptions.id === event.detail.type);
-        const extension = this.enabledReactionsTabsExtensions[extensionIndex];
-        extension.componentOptions.numberOfReactions = event.detail.numberOfReactions;
-        this.enabledReactionsTabsExtensions.splice(extensionIndex,1,extension);
+        if (extensionIndex >= 0 ) {
+          const extension = this.enabledReactionsTabsExtensions[extensionIndex];
+          extension.componentOptions.numberOfReactions = event.detail.numberOfReactions;
+          this.enabledReactionsTabsExtensions.splice(extensionIndex, 1, extension);
+        }
       }
     }
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
@@ -1,0 +1,22 @@
+export function registerActivityReactionTabs() {
+  /*const likeExtension = {
+    id: `like-${this.activityId}`,
+    icon: 'uiIconThumbUp',
+    reactionType: 'likes',
+    order: 2,
+    activityType: 'ACTIVITY',
+    activityId: this.activityId,
+    reactionNumber: this.activity.likes ? this.activity.likes.length : 0,
+    reactionListItems: this.activity.likes || [],
+    class: 'likers'
+  };*/
+  extensionRegistry.registerComponent('ActivityReactions', 'activity-reaction-action', {
+    id: 'like',
+    icon: 'uiIconThumbUp',
+    reactionType: 'likes',
+    order: 2,
+    activityType: 'ACTIVITY',
+    vueComponent: Vue.options.components['activity-likes-list'],
+    rank: 10,
+  });
+}

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
@@ -1,11 +1,9 @@
 export function registerActivityReactionTabs() {
   extensionRegistry.registerComponent('ActivityReactions', 'activity-reaction-action', {
     id: 'like',
-    icon: 'uiIconThumbUp',
-    reactionType: 'likes',
+    reactionLabel: 'likesLabel',
     numberOfReactions: 0,
     order: 2,
-    activityType: 'ACTIVITY',
     vueComponent: Vue.options.components['activity-likes-list'],
     rank: 10,
   });

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
@@ -1,19 +1,9 @@
 export function registerActivityReactionTabs() {
-  /*const likeExtension = {
-    id: `like-${this.activityId}`,
-    icon: 'uiIconThumbUp',
-    reactionType: 'likes',
-    order: 2,
-    activityType: 'ACTIVITY',
-    activityId: this.activityId,
-    reactionNumber: this.activity.likes ? this.activity.likes.length : 0,
-    reactionListItems: this.activity.likes || [],
-    class: 'likers'
-  };*/
   extensionRegistry.registerComponent('ActivityReactions', 'activity-reaction-action', {
     id: 'like',
     icon: 'uiIconThumbUp',
     reactionType: 'likes',
+    numberOfReactions: 0,
     order: 2,
     activityType: 'ACTIVITY',
     vueComponent: Vue.options.components['activity-likes-list'],

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
@@ -1,10 +1,9 @@
 export function registerActivityReactionTabs() {
   extensionRegistry.registerComponent('ActivityReactions', 'activity-reaction-action', {
     id: 'like',
-    reactionLabel: 'likesLabel',
+    reactionLabel: 'UIActivity.label.likesLabel',
     numberOfReactions: 0,
-    order: 2,
     vueComponent: Vue.options.components['activity-likes-list'],
-    rank: 10,
+    rank: 1,
   });
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/initComponents.js
@@ -3,11 +3,12 @@ import ActivityReactions from './components/ActivityReactions.vue';
 import ActivityReactionsListItems from './components/ActivityReactionsListItems.vue';
 import ActivityReactionsDrawer from './components/ActivityReactionsDrawer.vue';
 import ActivityReactionsMobile from './components/ActivityReactionsMobile.vue';
-
+import ActivityLikesList from './components/ActivityLikesList.vue';
 const components = {
   'activity-reactions-app': ActivityReactionsApp,
   'activity-reactions': ActivityReactions,
   'activity-reactions-list-items': ActivityReactionsListItems,
+  'activity-likes-list': ActivityLikesList,
   'activity-reactions-drawer': ActivityReactionsDrawer,
   'activity-reactions-mobile': ActivityReactionsMobile
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/initComponents.js
@@ -4,11 +4,13 @@ import ActivityReactionsListItems from './components/ActivityReactionsListItems.
 import ActivityReactionsDrawer from './components/ActivityReactionsDrawer.vue';
 import ActivityReactionsMobile from './components/ActivityReactionsMobile.vue';
 import ActivityLikesList from './components/ActivityLikesList.vue';
+import ActivityLikerItem from './components/ActivityLikerItem.vue';
 const components = {
   'activity-reactions-app': ActivityReactionsApp,
   'activity-reactions': ActivityReactions,
   'activity-reactions-list-items': ActivityReactionsListItems,
   'activity-likes-list': ActivityLikesList,
+  'activity-liker-item': ActivityLikerItem,
   'activity-reactions-drawer': ActivityReactionsDrawer,
   'activity-reactions-mobile': ActivityReactionsMobile
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
@@ -1,6 +1,8 @@
 import './initComponents.js';
+import * as extensions from './extensions.js';
 
 // get overrided components if exists
+extensions.registerActivityReactionTabs();
 if (extensionRegistry) {
   const components = extensionRegistry.loadComponents('ActivityReactions');
   if (components && components.length > 0) {
@@ -9,3 +11,4 @@ if (extensionRegistry) {
     });
   }
 }
+

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
@@ -11,4 +11,3 @@ if (extensionRegistry) {
     });
   }
 }
-

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -3,7 +3,7 @@
     <a
       :id="id"
       :href="url"
-      class="flex-nowrap flex-shrink-0 d-flex text-truncate container--fluid">
+      class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid">
       <v-avatar
         :size="size"
         :class="avatarClass"
@@ -13,7 +13,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy">
       </v-avatar>
-      <div v-if="fullname || $slots.subTitle" class="pull-left ms-2 d-flex flex-column text-truncate">
+      <div v-if="fullname || $slots.subTitle" class="pull-left ms-2 d-flex flex-column align-start text-truncate">
         <p
           v-if="fullname"
           :class="fullnameStyle"


### PR DESCRIPTION
before these changes , reactions in the reactions drawer were displayed in just one list in addition to a likes list  which wasn't recommended as a good UX practice and is confusing for some users . with this implementation the reactions are displayed by type and in i made sure that the drawer can support new reactions extensions that can be added in the ActivityReactions.vue file. 