### PR TITLE
MEED-265 : add a new prop to the activity-rich-editor allowing the use of extended plugins 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-composer-app/components/ActivityComposerDrawer.vue
@@ -19,6 +19,7 @@
             :template-params="templateParams"
             :placeholder="composerPlaceholder"
             ck-editor-type="activityContent"
+            use-extra-plugins
             autofocus />
         </v-card-text>
         <v-card-actions class="d-flex px-4">

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -18,6 +18,7 @@
           :activity-id="activityId"
           :template-params="templateParams"
           suggestor-type-of-relation="mention_comment"
+          use-extra-plugins
           autofocus
           @ready="handleEditorReady" />
         <extension-registry-components

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -39,6 +39,7 @@
               :max-length="MESSAGE_MAX_LENGTH"
               :placeholder="$t('UIActivity.share.sharedActivityPlaceholder')"
               ck-editor-type="activityShare"
+              use-extra-plugins
               class="flex"
               @validity-updated="validInput = $event" />
           </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -62,6 +62,10 @@ export default {
     autofocus: {
       type: Boolean,
       default: false
+    },
+    useExtraPlugins: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -165,7 +169,7 @@ export default {
       }
 
       const ckEditorExtensions = extensionRegistry.loadExtensions('ActivityComposer', 'ckeditor-extensions');
-      if (ckEditorExtensions && ckEditorExtensions.length && (this.ckEditorType === 'activityContent' || this.ckEditorType.startsWith('comment_'))) {
+      if (ckEditorExtensions && ckEditorExtensions.length && this.useExtraPlugins) {
         ckEditorExtensions.forEach(ckEditorExtension => {
           if (ckEditorExtension.extraPlugin) {
             extraPlugins = `${extraPlugins},${ckEditorExtension.extraPlugin}`;


### PR DESCRIPTION
Before this change, only CKEditor of Type 'ActivityContent' or its type starts with 'comment_' can extend additional plugins.
after this change, a dedicated parameter has been defined to allow reusing the extended plugins of Activity Rich Editor.