### PR TITLE
EXO-58875 : Remove conflicting JAXRS implementation (#1651)

### DIFF
--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -84,6 +84,12 @@
     <dependency>
       <groupId>org.exoplatform.core</groupId>
       <artifactId>exo.core.component.document</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.kernel</groupId>


### PR DESCRIPTION
We had some random failures when running eXo platform server, especially when we had Startable Rest services.
The problem was caused by the presence of CXF jars implementation that were implementing JAXRS 2.0, which is not compatible with eXo rest services (JAXRS 1.0)
This fix removes the extra dependencies of Apache CXF to avoid having the startup error

(cherry picked from commit 49b9269a76bc415307b98c5c86a09920c29da7e6)