### PR TITLE
MEED-336-337: Add emoji and hashtag plugins to new editor toolbar

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -145,10 +145,10 @@ export default {
       }
       CKEDITOR.dtd.$removeEmpty['i'] = false;
 
-      let extraPlugins = 'simpleLink,suggester,widget';
+      let extraPlugins = 'simpleLink,suggester,widget,emoji';
       let removePlugins = 'image,maximize,resize';
       const toolbar = [
-        ['Bold', 'Italic', 'BulletedList', 'NumberedList', 'Blockquote'],
+        ['Bold', 'Italic', 'BulletedList', 'NumberedList', 'Blockquote','emoji'],
       ];
 
       const windowWidth = $(window).width();

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -73,6 +73,8 @@ export default {
       SMARTPHONE_LANDSCAPE_WIDTH: 768,
       inputVal: null,
       editor: null,
+      newEditorToolbarEnabled: eXo.env.portal.editorToolbarEnabled,
+      tagSuggesterEnabled: eXo.env.portal.activityTagsEnabled,
     };
   },
   computed: {
@@ -148,9 +150,14 @@ export default {
       let extraPlugins = 'simpleLink,suggester,widget,emoji';
       let removePlugins = 'image,maximize,resize';
       const toolbar = [
-        ['Bold', 'Italic', 'BulletedList', 'NumberedList', 'Blockquote','emoji'],
+        ['Bold', 'Italic', 'BulletedList', 'NumberedList', 'Blockquote'],
       ];
-
+      if (this.newEditorToolbarEnabled) {
+        if (this.tagSuggesterEnabled) {
+          toolbar[0].push('tagSuggester');
+        }
+        toolbar[0].push('emoji');
+      }
       const windowWidth = $(window).width();
       const windowHeight = $(window).height();
       if (windowWidth > windowHeight && windowWidth < this.SMARTPHONE_LANDSCAPE_WIDTH) {


### PR DESCRIPTION
This PR implements a new ckeditor plugins allow to add the hashtag and the emoji options to the editor toolbar, these two plugins are available only when the new toolbar editor flag is enabled.