### PR TITLE
Task-55684: Current activity template params are lost when liking or disliking

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -1200,8 +1200,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
         updatedActivity.setLikerIds(new HashSet<>(Arrays.asList(existingActivity.getLikeIdentityIds())));
       if (existingActivity.getPermaLink() != null)
         updatedActivity.setPermaLink(existingActivity.getPermaLink());
-      if (existingActivity.getTemplateParams() != null)
-        updatedActivity.setTemplateParams(existingActivity.getTemplateParams());
+      if (existingActivity.getTemplateParams() != null) {
+        Map<String, String> updatedActivityTemplateParams = updatedActivity.getTemplateParams();
+        updatedActivityTemplateParams.putAll(existingActivity.getTemplateParams());
+        updatedActivity.setTemplateParams(updatedActivityTemplateParams);
+      }
       if (existingActivity.getUpdated() != null)
         updatedActivity.setUpdatedDate(existingActivity.getUpdated());
       updatedActivity.setHidden(existingActivity.isHidden());


### PR DESCRIPTION
Prior to this change, when liking or disliking an activity with attached files, its template params are erased with files ones even if it has other template params. After this commit, we ensure to preserve the current template params when liking or disliking. 