### PR TITLE
BUILDERS-180: adding a named slot inside ExoNotificationAlert.vue

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoNotificationAlert.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoNotificationAlert.vue
@@ -12,6 +12,8 @@
     <span class="text-color">
       {{ alertMessage }}
     </span>
+    <slot name="actions">
+    </slot>
     <v-btn
       v-if="alert && alert.click"
       class="primary--text"

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoNotificationAlert.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoNotificationAlert.vue
@@ -9,9 +9,7 @@
     dismissible
     colored-border
     outlined>
-    <span class="text-color">
-      {{ alertMessage }}
-    </span>
+    <span v-sanitized-html="alertMessage" class="text-color"></span>
     <slot name="actions">
     </slot>
     <v-btn
@@ -20,15 +18,6 @@
       text
       @click="alert.click">
       {{ alert.clickMessage }}
-    </v-btn>
-    <v-btn
-      slot="close"
-      slot-scope="{toggle}"
-      icon
-      small
-      light
-      @click="toggle">
-      <v-icon>close</v-icon>
     </v-btn>
   </v-alert>
 </template>


### PR DESCRIPTION
In order to pass the `follow on explorer link` when transaction is sent, while keeping the use of our `reusable alert`, a `named slot `has been added to ensure this behaviour and enhance flexibility 