### PR TITLE
TASK-56897: fix date picker on safari

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
@@ -26,7 +26,7 @@ export function getDateObjectFromString(value, isISOString) {
 
       // if we do new Date(value), if will generate a date with Time = 00:00 UTC, then when it is translated
       // in user timezone, the day can change
-      return new Date(`${value} 00:00:00`);
+      return new Date(`${value}T00:00:00`);
     }
   } else if (String(value).indexOf('/') >= 0) {
     const [date, month, year] = value.trim().split('/');


### PR DESCRIPTION
ISSUE: when using a safari browser the user can't select a date using the date picker component
FIX: added the 'T' character to the ISO date string to indicate the beginning of the time element as indicated in the [ECMA-262](https://www.ecma-international.org/publications-and-standards/standards/ecma-262/) specification.