### PR TITLE
feat: left menu review Add a space from the left menu - Desktop - MEED-611 - Meeds-io/MIPs#16

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoRecentSpacesHamburgerNavigation.vue
@@ -4,15 +4,6 @@
       <v-list-item-icon class="d-flex d-sm-none backToMenu me-2 my-5 icon-default-color" @click="closeMenu()">
         <i class="fas fa-arrow-left"></i>
       </v-list-item-icon>
-      <a  
-        v-if="canAddSpaces"
-        :href="allSpacesLink" 
-        @click="leftNavigationActionEvent('addNewSpace')"
-        class="addNewSpaceIcon px-2 primary rounded py-1">
-        <v-icon 
-          class="fas fa-plus white--text" 
-          size="16" />
-      </a>
       <v-list-item class="recentSpacesTitle">
         <v-list-item-icon 
           class="me-2 align-self-center " 
@@ -64,7 +55,6 @@ export default {
       itemsToShow: 15,
       canAddSpaces: false,
       showFilter: false,
-      allSpacesLink: `${eXo.env.portal.context}/${ eXo.env.portal.portalName }/all-spaces?createSpace=true`,
       keyword: '',
     };
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesHamburgerNavigation.vue
@@ -15,7 +15,7 @@
         </v-list-item-content>
       </v-list-item>
       <v-list-item
-        v-else 
+        v-else
         @mouseover="showItemActions = true" 
         @mouseleave="showItemActions = false">
         <v-list-item-icon class="mb-2 mt-3 me-6 titleIcon">
@@ -24,7 +24,12 @@
         <v-list-item-content class="subtitle-1 titleLabel">
           {{ $t('menu.spaces.lastVisitedSpaces') }}
         </v-list-item-content>
-        <v-list-item-action v-if="toggleArrow" class="my-0">
+        <v-list-item-action v-if="toggleArrow" class="my-0 d-flex flex-row align-center">
+          <v-btn icon @click="leftNavigationActionEvent('addNewSpace')">
+            <v-icon class="me-0 pa-2 icon-default-color clickable" small>
+              fa-plus
+            </v-icon>
+          </v-btn>
           <v-btn icon @click="openOrCloseDrawer()">
             <v-icon class="me-0 pa-2 icon-default-color clickable" small>
               {{ arrowIconClass }} 
@@ -62,7 +67,8 @@ export default {
       secondLevelVueInstance: null,
       secondeLevel: false,
       showItemActions: false,
-      arrowIcon: 'fa-arrow-right'
+      arrowIcon: 'fa-arrow-right',
+      allSpacesLink: `${eXo.env.portal.context}/${ eXo.env.portal.portalName }/all-spaces?createSpace=true`,
     };
   },
   computed: {
@@ -154,7 +160,11 @@ export default {
           this.$emit('close-second-level');
         }
       }
-    }
+    },
+    leftNavigationActionEvent(clickedItem) {
+      document.dispatchEvent(new CustomEvent('space-left-navigation-action', {detail: clickedItem} ));
+      window.location.href  = this.allSpacesLink;
+    },
   },
 };
 </script>


### PR DESCRIPTION
This change allows to put the add space icon in the recent recent space menu item instead of the recent space panel in the second level of the left navigation menu.