### PR TITLE
TASK-57112 Revert "Task-57018: Hidden space indication in an event for a member"

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
@@ -32,7 +32,7 @@
             class="pull-left text-truncate ms-2">
             <p
               class="text-truncate subtitle-2 my-auto hidden-space">
-              {{ displayName }}
+              {{ $t('spacesList.label.hiddenSpace') }}
             </p>
           </div>
         </a>


### PR DESCRIPTION
This reverts commit 40742e17a370809b2f0b437df23825edb2b6b914.
This commit was introduced into 6.3.x with a wrong PR (#1452)