### PR TITLE
TASK-57941: Fix the title in SpaceInfos Portlet is positioned on the center

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
+    <div class="body-1 text-uppercase text-sub-title">{{ $t("social.space.description.title") }}</div>
     <div id="spaceInfosApp">
-      <div class="body-1 text-uppercase text-sub-title center">{{ $t("social.space.description.title") }}</div>
       <p id="spaceDescription">{{ description }}</p>
       <div id="spaceManagersList">
         <h5>{{ $t("social.space.description.managers") }}</h5>


### PR DESCRIPTION
FIX : The problem is that the title is centered and is positioned by the padding of the CSS class spaceInfosApp, fixed by moving the title outside this class.