### PR TITLE
Task-51701: Spaces administration technical label on registration for closed spaces.

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/social/SpacesAdministrationPortlet_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/social/SpacesAdministrationPortlet_en.properties
@@ -29,7 +29,7 @@ social.spaces.administration.manageSpaces.registration=Registration
 
 social.spaces.administration.manageSpaces.registration.open=Open
 social.spaces.administration.manageSpaces.registration.validation=Validation
-social.spaces.administration.manageSpaces.registration.close=Closed
+social.spaces.administration.manageSpaces.registration.closed=Closed
 
 social.spaces.administration.manageSpaces.applications=Manage spaces' applications
 social.spaces.administration.manageSpaces.applications.remove=Remove


### PR DESCRIPTION
Problem: In registration case we have ‘social.spaces.administration.manageSpaces.registration.closed’ instead of ‘closed’.
Fix: modified technical label 'social.spaces.administration.manageSpaces.registration.close' to 'social.spaces.administration.manageSpaces.registration.closed' in SpacesAdministrationPortlet_en.properties file.