### PR TITLE
Task-59071: Empty Email notification info area , after sharing a post/article to another space (#1727)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -251,7 +251,7 @@ public class ActivityManagerImpl implements ActivityManager {
     }
     checkCanShareActivityToSpaces(spaceIds, viewer);
     activityShareAction.setUserIdentityId(Long.parseLong(viewerIdentity.getId()));
-    List<ExoSocialActivity> sharedActivities = createShareActivities(activityTemplate, activityShareAction, viewerIdentity.getId());
+    List<ExoSocialActivity> sharedActivities = createShareActivities(activityTemplate, activityShareAction, viewerIdentity.getId(),activity);
     Set<Long> sharedActivityIds = sharedActivities.stream()
                                                    .map(tmpActivity -> Long.parseLong(tmpActivity.getId()))
                                                    .collect(Collectors.toSet());
@@ -845,7 +845,8 @@ public class ActivityManagerImpl implements ActivityManager {
 
   private List<ExoSocialActivity> createShareActivities(ExoSocialActivity activityTemplate,
                                                         ActivityShareAction activityShareAction,
-                                                        String viewerIdentityId) {
+                                                        String viewerIdentityId,
+                                                        ExoSocialActivity activity) {
     String title = activityTemplate == null || activityTemplate.getTitle() == null ? "" : activityTemplate.getTitle();
     String type = activityTemplate == null ? null : activityTemplate.getType();
     Map<String, String> templateParams = activityTemplate == null
@@ -864,6 +865,7 @@ public class ActivityManagerImpl implements ActivityManager {
       Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
       ExoSocialActivity sharedActivity = new ExoSocialActivityImpl();
       sharedActivity.setTitle(title);
+      sharedActivity.setBody(activity != null ? activity.getTitle() : null);
       sharedActivity.setType(type);
       sharedActivity.setUserId(viewerIdentityId);
       sharedActivity.setTemplateParams(templateParams);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/ActivityNotificationImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/ActivityNotificationImpl.java
@@ -119,5 +119,15 @@ public class ActivityNotificationImpl extends ActivityListenerPlugin {
     ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(LikeCommentPlugin.ID)))
             .execute(ctx);
   }
-
+  @Override
+  public void shareActivity(ActivityLifeCycleEvent event) {
+    // Create a new notification that contains all objects needed to create Mail notification with information about initial activity and new one
+    ExoSocialActivity originalActivity = event.getSource();
+    ExoSocialActivity activity = CommonsUtils.getService(ActivityManager.class).getActivity(originalActivity.getId());
+    NotificationContext ctx = NotificationContextImpl.cloneInstance().append(SocialNotificationUtils.ACTIVITY, activity);
+    ctx.append(SocialNotificationUtils.ORIGINAL_TITLE, originalActivity.getTitle());
+    ctx.append(SocialNotificationUtils.ORIGINAL_TITLE_SHARED, originalActivity.getBody());
+    ctx.getNotificationExecutor().with(ctx.makeCommand(PluginKey.key(SharedActivitySpaceStreamPlugin.ID)))
+       .execute(ctx);
+  }
 }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SharedActivitySpaceStreamPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SharedActivitySpaceStreamPlugin.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.social.notification.plugin;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.notification.Utils;
