### PR TITLE
Task-56663: initialize the user name input field with the url property username if its available

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/login/components/Login.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/login/components/Login.vue
@@ -93,6 +93,7 @@
                         id="username"
                         :placeholder="$t('portal.login.Username')"
                         name="username"
+                        v-model="username"
                         tabindex="1"
                         type="text"
                         aria-required="true">
@@ -184,6 +185,7 @@ export default {
   },
   data: () => ({
     rememberme: true,
+    username: '',
   }),
   computed: {
     companyName() {
@@ -225,7 +227,7 @@ export default {
     setupUserName(){
       const urlParams = new URLSearchParams(window.location.search);
       if (urlParams.has('username')) {
-        document.getElementById('username').value = urlParams.get('username');
+        this.username = urlParams.get('username');
       }
     }
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/login/components/Login.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/login/components/Login.vue
@@ -218,7 +218,16 @@ export default {
     document.title = this.$t('UILoginForm.label.login');
   },
   mounted() {
+    this.setupUserName();
     this.$root.$applicationLoaded();
   },
+  methods: {
+    setupUserName(){
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.has('username')) {
+        document.getElementById('username').value = urlParams.get('username');
+      }
+    }
+  }
 };
 </script>


### PR DESCRIPTION
ISSUE: when we scan the QR code in the mobile settings page, the expected behavior is for the user to be redirected to the login page where the user name field of the login form should be auto filled with the username  url property (..../portal/login?username=... )
FIX: check if the username property exists in the login url and if this is the case we simply set the user name input field value to this paramater 