### PR TITLE
52868 : fix filtering spaces with redactors (#1229)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -29,7 +29,6 @@
               include-spaces
               multiple
               only-redactor
-              only-manager
               autofocus />
           </div>
           <div class="d-flex flex-row">


### PR DESCRIPTION
We can have the option to exclude redactional spaces (spaces with at least one redactor), this is controlled by the property noRedactionalSpace
The fix will reactivate the option to check it before adding the space to the filtered list in the suggester

