### PR TITLE
Task-59079: Hide the delete icon when the default banner is set

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderBannerButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderBannerButton.vue
@@ -54,11 +54,7 @@ export default {
   },
   data: () => ({
     sendingImage: false,
-    isDefaultBanner: false,
   }),
-  updated() {
-    this.isDefaultBanner=this.user.banner.startsWith('/portal/rest/v1/social/users/default-image/');
-  },
   watch: {
     sendingImage() {
       if (this.sendingImage) {
@@ -67,9 +63,11 @@ export default {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       }
     },
-    user(){
-      this.isDefaultBanner=this.user.banner.startsWith('/portal/rest/v1/social/users/default-image/');
-    }
+  },
+  computed: {
+    isDefaultBanner() {
+      return this.user.banner.startsWith('/portal/rest/v1/social/users/default-image/');
+    },
   },
   methods: {
     removeBanner(){     


### PR DESCRIPTION
Prior to this change, When the default banner is displayed on a profile, the delete icon display.
To fix this,add the method computed , assign the value of isDefaultBanner.