### PR TITLE
MEED-281: Fix String trim method  (#1582)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/Utils.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/Utils.js
@@ -11,6 +11,6 @@ export function htmlToText(htmlContent) {
 }
 
 export function trim(text) {
-  return text && text.trim().replace(/(<p>(&nbsp;)*([ \\n\\r\\t])*<\/p>)*(<div>(&nbsp;)*( \\n\\r\\t)*<\/div>)*(\\r)*(\\n)*(\\t)*/g, '') || '';
+  return text && text.trim().replace(/(<p>(&nbsp;)*(\\n\\r\\t)*<\/p>)*(<div>(&nbsp;)*( \\n\\r\\t)*<\/div>)*(\\r)*(\\n)*(\\t)*/g, '') || '';
 }
 


### PR DESCRIPTION
prior to this change, trim() text does not work well with the specific text: "rrr", "ttt", "ssss" ...
after this change texts well displayed