### PR TITLE
TASK-54066: Impossible to edit a post which contains only a document.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -84,8 +84,8 @@ const defaultActivityOptions = {
     return Vue.prototype.$utils.trim(window.decodeURIComponent(templateParams
       && templateParams.default_title
       && templateParams.default_title
-      || activity.title.replaceAll('%', '%25')
-      || activity.body.replaceAll('%', '%25')
+      || (activity.title && activity.title.replaceAll('%', '%25'))
+      || (activity.body && activity.body.replaceAll('%', '%25'))
       || ''));
   },
   canShare: () => true,


### PR DESCRIPTION
ISSUES : Impossible to edit a post which contains only a document.
FIX : the problem is that when we create a post that contains only a document, we can't edit it. the problem is fixed by changing the condition of the function getBodyToEdit  because in this case activity.title is undefined so we can't edit it directly so we have to add a stop condition.