### PR TITLE
feat: Bookmark spaces as favorite Topbar space popover MEED-751- Meeds-io/MIPs#3

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/bannerLogo.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/bannerLogo.jsp
@@ -1,4 +1,10 @@
 <%@ page import="org.exoplatform.social.core.space.model.Space"%>
+<%@page import="org.exoplatform.social.core.space.spi.SpaceService"%>
+<%@ page import="org.exoplatform.container.ExoContainerContext"%>
+<%@page import="org.exoplatform.services.security.ConversationState"%>
+<%@ page import="org.exoplatform.social.metadata.favorite.FavoriteService"%>
+<%@ page import="org.exoplatform.social.metadata.favorite.model.Favorite"%>
+<%@ page import="org.exoplatform.social.core.identity.model.Identity"%>
 <%@ page import="org.exoplatform.social.core.space.SpaceUtils"%>
 <%@ page import="org.exoplatform.portal.config.UserPortalConfigService"%>
 <%@ page import="org.exoplatform.portal.application.PortalRequestContext"%>
@@ -15,6 +21,7 @@
 <%@ page import="org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider" %>
 <%@ page import="java.util.Optional" %>
 <%
+  String spaceId = null;
   String logoPath = null;
   String logoTitle = null;
   String portalPath = null;
@@ -23,6 +30,8 @@
   String imageClass = "";
   String homePath= "";
   int membersNumber= 0;
+  boolean isFavorite= false;
+  boolean isMember =false;
   List<Profile> managers = new ArrayList<>();
   String spaceDescription= "";
   Space space = SpaceUtils.getSpaceByContext();
@@ -44,6 +53,13 @@
     }
     titleClass = "company";
   } else {
+    FavoriteService favoriteService = ExoContainerContext.getService(FavoriteService.class);
+    String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
+    Identity userIdentity = identityManager.getOrCreateUserIdentity(authenticatedUser);
+    spaceId = space.getId();
+    SpaceService spaceService = ExoContainerContext.getService(SpaceService.class);
+    isMember = spaceService.isMember(space, authenticatedUser);
+    isFavorite = favoriteService.isFavorite(new Favorite(space.DEFAULT_SPACE_METADATA_OBJECT_TYPE, space.getId(), null, Long.parseLong(userIdentity.getId())));
     logoPath = space.getAvatarUrl();
     logoTitle = space.getDisplayName();
     String permanentSpaceName = space.getGroupId().split("/")[2];
@@ -71,6 +87,9 @@
   });
   <%} %>
   let params = {
+    id: `<%=spaceId%>`,
+    isFavorite: `<%=isFavorite%>`,
+    isMember: `<%=isMember%>`,
     logoPath: `<%=logoPath%>`,
     portalPath: `<%=portalPath%>`,
     logoTitle: `<%=logoTitle%>`,
@@ -108,7 +127,6 @@
           </a>
           <% } else { %>
           <div app-data="true" id="SpaceTopBannerLogo">
-            <v-cacheable-dom-app cache-id="SpaceTopBannerLogo"></v-cacheable-dom-app>
             <script type="text/javascript">
               require(["SHARED/spaceBannerLogoPopover"], app => app.init(params));
             </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
@@ -21,16 +21,16 @@
   </transition>
   <transition v-else>
     <activity-stream-activity
-        v-show="!activityDeleted"
-        :key="activity.id"
-        :activity="activity"
-        :activity-types="activityTypes"
-        :activity-actions="activityActions"
-        :comment-types="commentTypes"
-        :comment-actions="commentActions"
-        :is-activity-detail="isActivityDetail"
-        class="mb-6 contentBox"
-        @loaded="$emit('loaded')" />
+      v-show="!activityDeleted"
+      :key="activity.id"
+      :activity="activity"
+      :activity-types="activityTypes"
+      :activity-actions="activityActions"
+      :comment-types="commentTypes"
+      :comment-actions="commentActions"
+      :is-activity-detail="isActivityDetail"
+      class="mb-6 contentBox"
+      @loaded="$emit('loaded')" />
   </transition>
 </template>
 

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
@@ -87,10 +87,10 @@ export default {
       }
     },
     overlayStyle(){
-      if (this.avatarOverlayPosition) {
+      if (!this.avatarOverlayPosition) {
         return `right: ${this.iconSize + 4}px !important`;
       } 
-      return 'right: 4px !important';
+      return 'right: 0px !important';
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
@@ -42,6 +42,10 @@ export default {
       type: String,
       default: null,
     },
+    entityType: {
+      type: String,
+      default: null,
+    },
     id: {
       type: String,
       default: null,
@@ -143,6 +147,7 @@ export default {
                 typeLabel: this.typeLabel,
                 id: this.id,
                 spaceId: this.spaceId,
+                entityType: this.entityType,
               }
             }));
             this.isFavorite = false;
