### PR TITLE
MEED-289 Adjust favorite items to display with the height of the drawer

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/TopBarFavoritesDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/TopBarFavoritesDrawer.vue
@@ -55,7 +55,7 @@ export default {
     favoritesList: [],
     loading: false,
     offset: 0,
-    limit: 10,
+    limit: Math.round((window.innerHeight - 122) / 53),
     totalSize: 0,
     pageSize: 10,
     activityExtensions: [],


### PR DESCRIPTION
Prior to this change, the favorite drawer displays only the first 10 items with a load more button, so we’ll have a blank space.
This change adapts the total number of items to display with the screen that I'm using.