### PR TITLE
Task-56236: Receiver name in Kudos activity shows up after a while

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -104,7 +104,7 @@
           class="d-flex align-center text-color mx-0 mt-0 mb-2 text-wrap text-break">
           <span class="font-weight-bold" v-sanitized-html="title"></span>
           <exo-user-avatar
-            :profile-id="identityReceiver"
+            :identity="identityReceiver"
             extra-class="ms-2"
             fullname 
             popover 
@@ -143,7 +143,7 @@ export default {
     title: null,
     titleTooltip: null,
     isKudosActivity: false,
-    identityReceiver: '',
+    identityReceiver: {},
     summary: null,
     summaryTooltip: null,
     thumbnail: null,


### PR DESCRIPTION
Prior this change, the receiver name in Kudos activity in AS or activity detail shows up after a while.