### PR TITLE
fix : Space activity stream preload  some pre-fetched REST URLs aren't used in page - MEED-645 - Meeds-io/meeds#33

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
@@ -26,7 +26,7 @@
   } else if (space == null) {
     activitiesLoadingURL = "/portal/rest/v1/social/activities?limit=" + initialLimit + streamType  + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
   } else {
-    activitiesLoadingURL = "/portal/rest/v1/social/activities?spaceId=" + space.getId() + "&limit=" + initialLimit + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
+    activitiesLoadingURL = "/portal/rest/v1/social/activities?spaceId=" + space.getId() + "&limit=" + initialLimit + streamType +"&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
   }
   responseWrapper.addHeader("Link", "<" + activitiesLoadingURL + ">; rel=preload; as=fetch; crossorigin=use-credentials", false);
 %>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -100,7 +100,10 @@ export default {
     },
     pinActivityEnabled() {
       return eXo.env.portal.PinActivityEnabled && this.spaceId && (this.streamFilter === null || this.streamFilter === 'all_stream') || false;
-    }
+    },
+    streamFilterProperty() {
+      return eXo.env.portal.StreamFilterEnabled ? 'all_stream' : null;
+    },
   },
   watch: {
     loading() {
@@ -115,7 +118,7 @@ export default {
     },
   },
   created() {
-    this.streamFilter = eXo.env.portal.StreamFilterEnabled && !this.spaceId && localStorage.getItem('activity-stream-stored-filter') || null;
+    this.streamFilter = eXo.env.portal.StreamFilterEnabled && !this.spaceId && localStorage.getItem('activity-stream-stored-filter') || this.streamFilterProperty;
     document.addEventListener('activity-favorite-removed', event => {
       const favoriteActivity = event && event.detail && event.detail;
       if (this.streamFilter === 'user_favorite_stream') {


### PR DESCRIPTION
Prior to change some social activities URLs are prefetched while it's not used immediately in page rendering phase
this change is going to inhance performance by prefetch only necessary URLs used for the first rendering of the page