### PR TITLE
TASK:56691: disable the share and comment tooltips for mobile devices 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="d-inline-flex ms-lg-4">
     <!-- Added for mobile -->
-    <v-tooltip 
-    v-model="show"
-    bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           :id="`CommentLink${activityId}`"
@@ -56,6 +54,9 @@ export default {
     },
     commentTextColorClass() {
       return this.hasCommented && 'primary--text' || '';
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
   },
   watch: {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
@@ -43,7 +43,6 @@ export default {
   },
   data: () => ({
     hasCommented: false,
-    show: false,
   }),
   computed: {
     activityId() {
@@ -88,7 +87,6 @@ export default {
       this.hasCommented = this.activity && this.activity.hasCommented === 'true';
     },
     openCommentsDrawer() {
-      this.show = false;
       document.dispatchEvent(new CustomEvent('activity-comments-display', {detail: {
         activity: this.activity,
         newComment: true,

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="d-inline-flex ms-lg-4">
     <!-- Added for mobile -->
-    <v-tooltip 
-      v-model="show"
-      bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           v-if="isShareable"
@@ -70,6 +68,9 @@ export default {
     },
     shareIconColorClass() {
       return this.hasShared && 'primary--text' || 'disabled--text';
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -48,7 +48,6 @@ export default {
   },
   data: () => ({
     hasShared: false,
-    show: false,
   }),
   computed: {
     isShareable() {
@@ -94,7 +93,6 @@ export default {
       }
     },
     openShareDrawer() {
-      this.show = false;
       this.$root.$emit('activity-share-drawer-open', this.activityId, 'activityStream');
     },
   },


### PR DESCRIPTION
ISSUE: v-tooltip is not compatibale with the safari browser, the tooltip message stays displayed after the component is closed
FIX:  disable the tooltip component for mobile devices
