### PR TITLE
Task-56451 : Refactor Event guest invitation

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -177,11 +177,11 @@ public class EntityBuilder {
     identityEntity.setGlobalId(identity.getGlobalId());
     identityEntity.setRemoteId(identity.getRemoteId());
     identityEntity.setDeleted(identity.isDeleted());
-    if (OrganizationIdentityProvider.NAME.equals(identity.getProviderId())) {
-      identityEntity.setProfile(buildEntityProfile(identity.getProfile(), restPath, expand));
-    } else if (SpaceIdentityProvider.NAME.equals(identity.getProviderId())) {
+    if (SpaceIdentityProvider.NAME.equals(identity.getProviderId())) {
       Space space = getSpaceService().getSpaceByPrettyName(identity.getRemoteId());
       identityEntity.setSpace(buildEntityFromSpace(space, "", restPath, expand));
+    } else {
+      identityEntity.setProfile(buildEntityProfile(identity.getProfile(), restPath, expand));
     }
 
     updateCachedEtagValue(getEtagValue(identity.getId()));


### PR DESCRIPTION
Before this fix, when using another IdentityProvider than Organization or Space, the user profile was not filled, due to the use of if/else if
This commit change the if to if/else, so that, the special case for spaces is treaten in first, and then case for users.
So, by using an IdentityProvider for user different from space or organization, the profile is correctly filled.