### PR TITLE
52391 : Remove unneeded workaround for language codes

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
@@ -64,7 +64,6 @@ export function formatDateObjectToDisplay(dateObj, format, lang) {
     lang = eXo.env.portal.language;
   }
   if (format) {
-    lang = lang.replace(/[-_][a-z]+$/i, '');
     return new window.Intl.DateTimeFormat(lang, format).format(dateObj);
   } else {
     return getISODate(dateObj);


### PR DESCRIPTION
This will remove a workround for composite languages like pt-BR or ar-OM. and will pass the value correctly to the Date Formatter in Javascript