### PR TITLE
Task-161: Fix redirect to the space when deleting an activity

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -13,6 +13,7 @@
         v-if="!extendedComponent.overrideHeader"
         :activity="activity"
         :activity-actions="activityActions"
+        :is-activity-detail="isActivityDetail"
         :activity-type-extension="activityTypeExtension"
         :hide-menu="hideMenu"
         :class="isActivityShared && 'py-4 px-0' || 'py-2 ps-4 pe-1'" />
@@ -43,6 +44,7 @@
       <activity-head
         :activity="activity"
         :activity-actions="activityActions"
+        :is-activity-detail="isActivityDetail"
         :activity-type-extension="activityTypeExtension"
         :is-activity-shared="isActivityShared"
         :hide-menu="hideMenu"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
@@ -54,6 +54,7 @@
     <activity-head-menu
       :activity="activity"
       :activity-actions="activityActions"
+      :is-activity-detail="isActivityDetail"
       :activity-type-extension="activityTypeExtension" />
   </v-list-item>
 </template>
@@ -76,6 +77,10 @@ export default {
     activityActions: {
       type: Object,
       default: null,
+    },
+    isActivityDetail: {
+      type: Boolean,
+      default: false,
     },
     spaceStream: {
       type: Object,

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
@@ -48,6 +48,10 @@ export default {
       type: Object,
       default: null,
     },
+    isActivityDetail: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     menu: false,
@@ -83,7 +87,7 @@ export default {
       }
     },
     confirmAction(action) {
-      const result = action.click(this.activity, this.activityTypeExtension);
+      const result = action.click(this.activity, this.activityTypeExtension, this.isActivityDetail);
       if (result && result.finally && result.then) {
         this.loading = true;
         result.finally(() => {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -34,7 +34,7 @@
         indeterminate
         class="mx-auto my-10" />
     </div>
-    <template v-else>
+    <template v-else-if="!activityId && !isDeleted">
       <activity-not-found v-if="activityId" />
       <template v-else-if="!error">
         <activity-stream-empty-message-space v-if="spaceId" />
@@ -90,6 +90,7 @@ export default {
     hasMore: false,
     loading: false,
     error: false,
+    isDeleted: false,
   }),
   computed: {
     activitiesToDisplay() {
@@ -114,6 +115,9 @@ export default {
   created() {
     document.addEventListener('activity-deleted', event => {
       const activityId = event && event.detail;
+      if (this.activityId) {
+        this.isDeleted = true;
+      }
       if (activityId) {
         const index = this.activities.findIndex(activity => activityId === activity.id);
         if (index >= 0) {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -134,11 +134,20 @@ extensionRegistry.registerExtension('activity', 'action', {
     }
     return activity.canDelete === 'true';
   },
-  click: (activity, activityTypeExtension) => {
+  click: (activity, activityTypeExtension, isActivityDetail) => {
     document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
     return Vue.prototype.$activityService.deleteActivity(activity.id, activityTypeExtension.hideOnDelete)
       .then(() => {
         document.dispatchEvent(new CustomEvent('activity-deleted', {detail: activity.id}));
+        if (isActivityDetail) {
+          setTimeout(() => {
+            if (activity.activityStream.type === 'space') {
+              window.location.href = `${eXo.env.portal.context}/g/${activity.activityStream.space.groupId.replace(/\//g, ':')}`;
+            } else {
+              window.location.href = eXo.env.portal.context;
+            }
+          }, 500);
+        }
       })
       .finally(() => document.dispatchEvent(new CustomEvent('hideTopBarLoading')));
   },


### PR DESCRIPTION
Prior to this change when deleting an activity from the page activity details a new message with "Activity not found" is displayed.
After this change when deleting an activity, it will be redirect to to the space's home page if it is a space activity, else it will be redirect to the default home link.