### PR TITLE
fix: Pinned activities are displayed in the bottom of the space stream - MEED-841 - Meeds-io/meeds#345

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -90,7 +90,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
    */
   private Map<String, ActivityFileStoragePlugin> activityFileStorageByDSName = new HashMap<>();
 
-  private boolean                                pinActivityEnabled          = false;
+  private boolean                                pinActivityEnabled          = true;
 
   public RDBMSActivityStorageImpl(IdentityStorage identityStorage,
                                   SpaceStorage spaceStorage,


### PR DESCRIPTION
Prior this change pinned activities are not displayed in top stream when no property is defined