### PR TITLE
feat: Left menu review Adjust the space drawer from the left navigation menu - MEED-52 - Meeds-io/meeds#16

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -5,12 +5,12 @@
     py-0
     class="white d-none d-sm-block">
     <v-row v-if="navigationTree && navigationTree.length" class="mx-0 administrationTitle">
-      <v-list-item @mouseover="openDrawer()" @click="openDrawer()">
+      <v-list-item>
         <v-list-item-icon class="mb-2 mt-3 mr-6 titleIcon"><i class="uiIcon uiIconToolbarNavItem uiAdministrationIcon"></i></v-list-item-icon>
         <v-list-item-content class="subtitle-2 titleLabel clickable">
           {{ this.$t('menu.administration.title') }}
         </v-list-item-content>
-        <v-list-item-action class="my-0">
+        <v-list-item-action class="my-0" @click="toggleOpenDrawer()">
           <i class="uiIcon uiArrowRightIcon" color="grey lighten-1"></i>
         </v-list-item-action>
       </v-list-item>
@@ -27,6 +27,7 @@ export default {
       loading: false,
       navigations: [],
       embeddedTree: {},
+      secondeLevel: false
     };
   },
   computed: {
@@ -148,8 +149,13 @@ export default {
         vuetify: Vue.prototype.vuetifyOptions,
       }).$mount(parentId);
     },
-    openDrawer() {
-      this.$emit('open-second-level');
+    toggleOpenDrawer() {
+      this.secondeLevel = !this.secondeLevel;
+      if (this.secondeLevel) {
+        this.$emit('open-second-level');
+      } else {
+        this.$emit('close-second-level');
+      }
     },
     filterDisplayedNavigations(navigations, excludeHidden) {
       return navigations

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
@@ -1,13 +1,16 @@
 <template>
   <v-container class="recentDrawer" flat>
     <v-flex class="filterSpaces d-flex align-center">
+      <v-list-item-icon class="d-flex d-sm-none backToMenu me-2 my-5 icon-default-color" @click="closeMenu()">
+        <i class="fas fa-arrow-left"></i>
+      </v-list-item-icon>
       <a  
         v-if="canAddSpaces"
         :href="allSpacesLink" 
-        class="addNewSpaceIcon px-2 primary rounded py-6px">
+        class="addNewSpaceIcon px-2 primary rounded py-1">
         <v-icon 
           class="fas fa-plus white--text" 
-          size="20" />
+          size="16" />
       </a>
       <v-list-item class="recentSpacesTitle">
         <v-list-item-icon 
@@ -15,11 +18,11 @@
           @click="closeMenu()"> 
           <v-icon size="20" class="disabled--text">fas fa-filter </v-icon>
         </v-list-item-icon>
-        <v-list-item-content v-if="showFilter" class="recentSpacesTitleLabel body-1">
+        <v-list-item-content v-if="showFilter" class="recentSpacesTitleLabel">
           <v-text-field
             v-model="keyword"
-            placeholder="Filter spaces here"
-            class="recentSpacesFilter border-bottom-color body-2 pt-0 mt-0"
+            :placeholder="$t('menu.spaces.recentSpaces')"
+            class="recentSpacesFilter border-bottom-color pt-0 mt-0"
             single-line
             hide-details
             required
@@ -27,7 +30,7 @@
         </v-list-item-content>
         <v-list-item-content
           v-else
-          class="recentSpacesTitleLabel body-2 py-1 disabled--text border-bottom-color "
+          class="recentSpacesTitleLabel pt-1 pb-2px disabled--text border-bottom-color "
           @click="showFilter = true">
           {{ $t('menu.spaces.recentSpaces') }}
         </v-list-item-content>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
@@ -1,15 +1,25 @@
 <template>
   <v-container class="recentDrawer" flat>
-    <v-flex class="filterSpaces">
+    <v-flex class="filterSpaces d-flex align-center">
+      <a  
+        v-if="canAddSpaces"
+        :href="allSpacesLink" 
+        class="addNewSpaceIcon px-2 primary rounded py-6px">
+        <v-icon 
+          class="fas fa-plus white--text" 
+          size="20" />
+      </a>
       <v-list-item class="recentSpacesTitle">
-        <v-list-item-icon class="d-flex d-sm-none backToMenu" @click="closeMenu()">
-          <i class="uiIcon uiArrowBackIcon"></i>
+        <v-list-item-icon 
+          class="me-2 align-self-center " 
+          @click="closeMenu()"> 
+          <v-icon size="20" class="disabled--text">fas fa-filter </v-icon>
         </v-list-item-icon>
         <v-list-item-content v-if="showFilter" class="recentSpacesTitleLabel body-1">
           <v-text-field
             v-model="keyword"
             placeholder="Filter spaces here"
-            class="recentSpacesFilter body-1 pt-0"
+            class="recentSpacesFilter border-bottom-color body-2 pt-0 mt-0"
             single-line
             hide-details
             required
@@ -17,13 +27,12 @@
         </v-list-item-content>
         <v-list-item-content
           v-else
-          class="recentSpacesTitleLabel body-1"
+          class="recentSpacesTitleLabel body-2 py-1 disabled--text border-bottom-color "
           @click="showFilter = true">
           {{ $t('menu.spaces.recentSpaces') }}
         </v-list-item-content>
-        <v-list-item-action class="recentSpacesTitleIcon">
+        <v-list-item-action v-if="showFilter" class="recentSpacesTitleIcon position-absolute r-3">
           <v-btn
-            v-if="showFilter"
             text
             icon
             color="blue-grey darken-1"
@@ -31,44 +40,15 @@
             @click="closeFilter()">
             <v-icon size="18">mdi-close</v-icon>
           </v-btn>
-          <v-btn
-            v-else
-            text
-            icon
-            color="blue-grey darken-1"
-            size="20"
-            @click="showFilter = true">
-            <v-icon size="18" class="uiSearchIcon" />
-          </v-btn>
         </v-list-item-action>
       </v-list-item>
     </v-flex>
-    <v-divider class="my-0" />
-    <v-list
-      dense
-      nav
-      class="recentSpacesWrapper">
-      <v-list-item
-        v-if="canAddSpaces"
-        :href="allSpacesLink"
-        class="addSpaces my-2">
-        <v-list-item-avatar
-          class="me-3"
-          size="22"
-          tile>
-          <i class="uiPlusEmptyIcon"></i>
-        </v-list-item-avatar>
-        <v-list-item-content class="py-0 body-2 grey--text darken-4">
-          {{ $t('menu.spaces.createSpace') }}
-        </v-list-item-content>
-      </v-list-item>
-    </v-list>
     <exo-spaces-navigation-content
       :limit="itemsToShow"
       :page-size="itemsToShow"
       :keyword="keyword"
       show-more-button
-      class="recentSpacesWrapper" />
+      class="recentSpacesWrapper mt-4" />
   </v-container>
 </template>
 <script>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
@@ -3,17 +3,16 @@
     px-0
     pt-0
     class="border-box-sizing">
-    <v-row class="mx-0 clickable spacesNavigationTitle">
+    <v-row class="mx-0 spacesNavigationTitle">
       <v-list-item
-        link
-        @click="openDrawer()">
+        link>
         <v-list-item-icon class="mb-2 mt-3 me-6 titleIcon">
           <i class="uiIcon uiIconToolbarNavItem spacesIcon"></i>
         </v-list-item-icon>
         <v-list-item-content class="subtitle-1 titleLabel">
           {{ $t('menu.spaces.lastVisitedSpaces') }}
         </v-list-item-content>
-        <v-list-item-action class="my-0">
+        <v-list-item-action class="my-0" @click="toggleOpenDrawer()">
           <i class="uiIcon uiArrowRightIcon" color="grey lighten-1"></i>
         </v-list-item-action>
       </v-list-item>
@@ -45,6 +44,7 @@ export default {
       selectedSpace: null,
       spacesLimit: 7,
       secondLevelVueInstance: null,
+      secondeLevel: false
     };
   },
   computed: {
@@ -101,8 +101,13 @@ export default {
         });
       });
     },
