### PR TITLE
TASK-57609: Fix display of technical label in admin groups page

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -382,6 +382,7 @@ UsersManagement.status.disabledDescription=User account is disabled
 UsersManagement.delete=Delete
 UsersManagement.edit=Edit
 UsersManagement.role=Role
+UsersManagement.actions=Actions
 UsersManagement.button.enabled=Enabled
 UsersManagement.button.disabled=Disabled
 UsersManagement.filterBy=Filter by name or email


### PR DESCRIPTION
Prior to this change, a technical label in the tab `Actions` is displayed while listing the groups members using the data table.

after this fix, we will be able to display the tab label with the right display name.