### PR TITLE
TASK-57065: No message in Space invitation email

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
+++ b/extension/war/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
@@ -27,6 +27,7 @@
                                                     <%
                                                       String spaceUrl = "<a target=\"_blank\" style=\"color: #2f5e92; text-decoration: none; font-weight: bold; font-size:13px; font-family: HelveticaNeue,Helvetica,Arial,sans-serif;\" href=\""+ SPACE_URL + "\">" + _ctx.escapeHTML(SPACE) + "</a>";
                                                     %>
+                                                    <%=_ctx.appRes("Notification.message.SpaceInvitationPlugin", spaceUrl)%>
                                                 </p>
                                                 <div>
                                                     <a target="_blank" style="


### PR DESCRIPTION
Prior to this change, email notifcation of space invitation have no message because it wasn't already set in the template.
THis PR should add the message to the template