### PR TITLE
fix : Activity Stream some pre-fetched REST URLs aren't used in page - MEED-645 - Meeds-io/meeds#33

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
@@ -1,7 +1,7 @@
 export default {
   // Attention!!! when changing this, the list of preloaded
   // URLs has to change in JSP as well
-  FULL_ACTIVITY_IDS_EXPAND: 'ids,identity,likes,shared,commentsPreview,subComments',
+  FULL_ACTIVITY_IDS_EXPAND: 'ids,identity,likes,shared,commentsPreview,subComments,favorite',
   FULL_ACTIVITY_EXPAND: 'identity,likes,shared,commentsPreview,subComments,favorite',
   ACTIVITY_EXPAND: 'identity,likes,shared',
   FULL_COMMENT_EXPAND: 'identity,likes,subComments',

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
@@ -1,23 +1,23 @@
 export function getActivities(spaceId, streamType, limit, expand) {
-  let params = {};
+  const formData = new FormData();
 
   if (spaceId) {
-    params.spaceId = spaceId;
+    formData.append('spaceId', spaceId);
   }
 
   if (limit && limit > 0) {
-    params.limit = limit;
+    formData.append('limit', limit);
   }
 
   if (expand) {
-    params.expand = expand;
+    formData.append('expand', expand);
   }
 
   if (streamType) {
-    params.streamType = streamType.toUpperCase();
+    formData.append('streamType', streamType);
   }
 
-  params = $.param(params, true);
+  const params = decodeURIComponent(new URLSearchParams(formData).toString());
 
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/activities?${params}`, {
     method: 'GET',


### PR DESCRIPTION
Prior to change some social activities URLs are prefetched while it's not used immediately in page rendering phase
this change is going to inhance performance by prefetch only necessary URLs used for the first rendering of the page