### PR TITLE
Task 57394: Fix user Disconnect dialog not working properly #1486

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoConfirmDialog.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoConfirmDialog.vue
@@ -95,15 +95,16 @@ export default {
   },
   data: () => ({
     dialog: false,
+    closed: false,
   }),
   watch: {
     dialog() {
       if (this.dialog) {
+        this.closed = false;
         this.$emit('dialog-opened');
         document.dispatchEvent(new CustomEvent('modalOpened'));
       } else {
-        this.$emit('dialog-closed');
-        document.dispatchEvent(new CustomEvent('modalClosed'));
+        this.emitClosedEvent();
       }
     },
   },
@@ -114,8 +115,8 @@ export default {
         event.stopPropagation();
       }
 
+      this.$emit('ok');
       this.close(event);
-      this.$nextTick(() => this.$emit('ok'));
     },
     close(event) {
       if (event) {
@@ -124,12 +125,22 @@ export default {
       }
 
       this.$emit('closed');
-      this.dialog = false;
+      this.$nextTick(() => {
+        this.dialog = false;
+        this.emitClosedEvent();
+      });
     },
     open() {
       this.dialog = true;
       this.$emit('opened');
       this.$nextTick(() => this.dialog = true);
+    },
+    emitClosedEvent() {
+      if (!this.closed && !this.dialog) {
+        this.closed = true;
+        this.$emit('dialog-closed');
+        document.dispatchEvent(new CustomEvent('modalClosed'));
+      }
     },
   },
 };


### PR DESCRIPTION
ISSUE: when clicking the Disconnect button of a user and then confirm button in the confirmation dialog, the action of disconnecting doesn't work.
FIX: changed the dialog close method to set the dialog boolean variable to false and then call emitClosedEvent method to emit both the "dialog-closed" and the "modalClosed" events