### PR TITLE
TASK-55859: Time Zone is not considered in binding reports page start and end date

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -1347,11 +1347,10 @@ public class EntityBuilder {
     operationReportEntity.setBindingId(Long.toString(bindingOperationReport.getGroupSpaceBindingId()));
     operationReportEntity.setAddedUsersCount(Long.toString(bindingOperationReport.getAddedUsers()));
     operationReportEntity.setRemovedUsersCount(Long.toString(bindingOperationReport.getRemovedUsers()));
-    DateFormat dateFormat = new SimpleDateFormat(GROUP_BINDING_DATE_FORMAT);
     Date startDate = bindingOperationReport.getStartDate();
     Date endDate = bindingOperationReport.getEndDate();
-    operationReportEntity.setStartDate(startDate != null ? dateFormat.format(startDate) : "null");
-    operationReportEntity.setEndDate(endDate != null ? dateFormat.format(endDate) : "null");
+    operationReportEntity.setStartDate(startDate != null ? RestUtils.formatISO8601(startDate) : "null");
+    operationReportEntity.setEndDate(endDate != null ? RestUtils.formatISO8601(endDate) : "null");
     return operationReportEntity;
   }
 

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationBindingReports.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationBindingReports.vue
@@ -65,9 +65,13 @@
               data-placement="bottom">
               {{ props.item.group.name }}
             </td>
-            <td class="text-md-center">{{ props.item.startDate }}</td>
             <td class="text-md-center">
-              <div v-if="props.item.endDate !== 'null'"> {{ props.item.endDate }} </div>
+              <date-format :value="props.item.startDate" :format="dateFormat" />
+            </td>
+            <td class="text-md-center">
+              <div v-if="props.item.endDate !== 'null'">
+                <date-format :value="props.item.endDate" :format="dateFormat" />
+              </div>
               <div v-else class="inProgress">
                 <v-progress-circular
                   indeterminate
@@ -113,6 +117,14 @@ export default {
         `${this.$t('social.spaces.administration.binding.reports.filter.synchronize')}`
       ],
       operations: [],
+      dateFormat: {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric'
+      }
     };
   },
   computed: {


### PR DESCRIPTION

ISSUE: start and enddate in binding reports doesn't take in consideration the timezone, because it uses a wrong format of the returned date property and displays the value of the date without converting it depends on user lang
and timezone,
FIX: The PR should make sure to use a correct iso format date and use the common date-format component to format the date depends on user lang and timezone