### PR TITLE
MEED-297 Fix display of popover when user position has a apostrophe

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -188,7 +188,7 @@ public class LinkProvider {
                .append(identity.getProfile().getAvatarUrl())
                .append("',")
                .append("position: '")
-               .append(identity.getProfile().getPosition() == null ? "" : identity.getProfile().getPosition())
+               .append(identity.getProfile().getPosition() == null ? "" : identity.getProfile().getPosition().replace("'", "\\\\'"))
                .append("',")
                .append("external: '")
                .append(identity.getProfile().getProperty(Profile.EXTERNAL) != null && StringUtils.equals("true", String.valueOf(identity.getProfile().getProperty(Profile.EXTERNAL))))


### PR DESCRIPTION
Prior to this change, when displaying a user having apostrophe in position field, the activity content is completely hidden. This fix ensures to escape apostrophe character to build the correct value of HTML user profile link with popover.