### PR TITLE
fix: Space administrator still a space member when he deletes his own space membership from group management - EXO-58785 - Meeds-io/meeds#310

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
@@ -16,22 +16,24 @@
  */
 package org.exoplatform.social.core.listeners;
 
+import java.util.List;
+
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.config.UserACL;
-import org.exoplatform.services.organization.*;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.MembershipEventListener;
+import org.exoplatform.services.organization.MembershipTypeHandler;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
 import org.exoplatform.services.security.ConversationState;
-import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.model.Profile;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
-import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.social.core.space.SpaceUtils;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
-
-import java.util.List;
 
 /**
  * SocialMembershipListenerImpl is registered to OrganizationService to handle membership operation associated
@@ -53,7 +55,6 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
   @Override
   public void postDelete(Membership m) throws Exception {
     if (m.getGroupId().startsWith(SpaceUtils.SPACE_GROUP)) {
-      OrganizationService orgService = CommonsUtils.getService(OrganizationService.class);
       UserACL acl =  CommonsUtils.getService(UserACL.class);
       
       //only handles these memberships have types likes 'manager' 
@@ -65,17 +66,30 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
         if(state != null && state.getIdentity() != null && space.getEditor() == null) {
           space.setEditor(state.getIdentity().getUserId());
         }
-        boolean hasAllMembership = SpaceUtils.isUserHasMembershipTypesInGroup(m.getUserName(), m.getGroupId(), MembershipTypeHandler.ANY_MEMBERSHIP_TYPE);
-        boolean hasManagerMembership = hasAllMembership || SpaceUtils.isUserHasMembershipTypesInGroup(m.getUserName(), m.getGroupId(), acl.getAdminMSType());
-        boolean hasMemberMembership = hasManagerMembership || SpaceUtils.isUserHasMembershipTypesInGroup(m.getUserName(), m.getGroupId(), SpaceUtils.MEMBER);
-
+        IdentityRegistry identityRegistry = CommonsUtils.getService(IdentityRegistry.class);
+        Identity deletedMembershipIdentity = identityRegistry.getIdentity(m.getUserName());
+        OrganizationService orgService = CommonsUtils.getService(OrganizationService.class);
+        boolean hasManagerMembership =
+                                     deletedMembershipIdentity != null ? deletedMembershipIdentity.isMemberOf(m.getGroupId(),
+                                                                                                              acl.getAdminMSType())
+                                                                       : orgService.getMembershipHandler()
+                                                                                   .findMembershipByUserGroupAndType(m.getUserName(),
+                                                                                                                     m.getGroupId(),
+                                                                                                                     acl.getAdminMSType()) != null;
+        boolean hasMemberMembership =
+                                    deletedMembershipIdentity != null ? deletedMembershipIdentity.isMemberOf(m.getGroupId(),
+                                                                                                             SpaceUtils.MEMBER)
+                                                                      : orgService.getMembershipHandler()
+                                                                                  .findMembershipByUserGroupAndType(m.getUserName(),
+                                                                                                                    m.getGroupId(),
+                                                                                                                    SpaceUtils.MEMBER) != null;
         if (!hasManagerMembership) {
           spaceService.setManager(space, m.getUserName(), false);
         }
         if (!hasMemberMembership) {
           spaceService.removeMember(space, m.getUserName());
         }
-
+  
         SpaceUtils.refreshNavigation();
       }
     }

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
@@ -85,6 +85,7 @@
       <name>social.update.membership.event.listener</name>
       <set-method>addListenerPlugin</set-method>
       <type>org.exoplatform.social.core.listeners.SocialMembershipListenerImpl</type>
+      <priority>50</priority>
     </component-plugin>
     <component-plugin>
       <name>social.update.profile.event.listener</name>


### PR DESCRIPTION

Prior to this change, a spaces administrator still a space member even if deletes the corresponding space membership from group management. This is caused by SpaceUtils.isUserHasMembershipTypesInGroup method used to check if a user has a membership in a group which considers any spaces administrator a member of any space. After this commit, we will instead perform the check with Identity.isMemberOf method which will enhance performances.