### PR TITLE
Task-44481: Long names of spaces are incorrectly displayed (#1149)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="activityComposer" class="activityComposer pa-0">
-    <div v-if="!standalone" class="openLink mb-4">
+    <div v-if="!standalone" class="openLink mb-4 text-truncate">
       <a @click="openMessageComposer()">
         <i class="uiIconEdit"></i>
         {{ link.replace('{0}', postTarget) }}


### PR DESCRIPTION
Problem: The name of the space is displayed throughout the screen
Fix: Added ellipses to the space name when it is too long