### PR TITLE
Task-57171: Fix SpaceInfos Portlet: Title of space portlet is on bold…

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
-    <div>
-      <div class="body-1 text-uppercase text-sub-title">{{ $t("social.space.description.title") }}</div>
+    <div id="spaceInfosApp">
+      <div class="body-1 text-uppercase text-sub-title center">{{ $t("social.space.description.title") }}</div>
       <p id="spaceDescription">{{ description }}</p>
       <div id="spaceManagersList" class="px-1">
         <h5>{{ $t("social.space.description.managers") }}</h5>


### PR DESCRIPTION
… (#1542) (#1544)

Prior to this change, when i create a space "Space A" , then go to Space A ,
This is due to changing the title of space Description Portlet is on bold,
After this change, the title is the same style of other Portlet , it respected the platform guidelines.

(cherry picked from commit cbc964dff9eee0ed73c31b528a6ab05beaae6f18)