### PR TITLE
TASK-57147: Favorites metadatas are removed when updating an activity

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/tag/TagServiceImpl.java
@@ -54,7 +54,9 @@ public class TagServiceImpl implements TagService {
 
   private static final Pattern TAG_PATTERN   = Pattern.compile("<a [^>]*class=[\"']metadata-tag[\"'][^>]*>#([^\\s\u00A0]+)<[^>]*/a>");
 
-  public static final String                 TAG_ADDED_EVENT                = "exo.tag.added";
+  public static final String   TAG_ADDED_EVENT    = "exo.tag.added";
+
+  private static final String  TAGS_METADATA_TYPE = "tags";
 
   private static final int     DEFAULT_LIMIT = 10000;
 
@@ -115,7 +117,7 @@ public class TagServiceImpl implements TagService {
     if (StringUtils.isBlank(object.getType())) {
       throw new IllegalArgumentException("objectType is mandatory");
     }
-    List<MetadataItem> metadataItems = this.metadataService.getMetadataItemsByObject(object);
+    List<MetadataItem> metadataItems = this.metadataService.getMetadataItemsByMetadataTypeAndObject(TAGS_METADATA_TYPE, object);
     Set<TagName> storedTagNames = metadataItems.stream()
                                                .map(MetadataItem::getMetadata)
                                                .map(Metadata::getName)

--- a/component/core/src/test/java/org/exoplatform/social/metadata/tag/TagServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/tag/TagServiceTest.java
@@ -161,7 +161,7 @@ public class TagServiceTest extends AbstractCoreTest {
     assertEquals(TagService.METADATA_TYPE.getName(), metadata.getTypeName());
     assertEquals(audienceId, metadata.getAudienceId());
 
-    List<MetadataItem> metadataItems = metadataService.getMetadataItemsByObject(taggedObject1);
+    List<MetadataItem> metadataItems = metadataService.getMetadataItemsByMetadataTypeAndObject("tags", taggedObject1);
     assertNotNull(metadataItems);
     assertEquals(2, metadataItems.size());
     Set<TagName> storedTagNames = metadataItems.stream()
@@ -181,13 +181,13 @@ public class TagServiceTest extends AbstractCoreTest {
     assertEquals(1, savedTagNames.size());
     assertEquals(updatedTagNames, savedTagNames);
 
-    metadataItems = metadataService.getMetadataItemsByObject(taggedObject1);
+    metadataItems = metadataService.getMetadataItemsByMetadataTypeAndObject("tags", taggedObject1);
     assertNotNull(metadataItems);
     assertEquals(1, metadataItems.size());
     assertTrue(storedTagNames.contains(new TagName(tagName1)));
 
     TagObject taggedObject2 = new TagObject(objectType, objectId2, parentObjectId);
-    metadataItems = metadataService.getMetadataItemsByObject(taggedObject2);
+    metadataItems = metadataService.getMetadataItemsByMetadataTypeAndObject("tags", taggedObject2);
     assertNotNull(metadataItems);
     assertEquals(0, metadataItems.size());
 
@@ -199,7 +199,7 @@ public class TagServiceTest extends AbstractCoreTest {
     assertNotNull(savedTagNames);
     assertEquals(2, savedTagNames.size());
 
-    metadataItems = metadataService.getMetadataItemsByObject(taggedObject2);
+    metadataItems = metadataService.getMetadataItemsByMetadataTypeAndObject("tags", taggedObject2);
     assertNotNull(metadataItems);
     assertEquals(2, metadataItems.size());
 


### PR DESCRIPTION
Prior to this changes, when updating an activity several listener are invoked includes the tags metadata listener which will remove the deleted tags and add the new tags, at this stage the service was removing also
favorites metadatas, because it was getting mettadas wicthout specifying its types, and so delete the favorites metadatas of the activity while removing tags.
This PR should get metadats by object and type in the tagsService to allow filtering only tags metadatas.