### PR TITLE
Fix-52379 : Password can be change to the same one

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/social/UserSettings_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/social/UserSettings_en.properties
@@ -27,3 +27,4 @@ UserSettings.label.passwordMinLengthError=The password should be greater or equa
 UserSettings.label.passwordMaxLengthError=The password should be less or equal to {0} characters
 UserSettings.label.changePasswordSuccess=The password has been changed
 UserSettings.label.changePasswordFail=An error occurred while trying to change the password
+UserSettings.label.changePasswordIdentical=Your new password is identical to the old one, it was not changed

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
@@ -106,6 +106,7 @@
 const USER_NOT_FOUND_ERROR_CODE = 'USER_NOT_FOUND';
 const WRONG_USER_PASSWORD_ERROR_CODE = 'WRONG_USER_PASSWORD';
 const PASSWORD_UNKNOWN_ERROR_CODE = 'PASSWORD_UNKNOWN_ERROR_CODE';
+const UNCHANGED_NEW_PASSWORD_ERROR_CODE = 'UNCHANGED_NEW_PASSWORD';
 
 export default {
   data: () => ({
@@ -169,6 +170,8 @@ export default {
               this.error = this.$t('UserSettings.label.accountNotExist');
             } else if (error.indexOf(PASSWORD_UNKNOWN_ERROR_CODE) > -1) {
               this.error = this.$t('UserSettings.label.changePasswordFail');
+            } else if (error.indexOf(UNCHANGED_NEW_PASSWORD_ERROR_CODE) > -1) {
+              this.error = this.$t('UserSettings.label.changePasswordIdentical');
             } else {
               this.error = error;
             }


### PR DESCRIPTION
ISSUE : Password can be change to the same one
FIX : add another condition that will process the error code sent by the back-end part and if the case it will trigger an error message for that I also add a constant UNCHANGED_NEW_PASSWORD_ERROR_CODE and also adding a new error message into UserSettings_en .properties