### PR TITLE
feat: Space stream activities topbar UI for mobile - MEED-242

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -1,5 +1,30 @@
 <template>
-  <v-list-item>
+  <v-list-item v-if="isSpaceStream">
+    <exo-user-avatar
+      :identity="posterIdentity"
+      :size="42"
+      avatar />
+    <v-list-item-content class="py-0 accountTitleLabel ms-2">
+      <v-list-item-title class="font-weight-bold d-flex body-2 mb-0">
+        <exo-user-avatar
+          :identity="posterIdentity"
+          :extra-class="'me-5'"
+          fullname
+          bold-title
+          link-style
+          username-class />
+      </v-list-item-title>
+      <v-list-item-subtitle>
+        <activity-head-time
+          :activity="activity"
+          :is-activity-shared="isActivityShared"
+          is-mobile
+          no-icon
+          class="d-flex activity-head-time mt-1 ms-n1" />
+      </v-list-item-subtitle>
+    </v-list-item-content>
+  </v-list-item>
+  <v-list-item v-else>
     <exo-space-avatar
       :space="space"
       :size="42"
@@ -58,5 +83,11 @@ export default {
       default: null,
     }
   },
+  computed: {
+    isSpaceStream() {
+      return eXo.env.portal.spaceId !== '';
+    },
+  },
+
 };
 </script>


### PR DESCRIPTION
after this change, When  browsing a space activity stream
The activities should be adjusted so we only see username. No need to have the space name reminded since we are browsing the space itself