### PR TITLE
TASK-53671 : Opening the search on tags from comments drawer

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
@@ -5,6 +5,7 @@
     id="activityCommentsDrawer"
     allow-expand
     right
+    fixed
     disable-pull-to-refresh
     @closed="reset">
     <template slot="title">
@@ -101,6 +102,7 @@ export default {
   created() {
     document.addEventListener('activity-comments-display', this.displayActivityComments);
     document.addEventListener('activity-comment-edit', this.editActivityComments);
+    document.addEventListener('search-metadata-tag', this.closeDrawer);
 
     this.$root.$on('activity-comment-created', this.hideCommentRichEditor);
     this.$root.$on('activity-comment-updated', this.hideCommentRichEditor);
@@ -121,6 +123,10 @@ export default {
       this.limit = this.pageSize;
       this.hideCommentRichEditor();
       this.$root.selectedCommentId = null;
+    },
+    closeDrawer() {
+      this.reset();
+      this.$refs.activityCommentsDrawer.close();
     },
     addComment(comment) {
       this.$root.selectedCommentId = comment.id;

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
@@ -5,7 +5,6 @@
     id="activityCommentsDrawer"
     allow-expand
     right
-    fixed
     disable-pull-to-refresh
     @closed="reset">
     <template slot="title">

--- a/webapp/portlet/src/main/webapp/vue-apps/search/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/main.js
@@ -12,11 +12,10 @@ document.onclick = (event) => {
     if (tagName) {
       event.stopPropagation();
       event.preventDefault();
-      if (initialized) {
-        document.dispatchEvent(new CustomEvent('search-metadata-tag', {detail: tagName.replace('#', '')}));
-      } else {
+      if (!initialized) {
         init(tagName.replace('#', ''));
       }
+      document.dispatchEvent(new CustomEvent('search-metadata-tag', {detail: tagName.replace('#', '')}));
     }
   }
 };


### PR DESCRIPTION
When clicking on tags of comments in the comments drawer in order to do a research the unified search window  is displayed below the drawer with a dark mask in between the two components which is considered as a bad UI display . We fixed this by forcing the drawer to close each time a research is done .  