### PR TITLE
TASK-56691: fix share and comment tooltip on safari

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="d-inline-flex ms-lg-4">
     <!-- Added for mobile -->
-    <v-tooltip bottom>
+    <v-tooltip 
+    v-model="show"
+    bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           :id="`CommentLink${activityId}`"
@@ -43,6 +45,7 @@ export default {
   },
   data: () => ({
     hasCommented: false,
+    show: false,
   }),
   computed: {
     activityId() {
@@ -84,6 +87,7 @@ export default {
       this.hasCommented = this.activity && this.activity.hasCommented === 'true';
     },
     openCommentsDrawer() {
+      this.show = false;
       document.dispatchEvent(new CustomEvent('activity-comments-display', {detail: {
         activity: this.activity,
         newComment: true,

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="d-inline-flex ms-lg-4">
     <!-- Added for mobile -->
-    <v-tooltip bottom>
+    <v-tooltip 
+      v-model="show"
+      bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           v-if="isShareable"
@@ -48,6 +50,7 @@ export default {
   },
   data: () => ({
     hasShared: false,
+    show: false,
   }),
   computed: {
     isShareable() {
@@ -90,6 +93,7 @@ export default {
       }
     },
     openShareDrawer() {
+      this.show = false;
       this.$root.$emit('activity-share-drawer-open', this.activityId, 'activityStream');
     },
   },


### PR DESCRIPTION
ISSUE: comment and share tooltip doesn't close on safari
FIX: force close the tooltips after the user clicks on the share and comment button