### PR TITLE
Task-52443: Space popover label display problem (#1194)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -74,13 +74,13 @@
               <v-container class="pa-0">
                 <v-row no-gutters>
                   <v-col
-                    cols="4"
-                    class="pt-1 body-2 grey--text text--darken-1"
+                    cols="6"
+                    class="pt-1 body-2 grey--text text-truncate text--darken-1"
                     justify="center">
                     {{ $t('space.logo.banner.popover.managers') }}
                   </v-col>
                   <v-col
-                    cols="8"
+                    cols="6"
                     justify="center"
                     class="d-flex flex-nowrap pa-0">
                     <exo-user-avatar
@@ -209,7 +209,7 @@ export default {
     sizeToDisplay: {
       type: Number,
       default: function () {
-        return 4;
+        return 3;
       },
     },
   },


### PR DESCRIPTION
Problem: "Administrateurs" label is displayed as divided into two lines, while it should be displayed in only one line.
Fix: "Administrateurs" label is displayed in only one line.