### PR TITLE
TASK-57941: Improve design of SpaceInfos Portlet.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
-    <div id="spaceInfosApp">
-      <div class="body-1 text-uppercase text-sub-title center">{{ $t("social.space.description.title") }}</div>
+    <div>
+      <div class="body-1 text-uppercase text-sub-title">{{ $t("social.space.description.title") }}</div>
       <p id="spaceDescription">{{ description }}</p>
       <div id="spaceManagersList" class="px-1">
         <h5>{{ $t("social.space.description.managers") }}</h5>


### PR DESCRIPTION
Problems:
the backport of PR: https://github.com/Meeds-io/social/commit/57046f4e4e55728cd0a24dccc7f3a699ce82b084 was made before the PR: https://github.com/Meeds-io/social/commit/596124e933c91b33725b387612dcf3edea418d55 , the backport order should have been the other way around.

Fix:
I have added the latest diff from PR : https://github.com/Meeds-io/social/commit/57046f4e4e55728cd0a24dccc7f3a699ce82b084
to assure 
1-remove `center` class from `div` of the title.
2- remove duplicated id `spaceInfosApp` in component `ExoSpaceInfos.vue`