### PR TITLE
EXO-59307 : Add a small delays to ensure connection are stored and cached

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/manager/RelationshipManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/RelationshipManagerTest.java
@@ -32,6 +32,8 @@ import org.exoplatform.social.core.relationship.model.Relationship;
 import org.exoplatform.social.core.relationship.model.Relationship.Type;
 import org.exoplatform.social.core.test.AbstractCoreTest;
 
+import static java.lang.Thread.sleep;
+
 /**
  * Unit Tests for {@link RelationshipManager}
  *
@@ -205,7 +207,9 @@ public class RelationshipManagerTest extends AbstractCoreTest {
    */
   public void testGetWithRelationshipId() throws Exception {
     Relationship relationship = relationshipManager.inviteToConnect(rootIdentity, johnIdentity);
+    sleep(1);
     String relationshipId = relationship.getId();
+    assertNotNull(relationshipId);
     
     relationshipManager.confirm(johnIdentity, rootIdentity);
     relationship = relationshipManager.get(relationship.getId());
@@ -325,9 +329,12 @@ public class RelationshipManagerTest extends AbstractCoreTest {
    */
   public void testConfirmWithIdentity() throws Exception {
     Relationship rootToDemoRelationship = relationshipManager.inviteToConnect(rootIdentity, demoIdentity);
+    sleep(1);
     Relationship maryToRootRelationship = relationshipManager.inviteToConnect(maryIdentity, rootIdentity);
+    sleep(1);
     Relationship rootToJohnRelationship = relationshipManager.inviteToConnect(rootIdentity, johnIdentity);
-    
+    sleep(1);
+
     rootToJohnRelationship = relationshipManager.get(rootToJohnRelationship.getId());
     
     relationshipManager.confirm(rootIdentity, demoIdentity);
@@ -1025,6 +1032,7 @@ public class RelationshipManagerTest extends AbstractCoreTest {
     Relationship johnMaryRelationship = relationshipManager.invite(johnIdentity, maryIdentity);
     Relationship johnRootRelationship = relationshipManager.invite(johnIdentity, rootIdentity);
     Relationship maryDemoRelationship = relationshipManager.invite(maryIdentity, demoIdentity);
+    sleep(5);
 
     List<Identity> listIdentities = new ArrayList<Identity>();
     listIdentities.add(demoIdentity);
@@ -1440,8 +1448,10 @@ public class RelationshipManagerTest extends AbstractCoreTest {
   public void testGetLastConnections() throws Exception {
     Relationship maryToGhostRelationship = relationshipManager.inviteToConnect(ghostIdentity, maryIdentity);
     relationshipManager.confirm(maryIdentity, ghostIdentity);
+    sleep(1);
     Relationship maryToDemoRelationship = relationshipManager.inviteToConnect(demoIdentity, maryIdentity);
     relationshipManager.confirm(maryIdentity, demoIdentity);
+    sleep(1);
     Relationship paulToMaryRelationship = relationshipManager.inviteToConnect(paulIdentity, maryIdentity);
     relationshipManager.confirm(maryIdentity, paulIdentity);
     


### PR DESCRIPTION


Some UT fail because relationship entity is not yet cached and thus a Null valuje is returned. Sometimes storing Relationship may take time and we may get different values depending on the performance of Tests execution