### PR TITLE
TASK-59178: Use PATCH annotation from Meeds WS implementation

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -79,8 +79,7 @@ import org.exoplatform.upload.UploadService;
 import org.exoplatform.web.login.recovery.PasswordRecoveryService;
 
 import io.swagger.annotations.*;
-import io.swagger.jaxrs.PATCH;
-
+import org.exoplatform.services.rest.http.PATCH;
 /**
  * 
  * Provides REST Services for manipulating jobs related to users.


### PR DESCRIPTION
Prior to this change, All endpoints those use http patch requests are using the swagger jaxrs PATCH annotation,
This PR should use the PATCH annotation from Meeds WS implementation instead of swagger jaxrs annotation