### PR TITLE
TASK-57878: Links inside activity content are broken

### DIFF
--- a/webapp/portlet/.eslintrc.json
+++ b/webapp/portlet/.eslintrc.json
@@ -10,6 +10,7 @@
   "globals": {
     "activityComposer": true,
     "socialUIProfile": true,
-    "QRCode": true
+    "QRCode": true,
+    "ExtendedDomPurify": true
   }
 }

--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1428,6 +1428,9 @@
       <module>purifyVue</module>
     </depends>
     <depends>
+      <module>ExtendedDomPurify</module>
+    </depends>
+    <depends>
       <module>vueEllipsis</module>
     </depends>
     <depends>
@@ -1717,6 +1720,9 @@
     </depends>
     <depends>
       <module>commonVueComponents</module>
+    </depends>
+    <depends>
+      <module>ExtendedDomPurify</module>
     </depends>
     <depends>
       <module>ActivityComposer</module>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -34,7 +34,7 @@ export default {
   computed: {
     bodyElement() {
       return {
-        template: `<div>${this.body}</div>` || '',
+        template: ExtendedDomPurify.purify(`<div>${this.body}</div>`) || '',
       };
     },
     getBody() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -254,7 +254,7 @@ export default {
     },
     summaryElement() {
       return {
-        template: `<div>${this.summary}</div>` || '',
+        template: ExtendedDomPurify.purify(`<div>${this.summary}</div>`) || '',
       };
     },
   },


### PR DESCRIPTION
Prior to this change, when create an activity with links, the content are not well sanitized due to the fact that the owasp HTMLSanitize encodes the = char and the missing use of the autolinker.
This PR uses a new created ExtendedDomPurify amd module to use the autolinker and the DOMPurify to better sanaitize the content and manage the links