-    openDrawer() {
-      this.$emit('open-second-level');
+    toggleOpenDrawer() {
+      this.secondeLevel = !this.secondeLevel;
+      if (this.secondeLevel) {
+        this.$emit('open-second-level');
+      } else {
+        this.$emit('close-second-level');
+      }
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
@@ -6,7 +6,6 @@
     <v-row class="mx-0 clickable spacesNavigationTitle">
       <v-list-item
         link
-        @mouseover="openDrawer()"
         @click="openDrawer()">
         <v-list-item-icon class="mb-2 mt-3 me-6 titleIcon">
           <i class="uiIcon uiIconToolbarNavItem spacesIcon"></i>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
@@ -8,12 +8,12 @@
         <v-list-item
           v-for="space in filteredSpaces"
           :key="space.id"
-          :href="url(space)"
-          :class="homeIcon && (homeLink === url(space) && 'UserPageLinkHome' || 'UserPageLink')"
+          :href="space.spaceUrl"
+          :class="homeIcon && (homeLink === space.spaceUrl && 'UserPageLinkHome' || 'UserPageLink')"
           link
           class="px-2 spaceItem">
           <v-list-item-avatar 
-            size="28"
+            size="26"
             class="me-3 tile my-0 spaceAvatar"
             tile>
             <v-img :src="space.avatarUrl" />
@@ -41,14 +41,14 @@
             </template>
             <v-list class="pa-0">
               <v-list-item
-                :href="url(space)" 
+                :href="space.spaceUrl"
                 target="_blank"
                 link>
                 <v-icon size="15" class="fas fa-external-link-alt icon-default-color mr-3" />
                 <span class="text-color">{{ $t('menu.spaces.openInNewTab') }}</span>
               </v-list-item>
               <v-list-item
-                v-if="homeLink !== url(space)"
+                v-if="homeLink !== space.spaceUrl"
                 @click="$emit('selectHome', $event, space)">
                 <v-icon size="16" class="fas fa-home icon-default-color mr-3" />
                 <span class="text-color mt-1">{{ $t('menu.spaces.makeAsHomePage') }}</span>
@@ -126,7 +126,7 @@ export default {
       }
     },
     selectedSpaceIndex() {
-      return this.spaces.findIndex(space => this.url(space) === eXo.env.server.portalBaseURL || eXo.env.server.portalBaseURL.indexOf(`${this.url(space)}/`) === 0);
+      return this.spaces.findIndex(space => space.spaceUrl === eXo.env.server.portalBaseURL || eXo.env.server.portalBaseURL.indexOf(`${space.spaceUrl}/`) === 0);
     },
   },
   watch: {
@@ -141,6 +141,11 @@ export default {
         this.loadingSpaces = true;
         this.waitForEndTyping();
       }
+    },
+    spaces() {
+      this.spaces.forEach(space => {
+        space.spaceUrl = `${eXo.env.portal.context}${space.spaceUrl}`;
+      });
     },
     limitToFetch() {
       this.searchSpaces()
@@ -189,14 +194,6 @@ export default {
           this.waitForEndTyping();
         }
       }, this.endTypingKeywordTimeout);
