### PR TITLE
Task-51303: Cannot edit an activity or a comment which contain the character %

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -84,8 +84,8 @@ const defaultActivityOptions = {
     return Vue.prototype.$utils.trim(window.decodeURIComponent(templateParams
       && templateParams.default_title
       && templateParams.default_title
-      || activity.title
-      || activity.body
+      || activity.title.replaceAll('%', '%25')
+      || activity.body.replaceAll('%', '%25')
       || ''));
   },
   canShare: () => true,


### PR DESCRIPTION
Prior this change, the user cannot edit an activity or a comment containing the character % .
Fix: we should replace all % characters when getting content to edit