@@ -160,6 +165,7 @@ export default {
                 typeLabel: this.typeLabel,
                 id: this.id,
                 spaceId: this.spaceId,
+                entityType: this.entityType,
               }
             }));
             this.isFavorite = true;

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/SpacePopoverContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/SpacePopoverContent.vue
@@ -52,7 +52,8 @@
       <exo-space-favorite-action
         v-if="favoriteActionEnabled"
         :key="space.id"
-        :space="space" />
+        :is-favorite="space.isFavorite"
+        :space-id="space.id" />
       <extension-registry-components
         :params="params"
         class="d-flex"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -89,7 +89,7 @@
                       max="3"
                       retrieve-extra-information
                       avatar-overlay-position
-                      @open-detail="$root.$emit('displaySpaceHosts', mangersToDisplay)" />
+                      @open-detail="openDetails()" />
                   </v-col>
                 </v-row>
               </v-container>
@@ -107,7 +107,8 @@
                   :href="homePath"
                   color="primary"
                   text
-                  class="pa-0 pe-2">
+                  class="pa-0 pe-2"
+                  @click="popoverActionEvent('backToHome')">
                   <v-icon
                     dense
                     right
@@ -122,7 +123,8 @@
               <exo-space-favorite-action
                 v-if="favoriteActionEnabled"
                 :is-favorite="isFavorite"
-                :space-id="spaceId" />
+                :space-id="spaceId"
+                entity-type="SPACE_TOP_BAR_TIPTIP" />
               <extension-registry-components
                 :params="params"
                 name="SpacePopover"
@@ -217,5 +219,14 @@ export default {
       };
     },
   },
+  methods: {
+    popoverActionEvent(clickedItem) {
+      document.dispatchEvent(new CustomEvent('space-topbar-popover-action', {detail: clickedItem} ));
+    },
+    openDetails() {
+      this.$root.$emit('displaySpaceHosts', this.mangersToDisplay);
+      this.popoverActionEvent('displaySpaceHosts');
+    }
+  }
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -5,6 +5,7 @@
       elevation="2"
       v-model="menu"
       open-on-hover
+      transition="slide-x-transition"
       :close-on-content-click="false"
       :nudge-width="200"
       max-width="350"
@@ -36,15 +37,16 @@
       </template>
       <v-card elevation="2">
         <v-list class="pa-0">
-          <v-list-item>
+          <v-list-item class="pt-3">
             <v-list-item-avatar
+              class="spaceAvatar mt-0 align-self-start"
               width="60"
               height="60">
               <v-img
                 class="object-fit-cover"
                 :src="logoPath" />
             </v-list-item-avatar>
-            <v-list-item-content class="pb-0">
+            <v-list-item-content class="pb-0 pt-0">
               <v-list-item-title>
                 <v-tooltip bottom>
                   <template #activator="{ on, attrs }">
@@ -61,35 +63,33 @@
               <v-list-item-subtitle>
                 {{ membersNumber }} {{ $t('space.logo.banner.popover.members') }}
               </v-list-item-subtitle>
-              <p class="text-truncate-3 text-caption text--primary font-weight-medium">
+              <p class="text-truncate-2 text-caption text--primary font-weight-medium">
                 {{ spaceDescription }}
               </p>
             </v-list-item-content>
           </v-list-item>
         </v-list>
-        <v-divider />
         <v-list class="pa-0 mt-0 mb-0">
           <v-list-item class="pt-0 pb-0">
             <v-list-item-content>
               <v-container class="pa-0">
-                <v-row no-gutters>
+                <v-row no-gutters class="align-center">
                   <v-col
                     cols="6"
