### PR TITLE
TASK-52300 : Display when the original space is hidden for non members

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
@@ -30,6 +30,7 @@ spacesList.label.spaceTemplate=Template
 spacesList.label.yes=Yes
 spacesList.label.no=No
 spacesList.label.hidden=Hidden
+spacesList.label.hiddenSpace=Hidden space
 spacesList.label.registration=Registration
 spacesList.label.open=Open
 spacesList.label.validation=Validation

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
@@ -39,13 +39,16 @@ export default {
       return this.space && this.space.id;
     },
     displayName() {
-      return this.space && this.space.displayName;
+      return this.space && this.space.isMember ? this.space.displayName : this.$t('spacesList.label.hiddenSpace');
     },
     groupId() {
       return this.space && this.space.groupId;
     },
     avatarUrl() {
-      return this.space && this.space.avatarUrl || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/${this.prettyName}/avatar`;
+      return this.space && !this.space.isMember ? this.defaultAvatarUrl : this.space.avatarUrl || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/${this.prettyName}/avatar`;
+    },
+    defaultAvatarUrl() {
+      return `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/default-image/avatar`;
     },
     url() {
       if (!this.groupId) {


### PR DESCRIPTION
Before these changes , when sharing an activity in the activitystream , the originial Activity space name and log is always displayed even if the current user is not a member of that space . so i added the necessary implementation in order to check the membership of the user in the space of a shared Activity. 