### PR TITLE
Task-54884 : External users receive notification of published news from a space of which they are not a member

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/identity/provider/OrganizationIdentityProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/provider/OrganizationIdentityProvider.java
@@ -260,7 +260,7 @@ public class OrganizationIdentityProvider extends IdentityProvider<User> {
 
       String uExternal=foundUserProfile.getAttribute(UserProfile.OTHER_KEYS[2]);//external
       if (!StringUtils.equals(external, uExternal)) {
-        foundUserProfile.setAttribute(UserProfile.OTHER_KEYS[2], external);// "user.gender"
+        foundUserProfile.setAttribute(UserProfile.OTHER_KEYS[2], external);// "external"
         hasUpdated=true;
       }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/identity/provider/OrganizationIdentityProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/provider/OrganizationIdentityProvider.java
@@ -237,6 +237,7 @@ public class OrganizationIdentityProvider extends IdentityProvider<User> {
       //
       String position = (String) updatedProfile.getProperty(Profile.POSITION);
       String gender = (String) updatedProfile.getProperty(Profile.GENDER);
+      String external = (String) updatedProfile.getProperty(Profile.EXTERNAL);
 
       UserProfile foundUserProfile = organizationService.getUserProfileHandler()
                                                         .findUserProfileByName(userName);
@@ -256,6 +257,13 @@ public class OrganizationIdentityProvider extends IdentityProvider<User> {
         foundUserProfile.setAttribute(UserProfile.PERSONAL_INFO_KEYS[4], gender);// "user.gender"
         hasUpdated = true;
       }
+
+      String uExternal=foundUserProfile.getAttribute(UserProfile.OTHER_KEYS[2]);//external
+      if (!StringUtils.equals(external, uExternal)) {
+        foundUserProfile.setAttribute(UserProfile.OTHER_KEYS[2], external);// "user.gender"
+        hasUpdated=true;
+      }
+
       if (hasUpdated) {
         organizationService.getUserProfileHandler().saveUserProfile(foundUserProfile, false);
       }


### PR DESCRIPTION
Before this fix, the external status is tested in gatein profile, but is only present in social profile.
This commit update the listener which update the gatein profile when the social profile change to take care of this modification.
After that, as the external info is present in gatein profile, notification will be able to check it correctly.