### PR TITLE
Task-55473: Hide the attach option in the share drawer editor and in the kudos drawer

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -165,7 +165,7 @@ export default {
       }
 
       const ckEditorExtensions = extensionRegistry.loadExtensions('ActivityComposer', 'ckeditor-extensions');
-      if (ckEditorExtensions && ckEditorExtensions.length) {
+      if (ckEditorExtensions && ckEditorExtensions.length && (this.ckEditorType === 'activityContent' || this.ckEditorType.startsWith('comment_'))) {
         ckEditorExtensions.forEach(ckEditorExtension => {
           if (ckEditorExtension.extraPlugin) {
             extraPlugins = `${extraPlugins},${ckEditorExtension.extraPlugin}`;


### PR DESCRIPTION
Prior this change, attach file icon is displayed in share activity and send kudos composer