### PR TITLE
feat: Add a reusable common version history drawer component - EXO-59522 - Meeds-io/MIPs#19

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -593,3 +593,13 @@ UITopBarFavoritesPortlet.label.space=Space
 UITopBarFavoritesPortlet.label.seeAll=See all
 UITopBarFavoritesPortlet.label.iconTooltip=Check your recent favorites
 UITopBarFavoritesPortlet.label.NoFavorites=No favorites yet. Once you have added favorites (news, notes, documents, etc.), you will find these content there
+
+#####################################################################################
+#                              Version History Drawer                       #
+#####################################################################################
+versionHistory.label.title=Version history
+versionHistory.button.loadMore=Show more
+versionHistory.label.restore=restore
+versionHistory.label.empty=No version created yet!
+versionHistory.description.placeholder=write a summary here
+versionHistory.description.add=Click here to add a summary

--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1859,4 +1859,26 @@
       <module>vuetify</module>
     </depends>
   </module>
+
+  <module>
+    <name>versionHistoryDrawer</name>
+    <script>
+      <path>/js/versionHistoryDrawer.bundle.js</path>
+    </script>
+    <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>commonVueComponents</module>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+  </module>
 </gatein-resources>

--- a/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/components/VersionCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/components/VersionCard.vue
@@ -1,0 +1,226 @@
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2022 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <v-main>
+    <div
+      class="author-date-wrapper d-flex justify-space-between ">
+      <div class="version-author">
+        <span class="item-version border-radius primary px-2 font-weight-bold me-2 clickable">
+          V{{ versionObject.versionNumber }}
+        </span>
+        <span class="font-weight-bold text-truncate">{{ versionObject.authorFullName }}</span>
+      </div>
+      <div class="version-update-date">
+        <date-format
+          class="text-light-color text-truncate caption"
+          :value="versionDate"
+          :format="dateTimeFormat" />
+      </div>
+    </div>
+    <div class="description-restore-wrapper d-flex justify-space-between pt-2">
+      <br>
+      <div
+        v-if="enableEditDescription"
+        class="item-version-description">
+        <a
+          @click="showInput"
+          v-if="!versionObject.summary && descriptionInputHidden"
+          class="descriptionContent">
+          {{ $t('versionHistory.description.add') }}
+        </a>
+        <v-progress-circular
+          v-if="isUpdatingDescription"
+          :size="20"
+          color="primary"
+          indeterminate />
+        <v-tooltip
+          v-if="descriptionInputHidden"
+          bottom>
+          <template #activator="{ on, attrs }">
+            <p
+              v-bind="attrs"
+              v-on="on"
+              class="descriptionContent pa-0 text-truncate"
+              @click="showInput">
+              {{ versionObject.summary }}
+            </p>
+          </template>
+          <div
+            class="caption tooltip-version">
+            {{ versionObject.summary }}
+          </div>
+        </v-tooltip>
+        <v-text-field
+          ref="NewDescriptionInput"
+          v-show="!descriptionInputHidden && !isUpdatingDescription"
+          v-if="canManage"
+          v-model="newDescription"
+          :placeholder="$t('versionHistory.description.placeholder')"
+          class="description pa-0"
+          outlined
+          dense
+          autofocus
+          @keyup.enter="updateDescription">
+          <div slot="append" class="d-flex mt-1">
+            <v-icon
+              :class="descriptionMaxLengthReached && 'not-allowed' || 'clickable'"
+              :color="descriptionMaxLengthReached && 'grey--text' || 'primary'"
+              class="px-1"
+              small
+              @click="updateDescription">
+              fa-check
+            </v-icon>
+            <v-icon
+              class="clickable px-0"
+              color="red"
+              small
+              @click="resetInput">
+              fa-times
+            </v-icon>
+          </div>
+        </v-text-field>
+      </div>
+      <div
+        v-show="descriptionInputHidden"
+        v-if="!versionObject.current && canManage && !disableRestoreVersion"
+        class="item-version-restore">
+        <v-progress-circular
+          v-if="isRestoringVersion"
+          :size="20"
+          color="primary"
+          indeterminate />
+        <v-tooltip bottom>
+          <template #activator="{ on, attrs }">
+            <v-icon
+              v-if="!isRestoringVersion"
+              v-bind="attrs"
+              v-on="on"
+              size="22"
+              class="primary--text clickable pa-0 mt-1"
+              @click="restoreVersion">
+              mdi-restart
+            </v-icon>
+          </template>
+          <span class="caption">{{ $t('versionHistory.label.restore') }}</span>
+        </v-tooltip>
+      </div>
+    </div>
+  </v-main>
+</template>
+
+<script>
+export default {
+  props: {
+    version: {
+      type: Object,
+      default: () => {
+        return {};
+      }
+    },
+    enableEditDescription: {
+      type: Boolean,
+      default: () => {
+        return false;
+      },
+    },
+    disableRestoreVersion: {
+      type: Boolean,
+      default: () => {
+        return false;
+      },
+    },
+    canManage: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    }
+  },
+  data: () => ({
+    dateTimeFormat: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    },
+    MAX_DESCRIPTION_LENGTH: 500,
+    descriptionInputHidden: true,
+    newDescription: '',
+    versionObject: {},
+    isUpdatingDescription: false,
+    isRestoringVersion: false
+  }),
+  created() {
+    this.$root.$on('version-restored', (restoredVersion) => {
+      if (this.versionObject.id === restoredVersion.id) {
+        this.versionObject.current = true;
+      } else {
+        this.versionObject.current = false;
+      }
+      this.isRestoringVersion = false;
+    });
+    this.$root.$on('version-restore-error', () => {
+      this.isRestoringVersion = false;
+    });
+    this.$root.$on('version-description-updated', (version) => {
+      if (version.id === this.version.id) {
+        this.versionObject.summary = version.summary;
+        this.isUpdatingDescription = false;
+        this.descriptionInputHidden = true;
+      }
+    });
+    this.$root.$on('version-description-update-error', (version) => {
+      if (version.id === this.version.id) {
+        this.isUpdatingDescription = false;
+        this.descriptionInputHidden = false;
+      }
+    });
+    this.versionObject = Object.assign({}, this.version);
+  },
+  computed: {
+    versionDate() {
+      return this.versionObject && this.versionObject.updatedDate
+                                && this.versionObject.updatedDate.time
+                                || this.versionObject.createdDate.time;
+    },
+    descriptionMaxLengthReached() {
+      return this.newDescription && this.newDescription.length > this.MAX_DESCRIPTION_LENGTH;
+    },
+  },
+  methods: {
+    resetInput() {
+      this.descriptionInputHidden =  true;
+    },
+    updateDescription() {
+      if (this.descriptionMaxLengthReached) {
+        return;
+      }
+      this.isUpdatingDescription = true;
+      this.$emit('version-update-description', this.versionObject, this.newDescription);
+    },
+    showInput() {
+      this.newDescription = this.versionObject.summary;
+      this.descriptionInputHidden = !this.descriptionInputHidden;
+    },
+    restoreVersion() {
+      this.isRestoringVersion = true;
+      this.$emit('restore-version', this.versionObject);
+    }
+  }
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/components/VersionHistoryDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/components/VersionHistoryDrawer.vue
@@ -1,0 +1,145 @@
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2022 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <exo-drawer
+    @closed="closed"
+    ref="versionHistoryDrawer"
+    class="versionHistoryDrawer"
+    show-overlay
+    right>
+    <template slot="title">
+      {{ $t('versionHistory.label.title') }}
+    </template>
+    <template slot="content">
+      <div
+        v-if="isLoading"
+        class="text-center mt-5">
+        <v-progress-circular
+          indeterminate
+          color="primary" />
+      </div>
+      <div
+        v-if="!isLoading && versions.length === 0"
+        class="text-center mt-5">
+        <p class="grey--text darken-1">
+          {{ $t('versionHistory.label.empty') }}
+        </p>
+      </div>
+      <v-list
+        class="ma-3">
+        <v-list-item-group
+          active-class="bg-active">
+          <v-slide-y-transition group>
+            <v-list-item
+              v-for="(version,index) in versions"
+              :key="index"
+              :class="[version.current? 'current_version' : '']"
+              @click="openVersion($event, version)"
+              class="history-line pa-2 mb-2 border-color border-radius d-block">
+              <version-card
+                @version-update-description="updateVersionDescription"
+                @restore-version="restoreVersion"
+                :version="version"
+                :can-manage="canManage"
+                :disable-restore-version="disableRestoreVersion"
+                :enable-edit-description="enableEditDescription" />
+            </v-list-item>
+          </v-slide-y-transition>
+        </v-list-item-group>
+      </v-list>
+    </template>
+    <template slot="footer">
+      <div
+        v-if="showLoadMore"
+        class="d-flex mx-4">
+        <v-btn
+          @click="loadMore"
+          class="primary--text mx-auto"
+          text>
+          {{ $t('versionHistory.button.loadMore') }}
+        </v-btn>
+      </div>
+    </template>
+  </exo-drawer>
+</template>
+
+<script>
+
+export default {
+  props: {
+    versions: {
+      type: Array,
+      default: () => {
+        return [];
+      }
+    },
+    canManage: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    },
+    showLoadMore: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    },
+    isLoading: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    },
+    enableEditDescription: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    },
+    disableRestoreVersion: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    }
+  },
+  methods: {
+    open() {
+      this.$refs.versionHistoryDrawer.open();
+    },
+    closed() {
+      this.$emit('drawer-closed');
+    },
+    loadMore() {
+      this.$emit('load-more');
+    },
+    openVersion(event, version) {
+      if (event.target.tagName !== 'INPUT' && event.target.tagName !== 'BUTTON'
+          && !event.target.classList.contains('descriptionContent')) {
+        this.$emit('open-version', version);
+      }
+    },
+    updateVersionDescription(version, newDescription) {
+      this.$emit('version-update-description', version, newDescription);
+    },
+    restoreVersion(version) {
+      this.$emit('restore-version', version);
+    }
+  }
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/initComponents.js
@@ -1,0 +1,11 @@
+import VersionHistoryDrawer from './components/VersionHistoryDrawer.vue';
+import VersionCard from './components/VersionCard.vue';
+
+const components = {
+  'version-history-drawer': VersionHistoryDrawer,
+  'version-card': VersionCard,
+};
+
+for (const key in components) {
+  Vue.component(key, components[key]);
+}

--- a/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/main.js
@@ -1,0 +1,11 @@
+import './initComponents.js';
+
+// get overrided components if exists
+if (extensionRegistry) {
+  const components = extensionRegistry.loadComponents('VersionHistoryDrawer');
+  if (components && components.length > 0) {
+    components.forEach(cmp => {
+      Vue.component(cmp.componentName, cmp.componentOptions);
+    });
+  }
+}

--- a/webapp/portlet/webpack.common.js
+++ b/webapp/portlet/webpack.common.js
@@ -67,6 +67,7 @@ let config = {
     spaceBannerLogoPopover: './src/main/webapp/vue-apps/space-top-bannerlogo/main.js',
     topBarFavorites: './src/main/webapp/vue-apps/favorites-list-top-bar/main.js',
     popover: './src/main/webapp/vue-apps/popover/main.js',
+    versionHistoryDrawer: './src/main/webapp/vue-apps/version-history-drawer/main.js'
   },
   module: {
     rules: [


### PR DESCRIPTION
Add a reusable common version history drawer component in social commons in order to be able to use it inside addons such as notes and documents and to eliminate the redundant.