### PR TITLE
Task-53253: Double delete action to delete a space group

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
@@ -330,6 +330,13 @@ public interface SpaceService {
    * @LevelAPI Platform
    */
   void deleteSpace(Space space);
+  /**
+   * Deletes a space without deleting the user's group. When a space is deleted, all of its page navigations and its group will be deleted.
+   *
+   * @param space The space to be deleted.
+   * @LevelAPI Platform
+   */
+  default void deleteSpace(Space space, boolean deleteGroup) {}
 
   /**
    * Adds a user to the list of pending requests for joining a space.

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SocialGroupEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SocialGroupEventListenerImpl.java
@@ -72,7 +72,7 @@ public class SocialGroupEventListenerImpl extends GroupEventListener {
     String groupId = group.getId();
     Space space = spaceSrv.getSpaceByGroupId(groupId);
     if (space != null) {
-      spaceSrv.deleteSpace(space);
+      spaceSrv.deleteSpace(space, false);
     }
   }
 

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -1732,9 +1732,31 @@ public class SpaceServiceTest extends AbstractCoreTest {
     assertEquals("savedSpace.getDisplayName() must return: " + spaceDisplayName, spaceDisplayName, savedSpace.getDisplayName());
     assertEquals("savedSpace.getDescription() must return: " + spaceDescription, spaceDescription, savedSpace.getDescription());
     assertEquals("savedSpace.getGroupId() must return: " + groupId, groupId, savedSpace.getGroupId());
+    assertNotNull("the group " +groupId + " must exist", organizationService.getGroupHandler().findGroupById(groupId));
     spaceService.deleteSpace(space);
     savedSpace = spaceService.getSpaceByDisplayName(spaceDisplayName);
     assertNull("savedSpace must be null", savedSpace);
+    assertNull("the group " +groupId + " must be deleted after space deletion ", organizationService.getGroupHandler().findGroupById(groupId));
+  }
+
+
+  public void testDeleteSpaceWithoutDelitingGroup() throws Exception {
+    Space space = this.getSpaceInstance(0);
+    String spaceDisplayName = space.getDisplayName();
+    String spaceDescription = space.getDescription();
+    String groupId = space.getGroupId();
+    Space savedSpace = spaceService.getSpaceByDisplayName(spaceDisplayName);
+    assertNotNull("savedSpace must not be null", savedSpace);
+    assertEquals("savedSpace.getDisplayName() must return: " + spaceDisplayName, spaceDisplayName, savedSpace.getDisplayName());
+    assertEquals("savedSpace.getDescription() must return: " + spaceDescription, spaceDescription, savedSpace.getDescription());
+    assertEquals("savedSpace.getGroupId() must return: " + groupId, groupId, savedSpace.getGroupId());
+    assertNotNull("the group " +groupId + " must exist", organizationService.getGroupHandler().findGroupById(groupId));
+    spaceService.deleteSpace(space, false);
+    savedSpace = spaceService.getSpaceByDisplayName(spaceDisplayName);
+    assertNull("savedSpace must be null", savedSpace);
+    assertNotNull("the group " +groupId + " must exist after space deletion", organizationService.getGroupHandler().findGroupById(groupId));
+    Group group = organizationService.getGroupHandler().findGroupById(groupId);
+    organizationService.getGroupHandler().removeGroup(group, true);
   }
 
   public void testUpdateSpacePermissions() throws Exception {


### PR DESCRIPTION
Problem: The space group is deleted after clicking  twice on delete button
Fix: we set the broadcast event listener that it deletes a space without deleting the user's group. When a space is deleted, all of its page navigation and its group will be deleted and the listener get not started for a second time