### PR TITLE
Task-57307: Fix user popover when webRTC call is enabled

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
@@ -6,7 +6,7 @@
     open-on-hover
     :close-on-content-click="false"
     :left="popoverLeftPosition"
-    content-class="profile-popover-menu white"
+    content-class="space-logo-popover white"
     max-width="270"
     min-width="270"
     offset-y>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -8,9 +8,12 @@
     :left="popoverLeftPosition"
     :offset-x="offsetX"
     :offset-y="offsetY"
-    content-class="profile-popover-menu overflow-y-hidden white"
-    max-width="250"
-    min-width="250">
+    content-class="profile-popover-menu transparent"
+    color="transparent"
+    elevation="0"
+    max-width="356"
+    min-width="356"
+    max-height="160" >
     <template #activator="{ on, attrs }">
       <div 
         class="profile-popover user-wrapper"
@@ -85,7 +88,11 @@
         </a>
       </div>
     </template> 
-    <v-card elevation="0" class="pa-2">
+    <v-card 
+    elevation="1" 
+    class="pa-2"
+    max-width="250"
+    min-width="250" >
       <v-list-item class="px-0">
         <v-list-item-content class="py-0">
           <v-list-item-title>


### PR DESCRIPTION
Before this fix, when we activate webRTC, the user's popover window is badly displayed with the drawdown call options.
With this fix, we adjust the CSS style of the user popover when the webRTC option is enabled.