### PR TITLE
BUILDERS-216: Fix timestamp alignment in activity comments and drawer comments

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
@@ -52,7 +52,7 @@
             parent-element="div"
             element="div"
             class=" d-flex flex-column" />
-          <div class="py-0 my-1 align-start d-flex flex-row border-box-sizing">
+          <div class="py-0 my-1 align-center d-flex flex-row border-box-sizing">
             <activity-comment-actions
               :activity="activity"
               :comment="comment"
@@ -61,7 +61,7 @@
             <activity-comment-time
               :activity="activity"
               :comment="comment"
-              class="d-inline ps-2 activity-comment-head-time"
+              class="d-flex align-center ps-2 activity-comment-head-time"
               no-icon />
           </div>
           <div v-if="hasMoreRepliesToDisplay" class="py-0 my-1 align-start d-flex flex-row border-box-sizing">

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/footer/ActivityCommentTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/footer/ActivityCommentTime.vue
@@ -16,12 +16,12 @@
             v-if="isActivityEdited"
             :value="comment.updateDate"
             label="TimeConvert.label.Short.Edited"
-            class="text-capitalize-first-letter text-light-color text-truncate pt-1 ps-1"
+            class="text-capitalize-first-letter text-light-color text-truncate ps-1"
             short />
           <relative-date-format
             v-else
             :value="comment.createDate"
-            class="text-capitalize-first-letter text-light-color text-truncate pt-1 ps-1"
+            class="text-capitalize-first-letter text-light-color text-truncate ps-1"
             short />
         </v-btn>
       </template>


### PR DESCRIPTION
Prior to this change, the timestamp is not well aligned with comments actions buttons. In this PR, we align the comment timestamp to the comment actions.