### PR TITLE
TASK-52005: Fix new activity indicator that displayed in another space.

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/websocket/entity/ActivityStreamModification.java
+++ b/component/service/src/main/java/org/exoplatform/social/websocket/entity/ActivityStreamModification.java
@@ -37,9 +37,12 @@ public class ActivityStreamModification {
 
   private String eventName;
 
-  public ActivityStreamModification(String activityId, String eventName) {
+  private String spaceId;
+
+  public ActivityStreamModification(String activityId, String eventName, String spaceId) {
     this.activityId = activityId;
     this.eventName = eventName;
+    this.spaceId = spaceId;
   }
 
   @Override

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/common/ActivityStreamUpdater.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/common/ActivityStreamUpdater.vue
@@ -48,11 +48,13 @@ export default {
     },
     handleActivityStreamUpdates(updateParams) {
       // handle activity stream updates
-      this.$root.$emit(`activity-stream-activity-${updateParams.eventName}`, updateParams.activityId, updateParams.commentId, updateParams.parentCommentId);
+      this.$root.$emit(`activity-stream-activity-${updateParams.eventName}`, updateParams.activityId, updateParams.spaceId, updateParams.commentId, updateParams.parentCommentId);
     },
-    increaseActivitiesLimitToRetrieve(activityId) {
-      this.updatedActivities.add(activityId);
-      this.newerActivitiesCount = this.updatedActivities.size;
+    increaseActivitiesLimitToRetrieve(activityId, spaceId) {
+      if (!eXo.env.portal.spaceId || eXo.env.portal.spaceId === spaceId) {
+        this.updatedActivities.add(activityId);
+        this.newerActivitiesCount = this.updatedActivities.size;
+      }
     },
     displayNewActivities() {
       if (this.$activityStreamWebSocket.isDisconnected()) {


### PR DESCRIPTION
ISSUES : when creating a new post in a space, the new activity indicator is displayed in another space.
FIX : the problem that when creating a new message, the new activity indicator is displayed in another space and it is fixed by sending the spaceId of the space that the indicator should display in, in a websocket event and adding a condition allowing the display of the indicator in the relative space.