### PR TITLE
feat: Fix missing data in the number of reaction per period in contents analytics report - EXO-60102 - Meeds-io/meeds

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -429,9 +429,8 @@ public class ActivityManagerImpl implements ActivityManager {
     // as a solution we pass them throw the activity's template params
     String[] previousMentions = StringUtils.isEmpty(commentId) ? new String[0] : getActivity(commentId).getMentionedIds();
     activityStorage.saveComment(existingActivity, comment);
-
     if (StringUtils.isEmpty(commentId)) {
-      activityLifeCycle.saveComment(comment);
+      activityLifeCycle.saveComment(existingActivity);
     } else {
       if (previousMentions.length > 0) {
         String mentions = String.join(",", previousMentions);
@@ -512,10 +511,11 @@ public class ActivityManagerImpl implements ActivityManager {
     existingActivity.setLikeIdentityIds(identityIds);
     //broadcast is false : we don't want to launch update listeners for a like
     updateActivity(existingActivity, false);
+    ExoSocialActivity updatedActivity = getActivity(existingActivity.getId());
     if(existingActivity.isComment()){
-      activityLifeCycle.likeComment(existingActivity);
+      activityLifeCycle.likeComment(updatedActivity);
     } else {
-      activityLifeCycle.likeActivity(existingActivity);
+      activityLifeCycle.likeActivity(updatedActivity);
     }
   }
 


### PR DESCRIPTION
Prior to this change, there was no data in the number of reactions per period in the content analysis report when we like or comment on a post.After these changes, the data in the number of reactions per period has been correctly added.