### PR TITLE
fix : Activity Stream some pre-fetched REST URLs aren't used in page - MEED-645 - Meeds-io/meeds#33

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
@@ -21,7 +21,7 @@
   if (activityId != null) {
     activitiesLoadingURL = "/portal/rest/v1/social/activities/" + activityId + "?expand=identity,likes,shared,commentsPreview,subComments,favorite";
   } else if (space == null) {
-    activitiesLoadingURL = "/portal/rest/v1/social/activities?limit=" + initialLimit + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
+    activitiesLoadingURL = "/portal/rest/v1/social/activities?limit=" + initialLimit + "&streamType=ALL_STREAM" + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
   } else {
     activitiesLoadingURL = "/portal/rest/v1/social/activities?spaceId=" + space.getId() + "&limit=" + initialLimit + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
@@ -8,13 +8,13 @@ export function getActivities(spaceId, streamType, limit, expand) {
   if (limit && limit > 0) {
     formData.append('limit', limit);
   }
+  
+  if (streamType) {
+    formData.append('streamType', streamType.toUpperCase());
+  }
 
   if (expand) {
     formData.append('expand', expand);
-  }
-
-  if (streamType) {
-    formData.append('streamType', streamType.toUpperCase());
   }
 
   const params = decodeURIComponent(new URLSearchParams(formData).toString());


### PR DESCRIPTION
Prior to change some social activities URLs are prefetched while it's not used immediately in page rendering phase
this change is going to inhance performance by prefetch only necessary URLs used for the first rendering of the page