### PR TITLE
TASK-54423 Fix Message Error when Onboarding email isn't valid

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-register-onboarding/components/OnboardingRegister.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-register-onboarding/components/OnboardingRegister.vue
@@ -102,7 +102,7 @@ export default {
       } else if (this.errorCode === 'EMAIL_MANDATORY') {
         return this.$t('UILoginForm.label.emailMandatory');
       }
-      return this.errorCode && this.$t(`UILoginForm.label.${this.errorCode}`);
+      return this.errorCode;
     },
   },
 };


### PR DESCRIPTION
Prior to this change, the Message Error that is displayed, when already translated, is concatenated to a Label Key 'UILogin.label.'. This change will avoid this concatenation to display the right message.