### PR TITLE
fix: Fix can't edit activity containing % character and link with preview - EXO-60584 - Meeds-io/meeds#374

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -162,7 +162,7 @@ export default {
         this.originalBody = params.activityBody;
         this.activityId = params.activityId;
         this.spaceId = params.spaceId;
-        this.templateParams = params.activityParams || {};
+        this.templateParams = params.activityParams || params.templateParams || {};
         this.files = params.files || [];
         this.activityType = params.activityType;
       } else {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -81,7 +81,13 @@ const defaultActivityOptions = {
            || '');
   },
   getBodyToEdit: activity => {
-    const templateParams = encodeURIComponent(activity.templateParams);
+    let templateParams = activity.templateParams; 
+    if (templateParams.default_title && templateParams.default_title.includes('<oembed>') && templateParams.link){
+      const url = window.encodeURIComponent(templateParams.link);
+      templateParams.default_title = templateParams.default_title.replace(`<oembed>${url}</oembed>`, `<oembed>${templateParams.link}</oembed>`);
+      activity.title = activity.title.replace(`<oembed>${url}</oembed>`, `<oembed>${templateParams.link}</oembed>`);
+    }
+    templateParams = encodeURIComponent(activity.templateParams);
     return Vue.prototype.$utils.trim(window.decodeURIComponent(templateParams
       && templateParams.default_title
       && templateParams.default_title


### PR DESCRIPTION
Prior to this change, when we add a new post with text containing "%" character and a link with preview, it is not possible to edit it later, we have tow problem :
- The activity body to be edited contains a mal formed URI so we can't decode it .
- The generated oembed tag is encoded twice.

After this change, we will decode the oembed tag then encode the whole activity body to be edited in order to ensure the decode later.