### PR TITLE
Task-55414: Enable posting activities without message

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ActivityComposerDrawer.vue
@@ -128,7 +128,7 @@ export default {
   },
   methods: {
     isActivityBodyEdited(event) {
-      this.activityBodyEdited = (this.messageEdited && this.messageLength) || event.detail.length !== 0 || (event.detail.length === 0 && this.messageLength);
+      this.activityBodyEdited = (this.messageEdited && this.messageLength) || event.detail !== 0 || (event.detail === 0 && this.messageLength);
     },
     open(params) {
       params = params && params.detail;


### PR DESCRIPTION
Prior to this fix, we cannot post poll activity without a message from the composer. After this fix, we will be able to post an activity even without adding a message in the case of file activity for example.