### PR TITLE
Task-53659: Prevent closing message composer drawer when other drawers are opened

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ExoActivityComposer.vue
@@ -173,8 +173,7 @@ export default {
       ckEditorId: 'activityContent',
       link: `${this.$t('activity.composer.link')}`,
       filesToDetach: [],
-      filesToAttach: [],
-      attachmentsAppDrawerOpened: false,
+      filesToAttach: []
     };
   },
   computed: {
@@ -227,12 +226,6 @@ export default {
     this.$root.$on('remove-composer-attachment-item', attachment => {
       this.filesToDetach.push(attachment);
       this.activityBodyEdited = true;
-    });
-    this.$root.$on('attachments-app-drawer-opened', () => {
-      this.attachmentsAppDrawerOpened = true;
-    });
-    this.$root.$on('attachments-app-drawer-closed', () => {
-      this.attachmentsAppDrawerOpened = false;
     });
     this.$root.$on('abort-attachments-new-upload', (attachments) => {
       this.attachments = attachments;
@@ -423,7 +416,7 @@ export default {
       }
     },
     closeMessageComposer: function () {
-      if (!this.attachmentsAppDrawerOpened) {
+      if (eXo.openedDrawers.length === 0) {
         this.showMessageComposer = false;
         this.attachments = [];
         this.activityId = null;


### PR DESCRIPTION
Prior to this change, when the message composer drawer is opened with other drawers coming from its actions, the message composer drawer is closed before the other opened drawers. This is due to the fact that the message composer drawer is not an exo:drawer component which escapes it from the closing rule of exo-drawer components (from last open to first opened).
After this change, we ensure that closing message composer drawer is done only when no other drawer is opened.