### PR TITLE
MEED-338: Align placeholder in activity editor to the cursor

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -3,7 +3,7 @@
     <div
       v-if="displayPlaceholder"
       @click="hidePlaceholder()" 
-      class="caption text-sub-title position-absolute pa-5 full-width">
+      class="caption text-sub-title position-absolute pa-5 m-px full-width">
       {{ placeholder }}
     </div>
     <textarea

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -3,7 +3,7 @@
     <div
       v-if="displayPlaceholder"
       @click="hidePlaceholder()" 
-      class="caption text-sub-title position-absolute pa-5 m-px full-width">
+      class="caption text-sub-title position-absolute pa-5 ma-1px full-width">
       {{ placeholder }}
     </div>
     <textarea


### PR DESCRIPTION
Prior to this change, the placeholder in the activity composer text editor not well aligned with the cursor due to the border of the edited text zone.
In this Fix we add a margin 1px to align the placeholder  with the cursor.