### PR TITLE
Task-50286 : Add translation extension

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -49,9 +49,16 @@ export default {
     },
   },
   created() {
-    document.addEventListener(`extension-${this.extensionApp}-${this.activityTypeExtension}-updated`, this.refreshActivityTypes);
-    document.addEventListener(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`, this.refreshActivityActions);
-    document.addEventListener(`extension-${this.extensionApp}-${this.commentActionExtension}-updated`, this.refreshCommentActions);
+    console.warn(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`);
+    document.addEventListener(`extension-${this.extensionApp}-${this.activityTypeExtension}-updated`, () => {
+      this.refreshActivityTypes();
+    });
+    document.addEventListener(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`, () => {
+      this.refreshActivityActions();
+    });
+    document.addEventListener(`extension-${this.extensionApp}-${this.commentActionExtension}-updated`, () => {
+      this.refreshCommentActions();
+    });
     this.refreshActivityTypes();
     this.refreshActivityActions();
     this.refreshCommentActions();


### PR DESCRIPTION
Before this fix, when an activity action or comment is added with extensionRegistry.registerExtension, the listener configured in ActivityStream.vue is not launched, due to the fact that the listener must have one parameter for the event.
As the 3 refresh* functions have not parameter, they are never launched.

This fix modify the addListener to register an anonymous fucntion which call the register function, so that the event correctly call the refresh function