-                    class="pt-1 body-2 grey--text text-truncate text--darken-1"
-                    justify="center">
+                    class="body-2 grey--text text-truncate text--darken-1 text-left">
                     {{ $t('space.logo.banner.popover.managers') }}
                   </v-col>
                   <v-col
                     cols="6"
-                    justify="center"
-                    class="d-flex flex-nowrap pa-0">
+                    class="d-flex flex-nowrap justify-end pa-0">
                     <exo-user-avatars-list
                       :users="mangersToDisplay"
                       :icon-size="30"
                       :popover="false"
-                      max="4"
+                      max="3"
                       retrieve-extra-information
-                      avatar-overlay-position />
+                      avatar-overlay-position
+                      @open-detail="$root.$emit('displaySpaceHosts', mangersToDisplay)" />
                   </v-col>
                 </v-row>
               </v-container>
@@ -101,7 +101,7 @@
           class="pa-0 mt-0 mb-0">
           <v-list-item
             class="pt-0 pb-0">
-            <v-list-item-content>
+            <v-list-item-content class="py-1">
               <v-list-item-title>
                 <v-btn
                   :href="homePath"
@@ -111,7 +111,7 @@
                   <v-icon
                     dense
                     right
-                    class="me-1">
+                    class="me-1 ms-0">
                     mdi-home
                   </v-icon>
                   <span class="text-caption pt-1">{{ $t('space.logo.banner.popover.home') }}</span>
@@ -132,6 +132,7 @@
         </v-list>
       </v-card>
     </v-menu>
+    <space-hosts-drawer />
   </v-app>
 </template>
 
