### PR TITLE
MEED-430: Stream filter "my favorite spaces" should be enabled only when space favorites flag is enabled

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilter.vue
@@ -96,7 +96,8 @@ export default {
       },{
         text: this.$t('activity.filter.favoriteSpaces'),
         value: 'favorite_spaces_stream',
-      }];
+        enable: eXo.env.portal.spaceFavoritesEnabled,
+      }].filter(filter => filter.enable == null || filter.enable === true);
     },
   },
   created() {


### PR DESCRIPTION
This PR will remove "my favorite spaces" in stream filters when space favorites flag is disabled