### PR TITLE
MEED-368: Review activity composer editor UX when clicking outside

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -17,6 +17,7 @@
           :placeholder="$t('activity.composer.placeholder')"
           :activity-id="activityId"
           :template-params="templateParams"
+          context-name="activityComment"
           suggestor-type-of-relation="mention_comment"
           use-extra-plugins
           autofocus

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -219,6 +219,9 @@ export default {
           this.$activityService.createActivity(message, activityType, this.files, eXo.env.portal.spaceId, this.templateParams)
             .then(() => {
               document.dispatchEvent(new CustomEvent('activity-created', {detail: this.activityId}));
+              if (localStorage.getItem('activity-message')) {
+                localStorage.removeItem('activity-message');
+              }
               this.close();
             })
             .catch(error => {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -35,7 +35,9 @@
             :template-params="templateParams"
             :placeholder="composerPlaceholder"
             ck-editor-type="activityContent"
+            context-name="activityComposer"
             use-extra-plugins
+            use-draft-management
             autofocus />
         </v-card-text>
         <v-card-actions class="d-flex px-4">
@@ -219,8 +221,8 @@ export default {
           this.$activityService.createActivity(message, activityType, this.files, eXo.env.portal.spaceId, this.templateParams)
             .then(() => {
               document.dispatchEvent(new CustomEvent('activity-created', {detail: this.activityId}));
-              if (localStorage.getItem('activity-message')) {
-                localStorage.removeItem('activity-message');
+              if (localStorage.getItem('activity-message-activityComposer')) {
+                localStorage.removeItem('activity-message-activityComposer');
               }
               this.close();
             })

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -95,9 +95,10 @@ export default {
   },
   methods: {
     openComposerDrawer() {
+      const storageMessage = localStorage.getItem('activity-message') || '';
       document.dispatchEvent(new CustomEvent('activity-composer-drawer-open', {detail: {
         activityId: this.activityId,
-        activityBody: this.activityBody,
+        activityBody: this.activityBody || storageMessage,
         activityParams: this.activityParams,
         files: [],
         activityType: []

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -95,10 +95,9 @@ export default {
   },
   methods: {
     openComposerDrawer() {
-      const storageMessage = localStorage.getItem('activity-message') || '';
       document.dispatchEvent(new CustomEvent('activity-composer-drawer-open', {detail: {
         activityId: this.activityId,
-        activityBody: this.activityBody || storageMessage,
+        activityBody: this.activityBody,
         activityParams: this.activityParams,
         files: [],
         activityType: []

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -257,6 +257,9 @@ export default {
           change: function (evt) {
             const newData = evt.editor.getData();
             self.inputVal = newData;
+            if (!self.activityId) {
+              localStorage.setItem('activity-message', newData);
+            }
           },
           destroy: function () {
             self.inputVal = '';

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -73,6 +73,14 @@ export default {
       type: Boolean,
       default: false
     },
+    useDraftManagement: {
+      type: Boolean,
+      default: false
+    },
+    contextName: {
+      type: String,
+      default: null
+    }
   },
   data() {
     return {
@@ -81,7 +89,8 @@ export default {
       editor: null,
       newEditorToolbarEnabled: eXo.env.portal.editorToolbarEnabled,
       tagSuggesterEnabled: eXo.env.portal.activityTagsEnabled,
-      displayPlaceholder: true
+      displayPlaceholder: true,
+      baseUrl: eXo.env.server.portalBaseURL
     };
   },
   computed: {
@@ -143,20 +152,27 @@ export default {
     }
   },
   mounted() {
-    this.initCKEditor(true);
+    if (!this.value?.length && this.useDraftManagement) {
+      const storageMessage =  localStorage.getItem(`activity-message-${this.contextName}`);
+      const storageMessageObject =  storageMessage && JSON.parse(storageMessage) || {};
+      const storageMessageText = storageMessageObject?.url === eXo.env.server.portalBaseURL && storageMessageObject?.text || '';
+      this.initCKEditor(true,storageMessageText);
+    } else {
+      this.initCKEditor(true, this.value);
+    }
   },
   methods: {
-    initCKEditor: function (reset) {
-      if ( this.value !== '') {
+    initCKEditor: function (reset, textValue) {
+      if (textValue?.length) {
         this.displayPlaceholder = false;
       }
-      this.inputVal = this.replaceWithSuggesterClass(this.value);
+      this.inputVal = this.replaceWithSuggesterClass(textValue);
       this.editor = CKEDITOR.instances[this.ckEditorType];
       if (this.editor && this.editor.destroy && !this.ckEditorType.includes('editActivity')) {
         if (reset) {
           this.editor.destroy(true);
         } else {
-          this.initCKEditorData(this.value);
+          this.initCKEditorData(textValue);
           this.setEditorReady();
           return;
         }
@@ -226,6 +242,7 @@ export default {
         activityId: this.activityId,
         autoGrow_onStartup: false,
         autoGrow_maxHeight: 300,
+        startupFocus: 'end',
         on: {
           instanceReady: function () {
             self.editor = CKEDITOR.instances[self.ckEditorType];
@@ -257,8 +274,8 @@ export default {
           change: function (evt) {
             const newData = evt.editor.getData();
             self.inputVal = newData;
-            if (!self.activityId) {
-              localStorage.setItem('activity-message', newData);
+            if (!self.activityId && self.useDraftManagement && self.contextName) {
+              localStorage.setItem(`activity-message-${self.contextName}`,  JSON.stringify({'url': self.baseUrl, 'text': newData}));
             }
           },
           destroy: function () {


### PR DESCRIPTION
Prior to this change, when we write some text in the activity/ comment composer and we close the drawer without posting and reopen the drawer, the text disappear even we are in the same stream.
This change, allow to keep the in the activity composer editor while we are in the same page stream.