### PR TITLE
Task-50286 : Add Translation in 3 dots menu 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -49,9 +49,16 @@ export default {
     },
   },
   created() {
-    document.addEventListener(`extension-${this.extensionApp}-${this.activityTypeExtension}-updated`, this.refreshActivityTypes);
-    document.addEventListener(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`, this.refreshActivityActions);
-    document.addEventListener(`extension-${this.extensionApp}-${this.commentActionExtension}-updated`, this.refreshCommentActions);
+    console.warn(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`);
+    document.addEventListener(`extension-${this.extensionApp}-${this.activityTypeExtension}-updated`, () => {
+      this.refreshActivityTypes();
+    });
+    document.addEventListener(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`, () => {
+      this.refreshActivityActions();
+    });
+    document.addEventListener(`extension-${this.extensionApp}-${this.commentActionExtension}-updated`, () => {
+      this.refreshCommentActions();
+    });
     this.refreshActivityTypes();
     this.refreshActivityActions();
     this.refreshCommentActions();

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -49,16 +49,9 @@ export default {
     },
   },
   created() {
-    console.warn(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`);
-    document.addEventListener(`extension-${this.extensionApp}-${this.activityTypeExtension}-updated`, () => {
-      this.refreshActivityTypes();
-    });
-    document.addEventListener(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`, () => {
-      this.refreshActivityActions();
-    });
-    document.addEventListener(`extension-${this.extensionApp}-${this.commentActionExtension}-updated`, () => {
-      this.refreshCommentActions();
-    });
+    document.addEventListener(`extension-${this.extensionApp}-${this.activityTypeExtension}-updated`, this.refreshActivityTypes);
+    document.addEventListener(`extension-${this.extensionApp}-${this.activityActionExtension}-updated`, this.refreshActivityActions);
+    document.addEventListener(`extension-${this.extensionApp}-${this.commentActionExtension}-updated`, this.refreshCommentActions);
     this.refreshActivityTypes();
     this.refreshActivityActions();
     this.refreshCommentActions();
@@ -100,7 +93,7 @@ export default {
       const extensions = extensionRegistry.loadExtensions(this.extensionApp, this.activityActionExtension);
       extensions.forEach(extension => {
         if (extension.id) {
-          this.activityActions[extension.id] = extension;
+          this.$set(this.activityActions, extension.id, extension);
         }
       });
     },
@@ -108,7 +101,7 @@ export default {
       const extensions = extensionRegistry.loadExtensions(this.extensionApp, this.commentActionExtension);
       extensions.forEach(extension => {
         if (extension.id) {
-          this.commentActions[extension.id] = extension;
+          this.$set(this.commentActions, extension.id, extension);
         }
       });
     },


### PR DESCRIPTION
Before this commit, when a new extension is registred, the activityAction list is updated in ActivityStream.vue, but the event was not transmitted to children (ActivityHeadMenu.vue). This is due to the fact that when updating activityActions object, we updated only element in the array, not all this array

This commit introduce correctly set the value of the object to be transmitted to children component