### PR TITLE
Fix random test fail in SpaceServiceTest

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -3395,6 +3395,10 @@ public class SpaceServiceTest extends AbstractCoreTest {
 
     spaceService.saveSpace(space2, true);
     tearDownSpaceList.add(space2);
+
+    // sleep 1ms to be sure that 2 spaces created in a row
+    // have not the same createdDate
+    Thread.sleep(1);
     return space2;
   }
 


### PR DESCRIPTION
If the execution of getLastSpace runs fast, and if 2 tests have the same creation, the getLastSpace function is no more relevant, and can return space1 as older than space2
This fix add a small 1ms sleep after space creation, so that we are sure that all spaces have different creationDate