### PR TITLE
Task-59193/59192: OIDC authentication fix and On the fly registration rework

### DIFF
--- a/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthLoginServletFilter.java
+++ b/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthLoginServletFilter.java
@@ -137,11 +137,11 @@ public class OAuthLoginServletFilter extends OAuthAbstractFilter {
                 return;
             }
         } else {
-            RequestDispatcher register = context.getRequestDispatcher("/WEB-INF/jsp/login/oauth_register.jsp");
-            if(register != null) {
-                register.forward(req, res);
-                return;
-            }
+            req.setAttribute("SSO.Login.Status", "USER_ACCOUNT_NOT_FOUND");
+            req.removeAttribute("portalUser");
+            authReg.removeAttributeOfClient(req, OAuthConstants.ATTRIBUTE_AUTHENTICATED_OAUTH_PRINCIPAL);
+            authReg.removeAttributeOfClient(req, OAuthConstants.ATTRIBUTE_AUTHENTICATED_PORTAL_USER);
+            log.warn("User {} does not have an account and On the fly registration is disabled, could not login !", portalUser.getDisplayName());
         }
 
         chain.doFilter(req, res);

--- a/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthLoginServletFilter.java
+++ b/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthLoginServletFilter.java
@@ -137,7 +137,7 @@ public class OAuthLoginServletFilter extends OAuthAbstractFilter {
                 return;
             }
         } else {
-            RequestDispatcher register = context.getRequestDispatcher("/login/jsp/oauth_register.jsp");
+            RequestDispatcher register = context.getRequestDispatcher("/WEB-INF/jsp/login/oauth_register.jsp");
             if(register != null) {
                 register.forward(req, res);
                 return;

--- a/component/oauth-auth/src/main/java/org/exoplatform/oauth/service/impl/OAuthRegistrationServicesImpl.java
+++ b/component/oauth-auth/src/main/java/org/exoplatform/oauth/service/impl/OAuthRegistrationServicesImpl.java
@@ -19,6 +19,7 @@
 package org.exoplatform.oauth.service.impl;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.commons.utils.MimeTypeResolver;
 import org.exoplatform.container.component.ComponentRequestLifecycle;
@@ -66,6 +67,8 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
     private final OrganizationService orgService;
     private final IdentityManager identityManager;
 
+    private final Random random = new Random();
+
     public OAuthRegistrationServicesImpl(InitParams initParams, OrganizationService orgService, IdentityManager identityManager) {
         ValueParam onFly = initParams.getValueParam("registerOnFly");
         String onFlyValue = onFly == null ? "" : onFly.getValue();
@@ -86,11 +89,9 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
 
     @Override
     public User detectGateInUser(HttpServletRequest request, OAuthPrincipal<? extends AccessTokenContext> principal) {
-      OAuthProviderType providerType = principal.getOauthProviderType();
-      User gtnUser = providerType.getOauthPrincipalProcessor().convertToGateInUser(principal);
 
-      String email = gtnUser.getEmail();
-      String username = gtnUser.getUserName();
+      String email = principal.getEmail();
+      String username = principal.getUserName();
 
       User foundUser = null;
 
@@ -119,25 +120,6 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
           }
         }
 
-        // find recent user logged in
-        Cookie[] cookies = request.getCookies();
-        if (foundUser == null && cookies != null && cookies.length > 0) {
-          for (Cookie cookie : cookies) {
-            if (OAuthAbstractFilter.COOKIE_LAST_LOGIN.equals(cookie.getName())) {
-              username = cookie.getValue();
-              if(username != null && username.length() > 0) {
-                query = new Query();
-                query.setUserName(username);
-                users = userHandler.findUsersByQuery(query, UserStatus.ANY);
-                if(users != null && users.getSize() > 0) {
-                  foundUser = users.load(0, 1)[0];
-                }
-              }
-              break;
-            }
-          }
-        }
-
       } catch (Exception ex) {
         log.error("Exception when trying to detect user: ", ex);
       }
@@ -151,11 +133,27 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
       OAuthProviderType providerType = principal.getOauthProviderType();
       User user = providerType.getOauthPrincipalProcessor().convertToGateInUser(principal);
       user.setPassword(randomPassword(16));
+      String userName = "";
 
       if (orgService instanceof ComponentRequestLifecycle) {
         RequestLifeCycle.begin((ComponentRequestLifecycle)orgService);
       }
       try {
+        if(StringUtils.isBlank(user.getUserName())) {
+          if(StringUtils.isNotBlank(user.getFirstName()) && StringUtils.isNotBlank(user.getLastName())) {
+            userName = user.getFirstName().concat(".").concat(user.getLastName()).toLowerCase();
+          } else {
+            user.setUserName(user.getEmail().substring(0, user.getEmail().indexOf('@')));
+          }
+
+          user.setUserName(userName);
+        }
+        User userWithSameUsername = orgService.getUserHandler().findUserByName(user.getUserName());
+        while (userWithSameUsername != null) {
+          userName = userName.concat(String.valueOf(this.random.nextInt(1000)));
+          user.setUserName(userName);
+          userWithSameUsername = orgService.getUserHandler().findUserByName(user.getUserName());
+        }
         orgService.getUserHandler().createUser(user, true);
 
         //User profile
@@ -166,7 +164,7 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
           newUserProfile = orgService.getUserProfileHandler().createUserProfileInstance(user.getUserName());
         }
 
-        newUserProfile.setAttribute(providerType.getUserNameAttrName(), principal.getUserName());
+        newUserProfile.setAttribute(providerType.getUserNameAttrName(), user.getUserName());
         profileHandler.saveUserProfile(newUserProfile, true);
 
         //
@@ -232,11 +230,10 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
       final String CHAR_ENABLED = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
       char[] chars = new char[length];
-      Random random = new Random();
       int rand;
       final int len = CHAR_ENABLED.length();
       for (int i = 0; i < length; i++) {
-        rand = random.nextInt(len) % len;
+        rand = this.random.nextInt(len) % len;
         chars[i] = CHAR_ENABLED.charAt(rand);
       }
       return new String(chars);

--- a/webapp/portlet/src/main/resources/locale/portlet/Login_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Login_en.properties
@@ -1,6 +1,7 @@
 UILoginForm.msg.Invalid-account=User Name and/or Password are wrong or empty. Please try again.
 UILoginForm.label.welcome=Welcome
 UILoginForm.label.login=Login
+UILoginForm.label.UserAccountNotFound=We are sorry. You cannot log in to the platform. Please, try again or contact your administrator.
 UILoginForm.label.Discard=Discard
 UILoginForm.label.user=User
 UILoginForm.label.forgot=Forgot your User Name/Password?


### PR DESCRIPTION
When we use OpenID authentication, if a user does not have an account, an accountg is created with his username as his email's username. If the user has already an account with that email in the platform, the user account won't be loaded and we will get a page requesting to input the password (unknown since it is generated on first login)
The current commit fixes the problem by :

Retrieve the user from eXo database using its email, and generate a correct username following pattern firstname.lastname (lowercase) when the username is not provided by the Oauth
Adding a function to load the user with its email instead of its username when the latter is null
(cherry picked from commit https://github.com/Meeds-io/social/pull/1745/commits/39e687e523165ba732e78cd1599ef79f0f2f106b)
Add possibility to share Login error from SSO filter with the Login Handler to display login failure resons for end users.
(cherry picked from commit https://github.com/Meeds-io/social/pull/1745/commits/1c27c159286b5d7981ea66bcb49b0d09b3cceb6d)