### PR TITLE
feat: Left menu review Adjust the space drawer from the left navigation menu - MEED-52 - meeds-io/meeds#16

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
@@ -1,15 +1,25 @@
 <template>
   <v-container class="recentDrawer" flat>
-    <v-flex class="filterSpaces">
+    <v-flex class="filterSpaces d-flex align-center">
+      <a  
+        v-if="canAddSpaces"
+        :href="allSpacesLink" 
+        class="addNewSpaceIcon px-2 primary rounded py-6px">
+        <v-icon 
+          class="fas fa-plus white--text" 
+          size="20" />
+      </a>
       <v-list-item class="recentSpacesTitle">
-        <v-list-item-icon class="d-flex d-sm-none backToMenu" @click="closeMenu()">
-          <i class="uiIcon uiArrowBackIcon"></i>
+        <v-list-item-icon 
+          class="me-2 align-self-center " 
+          @click="closeMenu()"> 
+          <v-icon size="20" class="disabled--text">fas fa-filter </v-icon>
         </v-list-item-icon>
         <v-list-item-content v-if="showFilter" class="recentSpacesTitleLabel body-1">
           <v-text-field
             v-model="keyword"
             placeholder="Filter spaces here"
-            class="recentSpacesFilter body-1 pt-0"
+            class="recentSpacesFilter border-bottom-color body-2 pt-0 mt-0"
             single-line
             hide-details
             required
@@ -17,13 +27,12 @@
         </v-list-item-content>
         <v-list-item-content
           v-else
-          class="recentSpacesTitleLabel body-1"
+          class="recentSpacesTitleLabel body-2 py-1 disabled--text border-bottom-color "
           @click="showFilter = true">
           {{ $t('menu.spaces.recentSpaces') }}
         </v-list-item-content>
-        <v-list-item-action class="recentSpacesTitleIcon">
+        <v-list-item-action v-if="showFilter" class="recentSpacesTitleIcon position-absolute r-3">
           <v-btn
-            v-if="showFilter"
             text
             icon
             color="blue-grey darken-1"
@@ -31,44 +40,15 @@
             @click="closeFilter()">
             <v-icon size="18">mdi-close</v-icon>
           </v-btn>
-          <v-btn
-            v-else
-            text
-            icon
-            color="blue-grey darken-1"
-            size="20"
-            @click="showFilter = true">
-            <v-icon size="18" class="uiSearchIcon" />
-          </v-btn>
         </v-list-item-action>
       </v-list-item>
     </v-flex>
-    <v-divider class="my-0" />
-    <v-list
-      dense
-      nav
-      class="recentSpacesWrapper">
-      <v-list-item
-        v-if="canAddSpaces"
-        :href="allSpacesLink"
-        class="addSpaces my-2">
-        <v-list-item-avatar
-          class="me-3"
-          size="22"
-          tile>
-          <i class="uiPlusEmptyIcon"></i>
-        </v-list-item-avatar>
-        <v-list-item-content class="py-0 body-2 grey--text darken-4">
-          {{ $t('menu.spaces.createSpace') }}
-        </v-list-item-content>
-      </v-list-item>
-    </v-list>
     <exo-spaces-navigation-content
       :limit="itemsToShow"
       :page-size="itemsToShow"
       :keyword="keyword"
       show-more-button
-      class="recentSpacesWrapper" />
+      class="recentSpacesWrapper mt-4" />
   </v-container>
 </template>
 <script>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
@@ -6,7 +6,6 @@
     <v-row class="mx-0 clickable spacesNavigationTitle">
       <v-list-item
         link
-        @mouseover="openDrawer()"
         @click="openDrawer()">
         <v-list-item-icon class="mb-2 mt-3 me-6 titleIcon">
           <i class="uiIcon uiIconToolbarNavItem spacesIcon"></i>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
@@ -13,7 +13,7 @@
           link
           class="px-2 spaceItem">
           <v-list-item-avatar 
-            size="26"
+            size="28"
             class="me-3 tile my-0 spaceAvatar"
             tile>
             <v-img :src="space.avatarUrl" />


### PR DESCRIPTION
This change allows to adjust the recent visited spaces second level menu when clicking on the recent spaces menu items in the left navigation drawer.
Also in this PR we edit the way to Access to recent spaces panel to click action instead of mouseover action.
