### PR TITLE
Task-54820: unify the Title Style of the External spaces list portlet

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -16,7 +16,7 @@
               flat
               class="flex">
               <v-card-title class="external-spaces-list-title subtitle-1 text-uppercase pb-2">
-                <span class="title">
+                <span class="body-1 text-uppercase text-sub-title">
                   {{ $t('externalSpacesList.title.yourSpaces') }}
                 </span>
               </v-card-title>

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -16,7 +16,7 @@
               flat
               class="flex">
               <v-card-title class="external-spaces-list-title subtitle-1 text-uppercase pb-2">
-                <span class="body-1 text-uppercase text-sub-title">
+                <span class="body-1 text-sub-title">
                   {{ $t('externalSpacesList.title.yourSpaces') }}
                 </span>
               </v-card-title>


### PR DESCRIPTION
Problem: The external spaces portlet title style is different than the style of the other widgets in the snapshot page
Fix: Unify the title style of external spaces portlet to be coherent with the other portlet's styles