### PR TITLE
fix : Activity Stream some pre-fetched REST URLs aren't used in page - MEED-645 - Meeds-io/meeds#33

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
@@ -20,12 +20,13 @@
   long initialLimit = limitToDisplay * 2;
   String activitiesLoadingURL;
   boolean isStreamFilterEnabled = Boolean.parseBoolean(PropertyManager.getProperty("exo.feature.StreamFilter.enabled"));
+  String streamType = isStreamFilterEnabled ? "&streamType=ALL_STREAM" : "";
   if (activityId != null) {
     activitiesLoadingURL = "/portal/rest/v1/social/activities/" + activityId + "?expand=identity,likes,shared,commentsPreview,subComments,favorite";
   } else if (space == null) {
-    activitiesLoadingURL = "/portal/rest/v1/social/activities?limit=" + initialLimit + isStreamFilterEnabled ? "&streamType=ALL_STREAM" : ""  + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
+    activitiesLoadingURL = "/portal/rest/v1/social/activities?limit=" + initialLimit + streamType  + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
   } else {
-    activitiesLoadingURL = "/portal/rest/v1/social/activities?spaceId=" + space.getId() + "&limit=" + initialLimit + isStreamFilterEnabled ? "&streamType=ALL_STREAM" : "" + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
+    activitiesLoadingURL = "/portal/rest/v1/social/activities?spaceId=" + space.getId() + "&limit=" + initialLimit + streamType + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
   }
   responseWrapper.addHeader("Link", "<" + activitiesLoadingURL + ">; rel=preload; as=fetch; crossorigin=use-credentials", false);
 %>


### PR DESCRIPTION
Prior to change some social activities URLs are prefetched while it's not used immediately in page rendering phase
this change is going to inhance performance by prefetch only necessary URLs used for the first rendering of the page