### PR TITLE
MEED-BUG-290: Fix bookmark an item from the unified search

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/FavoriteService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/FavoriteService.js
@@ -12,7 +12,7 @@ export function getFavorites(offset, limit,returnSize) {
 }
 
 export function addFavorite(objectType, objectId, parentObjectId, spaceId) {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/favorites/${objectType}/${objectId}?parentObjectId=${parentObjectId || ''}&spaceId=${spaceId}&ignoreWhenExisting=true`, {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/favorites/${objectType}/${objectId}?parentObjectId=${parentObjectId || ''}&spaceId=${spaceId || 0}&ignoreWhenExisting=true`, {
     method: 'POST',
     credentials: 'include',
   }).then(resp => {


### PR DESCRIPTION
Prior to this change, when sending an empty spaceId, a parsing error happens in REST endpoint that leads to an HTTP 404 (This may happen on items added outside Spaces).
This fix will ensure to send a 0 in case of empty spaceId to avoid such an error.

(cherry picked from commit ef8db07892d3b4388ae9f6c0dee605b557e405da)