### PR TITLE
TASK-56851: Add and ellipsis to space name in space Access portlet when the space name is very long

### DIFF
--- a/webapp/portlet/src/main/webapp/groovy/social/webui/UISpaceAccess.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/webui/UISpaceAccess.gtmpl
@@ -34,7 +34,7 @@
 	jsManager.require("SHARED/socialUtil", "socialUtil");
 %>
   <% if ("social.space.access.join-space".equals(status)) {
-    memberRestrict = memberRestrict.replace("{0}", "<b>" + spaceDisplayName + "</b>");
+    memberRestrict = memberRestrict.replace("{0}", "<p title="+ spaceDisplayName +" class=\"text-truncate\"><b>" + spaceDisplayName + "</b></p>");
     %>
     <div class="spaceAccessBlock lockIcon">
       <h3>$pageTitle</h3>
@@ -45,14 +45,14 @@
     </div>
   <% } else if ("social.space.access.closed-space".equals(status)) { 
     def closedSpace = _ctx.appRes("UISpaceAccess.closedSpace");
-    closedSpace = closedSpace.replace("{0}", "<b>" + spaceDisplayName + "</b>");
+    closedSpace = closedSpace.replace("{0}", "<p title="+ spaceDisplayName + " class=\"text-truncate\"><b>" + spaceDisplayName + "</b></p>");
     %>
     <div class="spaceAccessBlock denyIcon">
       <h3><%=_ctx.appRes("UISpaceAccess.accessDenied"); %></h3>
       <div class="spaceAccessInfo">$closedSpace</div>
     </div>
   <%}  else if ("social.space.access.request-join-space".equals(status)) {
-    memberRestrict = memberRestrict.replace("{0}", "<b>" + spaceDisplayName + "</b>");
+    memberRestrict = memberRestrict.replace("{0}", "<p title="+ spaceDisplayName + " class=\"text-truncate\"><b>" + spaceDisplayName + "</b></p>");
     %>
     <div class="spaceAccessBlock lockIcon">
       <h3>$pageTitle</h3>
@@ -63,12 +63,12 @@
     </div>
   <% } else if ("social.space.access.requested-join-space".equals(status) || "social.space.access.requested.success".equals(status)) {
     def requestedJoinSpace = _ctx.appRes("UISpaceAcess.requested-join-space");
-    requestedJoinSpace = requestedJoinSpace.replace("{0}", "<b>" + spaceDisplayName + "</b>");
+    requestedJoinSpace = requestedJoinSpace.replace("{0}", "<p title="+ spaceDisplayName + " class=\"text-truncate\"><b>" + spaceDisplayName + "</b></p>");
     %>
     <div class="alert alert-success"><i class="uiIconSuccess"></i>$requestedJoinSpace</div>
   <% } else if ("social.space.access.invited-space".equals(status)) {
     def invitedToSpace = _ctx.appRes("UISpaceAccess.invited-space");
-    invitedToSpace = invitedToSpace.replace("{0}", "<b>" + spaceDisplayName + "</b>"); 
+    invitedToSpace = invitedToSpace.replace("{0}", "<p title="+ spaceDisplayName + " class=\"text-truncate\"><b>" + spaceDisplayName + "</b></p>");
     %>
     <div class="spaceAccessBlock">
       <div class="spaceAccessInfo">$invitedToSpace</div>


### PR DESCRIPTION
Prior to this change, On mobile screen, when the space where the user has been invited has a long name then it's not well displayed in the space access page and the name overflows the spaceblock access area.
Ths Pr should add the class text-truncate after adding it to the dedicated portlet style in platform-ui to truncate the name and display an ellipsis with a html tooltip