### PR TITLE
task-57941: Fix the title in SpaceInfos Portlet is positioned on the center

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,9 +1,9 @@
 <template>
   <v-app>
-    <div class="body-1 text-uppercase text-sub-title">{{ $t("social.space.description.title") }}</div>
-    <div id="spaceInfosApp">
+    <div>
+      <div class="body-1 text-uppercase text-sub-title">{{ $t("social.space.description.title") }}</div>
       <p id="spaceDescription">{{ description }}</p>
-      <div id="spaceManagersList">
+      <div id="spaceManagersList" class="px-1">
         <h5>{{ $t("social.space.description.managers") }}</h5>
         <div id="spaceManagers">
           <exo-user-avatar
@@ -18,7 +18,7 @@
             popover />
         </div>
       </div>
-      <div v-if="redactors && redactors.length" id="spaceRedactorsList">
+      <div v-if="redactors && redactors.length" id="spaceRedactorsList" class="px-1">
         <h5>{{ $t("social.space.description.redactors") }}</h5>
         <div id="spaceRedactors">
           <exo-user-avatar


### PR DESCRIPTION
FIX : The problem is that the title is centered and is positioned by the padding of the CSS class spaceInfosApp, fixed by moving the title outside this class and adding  vuetify spacing Property.