### PR TITLE
50499 : remove access restriction from Mobile section in user settings

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/userSettingMobile.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/userSettingMobile.jsp
@@ -1,14 +1,3 @@
-<%@ page import="org.exoplatform.commons.api.settings.ExoFeatureService"%>
-<%@ page import="org.exoplatform.commons.utils.CommonsUtils"%>
-<%@ page import="org.exoplatform.services.security.ConversationState"%>
-
-<%
-  ExoFeatureService featureService = CommonsUtils.getService(ExoFeatureService.class);
-	boolean isEnabled = featureService.isFeatureActiveForUser("UserSettingMobile",
-	                      ConversationState.getCurrent().getIdentity().getUserId());;
-%>
-<% if(isEnabled) { %>
-
 <div class="VuetifyApp">
     <div id="UserSettingMobile">
         <script type="text/javascript">
@@ -16,4 +5,3 @@
         </script>
     </div>
 </div>
-<%}%>


### PR DESCRIPTION
This fix will make Mobile settings appear for all authenticated users. This settings was hidden until the release of iOS application.