### PR TITLE
feat: left menu review Space details panel - Tooltips for actions - MEED-760 - Meeds-io/MIPs#16

### DIFF
--- a/extension/war/src/main/resources/locale/portal/HamburgerMenu_en.properties
+++ b/extension/war/src/main/resources/locale/portal/HamburgerMenu_en.properties
@@ -3,6 +3,7 @@ menu.spaces.recentSpaces=Filter spaces here
 menu.spaces.createSpace=Create space
 menu.spaces.showMore=Show more
 menu.spaces.makeAsHomePage=Make it your home page
+menu.spaces.unreadActivities=Coming soon: Mark activities as read
 menu.spaces.openInNewTab=Open in new tab
 menu.confirmation.title.changeHome=Change site home link ?
 menu.confirmation.message.changeHome=Would you like to change home link of current site to {0} ?

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
@@ -74,23 +74,38 @@
     </v-flex>
     <v-flex>
       <v-list-item-action class="my-0 py-3 d-flex flex-row align-center justify-space-around me-0">
-        <v-btn
-          v-if="homeLink !== url"
-          link
-          icon 
-          @click="selectHome()">
-          <v-icon class="me-0 pa-2 icon-default-color" small>
-            fa-house-user
-          </v-icon>
-        </v-btn>
-        <v-btn
-          icon 
-          disabled
-          @click="leftNavigationActionEvent('openInNewTab')">
-          <v-icon class="me-0 pa-2 icon-default-color" small>
-            fa-envelope-open-text
-          </v-icon>
-        </v-btn>
+        <v-tooltip bottom>
+          <template #activator="{ on, attrs }">
+            <v-btn
+              v-bind="attrs" 
+              v-on="on" 
+              link
+              icon 
+              @click="selectHome()">
+              <v-icon class="me-0 pa-2 icon-default-color" small>
+                fa-house-user
+              </v-icon>
+            </v-btn>
+          </template>
+          <span>
+            {{ $t('menu.spaces.makeAsHomePage') }}
+          </span>
+        </v-tooltip>
+        <v-tooltip bottom>
+          <template #activator="{ on, attrs }">
+            <v-btn
+              v-bind="attrs" 
+              v-on="on" 
+              icon>
+              <v-icon class="me-0 pa-2 disabled--text not-clickable" small>
+                fa-envelope-open-text
+              </v-icon>
+            </v-btn>
+          </template>
+          <span>
+            {{ $t('menu.spaces.unreadActivities') }}
+          </span>
+        </v-tooltip>
         <exo-space-favorite-action
           v-if="favoriteActionEnabled"
           :is-favorite="isFavorite"


### PR DESCRIPTION
Add tooltip for mark as home page and for unread activities actions in the space detail panel (in the left navigation menu)