### PR TITLE
fix: Factorize CKEditor Placeholder computing for better stability -MEED-711

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -3,7 +3,7 @@
     <div
       v-if="displayPlaceholder"
       @click="setFocus"
-      class="caption text-sub-title position-absolute pa-5 ma-1px full-width">
+      class="caption text-sub-title position-absolute t-0 pa-5 ma-1px full-width">
       {{ placeholder }}
     </div>
     <textarea


### PR DESCRIPTION
Before this change, When creating a comment and close the drawer without  click on the comment button and then reopen the drawer, the comment text still displayed with the placeholder at the same time.
This change allows to remove the placeholder when the editor isn't empty.