### PR TITLE
Task-56626: closing an ExoConfirmDialog introduces a regression with the gray screen overlay component #1468

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoConfirmDialog.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoConfirmDialog.vue
@@ -114,8 +114,8 @@ export default {
         event.stopPropagation();
       }
 
-      this.$emit('ok');
       this.close(event);
+      this.$nextTick(() => this.$emit('ok'));
     },
     close(event) {
       if (event) {
@@ -124,7 +124,7 @@ export default {
       }
 
       this.$emit('closed');
-      this.$nextTick(() => this.dialog = false);
+      this.dialog = false;
     },
     open() {
       this.dialog = true;


### PR DESCRIPTION
ISSUE: we have a drawer open and from that drawer we open an exo dialog (ExoConfirmDialog component) and we click on the ok button, the dialog button will emit an 'ok' event and call ExoConfirmDialog's close method to close the drawer.
emitting the 'ok' event will closes the dialog and then the drawer, the problem is that in this case the 'ok' event will be emitted before we change the value for the dialog boolean variable and the modalClosed event won't be dispatched in this case

FIX: change the dialog variable to false directly without waiting for the next tick and we emit el 'ok' event after the next tick to ensure that the dialog is closed and more importantly the modalClosed event is dispatched