### PR TITLE
feat: Inverse Spaces and People navigations in Sites - MEED-514 - Meeds-io/MIPs#16

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/portal/global/navigation.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/portal/global/navigation.xml
@@ -32,15 +32,15 @@
     </node>
 
     <node>
-      <name>spaces</name>
-      <label>#{portal.global.spaces}</label>
-      <page-reference>portal::global::all-spaces</page-reference>
-    </node>
-
-    <node>
       <name>people</name>
       <label>#{portal.global.people}</label>
       <page-reference>portal::global::all-people</page-reference>
+    </node>
+
+    <node>
+      <name>spaces</name>
+      <label>#{portal.global.spaces}</label>
+      <page-reference>portal::global::all-spaces</page-reference>
     </node>
 
     <node>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/social-portal-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/social-portal-configuration.xml
@@ -192,7 +192,7 @@
               <boolean>${exo.social.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.social.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.social.portalConfig.metadata.importmode:merge}</string>
             </field>
           </object>
         </object-param>


### PR DESCRIPTION
This change will display People navigation before Spaces by using 'merge' importMode in navigation to apply it on existing sites.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
