### PR TITLE
Task-52365: Display results when going back to the search filtered on favorites

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchResults.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchResults.vue
@@ -169,8 +169,7 @@ export default {
       });
     },
     enabledConnectors() {
-      return this.connectors && this.connectors.filter(connector => connector.enabled)
-        .sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase())) || [];
+      return this.sortedConnectors && this.sortedConnectors.filter(connector => connector.enabled) || [];
     },
     enabledConnectorNames() {
       return this.enabledConnectors.map(connector => connector.name);


### PR DESCRIPTION
Prior this change, unified search does not work after using the browser's return option. this is due to trying to sort connections by labels.
Fix: Filter connectors after sort it