### PR TITLE
MEED-511: Delete activity draft when updating a message previoly posted

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -200,6 +200,7 @@ export default {
         this.$activityService.updateActivity(this.activityId, message, activityType, this.files, this.templateParams)
           .then(() => {
             document.dispatchEvent(new CustomEvent('activity-updated', {detail: this.activityId}));
+            this.cleareActivityMessage();
             this.close();
           })
           .catch(error => {
@@ -221,9 +222,7 @@ export default {
           this.$activityService.createActivity(message, activityType, this.files, eXo.env.portal.spaceId, this.templateParams)
             .then(() => {
               document.dispatchEvent(new CustomEvent('activity-created', {detail: this.activityId}));
-              if (localStorage.getItem('activity-message-activityComposer')) {
-                localStorage.removeItem('activity-message-activityComposer');
-              }
+              this.cleareActivityMessage();
               this.close();
             })
             .catch(error => {
@@ -235,6 +234,11 @@ export default {
         }
       }
     },
+    cleareActivityMessage() {
+      if (localStorage.getItem('activity-message-activityComposer')) {
+        localStorage.removeItem('activity-message-activityComposer');
+      }
+    }
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change, when updating an existing activity message from the activity composer drawer and the click to add a new activity message the last activity updated message remains in the text editor area.
This change, allow to delete the message from the local storage after updating an existing activity message.