### PR TITLE
fix:  History version drawer is empty - EXO-60449

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/components/VersionHistoryDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/version-history-drawer/components/VersionHistoryDrawer.vue
@@ -29,8 +29,8 @@
           active-class="bg-active">
           <v-slide-y-transition group>
             <v-list-item
-              v-for="version in versions"
-              :key="version.id"
+              v-for="(version,index) in versions"
+              :key="index"
               :class="[version.current? 'current_version' : '']"
               @click="openVersion($event, version)"
               class="history-line pa-2 mb-2 border-color border-radius d-block">


### PR DESCRIPTION
…-60449

Prior to this fix, the drawer of version history for notes is empty