### PR TITLE
MEED-314 Allow to add Link in generic Alert Component (#1628)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoNotificationAlert.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoNotificationAlert.vue
@@ -13,6 +13,16 @@
     <slot name="actions">
     </slot>
     <v-btn
+      v-if="alert && alert.link"
+      :href="alert.link"
+      :class="alert.linkClass"
+      target="_blank"
+      rel="nofollow noreferrer noopener"
+      class="primary--text"
+      text>
+      {{ alert.linkMessage }}
+    </v-btn>
+    <v-btn
       v-if="alert && alert.click"
       class="primary--text"
       text


### PR DESCRIPTION
Prior to this change, the alert component contains only specific sections such as the displayed message.
This change allows to append a part to add a link in the generic alert component.