### PR TITLE
TASK-58517: Remove user notification settings customization for dlp and anti-malware

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationGroup.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationGroup.vue
@@ -34,7 +34,7 @@ export default {
       return this.settings && this.settings.groupsLabels && this.settings.groupsLabels[this.group.groupId];
     },
     manageNotification() {
-      return this.group && this.group.pluginInfos && this.group.pluginInfos.length && this.group.groupId !== 'quarantine' && this.group.groupId !== 'malwareDetection';
+      return this.group && this.group.pluginInfos && this.group.pluginInfos.length ;
     },
   },
   methods: {


### PR DESCRIPTION
Prior to this change, notifications groups of dlp and anti-malware are not displayed in user settings due to this customization
This PR should remove this customization and allow displaying these groups in user settings once registered in their addons.