### PR TITLE
[Accessibility-Image C1.2] Add presentation role on users and spaces avatar images that should be ignored by AT

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
@@ -24,7 +24,8 @@
               :src="seeMoreLikerToDisplay.avatar"
               :title="seeMoreLikerToDisplay.fullname"
               class="object-fit-cover"
-              loading="lazy">
+              loading="lazy"
+              role="presentation">
             <span class="seeMoreLikersDetails">+{{ showMoreLikersNumber }}</span>
           </v-avatar>
         </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -23,7 +23,8 @@
             :src="thumbnail"
             :alt="title"
             class="object-fit-cover my-auto"
-            loading="lazy">
+            loading="lazy"
+            role="presentation">
           <v-icon
             v-else
             :size="defaultIconSize"
@@ -62,7 +63,8 @@
           :src="thumbnail"
           :alt="title"
           class="object-fit-cover my-auto"
-          loading="lazy">
+          loading="lazy"
+          role="presentation">
         <v-icon
           v-else
           :size="defaultIconSize"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
@@ -10,7 +10,8 @@
       <img
         :src="avatarUrl"
         class="object-fit-cover my-auto"
-        loading="lazy">
+        loading="lazy"
+        role="presentation">
     </v-avatar>
     {{ displayName }}
   </a>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadUser.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadUser.vue
@@ -8,7 +8,8 @@
       <img
         :src="avatarUrl"
         class="object-fit-cover my-auto"
-        loading="lazy">
+        loading="lazy"
+        role="presentation">
     </v-list-item-avatar>
   </a>
   <a

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -5,7 +5,8 @@
         <img
           :src="avatarUrl"
           class="object-fit-cover my-auto"
-          loading="lazy">
+          loading="lazy"
+          role="presentation">
       </v-list-item-avatar>
       <v-list-item-content class="flex px-0 py-0 mb-2 flex-shrink-1 border-box-sizing rich-editor-content">
         <exo-activity-rich-editor

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -57,7 +57,7 @@
           class="identitySuggesterItem"
           @click:close="remove(item)">
           <v-avatar left>
-            <v-img :src="item.profile.avatarUrl" />
+            <v-img :src="item.profile.avatarUrl" role="presentation" />
           </v-avatar>
           <span class="text-truncate">
             {{ item.profile.external ? item.profile.fullName.concat(' (').concat($t('userAvatar.external.label')).concat(')') : item.profile.fullName }}

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
@@ -11,7 +11,8 @@
         :src="avatarUrl"
         :class="avatarClass"
         class="object-fit-cover ma-auto"
-        loading="lazy">
+        loading="lazy"
+        role="presentation">
     </v-avatar>
     <div v-if="displayName || $slots.subTitle" class="pull-left text-truncate ms-2 d-flex">
       <p

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -11,7 +11,8 @@
         <img
           :src="avatarUrl"
           class="object-fit-cover ma-auto"
-          loading="lazy">
+          loading="lazy"
+          role="presentation">
       </v-avatar>
       <div v-if="fullname || $slots.subTitle" class="pull-left ms-2 d-flex flex-column text-truncate">
         <p

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpaceItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpaceItem.vue
@@ -11,7 +11,8 @@
           :width="avatarSize"
           :max-height="avatarSize"
           :max-width="avatarSize"
-          class="mx-auto spaceAvatar" />
+          class="mx-auto spaceAvatar"
+          role="presentation" />
       </v-avatar>
     </v-list-item-avatar>
     <v-list-item-content

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesRequestsItems.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesRequestsItems.vue
@@ -22,7 +22,8 @@
                   :width="avatarSize"
                   :max-height="avatarSize"
                   :max-width="avatarSize"
-                  class="mx-auto spaceAvatar" />
+                  class="mx-auto spaceAvatar"
+                  role="presentation" />
               </v-avatar>
             </v-list-item-avatar>
             <v-list-item-content class="py-0">

--- a/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverviewPeopleListItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverviewPeopleListItem.vue
@@ -12,7 +12,8 @@
           :width="avatarSize"
           :max-height="avatarSize"
           :max-width="avatarSize"
-          class="mx-auto userAvatar" />
+          class="mx-auto userAvatar"
+          role="presentation" />
       </v-avatar>
     </v-list-item-avatar>
     <v-list-item-content

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderAvatar.vue
@@ -7,7 +7,8 @@
       :lazy-src="(avatarData || user && user.avatar) || ''" 
       :src="(avatarData || user && user.avatar) || ''" 
       transition="none"
-      eager />
+      eager
+      role="presentation" />
     <v-file-input
       v-if="owner && !sendingImage"
       v-show="hover"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -15,7 +15,8 @@
                 :src="manager.avatar"
                 alt="avatar"
                 class="object-fit-cover ma-auto"
-                loading="lazy">
+                loading="lazy"
+                role="presentation">
             </v-avatar>
             {{ manager.fullname }}
           </a>
@@ -35,7 +36,8 @@
                 :src="redactor.avatar"
                 alt="avatar"
                 class="object-fit-cover ma-auto"
-                loading="lazy">
+                loading="lazy"
+                role="presentation">
             </v-avatar>
             {{ redactor.fullname }}
           </a>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingAvatar.vue
@@ -4,7 +4,7 @@
     :size="size"
     class="spaceAvatar"
     tile>
-    <v-img :src="avatarData || avatarUrl || ''" />
+    <v-img :src="avatarData || avatarUrl || ''" role="presentation"/>
     <v-file-input
       v-if="!sendingImage"
       v-show="hover"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -101,6 +101,7 @@
                         :title="lastManagerToDisplay.fullName"
                         class="object-fit-cover"
                         loading="lazy"
+                        role="presentation"
                         :alt="lastManagerToDisplay.fullName">
                       <span
                         id="showMoreManagers"

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/components/SpacesOverviewSpacesListItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/components/SpacesOverviewSpacesListItem.vue
@@ -12,7 +12,8 @@
           :width="avatarSize"
           :max-height="avatarSize"
           :max-width="avatarSize"
-          class="mx-auto spaceAvatar" />
+          class="mx-auto spaceAvatar"
+          role="presentation" />
       </v-avatar>
     </v-list-item-avatar>
     <v-list-item-content

--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
@@ -15,7 +15,8 @@
                 <img
                   :src="user.avatar"
                   class="ma-auto object-fit-cover"
-                  loading="lazy">
+                  loading="lazy"
+                  role="presentation">
               </v-avatar>
             </a>
           </li>


### PR DESCRIPTION
In This Task we add **role presentation**  for all decorative images like users or spaces avatars, that should be ignored by accessibility assistive technology.