### PR TITLE
Task-48748: Pass user enabled/disabled/deleted status to extension registry components

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -229,6 +229,12 @@ export default {
     username() {
       return this.identity?.username || this.retrievedIdentity?.username || this.profileId;
     },
+    enabled() {
+      return this.identity?.enabled || this.retrievedIdentity?.enabled;  
+    },  
+    deleted() {
+      return this.identity?.deleted || this.retrievedIdentity?.deleted;
+    },    
     userFullname() {
       return this.identity?.fullname || this.retrievedIdentity?.fullname;
     },
@@ -266,13 +272,15 @@ export default {
     params() {
       return {
         identityType: 'USER_PROFILE',
-        identityId: this.username,
+        identityId: this.username,        
       };
     },
     userIdentity() {
       return {
         id: this.identityId,
         username: this.username,
+        enabled: this.enabled,
+        deleted: this.deleted,       
         fullName: this.userFullname,
         position: this.position,
         avatar: this.avatarUrl,

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverUser.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverUser.vue
@@ -86,6 +86,8 @@ export default {
       return {
         identityType: 'USER_PROFILE',
         identityId: this.identity && this.identity.username,
+        identityEnabled: this.identity && this.identity.enabled,
+        identityDeleted: this.identity && this.identity.deleted,        
       };
     },
     enabledExtensionComponents() {
@@ -131,6 +133,8 @@ export default {
       const data = event?.detail;
       this.identity = {
         id: data?.id,
+        enabled: data?.enabled,
+        deleted: data?.deleted,        
         username: data?.username,
         fullname: data?.fullName,
         avatar: data?.avatar,


### PR DESCRIPTION

Prior to this change it was possible to perform actions with deleted/disabled users fix:

We will pass the user status enabled/disabled/deleted to the other components injected with the extension registry to allow components to set specific behavior depending on the user status.

(cherry picked from commit 48e16f481e63e61eef9697b78a8c0416dd16f246)