### PR TITLE
feat: Left menu review Display second panels (recent spaces / admin)-Desktop - MEED-609 - Meeds-io/meeds#16

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -5,7 +5,9 @@
     py-0
     class="white d-none d-sm-block">
     <v-row v-if="navigationTree && navigationTree.length" class="mx-0 administrationTitle">
-      <v-list-item @mouseover="showItemActions = true">
+      <v-list-item 
+        @mouseover="showItemActions = true"
+        @mouseleave="showItemActions = false">
         <v-list-item-icon class="mb-2 mt-3 mr-6 titleIcon"><i class="uiIcon uiIconToolbarNavItem uiAdministrationIcon"></i></v-list-item-icon>
         <v-list-item-content class="subtitle-2 titleLabel">
           {{ this.$t('menu.administration.title') }}
@@ -33,7 +35,8 @@ export default {
       embeddedTree: {},
       secondeLevel: false,
       showItemActions: false,
-      arrowIcon: 'fa-arrow-right'
+      arrowIcon: 'fa-arrow-right',
+      isInSecondeLevel: false
     };
   },
   computed: {
@@ -99,16 +102,29 @@ export default {
       return this.arrowIcon;
     },
     toggleArrow() {
-      return this.showItemActions;
+      if (this.isInSecondeLevel && this.secondeLevel) {
+        return true;
+      } else {
+        return this.showItemActions;
+      }
     }
+  },
+  watch: {
+    secondeLevel() {
+      this.isInSecondeLevel = true;
+    },
   },
   created() {
     Promise.resolve(this.retrieveAdministrationMenu())
       .finally(() => this.$root.$applicationLoaded());
 
     document.addEventListener('second-level-hidden', () => {
-      this.arrowIcon= 'fa-arrow-right';
-      this.showItemActions = false;
+      this.hideSecondeItem();
+    });
+    document.addEventListener('second-level-opened', (event) => {
+      if ( event && event.detail && event.detail.contentDetail.id !== 'HamburgerMenuNavigationAdministration') {
+        this.hideSecondeItem();
+      }
     });
   },
   methods: {
@@ -175,6 +191,11 @@ export default {
         this.arrowIcon = 'fa-arrow-right';
         this.$emit('close-second-level');
       }
+    },
+    hideSecondeItem() {
+      this.arrowIcon= 'fa-arrow-right';
+      this.showItemActions = false;
+      this.secondeLevel = false;
     },
     filterDisplayedNavigations(navigations, excludeHidden) {
       return navigations

--- a/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -35,8 +35,7 @@ export default {
       embeddedTree: {},
       secondeLevel: false,
       showItemActions: false,
-      arrowIcon: 'fa-arrow-right',
-      isInSecondeLevel: false
+      arrowIcon: 'fa-arrow-right'
     };
   },
   computed: {
@@ -102,17 +101,8 @@ export default {
       return this.arrowIcon;
     },
     toggleArrow() {
-      if (this.isInSecondeLevel && this.secondeLevel) {
-        return true;
-      } else {
-        return this.showItemActions;
-      }
+      return this.secondeLevel || this.showItemActions;
     }
-  },
-  watch: {
-    secondeLevel() {
-      this.isInSecondeLevel = true;
-    },
   },
   created() {
     Promise.resolve(this.retrieveAdministrationMenu())

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
@@ -153,6 +153,9 @@ export default {
         return;
       }
       this.secondLevel = true;
+      document.dispatchEvent(new CustomEvent('second-level-opened', {
+        detail: {'contentDetail': contentDetail}
+      }));
 
       if (this.openedSecondLevel !== contentDetail.id && this.vueChildInstances[contentDetail.id].mountSecondLevel) {
         this.openedSecondLevel = contentDetail.id;

--- a/webapp/portlet/src/main/webapp/vue-apps/site-navigation/components/ExoSiteHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/site-navigation/components/ExoSiteHamburgerNavigation.vue
@@ -30,7 +30,7 @@
                 v-text="nav.label" />
             </v-list-item-content>
             <v-list-item-icon @click="selectHome($event, nav)">
-              <span class="fas mt-1 UserPageHome">
+              <span class="fas mt-1 UserPageHome icon-default-color">
               </span>
             </v-list-item-icon>
           </v-list-item>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
@@ -51,8 +51,7 @@ export default {
       secondLevelVueInstance: null,
       secondeLevel: false,
       showItemActions: false,
-      arrowIcon: 'fa-arrow-right',
-      isInSecondeLevel: false
+      arrowIcon: 'fa-arrow-right'
     };
   },
   computed: {
@@ -65,17 +64,8 @@ export default {
       return this.arrowIcon;
     },
     toggleArrow() {
-      if (this.isInSecondeLevel && this.secondeLevel) {
-        return true;
-      } else {
-        return this.showItemActions;
-      }
+      return this.secondeLevel || this.showItemActions;
     }
-  },
-  watch: {
-    secondeLevel() {
-      this.isInSecondeLevel = true;
-    },
   },
   created() {
     document.addEventListener('homeLinkUpdated', () => {

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
@@ -4,7 +4,9 @@
     pt-0
     class="border-box-sizing">
     <v-row class="mx-0 spacesNavigationTitle">
-      <v-list-item @mouseover="showItemActions = true">
+      <v-list-item 
+        @mouseover="showItemActions = true" 
+        @mouseleave="showItemActions = false">
         <v-list-item-icon class="mb-2 mt-3 me-6 titleIcon">
           <i class="uiIcon uiIconToolbarNavItem spacesIcon"></i>
         </v-list-item-icon>
@@ -49,7 +51,8 @@ export default {
       secondLevelVueInstance: null,
       secondeLevel: false,
       showItemActions: false,
-      arrowIcon: 'fa-arrow-right'
+      arrowIcon: 'fa-arrow-right',
+      isInSecondeLevel: false
     };
   },
   computed: {
@@ -62,16 +65,29 @@ export default {
       return this.arrowIcon;
     },
     toggleArrow() {
-      return this.showItemActions;
+      if (this.isInSecondeLevel && this.secondeLevel) {
+        return true;
+      } else {
+        return this.showItemActions;
+      }
     }
+  },
+  watch: {
+    secondeLevel() {
+      this.isInSecondeLevel = true;
+    },
   },
   created() {
     document.addEventListener('homeLinkUpdated', () => {
       this.homeLink = eXo.env.portal.homeLink;
     });
     document.addEventListener('second-level-hidden', () => {
-      this.arrowIcon= 'fa-arrow-right';
-      this.showItemActions = false;
+      this.hideSecondeItem();
+    });
+    document.addEventListener('second-level-opened', (event) => {
+      if ( event && event.detail && event.detail.contentDetail.id !== 'HamburgerMenuNavigationSpaces') {
+        this.hideSecondeItem();
+      }
     });
   },
   methods: {
@@ -115,6 +131,11 @@ export default {
           this.$emit('close-second-level');
         });
       });
+    },
+    hideSecondeItem() {
+      this.arrowIcon= 'fa-arrow-right';
+      this.showItemActions = false;
+      this.secondeLevel = false;
     },
     openOrCloseDrawer() {
       this.secondeLevel = !this.secondeLevel;


### PR DESCRIPTION
Prior to this changes there is some ui glitch when displaying/hovering the left navigation menu arrow and displaying the menu second level.
This change allow to fix the show/hide of the right arrow in recent spaces menu item and administration item to display/hide the menu second level.