### PR TITLE
Task-57018: Hidden space indication in an event for a member . (#1452)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -178,8 +178,10 @@ public class EntityBuilder {
     identityEntity.setRemoteId(identity.getRemoteId());
     identityEntity.setDeleted(identity.isDeleted());
     if (SpaceIdentityProvider.NAME.equals(identity.getProviderId())) {
+      ConversationState conversationState = ConversationState.getCurrent();
+      String currentUserId = conversationState.getIdentity().getUserId();
       Space space = getSpaceService().getSpaceByPrettyName(identity.getRemoteId());
-      identityEntity.setSpace(buildEntityFromSpace(space, "", restPath, expand));
+      identityEntity.setSpace(buildEntityFromSpace(space, currentUserId, restPath, expand));
     } else {
       identityEntity.setProfile(buildEntityProfile(identity.getProfile(), restPath, expand));
     }


### PR DESCRIPTION
Problem: when opening the event1 it's well indicated that it's added under a hidden space instead of display name for validation and hidden spaces.
 Fix: replace the empty value of parameter userId with the correct id of the current user in the method buildEntityFromSpace () to check if this user is a member of the space or not.