### PR TITLE
TASK-57941: Improve design of SpaceInfos Portlet. 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,9 +1,9 @@
 <template>
   <v-app>
-    <div id="spaceInfosApp">
-      <div class="body-1 text-uppercase text-sub-title center">{{ $t("social.space.description.title") }}</div>
+    <div>
+      <div class="body-1 text-uppercase text-sub-title">{{ $t("social.space.description.title") }}</div>
       <p id="spaceDescription">{{ description }}</p>
-      <div id="spaceManagersList">
+      <div id="spaceManagersList" class="px-1">
         <h5>{{ $t("social.space.description.managers") }}</h5>
         <div id="spaceManagers">
           <exo-user-avatar
@@ -18,7 +18,7 @@
             popover />
         </div>
       </div>
-      <div v-if="redactors && redactors.length" id="spaceRedactorsList">
+      <div v-if="redactors && redactors.length" id="spaceRedactorsList" class="px-1">
         <h5>{{ $t("social.space.description.redactors") }}</h5>
         <div id="spaceRedactors">
           <exo-user-avatar


### PR DESCRIPTION
Problems:
1-centralized title
2-duplicated application id `spaceInfosApp`
3-bad display of list managers and redactors of the space

Fix:
1-remove `center` class from `div` of the title.
2- remove duplicated id `spaceInfosApp` in component `ExoSpaceInfos.vue` and fix padding for this id selector in module platform-ui.
3-fix padding left and right for list of managers and redactors.

Co-authored-by: Montassar-Hamadi <mhamadi@exoplatform.com>