### PR TITLE
TASK-56601: Duplication and bad detection and display of tags

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/ActivityTagMetadataListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/ActivityTagMetadataListener.java
@@ -23,6 +23,9 @@ import java.util.Set;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.commons.utils.HTMLSanitizer;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.activity.ActivityLifeCycleEvent;
 import org.exoplatform.social.core.activity.ActivityListenerPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
@@ -38,7 +41,9 @@ import org.exoplatform.social.metadata.tag.model.TagObject;
  */
 public class ActivityTagMetadataListener extends ActivityListenerPlugin {
 
-  private ActivityManager activityManager;
+  private static final Log LOG = ExoLogger.getLogger(ActivityTagMetadataListener.class);
+
+  private ActivityManager  activityManager;
 
   private TagService      tagService;
 
@@ -75,6 +80,11 @@ public class ActivityTagMetadataListener extends ActivityListenerPlugin {
     Identity audienceIdentity = activityManager.getActivityStreamOwnerIdentity(activity.getId());
     long audienceId = Long.parseLong(audienceIdentity.getId());
     String content = getActivityBody(activity);
+    try {
+      content = HTMLSanitizer.sanitize(content);
+    } catch (Exception e) {
+      LOG.warn("Error while sanitizing activity content {}", content, e);
+    }
 
     Set<TagName> tagNames = tagService.detectTagNames(content);
     tagService.saveTags(new TagObject(objectType,

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
@@ -45,7 +45,7 @@ public class TagServiceImpl implements TagService {
 
   private static final Log     LOG           = ExoLogger.getLogger(TagServiceImpl.class);
 
-  private static final Pattern TAG_PATTERN   = Pattern.compile("<a [^>]*class=[\"']metadata-tag[\"'][^>]*>#([^\\s]+)<[^>]*/a>");
+  private static final Pattern TAG_PATTERN   = Pattern.compile("<a [^>]*class=[\"']metadata-tag[\"'][^>]*>#([^\\s\u00A0]+)<[^>]*/a>");
 
   public static final String                 TAG_ADDED_EVENT                = "exo.tag.added";
 


### PR DESCRIPTION

Prior to this changes, when creation a tag and then press the space button each time will create another tag with number of spaces converted to &nbsp; as the matcher of tags pattern will consider it as a normal character
follows the tag text wich will duplicate the tag depends on the number of spaces that follows it and display it with the &nbsp; in the unified search when selecting tags, this because of the returned html content of the
activity when searching for tags, This PR will sanitize the content to correctly unescape the &nbsp; and replacing it by spaces to allow the tags pattern matcher to work as expected.