### PR TITLE
TASK-53416: add description component

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-api</artifactId>
   <name>eXo PLF:: Social API</name>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-common</artifactId>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-core</artifactId>
   <name>eXo PLF:: Social Core Component</name>

--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-notification</artifactId>

--- a/component/oauth-auth/pom.xml
+++ b/component/oauth-auth/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>social-component</artifactId>
   <packaging>pom</packaging>

--- a/component/search/pom.xml
+++ b/component/search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.social</groupId>
     <artifactId>social-component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-search</artifactId>
   <packaging>jar</packaging>

--- a/component/service/pom.xml
+++ b/component/service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-service</artifactId>

--- a/component/webui/pom.xml
+++ b/component/webui/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-webui</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>social-extension</artifactId>
   <packaging>pom</packaging>

--- a/extension/war/pom.xml
+++ b/extension/war/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extension</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-extension-war</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social</artifactId>
-  <version>6.4.x-SNAPSHOT</version>
+  <version>6.4.x-experience-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: Social</name>
   <description>eXo Social - Enterprise Social Networking</description>
@@ -46,7 +46,7 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <org.exoplatform.commons.version>6.4.x-SNAPSHOT</org.exoplatform.commons.version>
+    <org.exoplatform.commons.version>6.4.x-experience-SNAPSHOT</org.exoplatform.commons.version>
 
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp</artifactId>
   <packaging>pom</packaging>

--- a/webapp/portlet/pom.xml
+++ b/webapp/portlet/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-experience-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-webapp-portlet</artifactId>

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -547,6 +547,9 @@ activity.label=activity
 #                                    Textarea                                       #
 #####################################################################################
 textarea.limitMessage=Only {0} characters allowed
+exoDescription.addDescription=Add a Description
+exoDescription.NoDescription=No Description
+exoDescription.applyButtonText=Apply
 
 #####################################################################################
 #                                    External                                       #

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_fr.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_fr.properties
@@ -547,6 +547,10 @@ activity.label=activit\u00E9
 #                                    Textarea                                       #
 #####################################################################################
 textarea.limitMessage=Seulement {0} caract\u00E8res autoris\u00E9s
+exoDescription.addDescription=Ajouter une description
+exoDescription.NoDescription=Pas de description
+exoDescription.applyButtonText=Appliquer
+
 
 #####################################################################################
 #                                    External                                       #

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDescription.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDescription.vue
@@ -1,0 +1,114 @@
+<template>
+  <div>
+    <span v-if="useCustomAddDescriptionContent && showAddDescription">
+      <slot name="add-description"></slot>
+    </span>
+    <div  v-if="showAddDescription && !useCustomAddDescriptionContent" class="d-flex justify-center">
+      <div class="mb-6">
+        <div class="d-flex justify-center">
+          <v-icon color="blue-grey lighten-4" large>chat</v-icon>
+        </div>
+        <div class="ml-2 font-weight-thin blue-grey--text lighten-6" >
+          {{noDescriptionText}}
+          </div>
+        <a class="primary--text text-decoration-underline"
+          @click="showAddDescription = false; showDescriptionEditor = true">
+          {{addDescriptionText}}</a>
+      </div>
+    </div>
+    <div v-if="!showAddDescription">
+      <div v-if="!showDescriptionEditor" class="d-flex justify-center mb-3">
+        <div
+          class="text-center ml-8 mr-8"
+          :data-text="placeholder"
+          contentEditable="true"
+          @click="showDescriptionEditor = true"
+          v-sanitized-html="value">
+          {{ value }}
+        </div>
+      </div>
+      <div 
+        v-else
+        class="ml-5 mr-5">
+        <exo-activity-rich-editor
+          ref="descriptionEditor"
+          v-model="value"
+          :max-length="descriptionLength"
+          ck-editor-type="activityContent"
+          autofocus>
+        </exo-activity-rich-editor>
+        <v-btn
+            class="btn mt-2 ml-auto mb-3 d-flex px-2 btn-primary v-btn v-btn--contained theme--light v-size--default"
+            @click="saveDescription">
+            {{applyButtonText}}
+        </v-btn>
+      </div>
+    </div>   
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    noDescriptionText: {
+      type: String,
+      default: function() {
+        return this.$t('exoDescription.NoDescription');
+      },
+    },
+    addDescriptionText: {
+      type: String,
+      default: function() {
+        return this.$t('exoDescription.addDescription');
+      },
+    },
+    applyButtonText: {
+      type: String,
+      default: function() {
+        return this.$t('exoDescription.applyButtonText');
+      },
+    },
+    description: {
+      type: String,
+      default: function() {
+        return '';
+      },
+    },
+    descriptionLength: {
+      type: Number,
+      default: function() {
+        return 2000;
+      },
+    },
+    useCustomAddDescriptionContent: {
+      type: Boolean,
+      default: function() {
+        return false;
+      },
+    },
+  },
+  data: () => ({
+    value: null,
+    showDescriptionEditor: false,
+    showAddDescription: false,
+  }),
+  created(){
+    this.value = this.description;
+    if (this.useCustomAddDescriptionContent){
+      this.$root.$on('add-new-description-click',()=>{this.showAddDescription = false; this.showDescriptionEditor = true;});
+    }
+    if (!this.description){
+      this.showAddDescription = true;
+    }
+  },
+  methods: {
+    saveDescription(){
+      this.showDescriptionEditor = false;
+      if (!this.value){
+        this.showAddDescription = true ;
+      }
+      this.$emit('applyDescription',this.value);
+    }
+  }
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDescription.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDescription.vue
@@ -6,7 +6,7 @@
     <div  v-if="showAddDescription && !useCustomAddDescriptionContent" class="d-flex justify-center">
       <div class="mb-6">
         <div class="d-flex justify-center">
