### PR TITLE
Task-52360: Do not reload page when clicking on Comments timestamp

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
@@ -59,7 +59,8 @@
               :comment-type-extension="commentTypeExtension"
               class="d-flex flex-row py-0 mb-auto flex-shrink-1" />
             <activity-comment-time
-              :activity="comment"
+              :activity="activity"
+              :comment="comment"
               class="d-inline ps-2 activity-comment-head-time"
               no-icon />
           </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/footer/ActivityCommentTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/footer/ActivityCommentTime.vue
@@ -3,24 +3,24 @@
     <v-tooltip bottom>
       <template v-slot:activator="{ on, attrs }">
         <v-btn
-          :href="activityLink"
           :height="20"
           class="hover-underline width-auto text-capitalize-first-letter d-inline px-0"
           x-small
           link
           text
           plain
+          @click="openCommentsDrawer"
           v-bind="attrs"
           v-on="on">
           <relative-date-format
             v-if="isActivityEdited"
-            :value="activity.updateDate"
+            :value="comment.updateDate"
             label="TimeConvert.label.Short.Edited"
             class="text-capitalize-first-letter text-light-color text-truncate pt-1 ps-1"
             short />
           <relative-date-format
             v-else
-            :value="activity.createDate"
+            :value="comment.createDate"
             class="text-capitalize-first-letter text-light-color text-truncate pt-1 ps-1"
             short />
         </v-btn>
@@ -33,6 +33,10 @@
 <script>
 export default {
   props: {
+    comment: {
+      type: Object,
+      default: null,
+    },
     activity: {
       type: Object,
       default: null,
@@ -53,17 +57,25 @@ export default {
   }),
   computed: {
     isActivityEdited() {
-      return this.activity && this.activity.updateDate !== this.activity.createDate;
+      return this.comment && this.comment.updateDate !== this.comment.createDate;
     },
-    activityId() {
-      return this.activity && this.activity.id;
-    },
-    activityLink() {
-      return `${this.$root.activityBaseLink}?id=${this.activityId}`;
+    commentId() {
+      return this.comment && this.comment.id;
     },
     activityPostedTime() {
-      return this.activity && (this.activity.updateDate || this.activity.createDate);
+      return this.comment && (this.comment.updateDate || this.comment.createDate);
     },
   },
+  methods: {
+    openCommentsDrawer() {
+      document.dispatchEvent(new CustomEvent('activity-comments-display', {detail: {
+        activity: this.activity,
+        selectedCommentId: this.commentId,
+        selectedActivityId: this.activity.id,
+        offset: 0,
+        limit: 200, // To display all
+      }}));
+    },
+  }
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
@@ -186,6 +186,10 @@ export default {
           this.newCommentEditor = !this.commentToEdit && options.newComment;
           this.selectedCommentIdToReply = !this.commentToEdit && options.commentId;
           this.highlightCommentId = options.highlightCommentId;
+          if (options.selectedCommentId && options.selectedActivityId) {
+            this.$root.selectedCommentId = options.selectedCommentId;
+            this.$root.selectedActivityId = options.selectedActivityId;
+          }
           this.highlightRepliesCommentId = options.highlightRepliesCommentId;
           if (!this.drawerOpened) {
             this.drawerOpened = true;


### PR DESCRIPTION
Open the selected comment in the comment drawer when clicking on comment timestamp without reloading the page.