### PR TITLE
Task-57037: AS : internal user flagged as external in AS

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -312,7 +312,7 @@ export default {
       }
     },
     isExternal() {
-      return this.identity && this.identity.external ;
+      return this.identity && this.identity.external === 'true';
     },
     externalTag() {
       return `( ${this.$t('userAvatar.external.label')} )`;


### PR DESCRIPTION
Prior this change, The user has always been considered as external if he is added once in the external group even after the remove from the group.
Fix : Update isExternal condition.