### PR TITLE
Task-57653: Fix copy paste url of search  from the address bar

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchApplication.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/components/SearchApplication.vue
@@ -129,6 +129,7 @@ export default {
             connector.enabled = selectedTypes.includes(connector.name);
           });
         }
+        this.term = parameters['q'] || '';
       }
     } else {
       $(document).on('keydown', (event) => {


### PR DESCRIPTION
ISSUE : when the user copy the Url of a search result and paste it in a new tab no result displayed , the search term is null 
FIX : extract the search term  from the pasted url  .