### PR TITLE
task-55619: Fix bad display of emoji on mail subject

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import liquibase.repackaged.org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -614,7 +615,8 @@ public class MailTemplateProvider extends TemplateProvider {
       templateContext.put("USER", Utils.addExternalFlag(identity));
       String imagePlaceHolder = SocialNotificationUtils.getImagePlaceHolder(language);
       String title = SocialNotificationUtils.processImageTitle(activity.getTitle(), imagePlaceHolder);
-      templateContext.put("SUBJECT", title);
+      String cleanedTitle = StringEscapeUtils.unescapeHtml4(title);
+      templateContext.put("SUBJECT", cleanedTitle);
       String subject = TemplateUtils.processSubject(templateContext);
 
       templateContext.put("PROFILE_URL", LinkProviderUtils.getRedirectUrl("user", identity.getRemoteId()));


### PR DESCRIPTION
ISSUES : When we like a comment or  activity that contains an emoji, the email received incorrectly displays the emoji in the email subject.
FIX : The problem is that the email subject can not display HTML entities. To fix it, just convert it with unescapeHtml4.