### PR TITLE
TASK-56773: fix suggested list overflowing when scrolling

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -31,7 +31,8 @@
       cache-items
       dense
       flat
-      @update:search-input="searchTerm = $event">
+      @update:search-input="searchTerm = $event"
+      attach>
       <template slot="no-data">
         <v-list-item class="pa-0">
           <v-list-item-title


### PR DESCRIPTION
ISSUE: When the suggested list of an autocomplete element is displayed and we scroll, the list moves and it overflow over the other elements.
FIX: Added the attach property to the v-autocomplete element, this causes the list to be attached to the text input element when scrolling.