+
+public class SharedActivitySpaceStreamPlugin extends BaseNotificationPlugin {
+
+  public static final String ID = "SharedActivitySpaceStreamPlugin";
+
+  protected ActivityStorage activityStorage;
+
+  public SharedActivitySpaceStreamPlugin(InitParams initParams , ActivityStorage activityStorage) {
+    super(initParams);
+    this.activityStorage = activityStorage;
+  }
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public boolean isValid(NotificationContext ctx) {
+    return true;
+  }
+
+  @Override
+  protected NotificationInfo makeNotification(NotificationContext ctx) {
+    try {
+      ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
+      String originalTitle = ctx.value(SocialNotificationUtils.ORIGINAL_TITLE);
+      String titleShared = ctx.value(SocialNotificationUtils.ORIGINAL_TITLE_SHARED);
+      Space space = Utils.getSpaceService().getSpaceByPrettyName(activity.getStreamOwner());
+      String poster = Utils.getUserId(activity.getPosterId());
+
+      return NotificationInfo.instance()
+                             .key(getId())
+                             .with(SocialNotificationUtils.POSTER.getKey(), poster)
+                             .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
+                             .with(SocialNotificationUtils.ORIGINAL_TITLE.getKey(), originalTitle)
+                             .with(SocialNotificationUtils.ORIGINAL_TITLE_SHARED.getKey(),titleShared)
+                             .to(Utils.getDestinataires(activity, space)).end();
+    } catch (Exception e) {
+      ctx.setException(e);
+    }
+    return null;
+  }
+}

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
@@ -64,6 +64,7 @@ public class SocialNotificationUtils {
   public final static ArgumentLiteral<String> SENDER = new ArgumentLiteral<String>(String.class, "sender");
   public final static ArgumentLiteral<ExoSocialActivity> ACTIVITY = new ArgumentLiteral<ExoSocialActivity>(ExoSocialActivity.class, "activity");
   public final static ArgumentLiteral<String> ORIGINAL_TITLE = new ArgumentLiteral<>(String.class, "original_title");
+  public static final ArgumentLiteral<String> ORIGINAL_TITLE_SHARED = new ArgumentLiteral<>(String.class, "original_title_shared");
   public final static ArgumentLiteral<Profile> PROFILE = new ArgumentLiteral<Profile>(Profile.class, "profile");
   public final static ArgumentLiteral<Space> SPACE = new ArgumentLiteral<Space>(Space.class, "space");
   public final static ArgumentLiteral<String> REMOTE_ID = new ArgumentLiteral<String>(String.class, "remoteId");

--- a/component/notification/src/test/resources/locale/notification/template/Notification_en.properties
+++ b/component/notification/src/test/resources/locale/notification/template/Notification_en.properties
@@ -224,6 +224,23 @@ Notification.digest.three.EditCommentPlugin=$USER_LIST <span style="color:#33333
 Notification.digest.more.EditCommentPlugin=$LAST3_USERS <span style="color:#333333">and</span> $COUNT <span style="color:#333333">other(s) edited comments:</span>
 
 #############################################################################
+#                         SharedActivitySpacePlugin                     #
+#############################################################################
+# For UI
+UINotification.label.SharedActivitySpacePlugin=Sahre on Space
+UINotification.title.SharedActivitySpaceStreamPlugin=An activity is Shared in one of my Space
+# For Subject
+Notification.subject.SharedActivitySpaceStreamPlugin=$USER shared an activity in the $SPACE
+# For template
+Notification.title.SharedActivitySpaceStreamPlugin=New post on your activity stream
+Notification.message.SharedActivitySpaceStreamPlugin={0} has shared an activity in the {1} space. See the post below
+Notification.intranet.message.SharedActivitySpaceStreamPlugin={0} has shared an activity in the {1} space
+# For Digest
+Notification.digest.one.SharedActivitySpaceStreamPlugin=$USER shared in $SPACE.
+Notification.digest.three.SharedActivitySpaceStreamPlugin=$USER_LIST shared in $SPACE.
+Notification.digest.more.SharedActivitySpaceStreamPlugin=$LAST3_USERS and $COUNT others shared in $SPACE.
+
+#############################################################################
 #                         NotificationByActivityType                        #
 #############################################################################
 LinkActivity.notification.label.source=Source

--- a/extension/war/src/main/resources/locale/notification/template/Notification_en.properties
+++ b/extension/war/src/main/resources/locale/notification/template/Notification_en.properties
@@ -244,6 +244,23 @@ Notification.digest.three.PostActivitySpaceStreamPlugin=$USER_LIST <span style="
 Notification.digest.more.PostActivitySpaceStreamPlugin=$LAST3_USERS <span style="color:#333333">and</span> $COUNT <span style="color:#333333">other(s) have posted in</span> $SPACE.
 
 #############################################################################
+#                         SharedActivitySpacePlugin                     #
+#############################################################################
+# For UI
+UINotification.label.SharedActivitySpacePlugin=Sahre on Space
+UINotification.title.SharedActivitySpaceStreamPlugin=An activity is Shared in one of my Space
+# For Subject
+Notification.subject.SharedActivitySpaceStreamPlugin=$USER shared an activity in the $SPACE
+# For template
+Notification.title.SharedActivitySpaceStreamPlugin=New post on your activity stream
+Notification.message.SharedActivitySpaceStreamPlugin={0} has shared an article "{1}" in the {2} space. See the post below
+Notification.intranet.message.SharedActivitySpaceStreamPlugin={0} has shared an activity in the {1} space
+# For Digest
+Notification.digest.one.SharedActivitySpaceStreamPlugin=$USER shared in $SPACE.
+Notification.digest.three.SharedActivitySpaceStreamPlugin=$USER_LIST shared in $SPACE.
+Notification.digest.more.SharedActivitySpaceStreamPlugin=$LAST3_USERS and $COUNT others shared in $SPACE.
+
+#############################################################################
 #                         NotificationByActivityType                        #
 #############################################################################
 LinkActivity.notification.label.source=Source

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/notification-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/notification-plugins-configuration.xml
@@ -696,6 +696,46 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
+    <component-plugin>
+      <name>notification.plugins</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.social.notification.plugin.SharedActivitySpaceStreamPlugin</type>
+      <description>Initial information for plugin.</description>
+      <init-params>
+        <object-param>
+          <name>template.SharedActivitySpaceStreamPlugin</name>
+          <description>The template of SharedActivitySpaceStreamPlugin</description>
+          <object
+                  type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+            <field name="pluginId">
+              <string>SharedActivitySpaceStreamPlugin</string>
+            </field>
+            <field name="resourceBundleKey">
+              <string>UINotification.label.SharedActivitySpaceStreamPlugin</string>
+            </field>
+            <field name="order">
+              <string>6</string>
+            </field>
+            <field name="defaultConfig">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>Instantly</string>
+                </value>
+              </collection>
+            </field>
+            <field name="groupId">
+              <string>activity_stream</string>
+            </field>
+            <field name="bundlePath">
+              <string>locale.notification.template.Notification</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
 
   <external-component-plugins>
     <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>

--- a/extension/war/src/main/webapp/WEB-INF/intranet-notification/templates/SharedActivitySpaceStreamPlugin.gtmpl
+++ b/extension/war/src/main/webapp/WEB-INF/intranet-notification/templates/SharedActivitySpaceStreamPlugin.gtmpl
@@ -1,0 +1,19 @@
+<li class="$READ clearfix" data-id="$NOTIFICATION_ID">
+  <div class="media">
+    <div class="avatarXSmall pull-left">
+      <img src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+    </div>
+    <div class="media-body">
+      <%
+       String profileUrl = "<a class=\"user-name text-bold\" href=\"javascript:void(0)\">" + _ctx.escapeHTML(USER) + "</a>";
+       String spaceUrl = "<span class=\"text-bold\">" + _ctx.escapeHTML(SPACE) + "</span>";
+      %>
+      <div class="contentSmall" data-link="$VIEW_FULL_DISCUSSION_ACTION_URL">
+        <div class="status"><%=_ctx.appRes("Notification.intranet.message.SharedActivitySpaceStreamPlugin", profileUrl, spaceUrl)%></div>
+        <div class="content"><i class="uiIcon uiIconComment uiIconLightGray"></i>$ACTIVITY</div>
+        <div class="lastUpdatedTime">$LAST_UPDATED_TIME</div>
+      </div>
+    </div>
+  </div>
+  <span class="remove-item" data-rest=""><i class="uiIconClose uiIconLightGray"></i></span>
+</li>

--- a/extension/war/src/main/webapp/WEB-INF/notification/templates/SharedActivitySpaceStreamPlugin.gtmpl
+++ b/extension/war/src/main/webapp/WEB-INF/notification/templates/SharedActivitySpaceStreamPlugin.gtmpl
@@ -1,0 +1,141 @@
+<table border="0" cellpadding="0" cellspacing="0" width="600" bgcolor="#ffffff" align="center" style="background-color: #ffffff; font-size: 13px;color:#333333;line-height: 18px;font-family: HelveticaNeue, Helvetica, Arial, sans-serif;">
+    <%
+      _templateContext.put("header_title", _ctx.appRes("Notification.title.SharedActivitySpaceStreamPlugin", _ctx.escapeHTML(SPACE)));
+      _ctx.include("war:/notification/templates/mail/NotificationHeader.gtmpl", _templateContext);
+    %>
+    <tr>
+        <td bgcolor="#ffffff" style="background-color: #ffffff;">
+            <table cellpadding="0" cellspacing="0" width="100%"  bgcolor="#ffffff" style="background-color: #ffffff; border-left:1px solid #d8d8d8;border-right:1px solid #d8d8d8;">
+                <tr>
+                    <td bgcolor="#ffffff" style="background-color: #ffffff;">
+                        <table border="0" cellpadding="0" cellspacing="0" width="92%" bgcolor="#ffffff" align="center" style="background-color: #ffffff; font-size: 13px;color:#333333;line-height: 18px;">
+                            <tr>
+                                <td align="left" bgcolor="#ffffff" style="background-color: #ffffff;padding: 10px 0;">
+                                    <p style="margin: 10px 0; color: #333333; font-family: HelveticaNeue,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 18px;"><%=_ctx.appRes("Notification.label.SayHello")%> <%=_ctx.escapeHTML(FIRSTNAME)%>,</p>
+                                    <p style="margin: 10px 0; color: #333333; font-family: HelveticaNeue,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 18px;">
+                                        <%
+                                          String titleShared = "<strong><a target=\"_blank\" style=\"color: #333333; font-family: 'HelveticaNeue Bold', Helvetica, Arial, sans-serif; text-decoration: none; font-size: 12px; font-weight: bold; white-space: nowrap; text-overflow: ellipsis; overflow: hidden; width: 70px; line-height: 18px;\" href=\""+ VIEW_FULL_DISCUSSION_ACTION_URL + "\">" + _ctx.escapeHTML(SHORT_TITLE) + "</a></strong>"
+                                          String profileUrl = "<strong><a target=\"_blank\" style=\"color: #2f5e92; font-family: 'HelveticaNeue Bold', Helvetica, Arial, sans-serif; text-decoration: none; font-size: 13px; line-height: 18px;\" href=\""+ PROFILE_URL + "\">" + _ctx.escapeHTML(USER) + "</a></strong>";
+                                          String spaceUrl = "<strong><a target=\"_blank\" style=\"color: #2f5e92; font-family: 'HelveticaNeue Bold', Helvetica, Arial, sans-serif; text-decoration: none; font-size: 13px; line-height: 18px;\" href=\""+ SPACE_URL + "\">" + _ctx.escapeHTML(SPACE) + "</a></strong>";
+                                        %>
+                                    <%=_ctx.appRes("Notification.message.SharedActivitySpaceStreamPlugin", profileUrl, titleShared, spaceUrl)%>:
+                                    </p>
+
+                                    <table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="#ffffff" align="center" style="background-color: #ffffff; font-size: 13px;color:#333333;line-height: 18px; margin-bottom: 15px; padding-left: 23px;">
+                                        <tbody>
+                                            <% if ( SUBJECT.length() > 0) { %>
+                                                <tr>
+                                                    <td align="left" bgcolor="#ffffff" style="color: #476A9C; padding-top: 13px; font-family: HelveticaNeue,Helvetica,Arial,sans-serif;"><%= profileUrl %></td>
+                                                </tr>
+                                                <tr>
+                                                    <td align="left" bgcolor="#ffffff" style="background-color: #f9f9f9; padding-top: 13px;  padding-bottom: 13px;"><%=_ctx.escapeHTML(SUBJECT)%></td>
+                                                </tr>
+                                                <tr>
+                                                    <td style="border: 1px solid #CDCCCC;"></td>
+                                                </tr>
+                                            <% } %>
+                                            <tr>
+                                                <td style="display: flex; align-items: center; padding-top: 17px;">
+                                                 <img width="45px" height="45px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$IMAGE" alt="" />
+                                                 <span style="background-color: #f9f9f9; font-family: 'HelveticaNeue Bold', Helvetica, Arial, sans-serif; font-weight: bold; font-size: 12px; color: #333333; padding-left: 15px; "><%=_ctx.escapeHTML(TITLE)%></span>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <p style="margin: 0 0 20px;">
+                                        <% if (OPEN_URL != null) { %>
+                                            <a target="_blank" style="
+                                                display: inline-block;
+                                                text-decoration: none;
+                                                font-size: 11px;
+                                                font-family: 'HelveticaNeue Bold', Helvetica, Arial, sans-serif;
+                                                color: #ffffff;
+                                                background-color: #567ab6;
+                                                background-image: -moz-linear-gradient(top, #638acd, #426393);
+                                                background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#638acd), to(#426393));
+                                                background-image: -webkit-linear-gradient(top, #638acd, #426393);
+                                                background-image: -o-linear-gradient(top, #638acd, #426393);
+                                                background-image: linear-gradient(to bottom, #638acd, #426393);
+                                                background-repeat: repeat-x;
+                                                border-radius: 4px;
+                                                -moz-border-radius: 4px;
+                                                padding: 5px 8px;
+                                                height: 11px;
+                                                line-height: 11px;
+                                                max-height: 11px;
+                                                text-align: center;
+                                                border: 1px solid #224886;
+                                                font-weight: bold;
+                                                -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                                -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                                box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                                vertical-align: middle;
+                                                " href="$OPEN_URL" title=<%=_ctx.appRes("Notification.label.Open.Title")%>""><%=_ctx.appRes("Notification.label.Open")%></a>
+                                            <% } %>
+                                        <a target="_blank" style="display: inline-block;
+                                                    text-decoration: none;
+                                                    font-size: 11px;
+                                                    font-family: 'HelveticaNeue Bold', Helvetica, Arial, sans-serif;
+                                                    color: #ffffff;
+                                                    background-color: #567ab6;
+                                                    background-image: -moz-linear-gradient(top, #638acd, #426393);
+                                                    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#638acd), to(#426393));
+                                                    background-image: -webkit-linear-gradient(top, #638acd, #426393);
+                                                    background-image: -o-linear-gradient(top, #638acd, #426393);
+                                                    background-image: linear-gradient(to bottom, #638acd, #426393);
+                                                    background-repeat: repeat-x;
+                                                    border-radius: 4px;
+                                                    -moz-border-radius: 4px;
+                                                    padding: 5px 8px;
+                                                    height: 11px;
+                                                    line-height: 11px;
+                                                    max-height: 11px;
+                                                    text-align: center;
+                                                    border: 1px solid #224886;
+                                                    font-weight: bold;
+                                                    -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                                    -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                                    box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                                    vertical-align: middle" href="$REPLY_ACTION_URL" title="Reply"><%=_ctx.appRes("Notification.label.Reply")%></a>
+                                        <a target="_blank" style="
+                                            display: inline-block;
+                                            text-decoration: none;
+                                            font-size: 11px;
+                                            font-family: HelveticaNeue, Helvetica, Arial, sans-serif,serif;
+                                            color: #333333;
+                                            background-color: #f1f1f1;
+                                            background-image: -moz-linear-gradient(top, #ffffff, #f1f1f1);
+                                            background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#f1f1f1));
+                                            background-image: -webkit-linear-gradient(top, #ffffff, #f1f1f1);
+                                            background-image: -o-linear-gradient(top, #ffffff, #f1f1f1);
+                                            background-image: linear-gradient(to bottom, #ffffff, #f1f1f1);
+                                            background-repeat: repeat-x;
+                                            border-radius: 4px;
+                                            -moz-border-radius: 4px;
+                                            padding: 5px 8px;
+                                            height: 11px;
+                                            line-height: 12px;
+                                            max-height: 11px;
+                                            text-align: center;
+                                            border: 1px solid #c7c7c7;
+                                            -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                            -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                            box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+                                            vertical-align: middle;
+                                            margin-left: 3px;
+                                        " href="$VIEW_FULL_DISCUSSION_ACTION_URL" target="_blank"><%=_ctx.appRes("Notification.label.ViewFullDiscussion")%></a>
+                                    </p>
+                                    <p style="margin: 10px 0; color: #999999">
+                                        <%=_ctx.appRes("Notification.label.footer", FOOTER_LINK)%>
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+
+        </td>
+    </tr><!--end content area-->
+    <% _ctx.include("war:/notification/templates/mail/NotificationFooter.gtmpl", _templateContext);%>
+</table>


### PR DESCRIPTION
Prior this change, when sharing post from space to other space , template mail not displayed the title or summary of post where shared , so the template email is applied to add a short message or an article , Add new notification shared for Activity (short message | Article) and implement the basic plugins for shared activity.