### PR TITLE
BUILDERS-178: kudos counter (mobile view)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
@@ -47,11 +47,9 @@
       :likers-number="likersNumber"
       :activity-id="activityId"
       :activity-poster-id="activityPosterId"
-      :max-items-to-show="maxLikersToShow"
-      @reactions="reactionsNumber" />
+      :max-items-to-show="maxLikersToShow" />
     <activity-reactions-mobile
       :activity="activity"
-      :kudos-number="kudosNumber"
       :likers-number="likersNumber"
       :comment-number="commentNumber"
       class="d-flex d-lg-none align-center"
@@ -89,7 +87,6 @@ export default {
   },
   data: () => ({
     maxLikersToShow: 4,
-    kudosNumber: 0
   }),
   computed: {
     seeMoreLikerToDisplay () {
@@ -115,9 +112,6 @@ export default {
       };
       this.$root.$emit(`open-reaction-drawer-selected-tab-${this.activityId}`, reactionTabDetails);
     },
-    reactionsNumber(kudosCount) {
-      this.kudosNumber = kudosCount;
-    }
   },
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsMobile.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsMobile.vue
@@ -16,11 +16,13 @@
       @click="openComments">
       {{ commentNumber }} {{ $t('UIActivity.comment.commentsLabel') }}
     </a>
-    <a
-      v-if="kudosNumber>0"
-      class="my-1 me-2 KudosNumber"
-      @click="open">
-      {{ kudosNumber }} Kudos</a>
+    <extension-registry-components
+        :params="extensionParams"
+        name="ActivityReactionsCount"
+        type="activity-reaction-count"
+        parent-element="div"
+        element="div"
+        class=" d-flex flex-column" />
   </div>
 </template>
 <script>
@@ -34,14 +36,17 @@ export default {
       type: Number,
       default: 0
     },
-    kudosNumber: {
-      type: Number,
-      default: 0
-    },
     commentNumber: {
       type: Number,
       default: 0
     }
+  },
+  computed: {
+    extensionParams() {
+      return {
+        activity: this.activity,
+      };
+    },
   },
   methods: {
     open() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/ActivityFooter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/footer/ActivityFooter.vue
@@ -46,7 +46,6 @@ export default {
   data: () => ({
     likersCount: 0,
     commentsCount: 0,
-    kudosCount: 0,
     likers: [],
   }),
   computed: {


### PR DESCRIPTION
Prior to this change, the kudos count in the mobile view was displayed right next to the kudos icon.
This PR will update the display of the number of kudos, so it will have the same behavior as the comments and the likes in the mobile view.