### PR TITLE
TASK-56601: Unescaped html characters in unified search last added tags list

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/ActivityTagMetadataListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/ActivityTagMetadataListener.java
@@ -21,11 +21,9 @@ package org.exoplatform.social.core.listeners;
 import java.util.Set;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.utils.HTMLSanitizer;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.activity.ActivityLifeCycleEvent;
 import org.exoplatform.social.core.activity.ActivityListenerPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
@@ -40,8 +38,6 @@ import org.exoplatform.social.metadata.tag.model.TagObject;
  * A listener to handle Tag update for Activity and Comment lifecycle
  */
 public class ActivityTagMetadataListener extends ActivityListenerPlugin {
-
-  private static final Log LOG = ExoLogger.getLogger(ActivityTagMetadataListener.class);
 
   private ActivityManager  activityManager;
 
@@ -80,11 +76,6 @@ public class ActivityTagMetadataListener extends ActivityListenerPlugin {
     Identity audienceIdentity = activityManager.getActivityStreamOwnerIdentity(activity.getId());
     long audienceId = Long.parseLong(audienceIdentity.getId());
     String content = getActivityBody(activity);
-    try {
-      content = HTMLSanitizer.sanitize(content);
-    } catch (Exception e) {
-      LOG.warn("Error while sanitizing activity content {}", content, e);
-    }
 
     Set<TagName> tagNames = tagService.detectTagNames(content);
     tagService.saveTags(new TagObject(objectType,

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.ListAccess;
@@ -81,6 +82,7 @@ public class TagServiceImpl implements TagService {
     if (StringUtils.isBlank(content)) {
       return Collections.emptySet();
     }
+    content = StringEscapeUtils.unescapeHtml(content);
     Set<TagName> tags = new HashSet<>();
     Matcher matcher = TAG_PATTERN.matcher(content);
     while (matcher.find()) {

--- a/component/core/src/test/java/org/exoplatform/social/metadata/tag/TagServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/tag/TagServiceTest.java
@@ -89,11 +89,11 @@ public class TagServiceTest extends AbstractCoreTest {
 
     String content =
                    "<div>Test tag #NoTagHere test test"
-                       + " <a target=\"_blank\" class=\"metadata-tag\" rel=\"noopener\">#ANewTagHere</a>&nbsp;.</div>";
+                       + " <a target=\"_blank\" class=\"metadata-tag\" rel=\"noopener\">#ANew'TagHere</a>&nbsp;.</div>";
     tagNames = tagService.detectTagNames(content);
     assertNotNull(tagNames);
     assertEquals(1, tagNames.size());
-    assertEquals(Collections.singleton(new TagName("ANewTagHere")), tagNames);
+    assertEquals(Collections.singleton(new TagName("ANew'TagHere")), tagNames);
   }
 
   public void testSaveTags() { // NOSONAR


### PR DESCRIPTION
Prior to this change, last added tags list are displayed with unescaped html characters, because the HTMLSanitizer was converting some char like apostrophe to html chars
This PR use StringEscapeUtils.unescapeHtml to avoid such unwanted conversion