### PR TITLE
TASK-57092 Fix redirection to members page in specific space when his admin  accept Request join

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
@@ -282,7 +282,7 @@ public class NotificationsRestService implements ResourceContainer {
     getSpaceService().addMember(space, userId);
 
     //redirect to space's members page and display a feedback message
-    String targetURL = Util.getBaseUrl() + LinkProvider.getActivityUriForSpace(space.getPrettyName(), space.getGroupId().replace("/spaces/", "")) + "/settings/members" + sb.toString();
+    String targetURL = Util.getBaseUrl() + LinkProvider.getActivityUriForSpace(space.getPrettyName(), space.getGroupId().replace("/spaces/", "")) + "/members" + sb.toString();
 
     // redirect to target page
     return Response.seeOther(URI.create(targetURL)).build();

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/AlertSpaceMembers.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/AlertSpaceMembers.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-alert
+    v-model="displayAlert"
+    :type="alertType"
+    dismissible
+    :icon="alertType === 'warning' ? 'mdi-alert-circle' : ''">
+    <span v-sanitized-html="alertMessage" class="mt-8"> </span>
+  </v-alert>
+</template>
+
+<script>
+export default {
+  props: {
+    spaceDisplayName: {
+      type: String,
+      default: null,
+    },
+  },
+  data: () => ({
+    displayAlert: false,
+    alertMessage: null,
+    alertType: null,
+  }),
+  created() {
+    const params = new URL(location.href).searchParams;
+    const feedbackMessage = params.get('feedbackMessage');
+    if (feedbackMessage && feedbackMessage === 'SpaceRequestAlreadyMember') {
+      const userName = params.get('userName');
+      this.$identityService.getIdentityByProviderIdAndRemoteId('organization', userName)
+        .then(identity => {
+          const userFullName = identity.profile.fullname;
+          this.alertType = 'warning';
+          this.alertMessage = this.$t(`Notification.feedback.message.${feedbackMessage}`, {
+            0: userFullName,
+            1: this.spaceDisplayName,
+          });
+          this.displayAlert = true;
+        });
+    }   
+  },
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
@@ -11,6 +11,7 @@
       @filter-changed="filter = $event"
       @invite-users="$refs.spaceInvitationDrawer.open()"
       @refresh="refreshInvited" />
+    <alert-space-members v-if="space" :space-display-name="space.displayName" />
 
     <people-card-list
       ref="spaceMembers"
@@ -54,7 +55,7 @@ export default {
     keyword: null,
     peopleCount: 0,
     loadingPeople: false,
-    space: {}
+    space: null,
   }),
   created() {
     this.$spaceService.getSpaceById(eXo.env.portal.spaceId)

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/initComponents.js
@@ -1,11 +1,13 @@
 import SpaceMembers from './components/SpaceMembers.vue';
 import SpaceMembersToolbar from './components/SpaceMembersToolbar.vue';
 import SpaceInvitationDrawer from './components/SpaceInvitationDrawer.vue';
+import AlertSpaceMembers from './components/AlertSpaceMembers.vue';
 
 const components = {
   'space-members': SpaceMembers,
   'space-members-toolbar': SpaceMembersToolbar,
   'space-invitation-drawer': SpaceInvitationDrawer,
+  'alert-space-members': AlertSpaceMembers,
 };
 
 for (const key in components) {


### PR DESCRIPTION
Problem: When an administrator of a space approved a membership request, the redirection was to the settings page.
Fix: set the correct url redirection to page members in space  when the administrator clicks on the approve button in the mail.
Improvement: added a new component vue AlertSpaceMembers which will be displayed when the administrator re-approves the request to join and the user is already a member of this space.