### PR TITLE
Task-57018: Hidden space indication in an event for a member .

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
@@ -32,7 +32,7 @@
             class="pull-left text-truncate ms-2">
             <p
               class="text-truncate subtitle-2 my-auto hidden-space">
-              {{ $t('spacesList.label.hiddenSpace') }}
+              {{ displayName }}
             </p>
           </div>
         </a>


### PR DESCRIPTION
Problem: when opening the event1 it's well indicated that it's added under a hidden space instead of display name for validation and hidden spaces.
Fix: replace the static translated value with the computed variable displayName.