### PR TITLE
MEED-339: Display the placeholder in the activity and comment composer

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -14,7 +14,7 @@
           v-model="message"
           :ck-editor-type="ckEditorId"
           :max-length="$activityConstants.COMMENT_MAX_LENGTH"
-          :placeholder="$t('activity.composer.placeholder', {0: $activityConstants.COMMENT_MAX_LENGTH})"
+          :placeholder="$t('activity.composer.placeholder')"
           :activity-id="activityId"
           :template-params="templateParams"
           suggestor-type-of-relation="mention_comment"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -95,7 +95,7 @@ export default {
   },
   computed: {
     composerPlaceholder() {
-      return this.$t('activity.composer.placeholder', {0: this.MESSAGE_MAX_LENGTH});
+      return this.$t('activity.composer.placeholder');
     },
     composerAction() {
       return this.activityId && 'update' || 'post';

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="activityRichEditor" :class="newEditorToolbarEnabled && 'newEditorToolbar' || ''">
+    <div
+      v-if="displayPlaceholder"
+      @click="hidePlaceholder()" 
+      class="caption text-sub-title position-absolute pa-5 full-width">
+      {{ placeholder }}
+    </div>
     <textarea
       ref="editor"
       :id="ckEditorType"
@@ -66,7 +72,7 @@ export default {
     useExtraPlugins: {
       type: Boolean,
       default: false
-    }
+    },
   },
   data() {
     return {
@@ -75,6 +81,7 @@ export default {
       editor: null,
       newEditorToolbarEnabled: eXo.env.portal.editorToolbarEnabled,
       tagSuggesterEnabled: eXo.env.portal.activityTagsEnabled,
+      displayPlaceholder: false
     };
   },
   computed: {
@@ -89,7 +96,7 @@ export default {
     },
     validLength() {
       return this.charsCount <= this.maxLength;
-    },
+    }
   },
   watch: {
     inputVal(val) {
@@ -133,6 +140,9 @@ export default {
   },
   methods: {
     initCKEditor: function (reset) {
+      if ( this.value !== '') {
+        this.displayPlaceholder = false;
+      }
       this.inputVal = this.replaceWithSuggesterClass(this.value);
       this.editor = CKEDITOR.instances[this.ckEditorType];
       if (this.editor && this.editor.destroy && !this.ckEditorType.includes('editActivity')) {
@@ -231,6 +241,11 @@ export default {
           },
           requestCanceled: function () {
             self.cleanupOembed();
+          },
+          blur: function (evt) {
+            if (evt.editor.getData() === '') {
+              self.displayPlaceholder = true;
+            }
           },
           change: function (evt) {
             const newData = evt.editor.getData();
@@ -345,6 +360,10 @@ export default {
         this.templateParams.registeredKeysForProcessor = '-';
       }
     },
+    hidePlaceholder() {
+      this.displayPlaceholder = false;
+      this.setFocus();
+    }
   }
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -3,7 +3,7 @@
     <div
       v-if="displayPlaceholder"
       @click="hidePlaceholder()" 
-      class="caption text-sub-title position-absolute pa-5 full-width">
+      class="caption text-sub-title position-absolute pa-5 ma-1px full-width">
       {{ placeholder }}
     </div>
     <textarea

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -81,7 +81,7 @@ export default {
       editor: null,
       newEditorToolbarEnabled: eXo.env.portal.editorToolbarEnabled,
       tagSuggesterEnabled: eXo.env.portal.activityTagsEnabled,
-      displayPlaceholder: false
+      displayPlaceholder: true
     };
   },
   computed: {
@@ -101,6 +101,13 @@ export default {
   watch: {
     inputVal(val) {
       if (this.editorReady) {
+        if (val!== '') {
+          if (this.displayPlaceholder) {
+            this.displayPlaceholder = false;
+          }
+        } else {
+          this.displayPlaceholder = true;
+        }
         this.$emit('input', val);
       }
     },
@@ -249,7 +256,6 @@ export default {
           },
           change: function (evt) {
             const newData = evt.editor.getData();
-
             self.inputVal = newData;
           },
           destroy: function () {


### PR DESCRIPTION
Prior to this change, the placeholder in the activity editor is not visible because we change the ckeditor enter mode to DIV,
This change allows to add a new div contains the placeholder text ("Share your thoughts here"), and it will be shown only when the edited text is empty.