### PR TITLE
Task-54194: Space members list .

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
@@ -134,6 +134,9 @@ export default {
         },{
           text: this.$t('peopleList.label.filter.manager'),
           value: 'manager',
+        },{
+          text: this.$t('peopleList.label.filter.redactor'),
+          value: 'redactor',
         }];
       }
     },


### PR DESCRIPTION
Problem: as a simple member/ a redactor of SpaceX, when I open members of space.the user could only check the members and managers list. despite that in version 6.3.x could check all redactors and members and managers.
Fix: Add the item redactor to the selection list. So at this moment the item redactors is shown and will be sent as a value of parameter role when clicked on it to can filter users by role.