### PR TITLE
49308: Add Ellipsis for the blue chips on the settings page for responsive layout

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -21,7 +21,7 @@
           <template v-if="enabledDigestLabel">
             <v-chip class="ma-2" color="primary">
               <span :class="{ 'mobile-chip-ellipsis' : isMobile }">
-                  {{ enabledDigestLabel }}
+                {{ enabledDigestLabel }}
               </span>
             </v-chip>
           </template>

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -20,7 +20,7 @@
         <v-list-item-title class="text-wrap">
           <template v-if="enabledDigestLabel">
             <v-chip class="ma-2" color="primary">
-               <span :class="{ 'mobile-chip-ellipsis' : isMobile }">
+              <span :class="{ 'mobile-chip-ellipsis' : isMobile }">
                   {{ enabledDigestLabel }}
               </span>
             </v-chip>
@@ -31,8 +31,8 @@
               :key="enabledNotificationLabel"
               class="ma-2"
               color="primary">
-                <span :class="{ 'mobile-chip-ellipsis' : isMobile }">
-                  {{ enabledNotificationLabel }}
+              <span :class="{ 'mobile-chip-ellipsis' : isMobile }">
+                {{ enabledNotificationLabel }}
               </span>
             </v-chip>
           </template>

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -20,7 +20,9 @@
         <v-list-item-title class="text-wrap">
           <template v-if="enabledDigestLabel">
             <v-chip class="ma-2" color="primary">
-              {{ enabledDigestLabel }}
+               <span :class="{ 'mobile-chip-ellipsis' : isMobile }">
+                  {{ enabledDigestLabel }}
+              </span>
             </v-chip>
           </template>
           <template v-if="enabledNotificationLabels && enabledNotificationLabels.length">
@@ -29,7 +31,9 @@
               :key="enabledNotificationLabel"
               class="ma-2"
               color="primary">
-              {{ enabledNotificationLabel }}
+                <span :class="{ 'mobile-chip-ellipsis' : isMobile }">
+                  {{ enabledNotificationLabel }}
+              </span>
             </v-chip>
           </template>
         </v-list-item-title>
@@ -58,6 +62,9 @@ export default {
     },
   },
   computed: {
+    isMobile() {
+      return this.$vuetify && this.$vuetify.breakpoint && this.$vuetify.breakpoint.name === 'xs';
+    },
     label() {
       return this.settings && this.settings.pluginLabels && this.settings.pluginLabels[this.plugin.type];
     },


### PR DESCRIPTION
ISSUE: in the settings page we need to display the blue label chips with ellipsis for mobile web
FIX: added custom style that will be applied to these chips only when the application is opened on a mobile browser