### PR TITLE
fix: Fix disappear of the text containing the character "% " when posting an activity - EXO-60468 - Meeds-io/meeds#369

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -342,9 +342,9 @@ export default {
           && this.templateParams.link
           && this.templateParams.default_title !== message) {
         this.templateParams.default_title = message;
-        const url = window.decodeURIComponent(this.templateParams.link);
-        this.templateParams.comment = window.decodeURIComponent(message)
-          .replace(`<oembed>${url}</oembed>`, '');
+        const url = window.encodeURIComponent(this.templateParams.link);
+        const codedMessage = window.encodeURIComponent(message.replace(`<oembed>${url}</oembed>`, ''));
+        this.templateParams.comment = window.decodeURIComponent(codedMessage);
       }
     },
     installOembed: function(embedResponse) {


### PR DESCRIPTION
Prior to this change, when we add a post, we paste a link with a preview and we paste a sentence containing "%" above the link. The sentence containing "%" disappears, the problem is that the sentence is a malformed URI so we can't decode it. After this change, the sentence does not disappear by encoding it before decoding.