### PR TITLE
fix : Activity Stream some pre-fetched REST URLs aren't used in page - MEED-645 - Meeds-io/meeds#336

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/activityStream.jsp
@@ -9,19 +9,24 @@
 <%@page import="org.exoplatform.container.ExoContainerContext"%>
 <%@page import="org.exoplatform.commons.api.settings.ExoFeatureService"%>
 <%@page import="org.exoplatform.services.security.ConversationState"%>
+<%@page import="org.exoplatform.commons.utils.PropertyManager"%>
 <%
   PortalRequestContext rcontext = (PortalRequestContext) PortalRequestContext.getCurrentInstance();
   PortalHttpServletResponseWrapper responseWrapper = (PortalHttpServletResponseWrapper) rcontext.getResponse();
   List<String> activitiesListURL = new ArrayList<>();
   String activityId = rcontext.getRequest().getParameter("id");
+  Space space = SpaceUtils.getSpaceByContext();
   long limitToDisplay = 10;
   long initialLimit = limitToDisplay * 2;
   String activitiesLoadingURL;
-  if (activityId == null) {
-    Space space = SpaceUtils.getSpaceByContext();
-    activitiesLoadingURL = "/portal/rest/v1/social/activities?spaceId=" + (space == null ? "" : space.getId()) + "&limit=" + initialLimit + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
-  } else {
+  boolean isStreamFilterEnabled = Boolean.parseBoolean(PropertyManager.getProperty("exo.feature.StreamFilter.enabled"));
+  String streamType = isStreamFilterEnabled ? "&streamType=ALL_STREAM" : "";
+  if (activityId != null) {
     activitiesLoadingURL = "/portal/rest/v1/social/activities/" + activityId + "?expand=identity,likes,shared,commentsPreview,subComments,favorite";
+  } else if (space == null) {
+    activitiesLoadingURL = "/portal/rest/v1/social/activities?limit=" + initialLimit + streamType  + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
+  } else {
+    activitiesLoadingURL = "/portal/rest/v1/social/activities?spaceId=" + space.getId() + "&limit=" + initialLimit + "&expand=ids,identity,likes,shared,commentsPreview,subComments,favorite";
   }
   responseWrapper.addHeader("Link", "<" + activitiesLoadingURL + ">; rel=preload; as=fetch; crossorigin=use-credentials", false);
 %>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
@@ -1,7 +1,7 @@
 export default {
   // Attention!!! when changing this, the list of preloaded
   // URLs has to change in JSP as well
-  FULL_ACTIVITY_IDS_EXPAND: 'ids,identity,likes,shared,commentsPreview,subComments',
+  FULL_ACTIVITY_IDS_EXPAND: 'ids,identity,likes,shared,commentsPreview,subComments,favorite',
   FULL_ACTIVITY_EXPAND: 'identity,likes,shared,commentsPreview,subComments,favorite',
   ACTIVITY_EXPAND: 'identity,likes,shared',
   FULL_COMMENT_EXPAND: 'identity,likes,subComments',

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/ActivityService.js
@@ -1,23 +1,23 @@
 export function getActivities(spaceId, streamType, limit, expand) {
-  let params = {};
+  const formData = new FormData();
 
   if (spaceId) {
-    params.spaceId = spaceId;
+    formData.append('spaceId', spaceId);
   }
 
   if (limit && limit > 0) {
-    params.limit = limit;
+    formData.append('limit', limit);
+  }
+  
+  if (streamType) {
+    formData.append('streamType', streamType.toUpperCase());
   }
 
   if (expand) {
-    params.expand = expand;
+    formData.append('expand', expand);
   }
 
-  if (streamType) {
-    params.streamType = streamType.toUpperCase();
-  }
-
-  params = $.param(params, true);
+  const params = decodeURIComponent(new URLSearchParams(formData).toString());
 
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/activities?${params}`, {
     method: 'GET',


### PR DESCRIPTION
Prior to change some social activities URLs are prefetched while it's not used immediately in page rendering phase
this change is going to inhance performance by prefetch only necessary URLs used for the first rendering of the page

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
