### PR TITLE
TASK-52323 : Suggester does not show name of member in suggestion list unless the fullname is written

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -237,7 +237,7 @@ export default {
       if (value && value.length) {
         window.setTimeout(() => {
           this.focus();
-          if (!this.previousSearchTerm || this.previousSearchTerm === this.searchTerm) {
+          if (!this.previousSearchTerm || this.previousSearchTerm !== this.searchTerm) {
             this.loadingSuggestions = 0;
             this.items = [];
 


### PR DESCRIPTION
ISSUE : when typing slowly the searched user's name in the space invitation drawer's input, no suggestions displayed because of the wrong test condition which, while typing a new chars in the search input, it tests the previous input text previousSearchTerm if it's equal to the new typed one searchTerm which is wrong.
In fact, while typing a new text to search, the variable searchTerm gets the current typed text so it won't get the same value as the variable previousSearchTerm to compare.

FIX : change the test condition to compare if the previous typed text variable is not equal to the current text variable before calling the api service searchSpacesOrUsers so it can make the search after every typed text regardless to the typing speed.