### PR TITLE
MEED-352-362: Unify the topbar space popover UI

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
@@ -87,10 +87,10 @@ export default {
       }
     },
     overlayStyle(){
-      if (this.avatarOverlayPosition) {
+      if (!this.avatarOverlayPosition) {
         return `right: ${this.iconSize + 4}px !important`;
       } 
-      return 'right: 4px !important';
+      return 'right: 0px !important';
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -37,16 +37,16 @@
       </template>
       <v-card elevation="2">
         <v-list class="pa-0">
-          <v-list-item>
+          <v-list-item class="pt-3">
             <v-list-item-avatar
-              class="spaceAvatar mt-0"
+              class="spaceAvatar mt-0 align-self-start"
               width="60"
               height="60">
               <v-img
                 class="object-fit-cover"
                 :src="logoPath" />
             </v-list-item-avatar>
-            <v-list-item-content class="pb-0">
+            <v-list-item-content class="pb-0 pt-0">
               <v-list-item-title>
                 <v-tooltip bottom>
                   <template #activator="{ on, attrs }">

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -5,6 +5,7 @@
       elevation="2"
       v-model="menu"
       open-on-hover
+      transition="slide-x-transition"
       :close-on-content-click="false"
       :nudge-width="200"
       max-width="350"
@@ -38,6 +39,7 @@
         <v-list class="pa-0">
           <v-list-item>
             <v-list-item-avatar
+              class="spaceAvatar mt-0"
               width="60"
               height="60">
               <v-img
@@ -61,35 +63,33 @@
               <v-list-item-subtitle>
                 {{ membersNumber }} {{ $t('space.logo.banner.popover.members') }}
               </v-list-item-subtitle>
-              <p class="text-truncate-3 text-caption text--primary font-weight-medium">
+              <p class="text-truncate-2 text-caption text--primary font-weight-medium">
                 {{ spaceDescription }}
               </p>
             </v-list-item-content>
           </v-list-item>
         </v-list>
-        <v-divider />
         <v-list class="pa-0 mt-0 mb-0">
           <v-list-item class="pt-0 pb-0">
             <v-list-item-content>
               <v-container class="pa-0">
-                <v-row no-gutters>
+                <v-row no-gutters class="align-center">
                   <v-col
                     cols="6"
-                    class="pt-1 body-2 grey--text text-truncate text--darken-1"
-                    justify="center">
+                    class="body-2 grey--text text-truncate text--darken-1 text-left">
                     {{ $t('space.logo.banner.popover.managers') }}
                   </v-col>
                   <v-col
                     cols="6"
-                    justify="center"
-                    class="d-flex flex-nowrap pa-0">
+                    class="d-flex flex-nowrap justify-end pa-0">
                     <exo-user-avatars-list
                       :users="mangersToDisplay"
                       :icon-size="30"
                       :popover="false"
-                      max="4"
+                      max="3"
                       retrieve-extra-information
-                      avatar-overlay-position />
+                      avatar-overlay-position
+                      @open-detail="$root.$emit('displaySpaceHosts', mangersToDisplay)" />
                   </v-col>
                 </v-row>
               </v-container>
@@ -101,7 +101,7 @@
           class="pa-0 mt-0 mb-0">
           <v-list-item
             class="pt-0 pb-0">
-            <v-list-item-content>
+            <v-list-item-content class="py-1">
               <v-list-item-title>
                 <v-btn
                   :href="homePath"
@@ -111,7 +111,7 @@
                   <v-icon
                     dense
                     right
-                    class="me-1">
+                    class="me-1 ms-0">
                     mdi-home
                   </v-icon>
                   <span class="text-caption pt-1">{{ $t('space.logo.banner.popover.home') }}</span>
@@ -132,6 +132,7 @@
         </v-list>
       </v-card>
     </v-menu>
+    <space-hosts-drawer />
   </v-app>
 </template>
 
@@ -182,9 +183,6 @@ export default {
     },
   },
   computed: {
-    KeepDisplayManagers() {
-      return this.managers && this.managers.length <= this.sizeToDisplay;
-    },
     mangersToDisplay() {
       return this.managers;
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/SpaceHostsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/SpaceHostsDrawer.vue
@@ -1,0 +1,50 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <exo-drawer ref="managersDrawer" right>
+    <template slot="title">
+      {{ $t('spacesList.title.managers') }}
+    </template>
+    <template v-if="displaySpaceHosts" slot="content">
+      <v-layout column class="ma-3">
+        <exo-user-avatar
+          v-for="host in displaySpaceHosts"
+          :key="host.id"
+          :profile-id="host.userName"
+          :extra-class="'my-2'"
+          popover />
+      </v-layout>
+    </template>
+  </exo-drawer>
+</template>
+<script>
+export default {
+  data: () => ({
+    displaySpaceHosts: null,
+  }),
+  mounted() {
+    this.$root.$on('displaySpaceHosts', displaySpaceHosts => {
+      this.displaySpaceHosts = displaySpaceHosts;
+      this.$refs.managersDrawer.open();
+    });
+  }
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/initComponents.js
@@ -1,9 +1,12 @@
 import ExoSpaceLogoBanner from './components/ExoSpaceLogoBanner.vue';
 import SpacePopoverActionComponents from './components/SpacePopoverActionComponents.vue';
+import SpaceHostsDrawer from './components/SpaceHostsDrawer.vue';
+
 
 const components = {
   'exo-space-logo-banner': ExoSpaceLogoBanner,
-  'space-popover-action-component': SpacePopoverActionComponents
+  'space-popover-action-component': SpacePopoverActionComponents,
+  'space-hosts-drawer': SpaceHostsDrawer,
 };
 
 for (const key in components) {


### PR DESCRIPTION
In this Task we try to unify the UI of the space topbar popover mention in the following points:

- Square space avatar with space name and number of members
- Description of the space (2 lines maximum then ellipsis)
- Space hosts list aligned to the right and sorted like it is in the verso of the space card (in spaces page): if more than 4 hosts, then a + XX is displayed on the last avatar (XX referring to the remaining hosts)