### PR TITLE
Task-43456: Past password in the "change password" form with the mouse (contextmenu) does't enable the save button

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/forgotpassword/reset_password.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/forgotpassword/reset_password.jsp
@@ -168,7 +168,7 @@
       $btnSubmit.attr('disabled', true).addClass('disabled');
     }
   });
-  $form.find('input[type="text"], input[type="password"]').on('keyup', function() {
+  $form.find('input[type="password"]').on('input', function() {
     $form.validate();
   });
 </script>


### PR DESCRIPTION
Problem: When pasting password from bloc-note in the change-password menu with the the mouse (contextMenu) doesn't enable the "Save" button as when using CTRL+V keyboard shortcut
Fix: we change the event 'keyup' with the event 'input' to make sure that the save button is enable when the fields are not empty