### PR TITLE
TASK-55889 Fix Date Picker Value when TZ is negative (#1422) (#1425)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/DatePicker.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/DatePicker.vue
@@ -28,7 +28,7 @@
         type="text"
         v-on="on">
       <v-date-picker
-        v-model="dateShortIso"
+        v-model="date"
         :first-day-of-week="1"
         :type="periodType"
         :locale="lang"
@@ -148,7 +148,6 @@ export default {
     dateFormatted: null,
     dateValue: null,
     menu: false,
-    dateShortIso: null,
   }),
   computed: {
     minDate() {
@@ -179,16 +178,10 @@ export default {
     },
     date() {
       this.emitDateValue();
-      if (this.date) {
-        this.dateShortIso=this.$dateUtil.getISODate(this.date);
-      }
-    },
-    dateShortIso(newVal) {
-      this.date = this.$dateUtil.getDateObjectFromString(newVal,true);
     },
   },
   mounted() {
-    // Force to close other DatePicker menus when opening a new one
+    // Force to close other DatePicker menus when opening a new one 
     $('.datePickerComponent input').on('click', (e) => {
       if (e.target && !$(e.target).parents(`#${this.id}`).length) {
         this.menu = false;
@@ -206,12 +199,12 @@ export default {
   },
   methods: {
     emitDateValue() {
-      const dateObj = this.date && new Date(this.date) || null;
+      const dateObj = this.date && this.$dateUtil.getDateObjectFromString(this.date, true) || null;
       if (this.disabled) {
         this.dateValue = null;
       } else {
         if (this.returnIso) {
-          this.dateValue = this.$dateUtil.getISODate(this.date);
+          this.dateValue = this.date;
         } else {
           this.dateValue = dateObj && dateObj.getTime() || null;
         }
@@ -225,12 +218,11 @@ export default {
     },
     computeDate() {
       if (this.value && String(this.value).trim()) {
-        if (!this.date) {
-          this.date = this.$dateUtil.getDateObjectFromString(this.value,true);
-        }
+        const dateObj = this.$dateUtil.getDateObjectFromString(String(this.value).trim(), true);
+        this.date = this.$dateUtil.getISODate(dateObj);
       } else {
         if ( this.defaultValue ) {
-          this.date = new Date();
+          this.date = this.$dateUtil.getISODate(new Date());
         } else {
           this.date = null;
         }

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
@@ -1,4 +1,4 @@
-const DIGIT_PATTERN = /^[1-9][0-9]*$/g;
+const DIGIT_PATTERN = /^[1-9]\d*$/g;
 
 /**
  * Return Date object from string value.
@@ -16,46 +16,47 @@ export function getDateObjectFromString(value, isISOString) {
   value = String(value).trim();
   if (new RegExp(DIGIT_PATTERN).test(value)) {
     return new Date(parseInt(value));
-  }
-  if (isISOString) {
+  } else if (isISOString) {
     if (value.length > 10) {
-      //long ISO format
+      // long ISO format
       return new Date(value);
     } else {
-      //short ISO format
-      //we need to set year, month, date, manually so that it use the current user time.
+      // short ISO format
+      // we need to set year, month, date, manually so that it use the current user time.
 
-      //if we do new Date(value), if will generate a date with Time = 00:00 UTC, then when it is translated
-      //in user timezone, the day can change
-      const [year, month, date] = value.trim().split('-');
-      const dateObj = new Date();
-      dateObj.setYear(year);
-      dateObj.setMonth(parseInt(month)-1);
-      dateObj.setDate(date);
-      return dateObj;
+      // if we do new Date(value), if will generate a date with Time = 00:00 UTC, then when it is translated
+      // in user timezone, the day can change
+      return new Date(`${value} 00:00:00`);
     }
-  } else {
+  } else if (String(value).indexOf('/') >= 0) {
     const [date, month, year] = value.trim().split('/');
-    const dateObj = new Date();
-    dateObj.setYear(year);
-    dateObj.setMonth(parseInt(month)-1);
-    dateObj.setDate(date);
-    return dateObj;
+    return new Date(year, parseInt(month) -1, date);
+  } else {
+    return new Date(value);
   }
 }
 
 /**
- * Return the ISO-8601 Date String value with format
- * YYYY-MM-DD, for example 2011-10-05
+ * Return the ISO Date String value with format
+ * yyyy-MM-dd, for example 2020-04-21.
+ * 
+ * This method will consider timezone offset and will avoid to
+ * return next or previous date due to Date.toISOString that considers
+ * timezone offset when converting to string
+ * 
  *
  * @param {Date} dateObj Date object
- * @returns {String} ISO 8601 date string with format YYYY-MM-DD
+ * @returns {String} ISO 8601 date string with format yyyy-MM-dd
  */
 export function getISODate(dateObj) {
   if (!dateObj) {
     return null;
   }
-  return dateObj.toISOString().substr(0,10);
+  // toISOString will modify time using timezone index
+  // This operation will compensate the diff to avoid switching
+  // into next or previous date
+  dateObj.setMinutes(dateObj.getMinutes() - dateObj.getTimezoneOffset());
+  return dateObj.toISOString().substring(0, 10);
 }
 
 /**

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperienceDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperienceDrawer.vue
@@ -183,6 +183,10 @@ export default {
         }
       }
 
+      if (this.error) {
+        return;
+      }
+
       if (!this.$refs.profileContactForm.validate() // Vuetify rules
         || !this.$refs.profileContactForm.$el.reportValidity()) { // Standard HTML rules
         this.handleError(this.$t('profileWorkExperiences.formValidationError'));


### PR DESCRIPTION
Prior to this change, the commit 9e27d5a had introduced a bug on date selection on 31 of a month. In fact, when changing the selected month to month that doesn't have a 31, the selected date is slided to the next month. This was fixed by a revert to the commit and a different fix of the original problem on Negative TimeZone.