### PR TITLE
50022: Responsive mobile footer

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
@@ -1,13 +1,9 @@
 <template>
   <v-app v-if="displaySpaceNavigations" class="spaceMenuParent white">
-    <v-dialog
-      v-if="isMobile"
-      :value="true"
-      hide-overlay
-      persistent
-      scrollable
-      internal-activator
-      content-class="spaceButtomNavigation white">
+  <v-footer 
+      v-if="isMobile" 
+      class="spaceButtomNavigation white">
+    <v-slide-group>
       <v-bottom-navigation
         :value="selectedNavigationUri"
         grow
@@ -25,7 +21,8 @@
           <i :class="nav.icon"></i>
         </v-btn>
       </v-bottom-navigation>
-    </v-dialog>
+    </v-slide-group>
+  </v-footer>    
     <v-tabs
       v-else
       :value="selectedNavigationUri"


### PR DESCRIPTION
ISSUE : TABS bar of space hide the footer of the drawer
FIX : changed the v-dialog component to v-footer for better mobile responsiveness
(cherry picked from commit ee7a65cf1a65948376453887e1e72da048aa75ca)