### PR TITLE
TASK-53835 Rename Search connector for better analytics identification

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
@@ -91,7 +91,7 @@
           <description>Search connector for spaces</description>
           <object type="org.exoplatform.social.core.search.SearchConnector">
             <field name="name">
-              <string>space</string>
+              <string>spaces</string>
             </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/v1/social/spaces?q={keyword}&limit={limit}&expand=managers]]></string>
@@ -126,7 +126,7 @@
           <description>Search connector for activities</description>
           <object type="org.exoplatform.social.core.search.SearchConnector">
             <field name="name">
-              <string>activity</string>
+              <string>activities</string>
             </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/v1/social/activities/search?q={keyword}&limit={limit}]]></string>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityFavoriteAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityFavoriteAction.vue
@@ -8,6 +8,7 @@
     :top="top"
     :right="right"
     :template-params="templateParams"
+    :type-label="extensionName"
     type="activity"
     @removed="removed"
     @remove-error="removeError"
@@ -20,6 +21,10 @@ export default {
   props: {
     activity: {
       type: Object,
+      default: null,
+    },
+    activityTypeExtension: {
+      type: String,
       default: null,
     },
     isActivityShared: {
@@ -51,6 +56,9 @@ export default {
     },
     templateParams() {
       return this.activity && this.activity.templateParams;
+    },
+    extensionName() {
+      return this.activityTypeExtension && this.activityTypeExtension.name;
     },
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
@@ -25,7 +25,10 @@
           <activity-head-space :space="space" />
         </template>
       </v-list-item-title>
-      <activity-head-time :activity="activity" :is-activity-shared="isActivityShared" class="d-flex activity-head-time" />
+      <activity-head-time
+        :activity="activity"
+        :is-activity-shared="isActivityShared"
+        class="d-flex activity-head-time" />
     </v-list-item-content>
     <extension-registry-components
       :params="params"
@@ -73,6 +76,7 @@ export default {
     params() {
       return {
         activity: this.activity,
+        activityTypeExtension: this.activityTypeExtension,
         isActivityShared: this.isActivityShared
       };
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
@@ -26,7 +26,7 @@
           dense
           @click="clickOnAction(action)">
           <v-icon size="13" class="dark-grey-color">{{ $t(action.icon) }}</v-icon>
-          <v-list-item-title class= "pl-3">{{ $t(action.labelKey) }}</v-list-item-title>
+          <v-list-item-title class="pl-3">{{ $t(action.labelKey) }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/header/ActivityCommentMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/header/ActivityCommentMenu.vue
@@ -26,7 +26,7 @@
           dense
           @click="clickOnAction(action)">
           <v-icon size="13" class="dark-grey-color">{{ $t(action.icon) }}</v-icon>
-          <v-list-item-title class= "pl-3">{{ $t(action.labelKey) }}</v-list-item-title>
+          <v-list-item-title class="pl-3">{{ $t(action.labelKey) }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
@@ -38,6 +38,10 @@ export default {
       type: String,
       default: null,
     },
+    typeLabel: {
+      type: String,
+      default: null,
+    },
     id: {
       type: String,
       default: null,
@@ -69,10 +73,6 @@ export default {
     small: {
       type: Boolean,
       default: true,
-    },
-    templateParams: {
-      type: Object,
-      default: null,
     },
   },
   data: () => ({
@@ -134,6 +134,14 @@ export default {
       if (this.isFavorite) {
         this.$favoriteService.removeFavorite(this.type, this.id)
           .then(() => {
+            document.dispatchEvent(new CustomEvent('favorite-removed', {
+              detail: {
+                type: this.type,
+                typeLabel: this.typeLabel,
+                id: this.id,
+                spaceId: this.spaceId,
+              }
+            }));
             this.isFavorite = false;
             this.$emit('removed');
             this.updateFavorite();
@@ -145,10 +153,10 @@ export default {
           .then(() => {
             document.dispatchEvent(new CustomEvent('favorite-added', {
               detail: {
-                'type': this.type,
-                'id': this.id,
-                'spaceId': this.spaceId,
-                'templateParams': this.templateParams,
+                type: this.type,
+                typeLabel: this.typeLabel,
+                id: this.id,
+                spaceId: this.spaceId,
               }
             }));
             this.isFavorite = true;

--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchResults.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchResults.vue
@@ -14,8 +14,8 @@
         <span class="subtitle-1">{{ $t('search.connector.label.favorites') }}</span>
       </v-chip>
       <search-tag-selector
-          v-if="tagsEnabled"
-          @tags-changed="selectTags" />
+        v-if="tagsEnabled"
+        @tags-changed="selectTags" />
       <v-menu
         v-model="connectorsListOpened"
         :close-on-content-click="false"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="spaceInfosApp" >
+  <div id="spaceInfosApp">
     <h5 class="center">{{ $t("social.space.description.title") }}</h5>
     <p id="spaceDescription">{{ description }}</p>
     <div id="spaceManagersList">

--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
@@ -1,28 +1,28 @@
 <template>
   <v-app v-if="displaySpaceNavigations" class="spaceMenuParent white">
-  <v-footer 
+    <v-footer 
       v-if="isMobile" 
       class="spaceButtomNavigation white">
-    <v-slide-group>
-      <v-bottom-navigation
-        :value="selectedNavigationUri"
-        grow
-        color="tertiary"
-        background-color="transparent"
-        class="spaceButtomNavigationParent"
-        flat>
-        <v-btn
-          v-for="nav in navigations"
-          :key="nav.id"
-          :value="nav.uri"
-          :href="nav.uri"
-          class="subtitle-2 spaceButtomNavigationItem">
-          <span>{{ nav.label }}</span>
-          <i :class="nav.icon"></i>
-        </v-btn>
-      </v-bottom-navigation>
-    </v-slide-group>
-  </v-footer>    
+      <v-slide-group>
+        <v-bottom-navigation
+          :value="selectedNavigationUri"
+          grow
+          color="tertiary"
+          background-color="transparent"
+          class="spaceButtomNavigationParent"
+          flat>
+          <v-btn
+            v-for="nav in navigations"
+            :key="nav.id"
+            :value="nav.uri"
+            :href="nav.uri"
+            class="subtitle-2 spaceButtomNavigationItem">
+            <span>{{ nav.label }}</span>
+            <i :class="nav.icon"></i>
+          </v-btn>
+        </v-bottom-navigation>
+      </v-slide-group>
+    </v-footer>    
     <v-tabs
       v-else
       :value="selectedNavigationUri"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingAvatar.vue
@@ -4,7 +4,7 @@
     :size="size"
     class="spaceAvatar"
     tile>
-    <v-img :src="avatarData || avatarUrl || ''" role="presentation"/>
+    <v-img :src="avatarData || avatarUrl || ''" role="presentation" />
     <v-file-input
       v-if="!sendingImage"
       v-show="hover"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-app class="transparent" flat v-if="displayed">
+  <v-app
+    class="transparent"
+    flat
+    v-if="displayed">
     <space-setting-general :space-id="spaceId" class="mb-6" />
     <space-setting-applications :space-id="spaceId" class="mb-6" />
     <template>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFormDrawer.vue
@@ -15,7 +15,8 @@
           v-model="stepper"
           vertical
           flat
-          class="ma-0 py-0 me-4" :class="`${isMobile ? 'pr-3' : ''}`">
+          class="ma-0 py-0 me-4"
+          :class="`${isMobile ? 'pr-3' : ''}`">
           <v-stepper-step
             :complete="stepper > 1"
             step="1"
@@ -198,7 +199,7 @@
             class="elevation-0 mb-14 me-2 pe-4"
             icon="mdi-alert-circle"
             type="warning">
-            <p v-sanitized-html="invitedSpacesWithExternals" />
+            <p v-sanitized-html="invitedSpacesWithExternals"></p>
           </v-alert>
         </div>
       </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -14,26 +14,26 @@
         </v-btn>
       </v-list-item-action>
     </v-list-item>
-        <v-flex v-if="hasNotificationSettings" class="d-flex flex-wrap" >
-          <template v-if="enabledDigestLabel">
-            <v-chip class="ma-2" color="primary">
-              <span class="text-truncate">
-                {{ enabledDigestLabel }}
-              </span>
-            </v-chip>
-          </template>
-          <template v-if="enabledNotificationLabels && enabledNotificationLabels.length">
-            <v-chip
-              v-for="enabledNotificationLabel in enabledNotificationLabels"
-              :key="enabledNotificationLabel"
-              class="ma-2"
-              color="primary">
-              <span class="text-truncate">
-                {{ enabledNotificationLabel }}
-              </span>
-            </v-chip>
-          </template>
-        </v-flex>
+    <v-flex v-if="hasNotificationSettings" class="d-flex flex-wrap">
+      <template v-if="enabledDigestLabel">
+        <v-chip class="ma-2" color="primary">
+          <span class="text-truncate">
+            {{ enabledDigestLabel }}
+          </span>
+        </v-chip>
+      </template>
+      <template v-if="enabledNotificationLabels && enabledNotificationLabels.length">
+        <v-chip
+          v-for="enabledNotificationLabel in enabledNotificationLabels"
+          :key="enabledNotificationLabel"
+          class="ma-2"
+          color="primary">
+          <span class="text-truncate">
+            {{ enabledNotificationLabel }}
+          </span>
+        </v-chip>
+      </template>
+    </v-flex>
     <v-list-item v-else dense>
       <v-list-item-content class="pa-0">
         <v-list-item-subtitle class="text-sub-title font-italic">


### PR DESCRIPTION
Prior to this change, the name of Activity search connector was 'activity' which is different from the name associated to operation collected in analytics in https://github.com/exoplatform/analytics/commit/30426a81a84c8f8ea45b7b1dd67cbfaf3cd0c276#diff-0b4b2f6d128bd203d0e84dfc2b122125e70fb551c6b9e4a78522b5e8a8ff1859R59 . In order to make this more generic, the connector name must be renamed to match already collected operation names in analytics to not break coherence of already collected analytics data.