### PR TITLE
TASK-36065: Second space manager is unable to correctly leave the space

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -1064,6 +1064,16 @@ public class SpaceUtils {
   }
 
   /**
+   * Removes the user from group with any(*) membership.
+   *
+   * @param remoteId target user remote id
+   * @param groupId group id
+   */
+  public static void removeUserFromGroupWithAnyMembership(String remoteId, String groupId) {
+    removeUserFromGroupWithMembership(remoteId, groupId, MembershipTypeHandler.ANY_MEMBERSHIP_TYPE);
+  }
+  
+  /**
    * Creates group navigation if not existed or return existing group navigation
    * based on groupId
    *

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -660,6 +660,9 @@ public class SpaceServiceImpl implements SpaceService {
       space.setMembers(members);
       this.updateSpace(space);
       SpaceUtils.removeUserFromGroupWithMemberMembership(userId, space.getGroupId());
+      setManager(space, userId, false);
+      removeRedactor(space, userId);
+      SpaceUtils.removeUserFromGroupWithAnyMembership(userId, space.getGroupId());
       spaceLifeCycle.memberLeft(space, userId);
     }
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/suggest/SpaceRestServices.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/suggest/SpaceRestServices.java
@@ -315,11 +315,9 @@ public class SpaceRestServices implements ResourceContainer {
         if (space == null) {
           return Response.status(HTTPStatus.NOT_FOUND).build();
         }
-  
         if (spaceService.isMember(space, userId)) {
           spaceService.removeMember(space, userId);
         }
-  
         return Response.ok().build();
       } catch (Exception e) {
         LOG.error("Error in space deny rest service: " + e.getMessage(), e);


### PR DESCRIPTION
Prior to this change, when a space manager attempts to leave the space, only member membershipType is handled in the leave rest endpoint, while the user will remain as a manager in the space which will cause two issues: button leave space is always displayed and you can't invite the user to the space again, also added `removeRedactor` because when the user joins the space again, he will be a redactor already.
This PR should remove the user as manager while leaving the space if it's already a manager