### PR TITLE
Task-52602: Pass the current app from which the activity will be shared to the emitted event

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -90,7 +90,7 @@ export default {
       }
     },
     openShareDrawer() {
-      this.$root.$emit('activity-share-drawer-open', this.activityId);
+      this.$root.$emit('activity-share-drawer-open', this.activityId, 'activityStream');
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -127,19 +127,11 @@ export default {
       this.sharing = true;
       this.$activityService.shareActivity(this.activityId, this.description, this.templateParams, spacePrettyNames)
         .then(() => {
-          if (this.selectedApps === 'newsApp') {
-            this.$root.$emit('activity-apps-shared', this.activityId, this.spaces.map(space => ({
-              prettyName: space.remoteId,
-              displayName: space && space.profile && space.profile.fullName,
-              avatarUrl: space && space.profile && space.profile.avatarUrl,
-            })));
-          } else {
-            this.$root.$emit('activity-shared', this.activityId, this.spaces.map(space => ({
-              prettyName: space.remoteId,
-              displayName: space && space.profile && space.profile.fullName,
-              avatarUrl: space && space.profile && space.profile.avatarUrl,
-            })));
-          }
+          this.$root.$emit('activity-shared', this.activityId, this.spaces.map(space => ({
+            prettyName: space.remoteId,
+            displayName: space && space.profile && space.profile.fullName,
+            avatarUrl: space && space.profile && space.profile.avatarUrl,
+          })), this.selectedApps);
           this.close();
           this.clear();
         })

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -82,6 +82,7 @@ export default {
     validInput: true,
     description: '',
     activityId: null,
+    selectedApps: '',
     spaces: [],
   }),
   computed: {
@@ -111,8 +112,9 @@ export default {
       this.description = '';
       this.sharing = false;
     },
-    open(activityId) {
+    open(activityId, selectedApps) {
       this.activityId = activityId;
+      this.selectedApps = selectedApps;
       if (this.activityId) {
         this.$refs.activityShareDrawer.open();
       }
@@ -125,11 +127,19 @@ export default {
       this.sharing = true;
       this.$activityService.shareActivity(this.activityId, this.description, this.templateParams, spacePrettyNames)
         .then(() => {
-          this.$root.$emit('activity-shared', this.activityId, this.spaces.map(space => ({
-            prettyName: space.remoteId,
-            displayName: space && space.profile && space.profile.fullName,
-            avatarUrl: space && space.profile && space.profile.avatarUrl,
-          })));
+          if (this.selectedApps === 'newsApp') {
+            this.$root.$emit('activity-apps-shared', this.activityId, this.spaces.map(space => ({
+              prettyName: space.remoteId,
+              displayName: space && space.profile && space.profile.fullName,
+              avatarUrl: space && space.profile && space.profile.avatarUrl,
+            })));
+          } else {
+            this.$root.$emit('activity-shared', this.activityId, this.spaces.map(space => ({
+              prettyName: space.remoteId,
+              displayName: space && space.profile && space.profile.fullName,
+              avatarUrl: space && space.profile && space.profile.avatarUrl,
+            })));
+          }
           this.close();
           this.clear();
         })

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -82,7 +82,7 @@ export default {
     validInput: true,
     description: '',
     activityId: null,
-    selectedApps: '',
+    currentApp: '',
     spaces: [],
   }),
   computed: {
@@ -112,9 +112,9 @@ export default {
       this.description = '';
       this.sharing = false;
     },
-    open(activityId, selectedApps) {
+    open(activityId, currentApp) {
       this.activityId = activityId;
-      this.selectedApps = selectedApps;
+      this.currentApp = currentApp;
       if (this.activityId) {
         this.$refs.activityShareDrawer.open();
       }
@@ -131,7 +131,7 @@ export default {
             prettyName: space.remoteId,
             displayName: space && space.profile && space.profile.fullName,
             avatarUrl: space && space.profile && space.profile.avatarUrl,
-          })), this.selectedApps);
+          })), this.currentApp);
           this.close();
           this.clear();
         })


### PR DESCRIPTION
Prior to this change, we don't indicate in the share activity emitted event the current app from which the activity will be shared which causes the display many times of the share activity notification alert. To fix this problem, we pass the current app to the emitted event in order to be used when displaying the share activity notification alert.