-          <v-icon color="blue-grey lighten-4" large>chat</v-icon>
+          <v-icon color="blue-grey lighten-4" large>mdi-message-text-outline</v-icon>
         </div>
         <div class="ml-2 font-weight-thin blue-grey--text lighten-6" >
           {{noDescriptionText}}

--- a/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
@@ -21,6 +21,7 @@ import DrawersOverlay from './components/DrawersOverlay.vue';
 import ActivityShareDrawer from './components/ActivityShareDrawer.vue';
 import FavoriteButton from './components/FavoriteButton.vue';
 import ChangesReminder from './components/ChangesReminder.vue';
+import ExoDescription from './components/ExoDescription.vue';
 
 const components = {
   'card-carousel': CardCarousel,
@@ -46,6 +47,7 @@ const components = {
   'exo-group-suggester': ExoGroupSuggester,
   'favorite-button': FavoriteButton,
   'changes-reminder': ChangesReminder,
+  'exo-description': ExoDescription,
 };
 
 for (const key in components) {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
@@ -73,8 +73,8 @@ function searchGroups(filter, groupMember, groupType, items, errorCallback) {
       data.entities.forEach((item) => {
         items.push({
           id: `group:${item.groupName}`,
-          remoteId: item.groupName,
-          spaceId: item.id,
+          remoteId: item.id,
+          spaceId: item.groupName,
           providerId: 'group',
           displayName: item.label,
           profile: {


### PR DESCRIPTION
added a generic description component.
ExoDescription define a description component that can be used to add a description to an element.
When there is no current description text, ExoDescription defines default content that instructs the user to add a description by clicking on the add description text. Adding custom content for when there is no description is possible with the "add-description" slot, in this case the template for the 'add-description' slot must launch a 'add-new-description-click' event when the user wants to add a new description. When implementing a template for the 'add-description' slot the  useCustomAddDescriptionContent property must be set to true so that the default implementation won't be displayed.
The 'applyDescription' event is launched after the user clicks on the apply button shown with the description editor (with the event containing the current description text), the description in this case can be empty and the content instructing the user to add a description will be shown.
ExoDescription also define some basic properties such as:
noDescriptionText, addDescriptionText : to further customize the text for the default no-description content. 
applyButtonText : customize the text for the apply button show with the description editor
description: representing the description text
descriptionLength: representing the maximum characters allowed for the  description, with the default being 2000 characters 
useCustomAddDescriptionContent: must be set to true when adding a template for the "add-description" slot
