### PR TITLE
TASK-52300 : Display when the original space is hidden for non members (make links not clickable for hidden spaces)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
@@ -2,7 +2,7 @@
   <a
     :id="id"
     :href="url"
-    class="text-none primary--text space-avatar activity-head-space-link">
+    :class="linkStyle">
     <v-avatar
       size="20"
       rounded
@@ -57,9 +57,12 @@ export default {
       const uri = this.groupId.replace(/\//g, ':');
       return `${eXo.env.portal.context}/g/${uri}/`;
     },
+    linkStyle() {
+      return `text-none primary--text space-avatar activity-head-space-link ${!this.space.isMember && 'not-clickable-link'}`;
+    }
   },
   mounted() {
-    if (this.spaceId && this.groupId) {
+    if (this.spaceId && this.groupId && this.space.isMember) {
       window.setTimeout(() => {
         this.initTiptip();
       }, 500);

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
@@ -2,7 +2,8 @@
   <a
     :id="id"
     :href="url"
-    :class="linkStyle">
+    :class="!this.space.isMember && 'not-clickable-link'"
+    class="text-none primary--text space-avatar activity-head-space-link">
     <v-avatar
       size="20"
       rounded
@@ -57,9 +58,6 @@ export default {
       const uri = this.groupId.replace(/\//g, ':');
       return `${eXo.env.portal.context}/g/${uri}/`;
     },
-    linkStyle() {
-      return `text-none primary--text space-avatar activity-head-space-link ${!this.space.isMember && 'not-clickable-link'}`;
-    }
   },
   mounted() {
     if (this.spaceId && this.groupId && this.space.isMember) {


### PR DESCRIPTION
Before these changes , when sharing an activity in the activity stream , the originial Activity space name and log is always displayed even if the current user is not a member of that space . so i added the necessary implementation in order to check the membership of the user in the space of a shared Activity.