### PR TITLE
Task-51620 : Add aria-label on publish activity, share activity and comment button

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
@@ -41,6 +41,7 @@
               <v-btn
                 :disabled="postDisabled"
                 :loading="loading"
+                :aria-label="$t(`activity.composer.${composerAction}`)"
                 type="button"
                 class="primary btn no-box-shadow"
                 @click="postMessage()">

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -24,6 +24,7 @@
     <v-btn
       :loading="commenting"
       :disabled="disableButton"
+      :aria-label="label"
       class="btn btn-primary ms-10"
       color="primary"
       @click="postComment">

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -56,12 +56,14 @@
       <div class="d-flex justify-end">
         <v-btn
           class="btn me-2"
+          :aria-label="$t('Confirmation.label.Cancel')"
           @click="close">
           {{ $t('Confirmation.label.Cancel') }}
         </v-btn>
         <v-btn
           :loading="sharing"
           :disabled="buttonDisabled"
+          :aria-label="$t('UIActivity.share')"
           class="btn btn-primary me-2"
           @click="shareActivity">
           {{ $t('UIActivity.share') }}


### PR DESCRIPTION
Before this fix, the publish activity button, share activity buttons and comment button do not respect RGAA Criteria 11.9 :
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-11-9
This commit add the aria-label attribute on theses button to make it compliant
