### PR TITLE
TASK-56600 Improve Tags Search by making it case insensitive

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/metadata/tag/model/TagName.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/tag/model/TagName.java
@@ -1,30 +1,43 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * 
  * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
- * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exoplatform.social.metadata.tag.model;
 
+import java.util.Objects;
+
+import org.apache.commons.lang.StringUtils;
+
 import lombok.*;
 
-@Data
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class TagName {
 
+  @Getter
+  @Setter
   private String name;
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TagName && StringUtils.equalsIgnoreCase(((TagName) obj).getName(), name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(StringUtils.lowerCase(name));
+  }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
@@ -18,14 +18,16 @@
  */
 package org.exoplatform.social.core.metadata.tag;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.listener.ListenerService;
@@ -37,9 +39,13 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.metadata.MetadataService;
-import org.exoplatform.social.metadata.model.*;
+import org.exoplatform.social.metadata.model.Metadata;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
 import org.exoplatform.social.metadata.tag.TagService;
-import org.exoplatform.social.metadata.tag.model.*;
+import org.exoplatform.social.metadata.tag.model.TagFilter;
+import org.exoplatform.social.metadata.tag.model.TagName;
+import org.exoplatform.social.metadata.tag.model.TagObject;
 
 public class TagServiceImpl implements TagService {
 
@@ -154,14 +160,12 @@ public class TagServiceImpl implements TagService {
 
     long limit = tagFilter.getLimit();
 
-    List<String> metadataNames = new ArrayList<>();
-    metadataNames = metadataService.findMetadataNamesByUserAndQuery(tagFilter.getTerm(),
-                                                            TagService.METADATA_TYPE.getName(),
-                                                             audienceIds,
-                                                             userIdentityId,
-                                                             limit);
+    List<String> metadataNames = metadataService.findMetadataNamesByUserAndQuery(tagFilter.getTerm(),
+                                                                                 TagService.METADATA_TYPE.getName(),
+                                                                                 audienceIds,
+                                                                                 userIdentityId,
+                                                                                 limit * 3);
     return metadataNames.stream().map(TagName::new).distinct().limit(limit).collect(Collectors.toList());
-
   }
 
   private void deleteTags(List<MetadataItem> tagMetadataItems, Set<TagName> tagsToDelete) {

--- a/component/core/src/test/java/org/exoplatform/social/metadata/tag/TagServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/tag/TagServiceTest.java
@@ -108,6 +108,7 @@ public class TagServiceTest extends AbstractCoreTest {
     String tagName1 = "tag1";
     String tagName2 = "tag2";
     tagNames1.add(new TagName(tagName1));
+    tagNames1.add(new TagName(tagName1.toLowerCase()));
     tagNames1.add(new TagName(tagName2));
 
     try {
@@ -149,7 +150,8 @@ public class TagServiceTest extends AbstractCoreTest {
                                                      userIdentityId);
     assertNotNull(savedTagNames);
     assertEquals(2, savedTagNames.size());
-    assertEquals(tagNames1, savedTagNames);
+    assertTrue(savedTagNames.contains(new TagName(tagName1)));
+    assertTrue(savedTagNames.contains(new TagName(tagName2)));
 
     Metadata metadata = metadataService.getMetadataByKey(new MetadataKey(TagService.METADATA_TYPE.getName(),
                                                                          tagName1,
@@ -162,12 +164,13 @@ public class TagServiceTest extends AbstractCoreTest {
     List<MetadataItem> metadataItems = metadataService.getMetadataItemsByObject(taggedObject1);
     assertNotNull(metadataItems);
     assertEquals(2, metadataItems.size());
-    assertEquals(tagNames1,
-                 metadataItems.stream()
-                              .map(MetadataItem::getMetadata)
-                              .map(Metadata::getName)
-                              .map(TagName::new)
-                              .collect(Collectors.toSet()));
+    Set<TagName> storedTagNames = metadataItems.stream()
+                  .map(MetadataItem::getMetadata)
+                  .map(Metadata::getName)
+                  .map(TagName::new)
+                  .collect(Collectors.toSet());
+    assertTrue(storedTagNames.contains(new TagName(tagName1)));
+    assertTrue(storedTagNames.contains(new TagName(tagName2)));
 
     Set<TagName> updatedTagNames = Collections.singleton(new TagName(tagName1));
     savedTagNames = tagService.saveTags(taggedObject1,
@@ -181,12 +184,7 @@ public class TagServiceTest extends AbstractCoreTest {
     metadataItems = metadataService.getMetadataItemsByObject(taggedObject1);
     assertNotNull(metadataItems);
     assertEquals(1, metadataItems.size());
-    assertEquals(updatedTagNames,
-                 metadataItems.stream()
-                              .map(MetadataItem::getMetadata)
-                              .map(Metadata::getName)
-                              .map(TagName::new)
-                              .collect(Collectors.toSet()));
+    assertTrue(storedTagNames.contains(new TagName(tagName1)));
 
     TagObject taggedObject2 = new TagObject(objectType, objectId2, parentObjectId);
     metadataItems = metadataService.getMetadataItemsByObject(taggedObject2);
@@ -194,7 +192,7 @@ public class TagServiceTest extends AbstractCoreTest {
     assertEquals(0, metadataItems.size());
 
     Set<TagName> tagNames2 = new HashSet<>();
-    tagNames2.add(new TagName(tagName1));
+    tagNames2.add(new TagName(tagName1.toUpperCase()));
     tagNames2.add(new TagName("tag3"));
 
     savedTagNames = tagService.saveTags(taggedObject2, tagNames2, audienceId, userIdentityId);
@@ -204,12 +202,13 @@ public class TagServiceTest extends AbstractCoreTest {
     metadataItems = metadataService.getMetadataItemsByObject(taggedObject2);
     assertNotNull(metadataItems);
     assertEquals(2, metadataItems.size());
-    assertEquals(tagNames2,
-                 metadataItems.stream()
-                              .map(MetadataItem::getMetadata)
-                              .map(Metadata::getName)
-                              .map(TagName::new)
-                              .collect(Collectors.toSet()));
+
+    storedTagNames = metadataItems.stream()
+                                  .map(MetadataItem::getMetadata)
+                                  .map(Metadata::getName)
+                                  .map(TagName::new)
+                                  .collect(Collectors.toSet());
+    assertEquals(tagNames2, storedTagNames);
   }
 
   public void testFindTags() throws Exception {
@@ -252,14 +251,20 @@ public class TagServiceTest extends AbstractCoreTest {
     tagNames.add(new TagName("tagJohn1"));
     tagNames.add(new TagName("tagJohn2"));
 
-    savedTags = tagService.saveTags(new TagObject("objectType", "objectId1"), tagNames, spaceIdentityIds.get(1), spaceCreators.get(1));
+    savedTags = tagService.saveTags(new TagObject("objectType", "objectId1"),
+                                    tagNames,
+                                    spaceIdentityIds.get(1),
+                                    spaceCreators.get(1));
     assertEquals(savedTags, tagNames);
 
     tagNames = new HashSet<>();
     tagNames.add(new TagName("tagJohnMary1"));
     tagNames.add(new TagName("tagJohnMary2"));
 
-    savedTags = tagService.saveTags(new TagObject("objectType", "objectId1"), tagNames, spaceIdentityIds.get(2), spaceCreators.get(2));
+    savedTags = tagService.saveTags(new TagObject("objectType", "objectId1"),
+                                    tagNames,
+                                    spaceIdentityIds.get(2),
+                                    spaceCreators.get(2));
     assertEquals(savedTags, tagNames);
 
     List<TagName> marySavedTags = tagService.findTags(null, Long.parseLong(maryIdentity.getId()));
@@ -282,7 +287,7 @@ public class TagServiceTest extends AbstractCoreTest {
     assertNotNull(marySavedTags);
     assertEquals(Arrays.asList("tagJohnMary1",
                                "tagJohnMary2",
-                               "tagMary2"),
+                               "tagMary1"),
                  marySavedTags.stream().map(TagName::getName).sorted().collect(Collectors.toList()));
 
     List<TagName> johnSavedTags = tagService.findTags(new TagFilter("mar", 0), Long.parseLong(johnIdentity.getId()));
@@ -294,7 +299,7 @@ public class TagServiceTest extends AbstractCoreTest {
     johnSavedTags = tagService.findTags(new TagFilter("mar", 2), Long.parseLong(johnIdentity.getId()));
     assertNotNull(johnSavedTags);
     assertEquals(Arrays.asList("tagJohnMary1",
-                              "tagJohnMary2"),
+                               "tagJohnMary2"),
                  johnSavedTags.stream().map(TagName::getName).sorted().collect(Collectors.toList()));
 
     johnSavedTags = tagService.findTags(new TagFilter("joh", 10), Long.parseLong(johnIdentity.getId()));
@@ -304,6 +309,41 @@ public class TagServiceTest extends AbstractCoreTest {
                                "tagJohnMary1",
                                "tagJohnMary2"),
                  johnSavedTags.stream().map(TagName::getName).sorted().collect(Collectors.toList()));
+  }
+
+  public void testFindTagsCaseInsensitive() throws Exception {
+    Set<TagName> tagNames = new HashSet<>();
+    tagNames.add(new TagName("tagMary1"));
+    tagNames.add(new TagName("tagMary2"));
+
+    long maryIdentityId = Long.parseLong(maryIdentity.getId());
+
+    TagObject tagObject = new TagObject("objectType", "objectId1");
+
+    Set<TagName> savedTags = tagService.saveTags(tagObject,
+                                                 tagNames,
+                                                 maryIdentityId,
+                                                 maryIdentityId);
+    assertEquals(savedTags, tagNames);
+
+    Set<TagName> tagNamesUpperCase = new HashSet<>();
+    tagNamesUpperCase.add(new TagName("tagMary1".toUpperCase()));
+    tagNamesUpperCase.add(new TagName("tagMary2".toUpperCase()));
+
+    savedTags = tagService.saveTags(tagObject,
+                                    tagNamesUpperCase,
+                                    maryIdentityId,
+                                    maryIdentityId);
+    assertEquals(tagNamesUpperCase, savedTags);
+
+    List<TagName> marySavedTags = tagService.findTags(null, maryIdentityId);
+    assertNotNull(marySavedTags);
+    assertEquals(2, marySavedTags.size());
+    assertTrue(marySavedTags.contains(new TagName("tagMary1".toUpperCase())));
+    assertTrue(marySavedTags.contains(new TagName("tagMary2".toUpperCase())));
+
+    Set<TagName> savedTagNames = tagService.getTagNames(tagObject);
+    assertEquals(tagNames, savedTagNames);
   }
 
   @SuppressWarnings("deprecation")

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search/activities-search-query.json
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search/activities-search-query.json
@@ -5,13 +5,14 @@
     "bool":{
       @term_query@
       "filter":[
-        @metadatas_query@
+        @favorite_query@
         {
           "terms":{
             "permissions": [@permissions@]
           }
         }
       ]
+      @tags_query@
     }
   },
   "highlight" : {

--- a/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ExoTopBarFavorites.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ExoTopBarFavorites.vue
@@ -23,7 +23,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           class="icon-default-color" 
           @click="openDrawer()"
           :title="$t('UITopBarFavoritesPortlet.label.iconTooltip')">
-          <v-icon size="22" class="pb-1" >fa-star</v-icon>
+          <v-icon size="22" class="pb-1">fa-star</v-icon>
         </v-btn>
         <exo-drawer
           ref="favoritesDrawer"

--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchTagList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchTagList.vue
@@ -107,14 +107,27 @@ export default {
       return this.$tagService.searchTags(this.query , this.searchLimit)
         .then(tagNames => {
           this.tags = tagNames.map(tagName => tagName.name) || [];
+          if (this.selectedTags && this.selectedTags.length) {
+            this.selectedTags = this.selectedTags.map(tag => {
+              const tagsLowerCase = this.tags.map(t => t.toLowerCase());
+              const tagLowerCase = tag.toLowerCase();
+              const tagIndex = tagsLowerCase.indexOf(tagLowerCase);
+              if (tagIndex >= 0) {
+                return this.tags[tagIndex];
+              } else {
+                return tag;
+              }
+            });
+          }
         });
     },
     handleTag(tag) {
-      if (this.selectedTags.includes(tag)) {
-        const tagIndex = this.selectedTags.indexOf(tag);
+      const selectedTagsLowerCase = this.selectedTags.map(t => t.toLowerCase());
+      const tagLowerCase = tag.toLowerCase();
+      if (selectedTagsLowerCase.includes(tagLowerCase)) {
+        const tagIndex = selectedTagsLowerCase.indexOf(tagLowerCase);
         this.selectedTags.splice(tagIndex , 1);
-      }
-      else {
+      } else {
         this.selectedTags.push(tag);
         document.dispatchEvent(new CustomEvent('search-tag'));
       }


### PR DESCRIPTION
Prior to this change, the Tags Search and listing are case sensitive. This change will list the Tags in Search UI in case insensitive (group same spelled tags) and will make a search on selected tag name in case insensitive way.