### PR TITLE
MEED-455 Shared activity display when hidden space

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
@@ -27,7 +27,7 @@
       </div>
     </a>
     <a
-      v-if="avatar"
+      v-else-if="avatar"
       v-bind="attrs"
       v-on="on"
       :id="id"


### PR DESCRIPTION
Prior this change, two labels "Hidden Space" and "Space name" appear on the activity when a platfrom admin post a activity in a hidden space(not a membre of).
Regression due to space popover refactoring.