### PR TITLE
Task-49046 : adding user have the same name as deleted one 

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/common/ObjectAlreadyExistsException.java
+++ b/component/api/src/main/java/org/exoplatform/social/common/ObjectAlreadyExistsException.java
@@ -1,26 +1,38 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.exoplatform.social.common;
 
-import lombok.Getter;
+/**
+ * @since 6.3.0
+ * @deprecated Deprecated from 6.3.0. Replaced by a new Exception org.exoplatform.commons.ObjectAlreadyExistsException
+ *             will be removed at 6.3.0
+ */
+@Deprecated(since="6.3.0", forRemoval=true)
+public class ObjectAlreadyExistsException extends org.exoplatform.commons.ObjectAlreadyExistsException {
 
-public class ObjectAlreadyExistsException extends Exception {
+    public ObjectAlreadyExistsException(Object existingObject) {
+        super(existingObject);
+    }
 
-  private static final long serialVersionUID = -9018382456987071070L;
+    public ObjectAlreadyExistsException(Object existingObject, String message) {
+        super(existingObject, message);
+    }
 
-  @Getter
-  private final Object      existingObject;                          // NOSONAR
-
-  public ObjectAlreadyExistsException(Object existingObject) {
-    this.existingObject = existingObject;
-  }
-
-  public ObjectAlreadyExistsException(Object existingObject, String message) {
-    super(message);
-    this.existingObject = existingObject;
-  }
-
-  public ObjectAlreadyExistsException(Object existingObject, String message, Throwable e) {
-    super(message, e);
-    this.existingObject = existingObject;
-  }
-
+    public ObjectAlreadyExistsException(Object existingObject, String message, Throwable e) {
+        super(existingObject, message, e);
+    }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
@@ -1,18 +1,18 @@
 /*
- * Copyright (C) 2003-2011 eXo Platform SAS.
- *
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Affero General Public License
- * as published by the Free Software Foundation; either version 3
- * of the License, or (at your option) any later version.
- *
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.exoplatform.social.core.listeners;
 
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
@@ -58,7 +59,7 @@ public class SocialUserEventListenerImpl extends UserEventListener {
       Identity identity = ids.findIdentity(OrganizationIdentityProvider.NAME, user.getUserName());
   
       if (isNew && identity != null && identity.isDeleted()) {
-        throw new RuntimeException("Unable to create a previously deleted user : " + user.getUserName());
+          throw new ObjectAlreadyExistsException(identity, "Unable to create a previously deleted user : " + user.getUserName());
       }
 
     }

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -400,6 +400,7 @@ UsersManagement.title.deleteCurrentUserWarning=Can't delete user
 UsersManagement.message.deleteCurrentUserWarning=You can\u2019t delete your user account while being logged in with it.
 UsersManagement.message.userWithSameNameAlreadyExists=A user account with the same name already exists.
 UsersManagement.message.userWithSameEmailAlreadyExists=A user account with the same email already exists.
+UsersManagement.message.LoginForDeletedUser=The username was already used for a previous deleted account. It cannot be reused.
 UsersManagement.group=Group
 UsersManagement.membershipType=Role
 UsersManagement.noData=No data

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementUserFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementUserFormDrawer.vue
@@ -255,6 +255,8 @@ export default {
         if (this.fieldError && this.fieldError.indexOf('USERNAME:') === 0) {
           if (this.fieldError === 'USERNAME:ALREADY_EXISTS') {
             this.$refs.userNameInput.setCustomValidity(this.$t('UsersManagement.message.userWithSameNameAlreadyExists'));
+          } else if (this.fieldError === 'USERNAME:ALREADY_EXISTS_AS_DELETED') {
+            this.$refs.userNameInput.setCustomValidity(this.$t('UsersManagement.message.LoginForDeletedUser'));
           } else {
             const usernameError = this.fieldError.replace('USERNAME:', '');
             this.$refs.userNameInput.setCustomValidity(usernameError);


### PR DESCRIPTION
Task-49046 : adding user have the same name as deleted one

ISSUES : when adding user have the same name as deleted one  an error message is displayed, with an unknown error message
FIX: To resolve this issue I worked on two  projects gatein-portal and social so in social  firstly i throw ObjectAlreadyExistsException instead of RuntimeException in 'SocialUserEventListenerImpl' also
I added a condition in the method 'handleError' if Error === 'USER:ALREADY_EXISTS_DELETED new error message displayed this error message is declared in 'Portlet_en.properties'