### PR TITLE
Task-55844: Fix delete attached file

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -1141,10 +1141,10 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       throw new IllegalArgumentException("Activity to update cannot be null");
     }
     if (existingActivity.getTemplateParams() != null) {
-      existingActivity.getTemplateParams().remove("id");
-      existingActivity.getTemplateParams().remove("DOCPATH");
-      existingActivity.getTemplateParams().remove("docTitle");
-      existingActivity.getTemplateParams().remove("mimeType");
+      existingActivity.getTemplateParams().put("id", "");
+      existingActivity.getTemplateParams().put("DOCPATH", "");
+      existingActivity.getTemplateParams().put("docTitle", "");
+      existingActivity.getTemplateParams().put("mimeType", "");
     }
     if (CollectionUtils.isNotEmpty(existingActivity.getFiles())) {
       try {


### PR DESCRIPTION
Prior to this change, it is not possible to detach the last attached file from any activity with attached files due to removed template params id, DOCPATH, docTitle, mimeType which will be overwritten by old activity template params values. After this change, we ensure to empty this params values instead of removing them in order to overwrite old activity template params values.