### PR TITLE
Task-57262: Filter space in analytics page does not display all spaces

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -239,7 +239,7 @@ export default {
           if (!this.previousSearchTerm || this.previousSearchTerm !== this.searchTerm) {
             this.loadingSuggestions = 0;
             this.items = [];
-
+            this.searchOptions.filterType='all';
             this.$suggesterService.searchSpacesOrUsers(value,
               this.items,
               this.typeOfRelations,

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -239,7 +239,6 @@ export default {
           if (!this.previousSearchTerm || this.previousSearchTerm !== this.searchTerm) {
             this.loadingSuggestions = 0;
             this.items = [];
-            this.searchOptions.filterType='all';
             this.$suggesterService.searchSpacesOrUsers(value,
               this.items,
               this.typeOfRelations,

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
@@ -3,7 +3,7 @@ import {getIdentityByProviderIdAndRemoteId, getIdentityById} from './IdentitySer
 export function searchSpacesOrUsers(filter, result, typeOfRelations, searchOptions, includeUsers, includeSpaces, onlyRedactor, excludeRedactionalSpace, onlyManager, searchStartedCallback, searchEndCallback) {
   if (includeSpaces) {
     searchStartedCallback('space');
-    searchSpaces(filter, result, onlyRedactor, excludeRedactionalSpace, onlyManager)
+    searchSpaces(filter, result, onlyRedactor, excludeRedactionalSpace, onlyManager , searchOptions.filterType )
       .finally(() => searchEndCallback && searchEndCallback('space'));
   }
   if (includeUsers) {
@@ -17,9 +17,9 @@ export function searchSpacesOrUsers(filter, result, typeOfRelations, searchOptio
 * excludeRedactionalSpace : space spaces that have no member promoted as redactor
 * onlyManager : search spaces where the user is a manager
 */
-function searchSpaces(filter, items, onlyRedactor, excludeRedactionalSpace, onlyManager) {
+function searchSpaces(filter, items, onlyRedactor, excludeRedactionalSpace, onlyManager,filterType) {
   const formData = new FormData();
-  formData.append('filterType', 'member');
+  formData.append('filterType', filterType );
   formData.append('limit', '20');
   formData.append('q', filter);
   const params = new URLSearchParams(formData).toString();

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
@@ -19,7 +19,7 @@ export function searchSpacesOrUsers(filter, result, typeOfRelations, searchOptio
 */
 function searchSpaces(filter, items, onlyRedactor, excludeRedactionalSpace, onlyManager,filterType) {
   const formData = new FormData();
-  formData.append('filterType', filterType );
+  formData.append('filterType', filterType || 'member');
   formData.append('limit', '20');
   formData.append('q', filter);
   const params = new URLSearchParams(formData).toString();

--- a/webapp/portlet/webpack.dev.js
+++ b/webapp/portlet/webpack.dev.js
@@ -15,7 +15,7 @@ let config = merge(webpackCommonConfig, {
     libraryTarget: 'amd'
   },
   mode: 'development',
-  devtool: 'inline-source-map'
+  devtool: 'eval-source-map'
 });
 
 module.exports = config;


### PR DESCRIPTION
Prior to this fix, when i filter space in analytics , except spaces that belongs member is display.
After this fix, we avoid displaying all spaces when filtering in analytics.