### PR TITLE
EXO-58935 : random error in RDBMSRelationshipManagerTest

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSRelationshipManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSRelationshipManagerTest.java
@@ -1577,12 +1577,15 @@ public class RDBMSRelationshipManagerTest extends AbstractCoreTest {
     Relationship maryToGhostRelationship = relationshipManager.inviteToConnect(ghostIdentity, maryIdentity);
     relationshipManager.confirm(maryIdentity, ghostIdentity);
     restartTransaction();
+    sleep(1);
     Relationship maryToDemoRelationship = relationshipManager.inviteToConnect(demoIdentity, maryIdentity);
     relationshipManager.confirm(maryIdentity, demoIdentity);
     restartTransaction();
+    sleep(1);
     Relationship paulToMaryRelationship = relationshipManager.inviteToConnect(paulIdentity, maryIdentity);
     relationshipManager.confirm(maryIdentity, paulIdentity);
-    
+    sleep(1);
+
     List<Identity> identities = relationshipManager.getLastConnections(maryIdentity, 10);
     assertEquals(3, identities.size());
     assertEquals(paulIdentity.getRemoteId(), identities.get(0).getRemoteId());


### PR DESCRIPTION
Unit test **testGetLastConnections** was failing because relations were stored in database in the same time, then when getting them from database, they are loaded in the same order which causes the ordering error
The following fix introduces a minor delay (1 ms) between each relation storing to make sure they are saved chronologically in the required order.