### PR TITLE
TASK-54423 Add Login.properties I18N file to be managed by crowdin

### DIFF
--- a/translations.properties
+++ b/translations.properties
@@ -51,6 +51,7 @@ webapp/UserPopup.properties=webapp/portlet/src/main/resources/locale/portlet/soc
 webapp/SpacesOverview.properties=webapp/portlet/src/main/resources/locale/portlet/social/SpacesOverview_en.properties
 webapp/SuggestionsPortlet.properties=webapp/portlet/src/main/resources/locale/portlet/social/SuggestionsPortlet_en.properties
 webapp/UserSettings.properties=webapp/portlet/src/main/resources/locale/portlet/social/UserSettings_en.properties
+webapp/Login.properties=webapp/portlet/src/main/resources/locale/portlet/Login_en.properties
 
 # navigation
 navigation/users.properties=extension/war/src/main/resources/locale/navigation/group/platform/users_en.properties


### PR DESCRIPTION
Prior to this change, the I18N keys of Login_en.properties wasn't managed by crowdin to generate other translation files for other languages.
This change will ensure to make this file managed by crowdin translations.