### PR TITLE
class attribute in extension registry components causes problems on s…

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -14,7 +14,7 @@
       type="activity-stream-drawers"
       parent-element="div"
       element="div"
-      class="drawer-parent" />
+      />
   </v-app>
 </template>
 


### PR DESCRIPTION
issue: [BUG]: TABS bar of space hide the footer of the drawer  #50022
fix: The class attribute in the enclosing div for the comments drawer and share drawer causes problems on safari.