### PR TITLE
Builders-228: Three dots and favorite icon UI should be 16px

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
@@ -16,7 +16,7 @@
           class="me-2"
           v-bind="attrs"
           v-on="on">
-          <v-icon size="18" class="icon-default-color">fas fa-ellipsis-v</v-icon>
+          <v-icon size="16" class="icon-default-color">fas fa-ellipsis-v</v-icon>
         </v-btn>
       </template>
       <v-list dense class="pa-0">

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
@@ -18,7 +18,7 @@
             <v-icon
               class="mx-auto"
               :class="favoriteIconColor"
-              size="18">
+              size="16">
               {{ favoriteIcon }}
             </v-icon>
           </div>


### PR DESCRIPTION
The font size of favorite icon and three dots menu icon in activity header shoud be 16px instead of 18px