### PR TITLE
fix: Factorize CKEditor Placeholder computing for better stability -MEED-711

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -2,8 +2,8 @@
   <div class="activityRichEditor" :class="newEditorToolbarEnabled && 'newEditorToolbar' || ''">
     <div
       v-if="displayPlaceholder"
-      @click="hidePlaceholder()" 
-      class="caption text-sub-title position-absolute pa-5 ma-1px full-width">
+      @click="setFocus"
+      class="caption text-sub-title position-absolute t-0 pa-5 ma-1px full-width">
       {{ placeholder }}
     </div>
     <textarea
@@ -112,14 +112,8 @@ export default {
   },
   watch: {
     inputVal(val) {
+      this.computePlaceHolderVisibility();
       if (this.editorReady) {
-        if (val!== '') {
-          if (this.displayPlaceholder) {
-            this.displayPlaceholder = false;
-          }
-        } else {
-          this.displayPlaceholder = true;
-        }
         this.$emit('input', val);
       }
     },
@@ -128,6 +122,7 @@ export default {
     },
     editorReady() {
       if (this.editorReady) {
+        this.computePlaceHolderVisibility();
         this.$emit('ready');
       } else {
         this.$emit('unloaded');
@@ -159,16 +154,14 @@ export default {
       const storageMessage =  localStorage.getItem(`activity-message-${this.contextName}`);
       const storageMessageObject =  storageMessage && JSON.parse(storageMessage) || {};
       const storageMessageText = storageMessageObject?.url === eXo.env.server.portalBaseURL && storageMessageObject?.text || '';
-      this.initCKEditor(true,storageMessageText);
+      this.initCKEditor(true, storageMessageText);
+      this.$emit('input', this.inputVal);
     } else {
       this.initCKEditor(true, this.value);
     }
   },
   methods: {
     initCKEditor: function (reset, textValue) {
-      if (textValue?.length) {
-        this.displayPlaceholder = false;
-      }
       this.inputVal = this.replaceWithSuggesterClass(textValue);
       this.editor = CKEDITOR.instances[this.ckEditorType];
       if (this.editor && this.editor.destroy && !this.ckEditorType.includes('editActivity')) {
@@ -272,11 +265,6 @@ export default {
           requestCanceled: function () {
             self.cleanupOembed();
           },
-          blur: function (evt) {
-            if (evt.editor.getData() === '') {
-              self.displayPlaceholder = true;
-            }
-          },
           change: function (evt) {
             const newData = evt.editor.getData();
             self.inputVal = newData;
@@ -295,6 +283,9 @@ export default {
       if (this.editor) {
         this.editor.destroy(true);
       }
+    },
+    computePlaceHolderVisibility() {
+      this.displayPlaceholder = this.editor?.status === 'ready' && !this.inputVal && !this.inputVal.trim();
     },
     replaceWithSuggesterClass: function(message) {
       const tempdiv = $('<div class=\'temp\'/>').html(message || '');
@@ -392,10 +383,6 @@ export default {
         this.templateParams.registeredKeysForProcessor = '-';
       }
     },
-    hidePlaceholder() {
-      this.displayPlaceholder = false;
-      this.setFocus();
-    }
   }
 };
 </script>


### PR DESCRIPTION
Before this change, When creating a comment and close the drawer without click on the comment button and then reopen the drawer, the comment text still displayed with the placeholder at the same time. This change allows to remove the placeholder when the editor isn't empty.