### PR TITLE
feat: left menu review Space name, description and apps display in space details panel  MEED-791 - Meeds-io/MIPs#16

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
@@ -30,7 +30,7 @@
             :src="avatar" />
         </v-list-item-avatar>
         <v-list-item-content class="pb-0 pt-0">
-          <a :href="url()" class="font-weight-bold text-truncate-2 text-break-all primary--text mb-2">{{ spaceDisplayName }}</a>
+          <a :href="url" class="font-weight-bold text-truncate-2 text-break-all primary--text mb-2">{{ spaceDisplayName }}</a>
           <v-list-item-subtitle>
             {{ membersCount }} {{ $t('space.logo.banner.popover.members') }}
           </v-list-item-subtitle>
@@ -69,7 +69,7 @@
               @click="selectHome()">
               <v-icon 
                 class="me-0 pa-2" 
-                :class="url() === homeLink && 'primary--text' || 'icon-default-color'" 
+                :class="url === homeLink && 'primary--text' || 'icon-default-color'" 
                 small>
                 fa-house-user
               </v-icon>
@@ -190,6 +190,14 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
+    url() {
+      if (this.space && this.space.groupId) {
+        const uriPart = this.space.groupId.replace(/\//g, ':');
+        return `${eXo.env.portal.context}/g/${uriPart}/`;
+      } else {
+        return '#';
+      }
+    },
   },
   watch: {
     spaceId: {
@@ -213,7 +221,7 @@ export default {
         .then(resp => resp && resp.ok && resp.json())
         .then(data => {
           data.forEach(navigation => {
-            navigation.uri = `${this.url()}${navigation.uri}`;
+            navigation.uri = `${this.url}${navigation.uri}`;
           });
           this.spaceNavigations = data || [];
         });
@@ -241,14 +249,6 @@ export default {
     },
     closeMenu() {
       this.$emit('close-menu');
-    },
-    url() {
-      if (this.space && this.space.groupId) {
-        const uriPart = this.space.groupId.replace(/\//g, ':');
-        return `${eXo.env.portal.context}/g/${uriPart}/`;
-      } else {
-        return '#';
-      }
     },
     leftNavigationActionEvent(clickedItem) {
       document.dispatchEvent(new CustomEvent('space-left-navigation-action', {detail: clickedItem} ));

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
@@ -30,7 +30,7 @@
             :src="avatar" />
         </v-list-item-avatar>
         <v-list-item-content class="pb-0 pt-0">
-          <a :href="url" class="font-weight-bold text-truncate-2 text-break-all primary--text mb-2">{{ spaceDisplayName }}</a>
+          <a :href="spaceURL" class="font-weight-bold text-truncate-2 text-break-all primary--text mb-2">{{ spaceDisplayName }}</a>
           <v-list-item-subtitle>
             {{ membersCount }} {{ $t('space.logo.banner.popover.members') }}
           </v-list-item-subtitle>
@@ -69,7 +69,7 @@
               @click="selectHome()">
               <v-icon 
                 class="me-0 pa-2" 
-                :class="url === homeLink && 'primary--text' || 'icon-default-color'" 
+                :class="isHomeLink && 'primary--text' || 'icon-default-color'" 
                 small>
                 fa-house-user
               </v-icon>
@@ -178,6 +178,9 @@ export default {
     favoriteActionEnabled() {
       return this.favoritesSpaceEnabled;
     },
+    isHomeLink() {
+      return this.spaceURL === this.homeLink;
+    },
     params() {
       return {
         identityType: 'space',
@@ -190,7 +193,7 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
-    url() {
+    spaceURL() {
       if (this.space && this.space.groupId) {
         const uriPart = this.space.groupId.replace(/\//g, ':');
         return `${eXo.env.portal.context}/g/${uriPart}/`;
@@ -221,7 +224,7 @@ export default {
         .then(resp => resp && resp.ok && resp.json())
         .then(data => {
           data.forEach(navigation => {
-            navigation.uri = `${this.url}${navigation.uri}`;
+            navigation.uri = `${this.spaceURL}${navigation.uri}`;
           });
           this.spaceNavigations = data || [];
         });

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
@@ -30,17 +30,14 @@
             :src="avatar" />
         </v-list-item-avatar>
         <v-list-item-content class="pb-0 pt-0">
-          <p class="blue--text text--darken-3 font-weight-bold text-truncate-2 text-break-all">{{ spaceDisplayName }}</p>
+          <a :href="url()" class="font-weight-bold text-truncate-2 text-break-all primary--text mb-2">{{ spaceDisplayName }}</a>
           <v-list-item-subtitle>
             {{ membersCount }} {{ $t('space.logo.banner.popover.members') }}
           </v-list-item-subtitle>
-          <p v-if="!isMobile" class="text-truncate-4 text-caption text--primary font-weight-medium mb-0 mt-2 text-break-all">
-            {{ description }}
-          </p>
         </v-list-item-content>
       </v-list-item>
     </v-flex>
-    <p v-if="isMobile" class="text-truncate-4 text-caption text--primary font-weight-medium pt-3 px-4 text-break-all">
+    <p class="text-truncate-4 text-caption text--primary font-weight-medium pt-3 px-4 text-break-all">
       {{ description }}
     </p>
     <v-flex>
@@ -124,12 +121,12 @@
           v-for="navigation in spaceNavigations"
           :key="navigation.id"
           :href="navigation.uri">
-          <v-list-item-icon class="me-3 my-3 d-flex">
+          <v-list-item-icon class="me-3 py-3 my-0 d-flex">
             <i 
               aria-hidden="true" 
               :class="`${applicationIcon(navigation.icon)} icon-default-color icon-default-size`"> </i>
           </v-list-item-icon>
-          <v-list-item-content>
+          <v-list-item-content class="mt-n1">
             {{ navigation.label }}
           </v-list-item-content>
         </v-list-item>


### PR DESCRIPTION
In this PR we adjust some UI glitch in the space panel:

1. The space name should be with the primary color and should be clickable to access the first page of the space
2. The description should be displayed below the space avatar as it is used when using mobile view
3. Space apps must be aligned with the icons