### PR TITLE
changed wraper element for the v-chips components to conserve their default resizing behavior

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -14,13 +14,12 @@
         </v-btn>
       </v-list-item-action>
     </v-list-item>
-
-    <v-list-item v-if="hasNotificationSettings" dense>
-      <v-list-item-content class="pa-0">
-        <v-list-item-title class="text-wrap">
+        <v-flex v-if="hasNotificationSettings" class="d-flex flex-wrap" >
           <template v-if="enabledDigestLabel">
             <v-chip class="ma-2" color="primary">
-              {{ enabledDigestLabel }}
+              <span class="text-truncate">
+                {{ enabledDigestLabel }}
+              </span>
             </v-chip>
           </template>
           <template v-if="enabledNotificationLabels && enabledNotificationLabels.length">
@@ -29,12 +28,12 @@
               :key="enabledNotificationLabel"
               class="ma-2"
               color="primary">
-              {{ enabledNotificationLabel }}
+              <span class="text-truncate">
+                {{ enabledNotificationLabel }}
+              </span>
             </v-chip>
           </template>
-        </v-list-item-title>
-      </v-list-item-content>
-    </v-list-item>
+        </v-flex>
     <v-list-item v-else dense>
       <v-list-item-content class="pa-0">
         <v-list-item-subtitle class="text-sub-title font-italic">


### PR DESCRIPTION
ISSUE: the settings chips overflow when the screen is not large enough
FIX: changed the wrapper element for the v-chip components to preserve their default resizing behavior