### PR TITLE
TASK-52377 : In user administration, the confirm password field is already filled.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementUserFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementUserFormDrawer.vue
@@ -96,7 +96,7 @@
         <v-card-text class="d-flex confirmPasswordField py-0">
           <input
             ref="confirmNewPassword"
-            v-model="confirmNewPassword"
+            v-model="user.confirmNewPassword"
             :disabled="saving || (!user.isInternal && !newUser)"
             :required="newUser"
             type="password"


### PR DESCRIPTION
ISSUES : the field confirm password is already filled when adding a new user.
FIX : change v-model to take as value user.confirmNewPassword instead of confirmNewPassword because all the modifications are carried out on the user variable as well as the reset when saving a new user.
