### PR TITLE
feat: Fix Banner height and disable Vuetify Theme definition - MEED-551 - Meeds-io/MIPs#10

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/overviewBanner.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/overviewBanner.jsp
@@ -61,7 +61,7 @@
                 style="background-image: url(<%=bannerUrl%>);
                        background-repeat: repeat;
                        background-clip: content-box;
-                       height: 119%;
+                       height: 133px;
                        width: 100%;">
                         <div 
                           class="d-flex justify-content-center flex-column text-center full-height"

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -830,7 +830,7 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/overviewBanner.jsp</value>
     </init-param>
-    <expiration-cache>31536000</expiration-cache>
+    <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
     <supports>
       <mime-type>text/html</mime-type>

--- a/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -48,6 +48,7 @@
        silent: !eXo.developing,
        iconfont: 'mdi',
        rtl: eXo.env.portal.orientation === 'rtl',
+       theme: { disable: true },
        breakpoint: {
          thresholds: {
            xs: 380,


### PR DESCRIPTION
Prior to this change, the Banner height was using a percentage instead of a fixed height. In addition, the Vuetify theme was erasing the Platform CSS classes, which leads to some inconsistent colors.