### PR TITLE
MEED-493: Remove extra plugin from share activity drawer

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -39,7 +39,6 @@
               :max-length="MESSAGE_MAX_LENGTH"
               :placeholder="$t('UIActivity.share.sharedActivityPlaceholder')"
               ck-editor-type="activityShare"
-              use-extra-plugins
               class="flex"
               @validity-updated="validInput = $event" />
           </div>


### PR DESCRIPTION
This change allow to remove the extra-plugins from the share activity drawer, to make sure that the usecase of sending kudos and its composer options is also applied when sharing an activity and when announcing a challenge.