### PR TITLE
fix : Hide digest mail notification from notification settings menu - EXO-54929 - Meeds-io/meeds#348

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -89,6 +89,10 @@
 <script>
 export default {
   props: {
+    allGroupsForAdmin: {
+      type: Boolean,
+      default: false,
+    },
     value: {
       type: Object,
       default: null,
@@ -374,6 +378,7 @@ export default {
               includeGroups: this.includeGroups,
               onlyRedactor: this.onlyRedactor,
               groupMember: this.groupMember,
+              allGroupsForAdmin: this.allGroupsForAdmin,
               groupType: this.groupType,
               noRedactorSpace: this.noRedactorSpace,
               onlyManager: this.onlyManager,

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
@@ -19,7 +19,7 @@ export function search(filter) {
   }
   if (filter.includeGroups) {
     filter.loadingCallback('group');
-    searchGroups(filter.term, filter.groupMember, filter.groupType, filter.items, filter.errorCallback)
+    searchGroups(filter.term, filter.groupMember, filter.groupType, filter.items, filter.allGroupsForAdmin, filter.errorCallback)
       .finally(() => filter.successCallback && filter.successCallback('group'));
   }
 }
@@ -57,11 +57,12 @@ function searchSpaces(filter, items, onlyRedactor, excludeRedactionalSpace, only
     });
 }
 
-function searchGroups(filter, groupMember, groupType, items, errorCallback) {
+function searchGroups(filter, groupMember, groupType, items, allGroupsForAdmin, errorCallback) {
   const formData = new FormData();
   formData.append('q', filter);
   formData.append('groupMember', groupMember);
   formData.append('groupType', groupType);
+  formData.append('allGroupsForAdmin', allGroupsForAdmin);
   const params = new URLSearchParams(formData).toString();
 
   return fetch(`/portal/rest/v1/groups/treeMembers?${params}`, { credentials: 'include' })

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationDrawer.vue
@@ -23,7 +23,7 @@
               class="mt-0" />
           </v-col>
         </v-row>
-        <template v-if="pluginOption.channelId === emailChannel">
+        <template v-if="pluginOption.channelId === emailChannel && digestMailNotificationEnabled">
           <v-row class="ma-0">
             <v-col>
               <label for="EMAIL_DIGEST" class="align-start">{{ $t('UINotification.label.selectBox-mail') }}</label>
@@ -85,7 +85,12 @@ export default {
     digest: null,
     emailChannel: null,
     listChannelOptions: [],
+    digestMailNotificationEnabled: false
   }),
+  created() {
+    this.$featureService.isFeatureEnabled('digestMailNotification')
+      .then(enabled => this.digestMailNotificationEnabled = enabled);
+  },
   computed: {
     digestOptions() {
       return this.settings && Object.keys(this.settings.digestLabels).map(digestLabel => ({

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -56,6 +56,15 @@ export default {
       default: null,
     },
   },
+  data (){
+    return {
+      digestMailNotificationEnabled: false,
+    };
+  },
+  created() {
+    this.$featureService.isFeatureEnabled('digestMailNotification')
+      .then(enabled => this.digestMailNotificationEnabled = enabled);
+  },
   computed: {
     label() {
       return this.settings && this.settings.pluginLabels && this.settings.pluginLabels[this.plugin.type];
@@ -67,7 +76,7 @@ export default {
       return this.hasInstantNotificationSettings || this.enabledDigest;
     },
     enabledDigest() {
-      return this.settings && this.settings.emailDigestChoices && this.settings.emailDigestChoices.find(choice => choice && choice.channelActive && choice.channelId === this.settings.emailChannel && choice.pluginId === this.plugin.type);
+      return this.digestMailNotificationEnabled ? this.settings && this.settings.emailDigestChoices && this.settings.emailDigestChoices.find(choice => choice && choice.channelActive && choice.channelId === this.settings.emailChannel && choice.pluginId === this.plugin.type) : [];
     },
     enabledDigestLabel() {
       return this.enabledDigest && this.settings.digestDescriptions && this.enabledDigest.value && this.enabledDigest.value !== 'Never' && this.settings.digestDescriptions[this.enabledDigest.value];


### PR DESCRIPTION

Prior to this change, many issues are related to digest email feature are reported and it needs to be fixed. Until re-worked this feature needs to be disabled.
After this change:

- For all users, we have hidden the digest mail notifications settings view and edit from manage notification settings with the FT flag exo.feature.digestMailNotifiaction which will be added and configured as false by default
- For old users having already enabled digestMailNotification settings, we have configured as following: "${exo.notification.NotificationDailyJob.expression:59 59 0,23 31 DEC ? 2099}" "${exo.notification.NotificationWeeklyJob.expression:59 59 0,23 31 DEC ? 2099}"
the default values of NotificationDailyJob and NotificationWeeklyJob expression properties with very distant period in order to guarantee that they will not receive digest mail notifications anymore despite their stored digestMailNotification settings as enabled (daily/weekly)