### PR TITLE
MAINT-52156: Fix display space chat settings (#1151)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
@@ -24,7 +24,7 @@ export default {
   }),
   created() {
     // add external components
-    const externalComponents = extensionRegistry.loadComponents('external-space').map(component => component.componentOptions.componentImpl);
+    const externalComponents = extensionRegistry.loadComponents('external-apps-space-settings').map(component => component.componentOptions.componentImpl);
     this.spaceExternalSettings.push(...externalComponents);
 
     document.addEventListener('addSpaceSettingsExternalComponents', (event) => {


### PR DESCRIPTION
ISSUE: The name of the registered extension component wasn't correctly set when loading the extension in the space settings
FIX: Correct the name of the lodaded  registered extension component