### PR TITLE
TASK-51462 : add activity poster id to activityReactions component

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
@@ -46,6 +46,7 @@
       ref="reactionsDrawer"
       :likers-number="likersNumber"
       :activity-id="activityId"
+      :activity-poster-id="activityPosterId"
       :max-items-to-show="maxLikersToShow"
       @reactions="reactionsNumber" />
     <activity-reactions-mobile
@@ -99,6 +100,9 @@ export default {
     },
     showMoreLikersNumber() {
       return this.likersNumber - this.maxLikersToShow + 1;
+    },
+    activityPosterId() {
+      return this.activity && this.activity.identity && this.activity.identity.profile && this.activity.identity.profile.username;
     }
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -60,6 +60,10 @@ export default {
       type: String,
       default: () => ''
     },
+    activityPosterId: {
+      type: String,
+      default: () => ''
+    },
     maxItemsToShow: {
       type: Number,
       default: 0
@@ -87,6 +91,7 @@ export default {
     reactionParams() {
       return {
         activityId: this.activityId,
+        activityPosterId: this.activityPosterId
       };
     },
   },


### PR DESCRIPTION
added activity poster id to activityReactions component because it's needed to handle specific use cases for kudos in the reactions drawer. 