### PR TITLE
 EXO-59193 : Allow getting login errors from Session attributes 

### DIFF
--- a/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthLoginServletFilter.java
+++ b/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthLoginServletFilter.java
@@ -137,11 +137,11 @@ public class OAuthLoginServletFilter extends OAuthAbstractFilter {
                 return;
             }
         } else {
-            RequestDispatcher register = context.getRequestDispatcher("/WEB-INF/jsp/login/oauth_register.jsp");
-            if(register != null) {
-                register.forward(req, res);
-                return;
-            }
+            req.setAttribute("SSO.Login.Status", "USER_ACCOUNT_NOT_FOUND");
+            req.removeAttribute("portalUser");
+            authReg.removeAttributeOfClient(req, OAuthConstants.ATTRIBUTE_AUTHENTICATED_OAUTH_PRINCIPAL);
+            authReg.removeAttributeOfClient(req, OAuthConstants.ATTRIBUTE_AUTHENTICATED_PORTAL_USER);
+            log.warn("User {} does not have an account and On the fly registration is disabled, could not login !", portalUser.getDisplayName());
         }
 
         chain.doFilter(req, res);

--- a/webapp/portlet/src/main/resources/locale/portlet/Login_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Login_en.properties
@@ -1,6 +1,7 @@
 UILoginForm.msg.Invalid-account=User Name and/or Password are wrong or empty. Please try again.
 UILoginForm.label.welcome=Welcome
 UILoginForm.label.login=Login
+UILoginForm.label.UserAccountNotFound=We are sorry. You cannot log in to the platform. Please, try again or contact your administrator.
 UILoginForm.label.Discard=Discard
 UILoginForm.label.user=User
 UILoginForm.label.forgot=Forgot your User Name/Password?


### PR DESCRIPTION
Using OpenID authentication and On the fly registration disabled, After a user login successfully in the OpenID provider, and when the user account is missing from the platform, we will add an attribute to the session to tell end user why he is not able to login.