### PR TITLE
Task-52568 : [bug][Settings] tooltip “Edit password” display in page

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
@@ -16,7 +16,7 @@
               </v-list-item-title>
             </v-list-item-content>
             <v-list-item-action>
-              <span v-exo-tooltip.bottom.body="allowedToChangePassword ? $t('UserSettings.button.tooltip.enabled') : $t('UserSettings.button.tooltip.disabled')">
+              <span v-exo-tooltip.bottom="allowedToChangePassword ? $t('UserSettings.button.tooltip.enabled') : $t('UserSettings.button.tooltip.disabled')">
                 <v-btn
                   :disabled="!allowedToChangePassword"
                   small


### PR DESCRIPTION
ISSUS : the tooltip is displayed in the page if I click on the arrow 'Edit password' FIX: to disappear  the tooltip if I click on the arrow i change the directive v-exo-tooltip.bottom.body in balise span to v-exo-tooltip.bottom in UserSettingSecurity.vue file