### PR TITLE
Task-57262: Filter space in analytics page does not display all spaces

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
@@ -3,7 +3,7 @@ import {getIdentityByProviderIdAndRemoteId, getIdentityById} from './IdentitySer
 export function searchSpacesOrUsers(filter, result, typeOfRelations, searchOptions, includeUsers, includeSpaces, onlyRedactor, excludeRedactionalSpace, onlyManager, searchStartedCallback, searchEndCallback) {
   if (includeSpaces) {
     searchStartedCallback('space');
-    searchSpaces(filter, result, onlyRedactor, excludeRedactionalSpace, onlyManager , searchOptions.filterType )
+    searchSpaces(filter, result, onlyRedactor, excludeRedactionalSpace, onlyManager , searchOptions?.filterType )
       .finally(() => searchEndCallback && searchEndCallback('space'));
   }
   if (includeUsers) {


### PR DESCRIPTION
Prior to this fix, when i filter space in analytics , except spaces that belongs member is display.
After this fix, we avoid displaying all spaces when filtering in analytics.