### PR TITLE
Task-50922: Allow to add Metadata items by configuration.

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataInitPlugin.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataInitPlugin.java
@@ -32,10 +32,8 @@ public class MetadataInitPlugin extends BaseComponentPlugin {
   protected Metadata          metadata;
 
   public MetadataInitPlugin(InitParams params) {
-    if (params != null) {
-      if (params.containsKey(METADATA_PARAM_NAME)) {
-        this.metadata = (Metadata) params.getObjectParam(METADATA_PARAM_NAME).getObject();
-      }
+    if (params != null && params.containsKey(METADATA_PARAM_NAME)) {
+      this.metadata = (Metadata) params.getObjectParam(METADATA_PARAM_NAME).getObject();
     }
     if (this.metadata == null) {
       throw new IllegalStateException("Metadata is mandatory");

--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataInitPlugin.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataInitPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.social.metadata;
+
+import org.exoplatform.container.component.BaseComponentPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.social.metadata.model.Metadata;
+
+import lombok.Getter;
+
+public class MetadataInitPlugin extends BaseComponentPlugin {
+
+  private static final String METADATA_PARAM_NAME = "metadata";
+
+  @Getter
+  protected Metadata          metadata;
+
+  public MetadataInitPlugin(InitParams params) {
+    if (params != null) {
+      if (params.containsKey(METADATA_PARAM_NAME)) {
+        this.metadata = (Metadata) params.getObjectParam(METADATA_PARAM_NAME).getObject();
+      }
+    }
+    if (this.metadata == null) {
+      throw new IllegalStateException("Metadata is mandatory");
+    }
+  }
+
+}

--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -165,6 +165,14 @@ public interface MetadataService {
   void addMetadataTypePlugin(MetadataTypePlugin metadataTypePlugin);
 
   /**
+   * Save a new {@link Metadata}
+   *
+   * @param metadataInitPlugin a {@link ComponentPlugin} defining
+   *          {@link Metadata} to save
+   */
+  void addMetadataPlugin(MetadataInitPlugin metadataInitPlugin);
+
+  /**
    * Retrieves a registered {@link MetadataTypePlugin} by name
    * 
    * @param name {@link MetadataType} name

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
 
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -309,6 +310,7 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   }
 
   @Override
+  @ExoTransactional
   public void start() {
     this.metadataPlugins.forEach(plugin -> {
       Metadata metadata = plugin.getMetadata();

--- a/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
@@ -34,6 +34,7 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.test.AbstractCoreTest;
 import org.exoplatform.social.metadata.model.*;
+import org.picocontainer.Startable;
 
 public class MetadataServiceTest extends AbstractCoreTest {
 
@@ -1123,6 +1124,33 @@ public class MetadataServiceTest extends AbstractCoreTest {
     names = metadataService.findMetadataNamesByAudiences(term, type, Collections.singleton(spaceIds.get(2)), 100);
     assertNotNull(names);
     assertEquals(count, names.size());
+  }
+
+  public void testAddMetadataInitPlugin() {
+    InitParams params = new InitParams();
+    Metadata metadata = new Metadata();
+    metadata.setAudienceId(2l);
+    metadata.setName("test8");
+    metadata.setType(userMetadataType);
+    metadata.setProperties(Collections.singletonMap("propName", "propValue"));
+
+    ObjectParameter parameter = new ObjectParameter();
+    parameter.setName("metadata");
+    parameter.setObject(metadata);
+    params.addParameter(parameter);
+    MetadataInitPlugin initPlugin = new MetadataInitPlugin(params);
+    metadataService.addMetadataPlugin(initPlugin);
+
+    ((Startable) metadataService).start();
+
+    Metadata storedMetadata = metadataService.getMetadataByKey(new MetadataKey(metadata.getTypeName(), metadata.getName(), metadata.getAudienceId()));
+    assertNotNull(storedMetadata);
+    assertEquals(metadata.getName(), storedMetadata.getName());
+    assertEquals(metadata.getTypeName(), storedMetadata.getTypeName());
+    assertEquals(metadata.getAudienceId(), storedMetadata.getAudienceId());
+    assertEquals(metadata.getProperties(), storedMetadata.getProperties());
+    assertTrue(storedMetadata.getCreatedDate() > 0);
+    assertEquals(0, storedMetadata.getCreatorId());
   }
 
   private int countTerms(List<String> names, String term) {


### PR DESCRIPTION
Prior to this change, it was not possible to add Metadata items by configuration. After this change, adding default Metadata items related to a specific Metadata type will be possible by configuration.