### PR TITLE
Fix-52379 : Password can be change to the same one

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/social/UserSettings_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/social/UserSettings_en.properties
@@ -27,3 +27,4 @@ UserSettings.label.passwordMinLengthError=The password should be greater or equa
 UserSettings.label.passwordMaxLengthError=The password should be less or equal to {0} characters
 UserSettings.label.changePasswordSuccess=The password has been changed
 UserSettings.label.changePasswordFail=An error occurred while trying to change the password
+UserSettings.label.changePasswordIdentical=Your new password is identical to the old one, it was not changed

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
@@ -106,6 +106,7 @@
 const USER_NOT_FOUND_ERROR_CODE = 'USER_NOT_FOUND';
 const WRONG_USER_PASSWORD_ERROR_CODE = 'WRONG_USER_PASSWORD';
 const PASSWORD_UNKNOWN_ERROR_CODE = 'PASSWORD_UNKNOWN_ERROR_CODE';
+const WRONG_NEW_PASSWORD_ERROR_CODE = 'WRONG_NEW_PASSWORD';
 
 export default {
   data: () => ({
@@ -143,21 +144,12 @@ export default {
       if (!this.$refs.form.$el.reportValidity()) {
         return;
       }
-
-      if (this.newPassword === this.currentPassword) {
-        this.$refs.confirmNewPassword.setCustomValidity(this.$t('UserSettings.label.changePasswordIdentical'));
-        if (!this.$refs.form.$el.reportValidity()) {
-          return;
-        }
-      }
       if (this.confirmNewPassword !== this.newPassword) {
         this.$refs.confirmNewPassword.setCustomValidity(this.$t('UserSettings.label.newPasswordsDoesNotMatch'));
         if (!this.$refs.form.$el.reportValidity()) {
           return;
         }
       }
-
-
       if (this.$refs.form.validate() && this.$refs.form.$el.reportValidity()) {
         this.success = null;
         this.error = null;
@@ -176,6 +168,8 @@ export default {
               this.error = this.$t('UserSettings.label.accountNotExist');
             } else if (error.indexOf(PASSWORD_UNKNOWN_ERROR_CODE) > -1) {
               this.error = this.$t('UserSettings.label.changePasswordFail');
+            } else if (error.indexOf(WRONG_NEW_PASSWORD_ERROR_CODE) > -1) {
+              this.error = this.$t('UserSettings.label.changePasswordIdentical');
             } else {
               this.error = error;
             }

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
@@ -144,12 +144,19 @@ export default {
         return;
       }
 
+      if (this.newPassword === this.currentPassword) {
+        this.$refs.confirmNewPassword.setCustomValidity(this.$t('UserSettings.label.changePasswordIdentical'));
+        if (!this.$refs.form.$el.reportValidity()) {
+          return;
+        }
+      }
       if (this.confirmNewPassword !== this.newPassword) {
         this.$refs.confirmNewPassword.setCustomValidity(this.$t('UserSettings.label.newPasswordsDoesNotMatch'));
         if (!this.$refs.form.$el.reportValidity()) {
           return;
         }
       }
+
 
       if (this.$refs.form.validate() && this.$refs.form.$el.reportValidity()) {
         this.success = null;

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
@@ -144,12 +144,14 @@ export default {
       if (!this.$refs.form.$el.reportValidity()) {
         return;
       }
+
       if (this.confirmNewPassword !== this.newPassword) {
         this.$refs.confirmNewPassword.setCustomValidity(this.$t('UserSettings.label.newPasswordsDoesNotMatch'));
         if (!this.$refs.form.$el.reportValidity()) {
           return;
         }
       }
+
       if (this.$refs.form.validate() && this.$refs.form.$el.reportValidity()) {
         this.success = null;
         this.error = null;

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
@@ -106,7 +106,7 @@
 const USER_NOT_FOUND_ERROR_CODE = 'USER_NOT_FOUND';
 const WRONG_USER_PASSWORD_ERROR_CODE = 'WRONG_USER_PASSWORD';
 const PASSWORD_UNKNOWN_ERROR_CODE = 'PASSWORD_UNKNOWN_ERROR_CODE';
-const WRONG_NEW_PASSWORD_ERROR_CODE = 'WRONG_NEW_PASSWORD';
+const UNCHANGED_NEW_PASSWORD_ERROR_CODE = 'UNCHANGED_NEW_PASSWORD';
 
 export default {
   data: () => ({
@@ -168,7 +168,7 @@ export default {
               this.error = this.$t('UserSettings.label.accountNotExist');
             } else if (error.indexOf(PASSWORD_UNKNOWN_ERROR_CODE) > -1) {
               this.error = this.$t('UserSettings.label.changePasswordFail');
-            } else if (error.indexOf(WRONG_NEW_PASSWORD_ERROR_CODE) > -1) {
+            } else if (error.indexOf(UNCHANGED_NEW_PASSWORD_ERROR_CODE) > -1) {
               this.error = this.$t('UserSettings.label.changePasswordIdentical');
             } else {
               this.error = error;


### PR DESCRIPTION
ISSUE : Password can be change to the same one
FIX : add another condition that will process the error code sent by the back-end part and if the case it will trigger an error message for that I also add a constant UNCHANGED_NEW_PASSWORD_ERROR_CODE and also adding a new error message into UserSettings_en .properties