### PR TITLE
MEED-295 Customize Vuetify Breakpoints to be compliant to CSS predefined Breakpoints

### DIFF
--- a/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -47,6 +47,15 @@
        silent: !eXo.developing,
        iconfont: 'mdi',
        rtl: eXo.env.portal.orientation === 'rtl',
+       breakpoint: {
+         thresholds: {
+           xs: 380,
+           sm: 540,
+           md: 768,
+           lg: 1024,
+           xl: 1280,
+         },
+       },
      };
 
      eXo.env.portal.activityTagsEnabled = <%=featureService.isFeatureActiveForUser("ActivityTags", userName)%>;


### PR DESCRIPTION
Prior to this change, the CSS Media Breakpoints defined in Vuetify JS aren't the same defined in vuetify.less (customized by different Breakpoints). Consequently, the value of JS variable  isn't the same as CSS. This change makes sure to use the same customized values introduced in CSS.