### PR TITLE
MEED-286: "New activities" information display and behavior in "personal stream"

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/websocket/ActivityStreamWebSocketService.java
+++ b/component/service/src/main/java/org/exoplatform/social/websocket/ActivityStreamWebSocketService.java
@@ -114,11 +114,11 @@ public class ActivityStreamWebSocketService implements Startable {
           continuationService.sendMessage(userId, COMETD_CHANNEL, message);
 
           // Send to stream owner connected users
-          Identity identity = this.identityManager.getIdentity(userId);
+          Identity identity = this.identityManager.getOrCreateUserIdentity(userId);
           Set<String> connectedUserIds = new HashSet<>(continuationBayeux.getConnectedUserIds());
           connectedUserIds.remove(userId);
           connectedUserIds.forEach(connectedUserId -> {
-            Identity connectedIdentity = this.identityManager.getIdentity(connectedUserId);
+            Identity connectedIdentity = this.identityManager.getOrCreateUserIdentity(connectedUserId);
             if (relationshipManager.getStatus(identity, connectedIdentity) == Relationship.Type.CONFIRMED) {
               try {
                 continuationService.sendMessage(connectedUserId, COMETD_CHANNEL, message);


### PR DESCRIPTION
Prior this change, when one of my connections post an activity outside a space, i don't receive the notification "New activities"