-    },
-    url(space) {
-      if (space && space.groupId) {
-        const uriPart = space.groupId.replace(/\//g, ':');
-        return `${eXo.env.portal.context}/g/${uriPart}/`;
-      } else {
-        return '#';
-      }
     },
   }
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
@@ -8,8 +8,8 @@
         <v-list-item
           v-for="space in filteredSpaces"
           :key="space.id"
-          :href="space.spaceUrl"
-          :class="homeIcon && (homeLink === space.spaceUrl && 'UserPageLinkHome' || 'UserPageLink')"
+          :href="url(space)"
+          :class="homeIcon && (homeLink === url(space) && 'UserPageLinkHome' || 'UserPageLink')"
           link
           class="px-2 spaceItem">
           <v-list-item-avatar 
@@ -41,14 +41,14 @@
             </template>
             <v-list class="pa-0">
               <v-list-item
-                :href="space.spaceUrl" 
+                :href="url(space)" 
                 target="_blank"
                 link>
                 <v-icon size="15" class="fas fa-external-link-alt icon-default-color mr-3" />
                 <span class="text-color">{{ $t('menu.spaces.openInNewTab') }}</span>
               </v-list-item>
               <v-list-item
-                v-if="homeLink !== space.spaceUrl"
+                v-if="homeLink !== url(space)"
                 @click="$emit('selectHome', $event, space)">
                 <v-icon size="16" class="fas fa-home icon-default-color mr-3" />
                 <span class="text-color mt-1">{{ $t('menu.spaces.makeAsHomePage') }}</span>
@@ -126,7 +126,7 @@ export default {
       }
     },
     selectedSpaceIndex() {
-      return this.spaces.findIndex(space => space.spaceUrl === eXo.env.server.portalBaseURL || eXo.env.server.portalBaseURL.indexOf(`${space.spaceUrl}/`) === 0);
+      return this.spaces.findIndex(space => this.url(space) === eXo.env.server.portalBaseURL || eXo.env.server.portalBaseURL.indexOf(`${this.url(space)}/`) === 0);
     },
   },
   watch: {
@@ -141,11 +141,6 @@ export default {
         this.loadingSpaces = true;
         this.waitForEndTyping();
       }
-    },
-    spaces() {
-      this.spaces.forEach(space => {
-        space.spaceUrl = `${eXo.env.portal.context}${space.spaceUrl}`;
-      });
     },
     limitToFetch() {
       this.searchSpaces()
@@ -194,6 +189,14 @@ export default {
           this.waitForEndTyping();
         }
       }, this.endTypingKeywordTimeout);
+    },
+    url(space) {
+      if (space && space.groupId) {
+        const uriPart = space.groupId.replace(/\//g, ':');
+        return `${eXo.env.portal.context}/g/${uriPart}/`;
+      } else {
+        return '#';
+      }
     },
   }
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
@@ -13,7 +13,7 @@
           link
           class="px-2 spaceItem">
           <v-list-item-avatar 
-            size="26"
+            size="28"
             class="me-3 tile my-0 spaceAvatar"
             tile>
             <v-img :src="space.avatarUrl" />


### PR DESCRIPTION
This change allows to adjust the recent visited spaces second level menu when clicking on the recent spaces menu items in  the left navigation drawer.
Also in this PR we edit the way to Access to recent spaces panel to click action instead of mouseover action.