@@ -182,9 +183,6 @@ export default {
     },
   },
   computed: {
-    KeepDisplayManagers() {
-      return this.managers && this.managers.length <= this.sizeToDisplay;
-    },
     mangersToDisplay() {
       return this.managers;
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -119,6 +119,10 @@
               </v-list-item-title>
             </v-list-item-content>
             <v-list-item-action class="space-logo-popover flex-row">
+              <exo-space-favorite-action
+                v-if="favoriteActionEnabled"
+                :is-favorite="isFavorite"
+                :space-id="spaceId" />
               <extension-registry-components
                 :params="params"
                 name="SpacePopover"
@@ -181,10 +185,30 @@ export default {
         return null;
       },
     },
+    spaceId: {
+      type: String,
+      default: ''
+    },
+    isFavorite: {
+      type: Boolean,
+      default: false
+    },
+    isMember: {
+      type: Boolean,
+      default: false
+    },
+  },
+  data: () => {
+    return {
+      favoritesSpaceEnabled: eXo.env.portal.spaceFavoritesEnabled,
+    };
   },
   computed: {
     mangersToDisplay() {
       return this.managers;
+    },
+    favoriteActionEnabled() {
+      return this.isMember && this.favoritesSpaceEnabled;
     },
     params() {
       return {

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/SpaceHostsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/SpaceHostsDrawer.vue
@@ -1,0 +1,50 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <exo-drawer ref="managersDrawer" right>
+    <template slot="title">
+      {{ $t('spacesList.title.managers') }}
+    </template>
+    <template v-if="displaySpaceHosts" slot="content">
+      <v-layout column class="ma-3">
+        <exo-user-avatar
+          v-for="host in displaySpaceHosts"
+          :key="host.id"
+          :profile-id="host.userName"
+          :extra-class="'my-2'"
+          popover />
+      </v-layout>
+    </template>
+  </exo-drawer>
+</template>
+<script>
+export default {
+  data: () => ({
+    displaySpaceHosts: null,
+  }),
+  mounted() {
+    this.$root.$on('displaySpaceHosts', displaySpaceHosts => {
+      this.displaySpaceHosts = displaySpaceHosts;
+      this.$refs.managersDrawer.open();
+    });
+  }
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/initComponents.js
@@ -1,9 +1,12 @@
 import ExoSpaceLogoBanner from './components/ExoSpaceLogoBanner.vue';
 import SpacePopoverActionComponents from './components/SpacePopoverActionComponents.vue';
+import SpaceHostsDrawer from './components/SpaceHostsDrawer.vue';
+
 
 const components = {
   'exo-space-logo-banner': ExoSpaceLogoBanner,
-  'space-popover-action-component': SpacePopoverActionComponents
+  'space-popover-action-component': SpacePopoverActionComponents,
+  'space-hosts-drawer': SpaceHostsDrawer,
 };
 
 for (const key in components) {

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/main.js
@@ -21,6 +21,9 @@ export function init(params) {
     popover = Vue.createApp({
       data: function() {
         return {
+          spaceId: params.id,
+          isFavorite: params.isFavorite,
+          isMember: params.isMember,
           logoPath: params.logoPath,
           portalPath: params.portalPath,
           imageClass: params.imageClass,
@@ -34,7 +37,9 @@ export function init(params) {
       },
       template: `<exo-space-logo-banner
                     id="SpaceTopBannerLogo"
-                    v-cacheable
+                    :space-id="spaceId"
+                    :is-favorite="isFavorite"
+                    :is-member="isMember"
                     :logo-path="logoPath" 
                     :portal-path="portalPath"
                     :logo-title="logoTitle" 

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
@@ -25,7 +25,8 @@
       <v-spacer />
       <exo-space-favorite-action
         v-if="space.isMember && favoritesSpaceEnabled"
-        :space="space" />
+        :is-favorite="space.isFavorite"
+        :space-id="space.id" />
       <template v-if="canUseActionsMenu">
         <v-btn
           v-if="space.canEdit"

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFavoriteAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFavoriteAction.vue
@@ -8,6 +8,7 @@
     :right="right"
     type="space"
     type-label="space"
+    :entity-type="entityType"
     @removed="removed"
     @remove-error="removeError"
     @added="added"
@@ -25,6 +26,10 @@ export default {
     isFavorite: {
       type: Boolean,
       default: false,
+    },
+    entityType: {
+      type: String,
+      default: null,
     },
     absolute: {
       type: Boolean,

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFavoriteAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFavoriteAction.vue
@@ -2,7 +2,7 @@
   <favorite-button
     :id="spaceId"
     :space-id="spaceId"
-    :favorite="isFavorite"
+    :favorite="favorite"
     :absolute="absolute"
     :top="top"
     :right="right"
@@ -18,9 +18,13 @@
 <script>
 export default {
   props: {
-    space: {
-      type: Object,
-      default: null,
+    spaceId: {
+      type: String,
+      default: '',
+    },
+    isFavorite: {
+      type: Boolean,
+      default: false,
     },
     absolute: {
       type: Boolean,
@@ -36,21 +40,16 @@ export default {
     },
   },
   data: () => ({
-    isFavorite: false,
+    favorite: false
   }),
-  computed: {
-    spaceId() {
-      return this.space?.id;
-    },
-  },
   created() {
-    this.isFavorite = this.space?.isFavorite === 'true';
+    this.favorite = this.isFavorite === 'true';
   },
   methods: {
     removed() {
       this.displayAlert(this.$t('Favorite.tooltip.SuccessfullyDeletedFavorite', {0: this.$t('spaceList.alert.label')}));
       this.$emit('removed');
-      document.dispatchEvent(new CustomEvent('space-favorite-removed', {detail: this.space.id}));
+      document.dispatchEvent(new CustomEvent('space-favorite-removed', {detail: this.spaceId}));
     },
     removeError() {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorDeletingFavorite', {0: this.$t('spaceList.alert.label')}), 'error');
@@ -58,7 +57,7 @@ export default {
     added() {
       this.displayAlert(this.$t('Favorite.tooltip.SuccessfullyAddedAsFavorite', {0: this.$t('spaceList.alert.label')}));
       this.$emit('added');
-      document.dispatchEvent(new CustomEvent('space-favorite-added', {detail: this.space.id}));
+      document.dispatchEvent(new CustomEvent('space-favorite-added', {detail: this.spaceId}));
     },
     addError() {
       this.displayAlert(this.$t('Favorite.tooltip.ErrorAddingAsFavorite', {0: this.$t('spaceList.alert.label')}), 'error');


### PR DESCRIPTION
In this Task we try to unify the UI of the space topbar popover mention in the following points:

- Square space avatar with space name and number of members
- Description of the space (2 lines maximum then ellipsis)
- Space hosts list aligned to the right and sorted like it is in the verso of the space card (in spaces page): if more than 4 hosts, then a + XX is displayed on the last avatar (XX referring to the remaining hosts)