### PR TITLE
fix: Adjust the display of icon filter and the space between time icon and text -MEED-793 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
@@ -4,7 +4,7 @@
     class="text-light-color">
     <v-icon
       v-if="!noIcon"
-      class="text-light-color"
+      class="text-light-color me-1"
       x-small>
       far fa-clock
     </v-icon>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilter.vue
@@ -29,6 +29,7 @@
     </select>
     <v-icon
       class="d-sm-none"
+      size="18"
       @click="openBottomMenuFilter">
       fa-filter
     </v-icon>


### PR DESCRIPTION
This change will fix:
- Size of filter icon in space activity stream
- Space between the time icon and the text in activity stream