### PR TITLE
Task-57171: Fix SpaceInfos Portlet: Title of space portlet is on bold

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <div id="spaceInfosApp">
-      <h5 class="center">{{ $t("social.space.description.title") }}</h5>
+      <div class="body-1 text-uppercase text-sub-title center">{{ $t("social.space.description.title") }}</div>
       <p id="spaceDescription">{{ description }}</p>
       <div id="spaceManagersList">
         <h5>{{ $t("social.space.description.managers") }}</h5>


### PR DESCRIPTION
Prior to this change, when i create a space "Space A" , then go to Space A ,
This is due to changing the title of space Description Portlet is on bold,
After this change, the title is the same style of other Portlet , it respected the platform guidelines.