### PR TITLE
fix: When commenting, placeholder should disappear - MEED-711 - meeds-io/meeds#1234

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -112,6 +112,9 @@ export default {
   },
   watch: {
     inputVal(val) {
+      if (val!== '') {
+        this.displayPlaceholder = false;
+      }
       if (this.editorReady) {
         if (val!== '') {
           if (this.displayPlaceholder) {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -112,11 +112,11 @@ export default {
   },
   watch: {
     inputVal(val) {
-      if (val!== '') {
+      if (val !== '') {
         this.displayPlaceholder = false;
       }
       if (this.editorReady) {
-        if (val!== '') {
+        if (val !== '') {
           if (this.displayPlaceholder) {
             this.displayPlaceholder = false;
           }


### PR DESCRIPTION
Before this change, When creating a comment and close the drawer without click on the comment button and then reopen the drawer, the comment text still displayed with the placeholder at the same time.
This change allows to remove the placeholder when the editor isn't empty.