### PR TITLE
TASK-54423 Avoid displaying header and footer when no extensions

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExtensionRegistryComponents.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExtensionRegistryComponents.vue
@@ -1,6 +1,6 @@
 <template>
   <ul v-if="parentElement === 'ul' && isEnabled">
-    <template v-if="$slots.header">
+    <template v-if="$slots.header && components.length">
       <slot name="header"></slot>
     </template>
     <template v-for="(component, index) in components">
@@ -14,12 +14,12 @@
         <slot name="separator"></slot>
       </template>
     </template>
-    <template v-if="$slots.footer">
+    <template v-if="$slots.footer && components.length">
       <slot name="footer"></slot>
     </template>
   </ul>
   <li v-else-if="parentElement === 'li' && isEnabled">
-    <template v-if="$slots.header">
+    <template v-if="$slots.header && components.length">
       <slot name="header"></slot>
     </template>
     <template v-for="(component, index) in components">
@@ -33,12 +33,12 @@
         <slot name="separator"></slot>
       </template>
     </template>
-    <template v-if="$slots.footer">
+    <template v-if="$slots.footer && components.length">
       <slot name="footer"></slot>
     </template>
   </li>
   <span v-else-if="parentElement === 'span' && isEnabled">
-    <template v-if="$slots.header">
+    <template v-if="$slots.header && components.length">
       <slot name="header"></slot>
     </template>
     <template v-for="(component, index) in components">
@@ -52,12 +52,12 @@
         <slot name="separator"></slot>
       </template>
     </template>
-    <template v-if="$slots.footer">
+    <template v-if="$slots.footer && components.length">
       <slot name="footer"></slot>
     </template>
   </span>
   <a v-else-if="parentElement === 'a' && isEnabled">
-    <template v-if="$slots.header">
+    <template v-if="$slots.header && components.length">
       <slot name="header"></slot>
     </template>
     <template v-for="(component, index) in components">
@@ -71,12 +71,12 @@
         <slot name="separator"></slot>
       </template>
     </template>
-    <template v-if="$slots.footer">
+    <template v-if="$slots.footer && components.length">
       <slot name="footer"></slot>
     </template>
   </a>
   <div v-else-if="isEnabled">
-    <template v-if="$slots.header">
+    <template v-if="$slots.header && components.length">
       <slot name="header"></slot>
     </template>
     <template v-for="(component, index) in components">
@@ -90,7 +90,7 @@
         <slot name="separator"></slot>
       </template>
     </template>
-    <template v-if="$slots.footer">
+    <template v-if="$slots.footer && components.length">
       <slot name="footer"></slot>
     </template>
   </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/login-oauth/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/login-oauth/extensions.js
@@ -19,5 +19,6 @@
 extensionRegistry.registerComponent('LoginFooter', 'login-footer', {
   id: 'oauth-providers',
   vueComponent: Vue.options.components['portal-login-oauth-providers'],
+  isEnabled: params => params && params.params && params.params.oAuthEnabled,
   rank: 10,
 });

--- a/webapp/portlet/src/main/webapp/vue-apps/login/components/Login.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/login/components/Login.vue
@@ -66,7 +66,7 @@
                     </div>
                   </template>
                   <template #footer>
-                    <div class="d-flex my-5">
+                    <div class="d-flex mt-5">
                       <v-divider class="my-auto white" />
                       <span class="mx-3 white--text text-uppercase">
                         {{ $t('UILoginForm.label.or') }}
@@ -121,7 +121,8 @@
                     <div id="UIPortalLoginFormAction" class="loginButton">
                       <button
                         :aria-label="$t('portal.login.Signin')"
-                        tabindex="4">
+                        tabindex="4"
+                        class="col-auto">
                         {{ $t('portal.login.Signin') }}
                       </button>
                     </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/user-register-onboarding/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-register-onboarding/extensions.js
@@ -19,5 +19,6 @@
 extensionRegistry.registerComponent('Register', 'register-extension', {
   id: 'onboarding',
   vueComponent: Vue.options.components['portal-register-onboarding'],
+  isEnabled: params => params && params.params && params.params.onboardingRegisterEnabled,
   rank: 80,
 });


### PR DESCRIPTION
Prior to this change, the separator 'OR' in Login and Register UI was displayed even when extensions aren't enabled. Thus this modification will ensure to enable extensions only when needed and to hide separators when no component.