### PR TITLE
fix: Fix can't edit activity containing % character and link with preview - EXO-60584 - Meeds-io/meeds#374

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -81,7 +81,7 @@ const defaultActivityOptions = {
            || '');
   },
   getBodyToEdit: activity => {
-    const templateParams = activity.templateParams;
+    const templateParams = encodeURIComponent(activity.templateParams);
     return Vue.prototype.$utils.trim(window.decodeURIComponent(templateParams
       && templateParams.default_title
       && templateParams.default_title


### PR DESCRIPTION

Prior to this change, we can not edit an activity with body containing ` % ` character and link with preview, the problem is that the activity body to be edited is a malformed URI which can not be decoded. After this change, we will encode the activity body to be edited.