### PR TITLE
TASK-55619: Fix bad display of emoji on mail subject

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -845,6 +845,7 @@ public class MailTemplateProvider extends TemplateProvider {
       SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
 
       String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
+      String originalTitle = notification.getValueOwnerParameter(SocialNotificationUtils.ORIGINAL_TITLE.getKey());
       ExoSocialActivity activity = Utils.getActivityManager().getActivity(activityId);
       Identity identity = Utils.getIdentityManager().getIdentity(activity.getPosterId(), true);
 
@@ -862,7 +863,7 @@ public class MailTemplateProvider extends TemplateProvider {
 
       String imagePlaceHolder = SocialNotificationUtils.getImagePlaceHolder(language);
       String title = SocialNotificationUtils.processImageTitle(activity.getTitle(), imagePlaceHolder);
-      templateContext.put("SUBJECT", title);
+      templateContext.put("SUBJECT", originalTitle);
       String subject = TemplateUtils.processSubject(templateContext);
 
       templateContext.put("SPACE_URL", LinkProviderUtils.getRedirectUrl("space", space.getId()));

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/ActivityNotificationImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/ActivityNotificationImpl.java
@@ -33,9 +33,10 @@ public class ActivityNotificationImpl extends ActivityListenerPlugin {
 
   @Override
   public void saveActivity(ActivityLifeCycleEvent event) {
-    ExoSocialActivity activity = event.getSource();
-    activity = CommonsUtils.getService(ActivityManager.class).getActivity(activity.getId());
+    ExoSocialActivity originalActivity = event.getSource();
+    ExoSocialActivity activity = CommonsUtils.getService(ActivityManager.class).getActivity(originalActivity.getId());
     NotificationContext ctx = NotificationContextImpl.cloneInstance().append(SocialNotificationUtils.ACTIVITY, activity);
+    ctx.append(SocialNotificationUtils.ORIGINAL_TITLE, originalActivity.getTitle());
 
     ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(PostActivityPlugin.ID)))
                                  .with(ctx.makeCommand(PluginKey.key(PostActivitySpaceStreamPlugin.ID)))

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/PostActivitySpaceStreamPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/PostActivitySpaceStreamPlugin.java
@@ -45,6 +45,7 @@ public class PostActivitySpaceStreamPlugin extends BaseNotificationPlugin {
     try {
       
       ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
+      String originalTitle = ctx.value(SocialNotificationUtils.ORIGINAL_TITLE);
       Space space = Utils.getSpaceService().getSpaceByPrettyName(activity.getStreamOwner());
       String poster = Utils.getUserId(activity.getPosterId());
       
@@ -52,6 +53,7 @@ public class PostActivitySpaceStreamPlugin extends BaseNotificationPlugin {
                                 .key(getId())
                                 .with(SocialNotificationUtils.POSTER.getKey(), poster)
                                 .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
+                                .with(SocialNotificationUtils.ORIGINAL_TITLE.getKey(), originalTitle)
                                 .to(Utils.getDestinataires(activity, space)).end();
     } catch (Exception e) {
       ctx.setException(e);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
@@ -63,6 +63,7 @@ public class SocialNotificationUtils {
   public final static ArgumentLiteral<String> LIKER = new ArgumentLiteral<String>(String.class, "likersId");
   public final static ArgumentLiteral<String> SENDER = new ArgumentLiteral<String>(String.class, "sender");
   public final static ArgumentLiteral<ExoSocialActivity> ACTIVITY = new ArgumentLiteral<ExoSocialActivity>(ExoSocialActivity.class, "activity");
+  public final static ArgumentLiteral<String> ORIGINAL_TITLE = new ArgumentLiteral<String>(String.class, "original_title");
   public final static ArgumentLiteral<Profile> PROFILE = new ArgumentLiteral<Profile>(Profile.class, "profile");
   public final static ArgumentLiteral<Space> SPACE = new ArgumentLiteral<Space>(Space.class, "space");
   public final static ArgumentLiteral<String> REMOTE_ID = new ArgumentLiteral<String>(String.class, "remoteId");


### PR DESCRIPTION
ISSUES : When we post an activity that contains an emoji, the email received incorrectly displays the emoji in the email subject.
FIX : The problem is that the content of the subject line is not rendered in HTML in emails.This problem is fixed by putting the literal character in the subject as it is without modification.