### PR TITLE
TASK-58470: When I modify the banner of profile I can no longer find the default banner

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
@@ -535,6 +535,9 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
       throw new IdentityStorageException(IdentityStorageException.Type.FAIL_TO_UPDATE_PROFILE, "Profile does not exist on RDBMS");
     } else {
       mapToProfileEntity(profile, entity);
+      if("DEFAULT_BANNER".equals(profile.getBannerUrl())){
+        entity.setBannerFileId(null);
+      }
       identityDAO.update(entity);
     }    
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -716,14 +716,21 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
           return Response.status(Response.Status.UNAUTHORIZED).entity("EMAIL:ALREADY_EXISTS").build();
         }
       }
-      updateProfileField(profile, fieldName, value, true);
+      if (value.equals("DEFAULT_BANNER")) {
+        profile.setListUpdateTypes(Arrays.asList(UpdateType.BANNER));
+        profile.setBannerUrl("DEFAULT_BANNER");
+        profile.removeProperty(name);
+        identityManager.updateProfile(profile, true);
+      } else{
+        updateProfileField(profile, fieldName, value, true);
+      }
     } catch (IllegalAccessException e) {
       LOG.error("User {} is not allowed to update attribute {}", currentUser, name);
       return Response.status(Status.UNAUTHORIZED).build();
     } catch (IdentityStorageException e) {
       return Response.serverError().entity(e.getMessageKey()).build();
     } catch (Exception e) {
-      return Response.serverError().entity("Can't update avatar, error = " + e.getMessage()).build();
+      return Response.serverError().entity("Can't update Banner, error = " + e.getMessage()).build();
     }
     return Response.noContent().build();
   }

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -588,7 +588,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertEquals(403, response.getStatus());
   }
 
-  public void testUpdateProfileAtribute() throws Exception {
+  public void testUpdateProfileAttribute() throws Exception {
     startSessionAs("root");
     String email = "root@test.com";
     byte[] formData = ("name=email&value=" + email).getBytes();
@@ -597,11 +597,9 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     ContainerResponse response = service("PATCH", getURLResource("users/root/"), "", headers, formData);
     assertNotNull(response);
     assertEquals(String.valueOf(response.getEntity()), 204, response.getStatus());
-
     Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root");
     assertNotNull(identity);
     assertEquals(email, identity.getProfile().getEmail());
-
     response = service("PATCH", getURLResource("users/john/"), "", headers, formData);
     assertNotNull(response);
     assertEquals("User root shouldn't be able to modify john attributes", 401, response.getStatus());
@@ -659,6 +657,15 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     String storedContent = IOUtil.getStreamContentAsString(bannerInputStream);
     String content = IOUtil.getStreamContentAsString(getClass().getClassLoader().getResourceAsStream("blank.gif"));
     assertEquals(content, storedContent);
+
+    // Test remove banner
+    byte[] formDataDefaultBanner = ("name=banner&value=DEFAULT_BANNER").getBytes();
+    ContainerResponse responseDefaultBanner = service("PATCH", getURLResource("users/root/"), "", headers, formDataDefaultBanner);
+    identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root");
+    //assertEquals("DEFAULT_BANNER", identity.getProfile().getBannerUrl());
+    assertNull(identity.getProfile().getProperty("banner"));
+    assertNotNull(responseDefaultBanner);
+    assertEquals(String.valueOf(responseDefaultBanner.getEntity()), 204, responseDefaultBanner.getStatus());
   }
 
 

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -263,8 +263,10 @@ export function deleteRelationship(userId) {
 
 export function updateProfileField(username, name, value) {
   const formData = new FormData();
+  const valueData = value || 'DEFAULT_BANNER'; 
   formData.append('name', name);
-  formData.append('value', value);
+  formData.append('value', valueData);
+
 
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${username}`, {
     method: 'PATCH',

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -1,5 +1,6 @@
 <template>
-  <v-app :class="owner && 'profileHeaderOwner' || 'profileHeaderOther'">
+  <v-app 
+    :class="owner && 'profileHeaderOwner' || 'profileHeaderOther'">
     <v-hover>
       <v-img
         slot-scope="{ hover }"
@@ -39,7 +40,7 @@
                     class="ma-auto pb-0" />
                 </div>
                 <div class="flex-grow-1"></div>
-                <div v-if="!skeleton" class="d-flex flex-grow-0 justify-end pe-2">
+                <div v-if="!skeleton" class="d-flex flex-row justify-end pe-6">
                   <profile-header-banner-button
                     v-if="owner"
                     :user="user"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderBannerButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderBannerButton.vue
@@ -1,13 +1,39 @@
 <template>
-  <v-file-input
-    v-if="!sendingImage"
-    v-show="hover"
-    ref="bannerInput"
-    prepend-icon="fa-file-image"
-    class="changeBannerButton me-4"
-    accept="image/*"
-    clearable
-    @change="uploadBanner" />
+  <div 
+    class="d-flex flex-row changeBannerButton"
+    v-if="hover">
+    <div 
+      v-if="!isDefaultBanner"
+      class="changeBannerButtonIcon me-2">
+      <v-btn 
+        class="d-flex justify-center"
+        dark
+        outlined
+        icon
+        x-small
+        rounded
+        border
+        @click="removeBanner">
+        <v-icon
+          class="text-center"
+          icon
+          rounded>
+          mdi-delete
+        </v-icon>
+      </v-btn>
+    </div>
+    <div class="changeBannerButtonIcon">
+      <v-file-input
+        v-if="!sendingImage"
+        ref="bannerInput"
+        class="d-flex justify-center"
+        prepend-icon="fa-file-image"
+        rounded
+        accept="image/*"
+        clearable
+        @change="uploadBanner" />
+    </div>
+  </div>
 </template>
 
 <script>
@@ -21,9 +47,14 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    user: {
+      type: Object,
+      default: () => null,
+    },
   },
   data: () => ({
     sendingImage: false,
+    isDefaultBanner: false,
   }),
   watch: {
     sendingImage() {
@@ -33,8 +64,19 @@ export default {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       }
     },
+    user(){
+      this.isDefaultBanner=this.user.banner.startsWith('/portal/rest/v1/social/users/default-image/');
+    }
   },
   methods: {
+    removeBanner(){     
+      return this.$userService.updateProfileField(eXo.env.portal.userName, 'banner', null)
+        .then(() => {
+          this.isDefaultBanner = true;
+          this.$emit('refresh');
+        })
+        .catch(error => this.$emit('error', error));
+    },
     uploadBanner(file) {
       if (file && file.size) {
         if (file.type && file.type.indexOf('image/') !== 0) {
@@ -48,7 +90,10 @@ export default {
         this.sendingImage = true;
         return this.$uploadService.upload(file)
           .then(uploadId => this.$userService.updateProfileField(eXo.env.portal.userName, 'banner', uploadId))
-          .then(() => this.$emit('refresh'))
+          .then(() => {
+            this.isDefaultBanner = false;
+            this.$emit('refresh');
+          })
           .catch(error => this.$emit('error', error))
           .finally(() => {
             this.sendingImage = false;


### PR DESCRIPTION
Prior to this change, when the banner of the profile changes, the banner that has been set by default can be put back.
To fix this, add a delete button when profile banner is changed, and when clicked change the profile banner to the default banner.