### PR TITLE
TASK-48986 : Add likes in reactions drawer (#1059)

### DIFF
--- a/component/service/src/main/resources/locale/social/Webui_en.properties
+++ b/component/service/src/main/resources/locale/social/Webui_en.properties
@@ -119,6 +119,7 @@ UIActivity.label.Unlike=Unlike
 UIActivity.label.likesLabel=Likes
 UIActivity.label.single_likeLabel=Like
 UIActivity.label.Show_All_Likers=All
+UIActivity.label.reactions=Reactions
 UIActivity.label.Reactions_Number=Reactions
 UIActivity.label.single_Reaction_Number=Reaction
 UIActivity.label.Reactions_in_Common=connections in common

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
@@ -1,0 +1,78 @@
+<template>
+  <div v-if="liker" class="activityLikerItem">
+    <exo-user-avatar
+      :username="userName"
+      :fullname="fullName"
+      :avatar-url="avatarUrl"
+      :url="profileUrl"
+      avatar-class="me-2"
+      size="42"
+      class="pl-3 pt-2 pb-1"
+      bold-title>
+      <template slot="subTitle">
+        <span v-if="!sameUser" class="caption text-bold">
+          {{ inCommonConnections }} {{ $t('UIActivity.label.Reactions_in_Common') }}
+        </span>
+      </template>
+    </exo-user-avatar>
+    <v-divider />
+  </div>
+</template>
+<script>
+
+export default {
+  props: {
+    liker: {
+      type: Object,
+      default: null
+    }
+  },
+  data () {
+    return {
+      userInformations: null,
+    };
+  },
+  computed: {
+    inCommonConnections() {
+      return this.userInformations && this.userInformations.connectionsInCommonCount || 0;
+    },
+    sameUser() {
+      return this.userInformations && this.userInformations.username === eXo.env.portal.userName;
+    },
+    notConnected() {
+      return this.userInformations && !this.userInformations.relationshipStatus && !this.sameUser;
+    },
+    userName() {
+      return this.liker && this.liker.username;
+    },
+    fullName() {
+      return this.liker && this.liker.fullname;
+    },
+    avatarUrl() {
+      return this.liker && this.liker.avatar;
+    },
+    profileUrl() {
+      return this.liker && this.userName && `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.userName}`;
+    },
+  },
+  created() {
+    this.retrieveUserInformations();
+  },
+  methods: {
+    retrieveUserInformations() {
+      return this.$userService.getUser(this.liker.username, 'all,connectionsInCommonCount,relationshipStatus')
+        .then(item => this.userInformations = item)
+        .catch((e) => {
+          console.error('Error while getting user details', e);
+        });
+    },
+    connect() {
+      this.$userService.connect(this.liker.username)
+        .then(this.retrieveUserInformations())
+        .catch((e) => {
+          console.error('Error while connecting to user', e);
+        });
+    },
+  },
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -1,0 +1,44 @@
+<template>
+  <div v-if="likers.length" class="likers-list">
+    <activity-liker-item
+      v-for="(liker , i) in likers"
+      :key="i"
+      :liker="liker" />
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    activityId: {
+      type: String,
+      default: () => ''
+    }
+  },
+  data () {
+    return {
+      likers: [],
+      limit: 10,
+    };
+  },
+  created() {
+    this.retrieveLikers();
+  },
+  methods: {
+    retrieveLikers() {
+      return this.$activityService.getActivityLikers(this.activityId, 0)
+        .then(data => {
+          this.likers = data.likes;
+          document.dispatchEvent(new CustomEvent('update-reaction-extension', {
+            detail: {
+              numberOfReactions: this.likers.length,
+              type: 'like'
+            }
+          }));
+        })
+        .catch((e => {
+          console.error('error retrieving activity likers' , e) ;
+        }));
+    },
+  },
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -5,68 +5,33 @@
     right
     fixed>
     <template slot="title">
-      <div class="activityReactionsTitle">
-        <v-tabs v-model="selectedTab">
-          <v-tab class="allLikersAndKudos text-color pe-3 ps-0" href="#tab-1">{{ $t('UIActivity.label.Show_All_Likers') }} {{ reactionsNumber }}</v-tab>
-          <v-tab class="allLikers pe-3 ps-0" href="#tab-2"><i class="uiIconThumbUp"></i> <span class="primary--text">{{ likersNumber }}</span></v-tab>
+      {{ $t('UIActivity.label.reactions') }}
+    </template>
+    <template v-if="drawerOpened" slot="content">
+      <div>
+        <v-tabs
+          slider-size="4"
+          fixed-tabs
+          v-model="selectedTab">
           <v-tab
             v-for="(tab, i) in enabledReactionsTabsExtensions"
             :key="i"
-            :href="`#tab-${tab.order}`"
-            :class="`all${tab.class}`"
-            class="pe-3 ps-0">
-            <i :class="tab.icon"></i>
-            <span :class="`${tab.class}NumberLabel`">{{ tab.kudosNumber }}</span>
+            :href="`#tab-${tab.componentOptions.rank}`"
+            class="text-capitalize">
+            <span>{{ $t(`${tab.componentOptions.reactionLabel}`) }} ({{ tab.componentOptions.numberOfReactions }})</span>
           </v-tab>
         </v-tabs>
+        <v-divider dark />
       </div>
-    </template>
-    <template v-if="drawerOpened" slot="content">
-      <v-tabs-items v-model="selectedTab">
-        <v-tab-item value="tab-1">
-          <activity-reactions-list-items
-            v-for="liker in likers"
-            :key="liker.id"
-            :user-id="liker.username"
-            :avatar="liker.avatar"
-            :name="liker.fullname"
-            class="px-3 likersList" />
-          <div v-for="(tab, i) in enabledReactionsTabsExtensions" :key="i">
-            <activity-reactions-list-items
-              v-for="(item, index) in tab.reactionListItems"
-              :key="index"
-              :user-id="item.senderId"
-              :avatar="item.senderAvatar"
-              :name="item.senderFullName"
-              :class="`${tab.class}List`"
-              :profile-url="item.senderURL"
-              class="px-3" />
-          </div>
-        </v-tab-item>
-        <v-tab-item value="tab-2">
-          <activity-reactions-list-items
-            v-for="liker in likers"
-            :key="liker.id"
-            :user-id="liker.username"
-            :avatar="liker.personLikeAvatarImageSource"
-            :name="liker.personLikeFullName"
-            :profile-url="liker.personLikeProfileUri"
-            class="px-3 likersList" />
-        </v-tab-item>
+      <v-tabs-items v-model="selectedTab" class="pt-3">
         <v-tab-item
           v-for="(tab, i) in enabledReactionsTabsExtensions"
           :key="i"
           :eager="true"
-          :value="`tab-${tab.order}`">
-          <activity-reactions-list-items
-            v-for="(item, index) in tab.reactionListItems"
-            :key="index"
-            :user-id="item.senderId"
-            :avatar="item.senderAvatar"
-            :name="item.senderFullName"
-            :class="`${tab.class}List`"
-            :profile-url="item.senderURL"
-            class="px-3" />
+          :value="`tab-${tab.componentOptions.rank}`">
+          <extension-registry-component
+            :component="tab"
+            :params="reactionParams" />
         </v-tab-item>
       </v-tabs-items>
     </template>
@@ -86,10 +51,6 @@
 <script>
 export default {
   props: {
-    likersNumber: {
-      type: Number,
-      default: 0
-    },
     extensionsReactions: {
       type: Array,
       default: null
@@ -110,30 +71,26 @@ export default {
       selectedTab: null,
       drawerOpened: false,
       activityReactionsExtensions: [],
-      likers: [],
       user: {}
     };
   },
   computed: {
-    reactionsNumber () {
-      let allReactionsNumber = this.likersNumber;
-      this.enabledReactionsTabsExtensions.forEach(item => {
-        allReactionsNumber += item.reactionListItems.length;
-      });
-      return allReactionsNumber;
-    },
-    hasMoreLikers() {
-      return this.likersNumber > this.limit;
-    },
-    kudosNumber() {
-      return this.reactionsNumber - this.likersNumber;
-    },
     enabledReactionsTabsExtensions() {
       if (!this.activityReactionsExtensions) {
         return [];
       }
-      return this.activityReactionsExtensions;
+      return this.activityReactionsExtensions.slice().sort((extension1, extension2) => {
+        return extension1.componentOptions.rank - extension2.componentOptions.rank;
+      });
     },
+    reactionParams() {
+      return {
+        activityId: this.activityId,
+      };
+    },
+  },
+  created() {
+    document.addEventListener('update-reaction-extension' , this.updateReaction);
   },
   methods: {
     open() {
@@ -142,31 +99,29 @@ export default {
       this.drawerOpened = true;
       if (this.lastLoadedActivityId !== this.activityId) {
         this.limit = 10;
-        this.likers = [];
         this.lastLoadedActivityId = this.activityId;
-        this.retrieveLikers();
       }
     },
     loadMore() {
       this.limit += 10;
-      this.retrieveLikers();
-    },
-    retrieveLikers() {
-      this.$refs.activityReactionsDrawer.startLoading();
-      this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
-        .then(data => this.likers = data && data.likes || [])
-        .finally(() => this.$refs.activityReactionsDrawer.endLoading());
     },
     cancel() {
       this.$refs.activityReactionsDrawer.close();
     },
     refreshReactions() {
       this.activityReactionsExtensions= [];
-      const contentsToLoad = extensionRegistry.loadExtensions('activity-reactions', 'activity-reactions') || [];
-      // eslint-disable-next-line eqeqeq
-      this.activityReactionsExtensions = contentsToLoad.filter(contentDetail => contentDetail.activityId == this.activityId );
-      this.$emit('reactions', this.kudosNumber);
+      this.activityReactionsExtensions = extensionRegistry.loadComponents('ActivityReactions') || [];
     },
+    updateReaction(event) {
+      if (event && event.detail) {
+        const extensionIndex = this.enabledReactionsTabsExtensions.findIndex(extension => extension.componentOptions.id === event.detail.type);
+        if (extensionIndex >= 0 ) {
+          const extension = this.enabledReactionsTabsExtensions[extensionIndex];
+          extension.componentOptions.numberOfReactions = event.detail.numberOfReactions;
+          this.enabledReactionsTabsExtensions.splice(extensionIndex, 1, extension);
+        }
+      }
+    }
   },
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/extensions.js
@@ -1,0 +1,9 @@
+export function registerActivityReactionTabs() {
+  extensionRegistry.registerComponent('ActivityReactions', 'activity-reaction-action', {
+    id: 'like',
+    reactionLabel: 'UIActivity.label.likesLabel',
+    numberOfReactions: 0,
+    vueComponent: Vue.options.components['activity-likes-list'],
+    rank: 1,
+  });
+}

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/initComponents.js
@@ -3,11 +3,14 @@ import ActivityReactions from './components/ActivityReactions.vue';
 import ActivityReactionsListItems from './components/ActivityReactionsListItems.vue';
 import ActivityReactionsDrawer from './components/ActivityReactionsDrawer.vue';
 import ActivityReactionsMobile from './components/ActivityReactionsMobile.vue';
-
+import ActivityLikesList from './components/ActivityLikesList.vue';
+import ActivityLikerItem from './components/ActivityLikerItem.vue';
 const components = {
   'activity-reactions-app': ActivityReactionsApp,
   'activity-reactions': ActivityReactions,
   'activity-reactions-list-items': ActivityReactionsListItems,
+  'activity-likes-list': ActivityLikesList,
+  'activity-liker-item': ActivityLikerItem,
   'activity-reactions-drawer': ActivityReactionsDrawer,
   'activity-reactions-mobile': ActivityReactionsMobile
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/main.js
@@ -1,6 +1,8 @@
 import './initComponents.js';
+import * as extensions from './extensions.js';
 
 // get overrided components if exists
+extensions.registerActivityReactionTabs();
 if (extensionRegistry) {
   const components = extensionRegistry.loadComponents('ActivityReactions');
   if (components && components.length > 0) {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -3,7 +3,7 @@
     <a
       :id="id"
       :href="url"
-      class="flex-nowrap flex-shrink-0 d-flex text-truncate container--fluid">
+      class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid">
       <v-avatar
         :size="size"
         :class="avatarClass"
@@ -13,7 +13,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy">
       </v-avatar>
-      <div v-if="fullname || $slots.subTitle" class="pull-left ms-2 d-flex flex-column text-truncate">
+      <div v-if="fullname || $slots.subTitle" class="pull-left ms-2 d-flex flex-column align-start text-truncate">
         <p
           v-if="fullname"
           :class="fullnameStyle"


### PR DESCRIPTION
before these changes , reactions in the reactions drawer were displayed in just one list in addition to a likes list which wasn't recommended as a good UX practice and is confusing for some users . with this implementation the reactions are displayed by type and in i made sure that the drawer can support new reactions extensions that can be added in the ActivityReactions.vue file.