### PR TITLE
fix: Add unique Identifier for Activity Composer Button - MEED-686

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -16,6 +16,7 @@
 -->
 <template>
   <exo-drawer
+    id="activityComposerDrawer"
     ref="activityComposerDrawer"
     v-model="drawer"
     disable-pull-to-refresh
@@ -63,6 +64,7 @@
       <div class="d-flex">
         <v-spacer />
         <v-btn
+          id="activityComposerPostButton"
           :disabled="postDisabled"
           :loading="loading"
           :aria-label="$t(`activity.composer.${composerAction}`)"


### PR DESCRIPTION
Prior to this change, there is a collision between post button in Poll Drawer and Activity Composer drawer that was fixed by using labels. Unfortunately, the automatic tests will be dependant from user's language and from Crowdin translation which should be improved. This change will add ids on Activity Composer drawer and post button to simplify identifying the post button in UI for better stability for automatic UI Tests.