### PR TITLE
MEED-347: Fix add ellipsis for activity and challenge title

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ActivityFavoriteItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ActivityFavoriteItem.vue
@@ -84,7 +84,7 @@ export default {
   methods: {
     favoriteTitle(title) {
       const regex = /(<([^>]+)>)/ig;
-      return title && title.replace(regex, '').split(' ').slice(0, 5).join(' ') || '';
+      return title && title.replace(regex, '') || '';
     },
     removed() {
       this.isFavorite = !this.isFavorite;


### PR DESCRIPTION
Before this change, the title of the activity and challenge in the favorite drawer is displayed with only the first 5 words.
In this PR we remove the restriction to display the first 5 words, and to display the title in one line with ellispsis