### PR TITLE
fix: Fix retrieving IMs of User Profile from extensible service

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -685,20 +685,16 @@
                 <type>org.exoplatform.social.core.profile.settings.IMTypesPlugin</type>
                 <init-params>
                     <value-param>
-                        <name>gtalk</name>
-                        <value>Gtalk</value>
+                        <name>skype</name>
+                        <value>Skype</value>
                     </value-param>
                     <value-param>
                         <name>msn</name>
                         <value>MSN</value>
                     </value-param>
                     <value-param>
-                        <name>yahoo</name>
-                        <value>Yahoo</value>
-                    </value-param>
-                    <value-param>
-                        <name>skype</name>
-                        <value>Skype</value>
+                        <name>facebook</name>
+                        <value>Facebook</value>
                     </value-param>
                     <value-param>
                         <name>other</name>

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/profileContactInformation.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/profileContactInformation.jsp
@@ -1,3 +1,8 @@
+<%@page import="org.exoplatform.social.rest.api.EntityBuilder"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.stream.Collectors"%>
+<%@page import="org.exoplatform.social.core.profile.settings.IMType"%>
+<%@page import="org.exoplatform.social.core.profile.settings.UserProfileSettingsService"%>
 <%@ page import="org.exoplatform.social.core.manager.IdentityManager"%>
 <%@ page import="org.exoplatform.commons.utils.CommonsUtils"%>
 <%@ page import="org.exoplatform.social.webui.Utils"%>
@@ -5,15 +10,19 @@
   IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
 	String profileOwnerId = Utils.getOwnerIdentityId();
 	int maxUploadSize = identityManager.getImageUploadLimit();
+
+	UserProfileSettingsService userProfileSettingsService = CommonsUtils.getService(UserProfileSettingsService.class);
+	List<String> imTypes = userProfileSettingsService.getIMTypes().stream().map(IMType::getId).collect(Collectors.toList());
+  String jsonImTypes = EntityBuilder.toJsonString(imTypes);
 %>
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application white v-application--is-ltr theme--light profileContactInformation"
     id="ProfileContactInformation">
-    <v-cacheable-dom-app cache-id="ProfileContactInformation_<%=profileOwnerId%>"></v-cacheable-dom-app>
+    <textarea id="imTypesDefault" class="hidden"><%=jsonImTypes%></textarea>
     <script type="text/javascript">
       require(['PORTLET/social-portlet/ProfileContactInformation'], 
-          app => app.init(<%=maxUploadSize%>)
+          app => app.init(<%=maxUploadSize%>, JSON.parse(document.getElementById('imTypesDefault').value))
       );
     </script>
   </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditIms.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditIms.vue
@@ -16,9 +16,13 @@ export default {
       default: () => null,
     },
   },
-  data: () => ({
-    items: ['skype', 'msn', 'facebook', 'github', 'other'],
-  }),
+  computed: {
+    items() {
+      const items = this.$root.imTypes.slice().filter(item => item !== 'other').sort();
+      items.push('other');
+      return items;
+    },
+  },
   created() {
     const extensions = extensionRegistry.loadExtensions('profile-contact', 'edit-ims');
     if (extensions && extensions.length) {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/main.js
@@ -21,12 +21,15 @@ const cacheId = `${appId}_${eXo.env.portal.profileOwnerIdentityId}`;
 //should expose the locale ressources as REST API 
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.social.ProfileContactInformation-${lang}.json`;
 
-export function init(uploadLimit) {
+export function init(uploadLimit, imTypes) {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     const appElement = document.createElement('div');
     appElement.id = appId;
 
     Vue.createApp({
+      data: () => ({
+        imTypes,
+      }),
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },


### PR DESCRIPTION
Fix meeds-io/meeds#241

Prior to this change, the list of IMs of a user profile was retrieved from an embedded list added in Frontend code (Vue file).
This change will allow retrieving the list of IMs from existing service (`UserProfileSettingsService`) that allows to extend supported IMs of user.