### PR TITLE
Task-59469: Space access : wrong behavior for a listed space and closed registration

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/SpaceAccessType.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/SpaceAccessType.java
@@ -48,7 +48,7 @@ public enum SpaceAccessType {
 
     @Override
     public boolean doCheck(String remoteId, Space space) {
-      return !getSpaceService().isMember(space, remoteId) && "close".equals(space.getRegistration());
+      return !getSpaceService().isMember(space, remoteId) && Space.CLOSED.equals(space.getRegistration());
     }
     
   },
@@ -56,7 +56,7 @@ public enum SpaceAccessType {
 
     @Override
     public boolean doCheck(String remoteId, Space space) {
-      return !getSpaceService().isMember(space, remoteId) && "open".equals(space.getRegistration());
+      return !getSpaceService().isMember(space, remoteId) && Space.OPEN.equals(space.getRegistration());
     }
     
   }, //request to join space validation
@@ -64,7 +64,7 @@ public enum SpaceAccessType {
 
     @Override
     public boolean doCheck(String remoteId, Space space) {
-      return !getSpaceService().isMember(space, remoteId) && "validation".equals(space.getRegistration());
+      return !getSpaceService().isMember(space, remoteId) && Space.VALIDATION.equals(space.getRegistration());
     }
     
   },


### PR DESCRIPTION
Problem: when user1 creates space1 as a listed and closed space and user2 is not a member of this space1, user2 can open yhis space and visualize its content

Fix: user2 should be redirected to "Access Denied" page with a displayed message:" You must be invited by an administrator to the $SPACE_NAME space to access this page", by changing the condition in of check in the spaceAccessType of the current space