### PR TITLE
TASK-57505 fix the problem of searching for activities that have the same keyword in search application

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ActivitySearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ActivitySearchConnector.java
@@ -47,8 +47,10 @@ public class ActivitySearchConnector {
       "  \"query_string\":{" +
       "    \"fields\": [\"body\", \"posterName\"]," +
       "    \"default_operator\": \"AND\"," +
-      "    \"query\": \"@term@\"" +
-      "  }" +
+      "    \"query\": \"@term@~\"," +
+      "    \"fuzziness\": 1," +
+      "    \"phrase_slop\": 1" +
+          "  }" +
       "},";
 
   private final ConfigurationManager    configurationManager;                                  // NOSONAR


### PR DESCRIPTION
Problem: nothing is displayed when the search term is a keyword of one or many activities.
Fix: The problem was in the query string used to search for activities. Therefore, it should use a fuzzy query with edit distance 1 to catch all activities with one changed character.