### PR TITLE
Task-53424 : Incoherence of colors of names in the activity's topbar when primary color is changed

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="activityComposer" class="activityComposer pa-0">
     <div v-if="!standalone" class="openLink mb-4 text-truncate">
-      <a @click="openMessageComposer()">
+      <a @click="openMessageComposer()" class="primary--text">
         <i class="uiIconEdit"></i>
         {{ link.replace('{0}', postTarget) }}
       </a>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadSpace.vue
@@ -3,7 +3,7 @@
     :id="id"
     :href="url"
     :class="!this.space.isMember && 'not-clickable-link hidden-space'"
-    class="text-none space-avatar activity-head-space-link">
+    class="text-none space-avatar primary--text activity-head-space-link">
     <v-avatar
       size="20"
       rounded


### PR DESCRIPTION
ISSUSE : When the user change the primary color in the branding names of users in activity stream changed but names of spaces and the label 'post' does not change. 
FIX : to fix this issuse i add css class 'primary--text'