### PR TITLE
TASK:56691: disable the share and comment tooltips for mobile devices

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="d-inline-flex ms-lg-4">
     <!-- Added for mobile -->
-    <v-tooltip bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           :id="`CommentLink${activityId}`"
@@ -53,6 +53,9 @@ export default {
     },
     commentTextColorClass() {
       return this.hasCommented && 'primary--text' || '';
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
   },
   watch: {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="d-inline-flex ms-lg-4">
     <!-- Added for mobile -->
-    <v-tooltip bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           v-if="isShareable"
@@ -67,6 +67,9 @@ export default {
     },
     shareIconColorClass() {
       return this.hasShared && 'primary--text' || 'disabled--text';
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
   },
   created() {


### PR DESCRIPTION
ISSUE: v-tooltip is not compatibale with the safari browser in Mobile Device. In fact, the tooltip message stays displayed after the component is closed.
FIX: disable Vuetify tooltip component for mobile devices.