### PR TITLE
TASK-56600 Improve Tags Search by making it case insensitive (#1456)

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/metadata/tag/model/TagName.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/tag/model/TagName.java
@@ -1,30 +1,43 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * 
  * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
- * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exoplatform.social.metadata.tag.model;
 
+import java.util.Objects;
+
+import org.apache.commons.lang.StringUtils;
+
 import lombok.*;
 
-@Data
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class TagName {
 
+  @Getter
+  @Setter
   private String name;
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TagName && StringUtils.equalsIgnoreCase(((TagName) obj).getName(), name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(StringUtils.lowerCase(name));
+  }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
@@ -18,14 +18,16 @@
  */
 package org.exoplatform.social.core.metadata.tag;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.listener.ListenerService;
@@ -37,9 +39,13 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.metadata.MetadataService;
-import org.exoplatform.social.metadata.model.*;
+import org.exoplatform.social.metadata.model.Metadata;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
 import org.exoplatform.social.metadata.tag.TagService;
-import org.exoplatform.social.metadata.tag.model.*;
+import org.exoplatform.social.metadata.tag.model.TagFilter;
+import org.exoplatform.social.metadata.tag.model.TagName;
+import org.exoplatform.social.metadata.tag.model.TagObject;
 
 public class TagServiceImpl implements TagService {
 
@@ -154,14 +160,12 @@ public class TagServiceImpl implements TagService {
 
     long limit = tagFilter.getLimit();
 
-    List<String> metadataNames = new ArrayList<>();
-    metadataNames = metadataService.findMetadataNamesByUserAndQuery(tagFilter.getTerm(),
-                                                            TagService.METADATA_TYPE.getName(),
-                                                             audienceIds,
-                                                             userIdentityId,
-                                                             limit);
+    List<String> metadataNames = metadataService.findMetadataNamesByUserAndQuery(tagFilter.getTerm(),
+                                                                                 TagService.METADATA_TYPE.getName(),
+                                                                                 audienceIds,
+                                                                                 userIdentityId,
+                                                                                 limit * 3);
     return metadataNames.stream().map(TagName::new).distinct().limit(limit).collect(Collectors.toList());
-
   }
 
   private void deleteTags(List<MetadataItem> tagMetadataItems, Set<TagName> tagsToDelete) {

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search/activities-search-query.json
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/search/activities-search-query.json
@@ -5,13 +5,14 @@
     "bool":{
       @term_query@
       "filter":[
-        @metadatas_query@
+        @favorite_query@
         {
           "terms":{
             "permissions": [@permissions@]
           }
         }
       ]
+      @tags_query@
     }
   },
   "highlight" : {

--- a/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ExoTopBarFavorites.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ExoTopBarFavorites.vue
@@ -23,7 +23,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           class="icon-default-color" 
           @click="openDrawer()"
           :title="$t('UITopBarFavoritesPortlet.label.iconTooltip')">
-          <v-icon size="22" class="pb-1" >fa-star</v-icon>
+          <v-icon size="22" class="pb-1">fa-star</v-icon>
         </v-btn>
         <exo-drawer
           ref="favoritesDrawer"

--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchTagList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchTagList.vue
@@ -107,14 +107,27 @@ export default {
       return this.$tagService.searchTags(this.query , this.searchLimit)
         .then(tagNames => {
           this.tags = tagNames.map(tagName => tagName.name) || [];
+          if (this.selectedTags && this.selectedTags.length) {
+            this.selectedTags = this.selectedTags.map(tag => {
+              const tagsLowerCase = this.tags.map(t => t.toLowerCase());
+              const tagLowerCase = tag.toLowerCase();
+              const tagIndex = tagsLowerCase.indexOf(tagLowerCase);
+              if (tagIndex >= 0) {
+                return this.tags[tagIndex];
+              } else {
+                return tag;
+              }
+            });
+          }
         });
     },
     handleTag(tag) {
-      if (this.selectedTags.includes(tag)) {
-        const tagIndex = this.selectedTags.indexOf(tag);
+      const selectedTagsLowerCase = this.selectedTags.map(t => t.toLowerCase());
+      const tagLowerCase = tag.toLowerCase();
+      if (selectedTagsLowerCase.includes(tagLowerCase)) {
+        const tagIndex = selectedTagsLowerCase.indexOf(tagLowerCase);
         this.selectedTags.splice(tagIndex , 1);
-      }
-      else {
+      } else {
         this.selectedTags.push(tag);
         document.dispatchEvent(new CustomEvent('search-tag'));
       }


### PR DESCRIPTION
Prior to this change, the Tags Search and listing are case sensitive. This change will list the Tags in Search UI in case insensitive (group same spelled tags) and will make a search on selected tag name in case insensitive way.