### PR TITLE
TASK-54179 Fix random fail that depends on build performances

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
@@ -974,6 +974,9 @@ public class IdentityStorageTest extends AbstractCoreTest {
 
     restartTransaction();
 
+    //Wait a bit before updating the avatar to make sure the avatarLastUpdated is changed
+    sleep(10);
+
     profile.setProperty(Profile.AVATAR, avatarAttachment);
     identityStorage.updateProfile(profile);
     profile = identityStorage.loadProfile(profile);
@@ -1006,6 +1009,9 @@ public class IdentityStorageTest extends AbstractCoreTest {
     assertNotNull(identityId);
     InputStream stream = identityStorage.getBannerInputStreamById(identity);
     assertNull(stream);
+
+    //Wait a bit before updating the avatar to make sure the bannerLastUpdated is changed
+    sleep(10);
 
     Profile profile = new Profile(identity);
     profile.setProperty(Profile.BANNER, bannerAttachment);
@@ -1062,6 +1068,9 @@ public class IdentityStorageTest extends AbstractCoreTest {
     assertNotNull(bannerLastUpdated);
 
     restartTransaction();
+
+    //Wait a bit before updating the avatar to make sure the bannerLastUpdated is changed
+    sleep(10);
 
     profile.setProperty(Profile.BANNER, bannerAttachment);
     identityStorage.updateProfile(profile);


### PR DESCRIPTION
Prior to this change, two sequential updates of avatars may happen in the same millisecond, thus the lastUpdatedTime field can be the same and thus the Unit Test fails. The fix will ensure to wait 10ms before making the second update.