### PR TITLE
feat: Space stream activities topbar UI for mobile - MEED-242 (#1825)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -1,5 +1,30 @@
 <template>
-  <v-list-item  class="text-truncate">
+  <v-list-item v-if="displayUserAvatar" class="text-truncate">
+    <exo-user-avatar
+      :identity="posterIdentity"
+      :size="42"
+      avatar />
+    <v-list-item-content class="py-0 accountTitleLabel ms-2">
+      <v-list-item-title class="font-weight-bold d-flex body-2 mb-0">
+        <exo-user-avatar
+          :identity="posterIdentity"
+          extra-class="me-5 text-truncate"
+          fullname
+          bold-title
+          link-style
+          username-class />
+      </v-list-item-title>
+      <v-list-item-subtitle>
+        <activity-head-time
+          :activity="activity"
+          :is-activity-shared="isActivityShared"
+          is-mobile
+          no-icon
+          class="d-flex activity-head-time" />
+      </v-list-item-subtitle>
+    </v-list-item-content>
+  </v-list-item>
+  <v-list-item v-else class="text-truncate">
     <exo-space-avatar
       :space="space"
       extra-class="text-truncate"
@@ -22,12 +47,13 @@
       </v-list-item-title>
       <v-list-item-subtitle>
         <v-row class="ms-2 text-truncate">
-          <v-col class="px-0 py-0 text-truncate" cols="9">
+          <v-col class="px-0 py-0 text-truncate" cols="7">
             <exo-user-avatar
               :identity="posterIdentity"
               extra-class="text-truncate"
               fullname
               link-style
+              smallFontSize
               username-class />
           </v-col>
           <v-col class="px-0 py-0 subTitle-2 align-center" cols="3">
@@ -36,7 +62,7 @@
               :is-activity-shared="isActivityShared"
               is-mobile
               no-icon
-              class="activity-head-time pt-0 ps-0" />
+              class="text-caption activity-head-time pt-0 ps-0" />
           </v-col>
         </v-row>
       </v-list-item-subtitle>
@@ -64,5 +90,11 @@ export default {
       default: null,
     }
   },
+  computed: {
+    displayUserAvatar() {
+      return eXo.env.portal.spaceId !== '' || !this.space;
+    },
+  },
+
 };
 </script>


### PR DESCRIPTION
after this change, When browsing a space activity stream The activities should be adjusted so we only see the username. No need to have the space name reminded since we are browsing the space itself
