### PR TITLE
TASK-56521 Improve Tests Stability

### DIFF
--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
@@ -537,6 +537,7 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
       comment.setTitle("comment " + i);
       comment.setUserId(rootIdentity.getId());
       activityManager.saveComment(rootActivity, comment);
+      Thread.sleep(10); // NOSONAR Make sure that comment update time is different
     }
 
     ContainerResponse response = service("GET",


### PR DESCRIPTION
Prior to this change, the saveComment were performant sufficiently to make multiple comments saving in the same millisecond. Thus, the tests failed due to the fact that multiple comments injected by tests were added in the same millisecond without being able to sort them efficiently. This change introduces a wait time between two inserts to make sure to have different date value between comments.