### PR TITLE
TASK-55136 : add a function to retrieve space IDs by user

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
@@ -144,7 +144,19 @@ public interface SpaceService {
    * @since  1.2.0-GA
    */
   ListAccess<Space> getMemberSpaces(String userId);
-  
+
+  /**
+   * Gets a list containing the IDs of all spaces that a user has the "member" role.
+   *
+   * @param userId The remote user Id.
+   * @return The list of Ids.
+   * @LevelAPI Platform
+   * @since  6.3.0
+   */
+  default List<String> getMemberSpacesIds(String userId) {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Gets a list access containing all spaces that a user has the "member" role. This list access matches with the provided space
    * filter.

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -1353,6 +1353,13 @@ public class SpaceServiceImpl implements SpaceService {
   public ListAccess<Space> getMemberSpaces(String userId) {
     return new SpaceListAccess(this.spaceStorage, userId, SpaceListAccess.Type.MEMBER);
   }
+  /**
+   * {@inheritDoc}
+   */
+  public List<String> getMemberSpacesIds(String remoteId) {
+    Identity userIdentity = identityManager.getOrCreateUserIdentity(remoteId);
+    return spaceStorage.getMemberSpaceIds(userIdentity.getId(),0, -1);
+  }
 
   /**
    * {@inheritDoc}

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -1356,6 +1356,7 @@ public class SpaceServiceImpl implements SpaceService {
   /**
    * {@inheritDoc}
    */
+  @Override
   public List<String> getMemberSpacesIds(String remoteId) {
     Identity userIdentity = identityManager.getOrCreateUserIdentity(remoteId);
     return spaceStorage.getMemberSpaceIds(userIdentity.getId(),0, -1);

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -3460,4 +3460,23 @@ public class SpaceServiceTest extends AbstractCoreTest {
     assertEquals(space5,testSpace5);
 
   }
+
+  public void testGetMemberSpaceIds() throws Exception {
+
+    User user = organizationService.getUserHandler().createUserInstance("shahin");
+    organizationService.getUserHandler().createUser(user, false);
+    Identity shahin = new Identity(OrganizationIdentityProvider.NAME, "shahin");
+
+    identityStorage.saveIdentity(shahin);
+    tearDownUserList.add(shahin);
+
+    List<Space> spaces = new ArrayList<>();
+    for(int i = 0; i < 2; i++) {
+      spaces.add(getSpaceInstance(i));
+    }
+    spaceService.addMember(spaces.get(0), "shahin");
+    assertEquals(1, spaceService.getMemberSpacesIds("shahin").size());
+    spaceService.removeMember(spaces.get(0), "shahin");
+    assertEquals(0, spaceService.getMemberSpacesIds("shahin").size());
+  }
 }


### PR DESCRIPTION
Having a dedicated function that returns directly all space idenity IDs in which the user is member, is needed to simplify retrieveing other data stored in DB and linked to space.