### PR TITLE
Task-47724: Fix connections number is not displayed correctly

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
@@ -336,6 +336,24 @@ public class CachedIdentityStorage implements IdentityStorage {
     exoProfileCache.remove(key);
     clearCache();
   }
+
+  /**
+   * Clear the identity cache.
+   *
+   * @param identity
+   * @param clearList
+   */
+  public void clearIdentityCache(Identity identity, boolean clearList) {
+    IdentityKey key = new IdentityKey(new Identity(identity.getId()));
+    exoIdentityCache.remove(key);
+    IdentityCompositeKey compositeKey = new IdentityCompositeKey(identity.getProviderId(), identity.getRemoteId());
+    if (exoIdentityIndexCache.get(compositeKey) != null) {
+      exoIdentityIndexCache.remove(compositeKey);
+    }
+    if (clearList) {
+      clearCache();
+    }
+  }
   
   /**
    * {@inheritDoc}

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedRelationshipStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedRelationshipStorage.java
@@ -194,6 +194,17 @@ public class CachedRelationshipStorage implements RelationshipStorage {
 
   }
 
+  /**
+   * Remove identity cache.
+   *
+   * @param identity
+   */
+  private void removeIdentityCache(Identity identity) {
+    if (identityStorage instanceof CachedIdentityStorage) {
+      ((CachedIdentityStorage) identityStorage).clearIdentityCache(identity, false);
+    }
+  }
+
   public CachedRelationshipStorage(final RDBMSRelationshipStorageImpl storage,
                                    final IdentityStorage identityStorage,
                                    final SocialStorageCacheService cacheService) {
@@ -237,6 +248,10 @@ public class CachedRelationshipStorage implements RelationshipStorage {
     exoRelationshipCache.put(key, new RelationshipData(r));
     exoRelationshipByIdentityCache.put(identityKey1, key);
     exoRelationshipByIdentityCache.put(identityKey2, key);
+
+    removeIdentityCache(r.getSender());
+    removeIdentityCache(r.getReceiver());
+
     clearCacheFor(relationship);
 
     return r;
@@ -261,6 +276,9 @@ public class CachedRelationshipStorage implements RelationshipStorage {
 
       identityKey = new RelationshipIdentityKey(relationship.getReceiver().getId(), relationship.getSender().getId());
       relationshipCacheIdentity.remove(identityKey);
+
+      removeIdentityCache(relationship.getSender());
+      removeIdentityCache(relationship.getReceiver());
     }
 
     //

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/identity/IdentityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/identity/IdentityRestResourcesTest.java
@@ -1,13 +1,23 @@
 package org.exoplatform.social.rest.impl.identity;
 
 import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
+import org.exoplatform.services.rest.tools.DummyContainerResponseWriter;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.manager.RelationshipManager;
+import org.exoplatform.social.core.relationship.model.Relationship;
 import org.exoplatform.social.rest.entity.*;
 import org.exoplatform.social.service.rest.api.VersionResources;
 import org.exoplatform.social.service.test.AbstractResourceTest;
+
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class IdentityRestResourcesTest extends AbstractResourceTest {
   private IdentityManager identityManager;
@@ -69,5 +79,48 @@ public class IdentityRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
     CollectionEntity collections = (CollectionEntity) response.getEntity();
     assertEquals(1, collections.getEntities().size());
+  }
+
+  public void testGetIdentityById() throws Exception {
+    startSessionAs("root");
+    Identity rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root");
+    Identity johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john");
+
+    ContainerResponse response = service("GET",
+                                         "/" + VersionResources.VERSION_ONE + "/social/identities/" + johnIdentity.getId(),
+                                         "",
+                                         null,
+                                         null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    EntityTag eTag = (EntityTag) response.getHttpHeaders().getFirst("ETAG");
+    assertNotNull(eTag);
+
+    MultivaluedMap<String, String> headers = new MultivaluedMapImpl();
+    headers.putSingle("If-None-Match", "\"" + eTag.getValue() + "\"");
+    response =
+             service("GET", "/" + VersionResources.VERSION_ONE + "/social/identities/" + johnIdentity.getId(), "", headers, null);
+    assertNotNull(response);
+    assertEquals(304, response.getStatus());
+
+    // a relationship has added, the cache identity should be cleared
+    relationshipManager.inviteToConnect(rootIdentity, johnIdentity);
+    relationshipManager.confirm(johnIdentity, rootIdentity);
+    headers = new MultivaluedMapImpl();
+    headers.putSingle("If-None-Match", "\"" + eTag.getValue() + "\"");
+    response =
+             service("GET", "/" + VersionResources.VERSION_ONE + "/social/identities/" + johnIdentity.getId(), "", headers, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+
+    // a relationship has removed, the cache identity should be cleared
+    Relationship relationship = relationshipManager.get(rootIdentity, johnIdentity);
+    relationshipManager.delete(relationship);
+    headers = new MultivaluedMapImpl();
+    headers.putSingle("If-None-Match", "\"" + eTag.getValue() + "\"");
+    response =
+             service("GET", "/" + VersionResources.VERSION_ONE + "/social/identities/" + johnIdentity.getId(), "", headers, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
   }
 }


### PR DESCRIPTION
Prior this change, the number of connections in the profile widget is not updated when a new connection is added, this due to that the identity cache is not updated in this case.
Fix : Clear identity cache when save or delete a relationShip.