### PR TITLE
BUILDERS-214: Browser tab's name is wrong for a kudos activity

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -92,25 +92,12 @@
         </v-icon>
       </v-avatar>
       <div class="my-4">
-        <div
-          v-if="title && !displayUserPopover"
-          v-sanitized-html="title"
-          :title="titleTooltip"
+        <dynamic-html-element
+          v-if="title"
+          :child="titleElement"
           :class="useEllipsisOnTitle && 'text-truncate-2' || ''"
-          class="font-weight-bold text-color mx-0 mt-0 mb-2 text-wrap text-break">
-        </div>
-        <div 
-          v-else
-          class="d-flex align-center text-color mx-0 mt-0 mb-2 text-wrap text-break">
-          <span class="font-weight-bold" v-sanitized-html="title"></span>
-          <exo-user-avatar
-            :identity="receiverIdentity"
-            extra-class="ms-2"
-            fullname 
-            popover 
-            bold-title
-            link-style />
-        </div>
+          class="font-weight-bold text-color mx-0 mt-0 mb-2 text-wrap text-break"
+          dir="auto" />
         <dynamic-html-element
           v-if="summary"
           :child="summaryElement"
@@ -142,7 +129,6 @@ export default {
   data: () => ({
     title: null,
     titleTooltip: null,
-    receiverIdentity: null,
     summary: null,
     summaryTooltip: null,
     thumbnail: null,
@@ -163,12 +149,6 @@ export default {
     },
     getSourceLink() {
       return this.activityTypeExtension && this.activityTypeExtension.getSourceLink;
-    },
-    getReceiver() {
-      return this.activityTypeExtension && this.activityTypeExtension.getReceiver;
-    },
-    displayUserPopover() {
-      return this.receiverIdentity !== null;
     },
     supportsThumbnail() {
       return this.activityTypeExtension && this.activityTypeExtension.supportsThumbnail;
@@ -259,6 +239,11 @@ export default {
         template: ExtendedDomPurify.purify(`<div>${this.summary}</div>`) || '',
       };
     },
+    titleElement() {
+      return {
+        template: ExtendedDomPurify.purify(`<div>${this.title}</div>`) || '',
+      };
+    },
   },
   watch: {
     activityTypeExtension(newVal, oldVal) {
@@ -275,13 +260,8 @@ export default {
       this.useEllipsisOnTitle = this.activityTypeExtension && !this.activityTypeExtension.noTitleEllipsis;
       this.useEllipsisOnSummary = this.activityTypeExtension && !this.activityTypeExtension.noSummaryEllipsis;
       this.title = this.getTitle && this.getTitle(this.activity, this.isActivityDetail);
-      this.receiverIdentity = this.getReceiver(this.activity, this.isActivityDetail);
       if (this.title && this.title.key) {
-        if (this.displayUserPopover) {
-          this.title = this.$t(this.title.key, '' || {});
-        } else {
-          this.title = this.$t(this.title.key, this.title.params || {});
-        }
+        this.title = this.$t(this.title.key, this.title.params || {});
       } else {
         this.title = this.$utils.trim(this.title);
       }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -93,7 +93,7 @@
       </v-avatar>
       <div class="my-4">
         <div
-          v-if="title && !isKudosActivity"
+          v-if="title && !displayUserPopover"
           v-sanitized-html="title"
           :title="titleTooltip"
           :class="useEllipsisOnTitle && 'text-truncate-2' || ''"
@@ -104,7 +104,7 @@
           class="d-flex align-center text-color mx-0 mt-0 mb-2 text-wrap text-break">
           <span class="font-weight-bold" v-sanitized-html="title"></span>
           <exo-user-avatar
-            :identity="identityReceiver"
+            :identity="receiverIdentity"
             extra-class="ms-2"
             fullname 
             popover 
@@ -142,8 +142,7 @@ export default {
   data: () => ({
     title: null,
     titleTooltip: null,
-    isKudosActivity: false,
-    identityReceiver: {},
+    receiverIdentity: null,
     summary: null,
     summaryTooltip: null,
     thumbnail: null,
@@ -165,8 +164,11 @@ export default {
     getSourceLink() {
       return this.activityTypeExtension && this.activityTypeExtension.getSourceLink;
     },
-    getActivityType() {
-      return this.activityTypeExtension && this.activityTypeExtension.getActivityType;
+    getReceiver() {
+      return this.activityTypeExtension && this.activityTypeExtension.getReceiver;
+    },
+    displayUserPopover() {
+      return this.receiverIdentity !== null;
     },
     supportsThumbnail() {
       return this.activityTypeExtension && this.activityTypeExtension.supportsThumbnail;
@@ -272,11 +274,10 @@ export default {
     retrieveActivityProperties() {
       this.useEllipsisOnTitle = this.activityTypeExtension && !this.activityTypeExtension.noTitleEllipsis;
       this.useEllipsisOnSummary = this.activityTypeExtension && !this.activityTypeExtension.noSummaryEllipsis;
-      this.isKudosActivity =  this.getActivityType && this.getActivityType(this.activity, this.isActivityDetail) === 'kudos';
       this.title = this.getTitle && this.getTitle(this.activity, this.isActivityDetail);
+      this.receiverIdentity = this.getReceiver(this.activity, this.isActivityDetail);
       if (this.title && this.title.key) {
-        if (this.isKudosActivity) {
-          this.identityReceiver = this.title.params[0];
+        if (this.displayUserPopover) {
           this.title = this.$t(this.title.key, '' || {});
         } else {
           this.title = this.$t(this.title.key, this.title.params || {});


### PR DESCRIPTION
Prior this change, when user open a kudos activity,the tab shows a wrong label for the kudos receiver