### PR TITLE
feat: Inverse Spaces and People navigations in Sites - MEED-514 - Meeds-io/MIPs#16

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/social-portal-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/social-portal-configuration.xml
@@ -192,7 +192,7 @@
               <boolean>${exo.social.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.social.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.social.portalConfig.metadata.importmode:merge}</string>
             </field>
           </object>
         </object-param>


### PR DESCRIPTION
This change will display People navigation before Spaces by using 'merge' importMode in navigation to apply it on existing sites. This commit has to be coupled with the commit https://github.com/Meeds-io/social/pull/1835/commits/78421e56cc3203de8593fdc3903a9993b460f057 to work.