### PR TITLE
fix: OpenId Connect does not working with ADFS - EXO-59388 - meeds-io/meeds#260

### DIFF
--- a/component/oauth-auth/src/main/java/org/exoplatform/oauth/service/impl/OAuthRegistrationServicesImpl.java
+++ b/component/oauth-auth/src/main/java/org/exoplatform/oauth/service/impl/OAuthRegistrationServicesImpl.java
@@ -133,25 +133,18 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
       OAuthProviderType providerType = principal.getOauthProviderType();
       User user = providerType.getOauthPrincipalProcessor().convertToGateInUser(principal);
       user.setPassword(randomPassword(16));
-      String userName = "";
 
       if (orgService instanceof ComponentRequestLifecycle) {
         RequestLifeCycle.begin((ComponentRequestLifecycle)orgService);
       }
       try {
         if(StringUtils.isBlank(user.getUserName())) {
-          if(StringUtils.isNotBlank(user.getFirstName()) && StringUtils.isNotBlank(user.getLastName())) {
-            userName = user.getFirstName().concat(".").concat(user.getLastName()).toLowerCase();
-          } else {
-            user.setUserName(user.getEmail().substring(0, user.getEmail().indexOf('@')));
-          }
-
-          user.setUserName(userName);
+          user.setUserName(user.getEmail().substring(0, user.getEmail().indexOf('@')));
         }
         User userWithSameUsername = orgService.getUserHandler().findUserByName(user.getUserName());
+        String userName = user.getUserName();
         while (userWithSameUsername != null) {
-          userName = userName.concat(String.valueOf(this.random.nextInt(1000)));
-          user.setUserName(userName);
+          user.setUserName(userName.concat(String.valueOf(this.random.nextInt(1000))));
           userWithSameUsername = orgService.getUserHandler().findUserByName(user.getUserName());
         }
         orgService.getUserHandler().createUser(user, true);


### PR DESCRIPTION
Prior to this change, it was impossible to login using OIDC with ADFS server, because meeds try to read user information by calling userinfo endpoint. But ADFS server do not provide claims in the userinfo endpoint.
This change modify how to create the eXo user when the user logs from external system like OIDC. Before this change we build the username like this : "firstname.lastname". But firstname and lastname can contains accentued chars and spaces.
This commit commit modify this to use the first part of the email as username (all before the @). And if there is already a user with this username, we add a random number after.