### PR TITLE
feat: Stream activities when mobile MIP#21

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
@@ -11,13 +11,13 @@
   </div>
   <transition v-else-if="pinnedActivity">
     <activity-stream-pinned-activity
-        :key="activity.id"
-        :activity="activity"
-        :activity-types="activityTypes"
-        :activity-actions="activityActions"
-        :comment-types="commentTypes"
-        :comment-actions="commentActions"
-        :is-activity-detail="isActivityDetail" />
+      :key="activity.id"
+      :activity="activity"
+      :activity-types="activityTypes"
+      :activity-actions="activityActions"
+      :comment-types="commentTypes"
+      :comment-actions="commentActions"
+      :is-activity-detail="isActivityDetail" />
   </transition>
   <transition v-else>
     <activity-stream-activity

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
@@ -2,47 +2,57 @@
   <v-list-item
     class="activity-head"
     dense>
-    <exo-user-avatar
-      :identity="posterIdentity"
-      :size="45"
-      :extra-class="'me-2'"
-      popover
-      avatar />
-    <v-list-item-content class="py-0 accountTitleLabel">
-      <v-list-item-title class="font-weight-bold d-flex body-2 mb-0">
-        <exo-user-avatar
-          :identity="posterIdentity"
-          fullname
-          popover
-          bold-title
-          link-style
-          username-class />
-        <template v-if="space">
-          <v-icon
-            v-if="$vuetify.rtl"
-            size="8"
-            class="mx-1 ps-1">
-            fa-chevron-left
-          </v-icon>
-          <v-icon
-            v-else
-            size="8"
-            class="mx-1 ps-1">
-            fa-chevron-right
-          </v-icon>
-          <exo-space-avatar 
-            :space="space" 
-            :size="20"
-            bold-title
-            link-style
-            popover />
-        </template>
-      </v-list-item-title>
-      <activity-head-time
+    <template v-if="isMobile">
+      <activity-mobile-head
         :activity="activity"
         :is-activity-shared="isActivityShared"
-        class="d-flex activity-head-time" />
-    </v-list-item-content>
+        :poster-identity="posterIdentity"
+        :space="space"
+        class="px-0" />
+    </template>
+    <template v-else>
+      <exo-user-avatar
+        :identity="posterIdentity"
+        :size="45"
+        :extra-class="'me-2'"
+        popover
+        avatar />
+      <v-list-item-content class="py-0 accountTitleLabel">
+        <v-list-item-title class="font-weight-bold d-flex body-2 mb-0">
+          <exo-user-avatar
+            :identity="posterIdentity"
+            fullname
+            popover
+            bold-title
+            link-style
+            username-class />
+          <template v-if="space">
+            <v-icon
+              v-if="$vuetify.rtl"
+              size="8"
+              class="mx-1 ps-1">
+              fa-chevron-left
+            </v-icon>
+            <v-icon
+              v-else
+              size="8"
+              class="mx-1 ps-1">
+              fa-chevron-right
+            </v-icon>
+            <exo-space-avatar
+              :space="space"
+              :size="20"
+              bold-title
+              link-style
+              popover />
+          </template>
+        </v-list-item-title>
+        <activity-head-time
+          :activity="activity"
+          :is-activity-shared="isActivityShared"
+          class="d-flex activity-head-time" />
+      </v-list-item-content>
+    </template>
     <extension-registry-components
       :params="params"
       class="d-flex flex-no-wrap mx-0 mt-0 mb-auto activity-header-actions"
@@ -100,6 +110,9 @@ export default {
     },
     posterIdentity() {
       return this.activity && this.activity.identity && this.activity.identity.profile && this.activity.identity.profile.dataEntity;
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="text-light-color text-truncate">
+  <div
+      :class="truncateText"
+      class="text-light-color">
     <v-icon
       v-if="!noIcon"
       class="text-light-color"
@@ -13,7 +15,8 @@
           :height="btnHeight"
           :disabled="isActivityShared"
           :x-small="btnXSmall"
-          class="hover-underline width-auto text-capitalize-first-letter px-0"
+          :class="btnClass"
+          class="hover-underline width-auto text-capitalize-first-letter px-0 "
           link
           text
           plain
@@ -23,13 +26,15 @@
             v-if="isActivityEdited"
             :value="activity.updateDate"
             :short="isMobile"
+            :class="truncateText"
             label="UIActivity.label.EditedFrom"
-            class="text-capitalize-first-letter text-light-color text-truncate relativeDateFormatClass" />
+            class="text-capitalize-first-letter text-light-color relativeDateFormatClass" />
           <relative-date-format
             v-else
             :value="activity.createDate"
             :short="isMobile"
-            class="text-capitalize-first-letter text-light-color text-truncate relativeDateFormatClass" />
+            :class="truncateText"
+            class="text-capitalize-first-letter text-light-color relativeDateFormatClass" />
         </v-btn>
       </template>
       <date-format :value="activityPostedTime" :format="dateFormat" />
@@ -80,13 +85,19 @@ export default {
       return this.activity && (this.activity.updateDate || this.activity.createDate);
     },
     btnHeight() {
-      return this.isMobile && '22' || '20';
+      return this.isMobile && '18' || '20';
     },
     btnXSmall() {
       return !this.isMobile;
     },
+    btnClass() {
+      return this.isMobile && 'text-caption' || ' ';
+    },
     relativeDateFormatClass() {
       return !this.isMobile && 'pt-1 ps-1' || '';
+    },
+    truncateText() {
+      return !this.isMobile && 'text-truncate' || ' ';
     }
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="truncateText"
-    class="text-light-color">
+      :class="truncateText"
+      class="text-light-color">
     <v-icon
       v-if="!noIcon"
       class="text-light-color me-1"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
@@ -4,7 +4,7 @@
     class="text-light-color">
     <v-icon
       v-if="!noIcon"
-      class="text-light-color"
+      class="text-light-color me-1"
       x-small>
       far fa-clock
     </v-icon>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-      :class="truncateText"
-      class="text-light-color">
+    :class="truncateText"
+    class="text-light-color">
     <v-icon
       v-if="!noIcon"
       class="text-light-color"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="caption text-light-color text-truncate">
+  <div class="text-light-color text-truncate">
     <v-icon
       v-if="!noIcon"
       class="text-light-color"
@@ -10,10 +10,10 @@
       <template #activator="{ on, attrs }">
         <v-btn
           :href="activityLink"
-          :height="20"
+          :height="btnHeight"
           :disabled="isActivityShared"
-          class="hover-underline width-auto text-capitalize-first-letter d-inline px-0"
-          x-small
+          :x-small="btnXSmall"
+          class="hover-underline width-auto text-capitalize-first-letter px-0"
           link
           text
           plain
@@ -21,13 +21,15 @@
           v-on="on">
           <relative-date-format
             v-if="isActivityEdited"
+            :value="activity.updateDate"
+            :short="isMobile"
             label="UIActivity.label.EditedFrom"
-            class="text-capitalize-first-letter text-light-color text-truncate pt-1 ps-1"
-            :value="activity.updateDate" />
+            class="text-capitalize-first-letter text-light-color text-truncate relativeDateFormatClass" />
           <relative-date-format
             v-else
-            class="text-capitalize-first-letter text-light-color text-truncate pt-1 ps-1"
-            :value="activity.createDate" />
+            :value="activity.createDate"
+            :short="isMobile"
+            class="text-capitalize-first-letter text-light-color text-truncate relativeDateFormatClass" />
         </v-btn>
       </template>
       <date-format :value="activityPostedTime" :format="dateFormat" />
@@ -47,6 +49,10 @@ export default {
       default: false,
     },
     isActivityShared: {
+      type: Boolean,
+      default: () => false
+    },
+    isMobile: {
       type: Boolean,
       default: () => false
     },
@@ -73,6 +79,15 @@ export default {
     activityPostedTime() {
       return this.activity && (this.activity.updateDate || this.activity.createDate);
     },
+    btnHeight() {
+      return this.isMobile && '22' || '20';
+    },
+    btnXSmall() {
+      return !this.isMobile;
+    },
+    relativeDateFormatClass() {
+      return !this.isMobile && 'pt-1 ps-1' || '';
+    }
   },
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -1,3 +1,19 @@
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2022 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
 <template>
   <v-list-item v-if="displayUserAvatar" class="text-truncate">
     <exo-user-avatar

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -45,19 +45,20 @@
           link-style
           username-class />
       </v-list-item-title>
-      <v-list-item-subtitle class="d-flex flex-row align-center flex-nowrap">
-        <exo-user-avatar
-          :identity="posterIdentity"
-          extra-class="text-truncate ms-2 me-1"
-          fullname
-          link-style
-          small-font-size
-          username-class />
-        <activity-head-time
-          :activity="activity"
-          :is-activity-shared="isActivityShared"
-          is-mobile
-          no-icon />
+      <v-list-item-subtitle class="d-flex flex-row flex-nowrap">
+          <exo-user-avatar
+              :identity="posterIdentity"
+              extra-class="text-truncate ms-2 me-1"
+              fullname
+              link-style
+              smallFontSize
+              username-class />
+          <activity-head-time
+              :activity="activity"
+              :is-activity-shared="isActivityShared"
+              is-mobile
+              no-icon
+              class="text-caption activity-head-time pt-0 ps-0" />
       </v-list-item-subtitle>
     </v-list-item-content>
   </v-list-item>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -45,20 +45,19 @@
           link-style
           username-class />
       </v-list-item-title>
-      <v-list-item-subtitle class="d-flex flex-row flex-nowrap">
-          <exo-user-avatar
-              :identity="posterIdentity"
-              extra-class="text-truncate ms-2 me-1"
-              fullname
-              link-style
-              smallFontSize
-              username-class />
-          <activity-head-time
-              :activity="activity"
-              :is-activity-shared="isActivityShared"
-              is-mobile
-              no-icon
-              class="text-caption activity-head-time pt-0 ps-0" />
+      <v-list-item-subtitle class="d-flex flex-row align-center flex-nowrap">
+        <exo-user-avatar
+          :identity="posterIdentity"
+          extra-class="text-truncate ms-2 me-1"
+          fullname
+          link-style
+          small-font-size
+          username-class />
+        <activity-head-time
+          :activity="activity"
+          :is-activity-shared="isActivityShared"
+          is-mobile
+          no-icon />
       </v-list-item-subtitle>
     </v-list-item-content>
   </v-list-item>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -45,26 +45,20 @@
           link-style
           username-class />
       </v-list-item-title>
-      <v-list-item-subtitle>
-        <v-row class="ms-2 text-truncate">
-          <v-col class="px-0 py-0 text-truncate" cols="7">
-            <exo-user-avatar
+      <v-list-item-subtitle class="d-flex flex-row flex-nowrap">
+          <exo-user-avatar
               :identity="posterIdentity"
-              extra-class="text-truncate"
+              extra-class="text-truncate ms-2 me-1"
               fullname
               link-style
               smallFontSize
               username-class />
-          </v-col>
-          <v-col class="px-0 py-0 subTitle-2 align-center" cols="3">
-            <activity-head-time
+          <activity-head-time
               :activity="activity"
               :is-activity-shared="isActivityShared"
               is-mobile
               no-icon
               class="text-caption activity-head-time pt-0 ps-0" />
-          </v-col>
-        </v-row>
       </v-list-item-subtitle>
     </v-list-item-content>
   </v-list-item>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -1,5 +1,30 @@
 <template>
-  <v-list-item  class="text-truncate">
+  <v-list-item v-if="displayUserAvatar" class="text-truncate">
+    <exo-user-avatar
+      :identity="posterIdentity"
+      :size="42"
+      avatar />
+    <v-list-item-content class="py-0 accountTitleLabel ms-2">
+      <v-list-item-title class="font-weight-bold d-flex body-2 mb-0">
+        <exo-user-avatar
+          :identity="posterIdentity"
+          extra-class="me-5 text-truncate"
+          fullname
+          bold-title
+          link-style
+          username-class />
+      </v-list-item-title>
+      <v-list-item-subtitle>
+        <activity-head-time
+          :activity="activity"
+          :is-activity-shared="isActivityShared"
+          is-mobile
+          no-icon
+          class="d-flex activity-head-time" />
+      </v-list-item-subtitle>
+    </v-list-item-content>
+  </v-list-item>
+  <v-list-item v-else class="text-truncate">
     <exo-space-avatar
       :space="space"
       extra-class="text-truncate"
@@ -22,12 +47,13 @@
       </v-list-item-title>
       <v-list-item-subtitle>
         <v-row class="ms-2 text-truncate">
-          <v-col class="px-0 py-0 text-truncate" cols="9">
+          <v-col class="px-0 py-0 text-truncate" cols="7">
             <exo-user-avatar
               :identity="posterIdentity"
               extra-class="text-truncate"
               fullname
               link-style
+              smallFontSize
               username-class />
           </v-col>
           <v-col class="px-0 py-0 subTitle-2 align-center" cols="3">
@@ -36,7 +62,7 @@
               :is-activity-shared="isActivityShared"
               is-mobile
               no-icon
-              class="activity-head-time pt-0 ps-0" />
+              class="text-caption activity-head-time pt-0 ps-0" />
           </v-col>
         </v-row>
       </v-list-item-subtitle>
@@ -64,5 +90,11 @@ export default {
       default: null,
     }
   },
+  computed: {
+    displayUserAvatar() {
+      return eXo.env.portal.spaceId !== '' || !this.space;
+    },
+  },
+
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityMobileHead.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-list-item  class="text-truncate">
+    <exo-space-avatar
+      :space="space"
+      extra-class="text-truncate"
+      :size="42"
+      avatar />
+    <exo-user-avatar
+      :identity="posterIdentity"
+      :size="31"
+      extra-class="ms-n4 mt-6"
+      avatar />
+    <v-list-item-content class="py-0 accountTitleLabel text-truncate">
+      <v-list-item-title class="font-weight-bold d-flex body-2 mb-0">
+        <exo-space-avatar
+          :space="space"
+          extra-class="text-truncate"
+          fullname
+          bold-title
+          link-style
+          username-class />
+      </v-list-item-title>
+      <v-list-item-subtitle>
+        <v-row class="ms-2 text-truncate">
+          <v-col class="px-0 py-0 text-truncate" cols="9">
+            <exo-user-avatar
+              :identity="posterIdentity"
+              extra-class="text-truncate"
+              fullname
+              link-style
+              username-class />
+          </v-col>
+          <v-col class="px-0 py-0 subTitle-2 align-center" cols="3">
+            <activity-head-time
+              :activity="activity"
+              :is-activity-shared="isActivityShared"
+              is-mobile
+              no-icon
+              class="activity-head-time pt-0 ps-0" />
+          </v-col>
+        </v-row>
+      </v-list-item-subtitle>
+    </v-list-item-content>
+  </v-list-item>
+</template>
+
+<script>
+export default {
+  props: {
+    activity: {
+      type: Object,
+      default: null,
+    },
+    isActivityShared: {
+      type: Boolean,
+      default: () => false
+    },
+    posterIdentity: {
+      type: Object,
+      default: null,
+    },
+    space: {
+      type: Object,
+      default: null,
+    }
+  },
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilter.vue
@@ -29,6 +29,7 @@
     </select>
     <v-icon
       class="d-sm-none"
+      size="18"
       @click="openBottomMenuFilter">
       fa-filter
     </v-icon>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/initComponents.js
@@ -13,6 +13,7 @@ import ActivityStreamPinnedActivity from './components/pinned-activity/ActivityS
 import ActivityStreamLoader from './components/activity/ActivityStreamLoader.vue';
 import ActivityStreamFilter from './components/toolbar/ActivityStreamFilter.vue';
 import ActivityHead from './components/activity/header/ActivityHead.vue';
+import ActivityMobileHead from './components/activity/header/ActivityMobileHead.vue';
 import ActivityHeadTime from './components/activity/header/ActivityHeadTime.vue';
 import ActivityHeadMenu from './components/activity/header/ActivityHeadMenu.vue';
 import ActivityBody from './components/activity/content/ActivityBody.vue';
@@ -58,6 +59,7 @@ const components = {
   'activity-stream-loader': ActivityStreamLoader,
   'activity-stream-filter': ActivityStreamFilter,
   'activity-head': ActivityHead,
+  'activity-mobile-head': ActivityMobileHead,
   'activity-head-time': ActivityHeadTime,
   'activity-head-menu': ActivityHeadMenu,
   'activity-body': ActivityBody,

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoSpaceAvatar.vue
@@ -9,8 +9,9 @@
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar not-clickable-link">
       <v-avatar
         :size="size"
+        :class="pullLeft"
         tile
-        class="pull-left my-auto">
+        class="my-auto">
         <img
           :src="defaultAvatarUrl"
           class="object-fit-cover ma-auto"
@@ -18,7 +19,7 @@
           role="presentation">
       </v-avatar>
       <div
-        :class="!subtitleNewLine && 'd-flex'"
+        :class="subtitleNewLineClass"
         class="pull-left text-truncate ms-2">
         <p
           class="text-truncate subtitle-2 my-auto hidden-space">
@@ -35,8 +36,9 @@
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
+        :class="pullLeft"
         tile
-        class="pull-left my-auto">
+        class="my-auto">
         <img
           :src="avatarUrl"
           :class="avatarClass"
@@ -54,8 +56,8 @@
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <div
         v-if="displayName || $slots.subTitle"
-        :class="!subtitleNewLine && 'd-flex'"
-        class="pull-left text-truncate ms-2">
+        :class="subtitleNewLineClass"
+        class="text-truncate ms-2">
         <p
           v-if="displayName"
           :class="[fullnameStyle, linkStyle && 'primary--text' || '']"
@@ -77,8 +79,9 @@
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
+        :class="pullLeft"
         tile
-        class="pull-left my-auto">
+        class="my-auto">
         <img
           :src="avatarUrl"
           :class="avatarClass"
@@ -88,8 +91,8 @@
       </v-avatar>
       <div
         v-if="displayName || $slots.subTitle"
-        :class="!subtitleNewLine && 'd-flex'"
-        class="pull-left text-truncate ms-2">
+        :class="subtitleNewLineClass"
+        class="text-truncate ms-2">
         <p
           v-if="displayName"
           :class="[fullnameStyle, linkStyle && 'primary--text' || '']"
@@ -208,6 +211,12 @@ export default {
     },
     defaultAvatarUrl() {
       return `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/default-image/avatar`;
+    },
+    pullLeft() {
+      return this.isMobile && ' ' || 'pull-left';
+    },
+    subtitleNewLineClass() {
+      return !this.subtitleNewLine && `d-flex${this.pullLeft}` || this.pullLeft;
     },
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -12,7 +12,8 @@
       :class="avatarClass">
       <v-avatar
         :size="size"
-        class="ma-0 pull-left">
+        :class="pullLeft"
+        class="ma-0">
         <img
           :src="avatarUrl"
           class="object-fit-cover ma-auto"
@@ -24,7 +25,8 @@
       v-else-if="fullname"
       :id="id"
       :href="profileUrl"
-      class="pull-left d-flex align-start text-truncate">
+      :class="pullLeft"
+      class="d-flex align-start text-truncate">
       <span
         v-if="userFullname"
         :class="[fullnameStyle, linkStyle && 'primary--text' || '']"
@@ -80,7 +82,8 @@
       :class="avatarClass">
       <v-avatar
         :size="size"
-        class="ma-0 pull-left">
+        :class="pullLeft"
+        class="ma-0">
         <img
           :src="avatarUrl"
           class="object-fit-cover ma-auto"
@@ -92,7 +95,8 @@
       v-else-if="fullname"
       :id="id"
       :href="profileUrl"
-      class="pull-left d-flex align-start text-truncate">
+      :class="pullLeft"
+      class="d-flex align-start text-truncate">
       <span
         v-if="userFullname"
         :class="[fullnameStyle, linkStyle && 'primary--text' || '']"
@@ -287,6 +291,9 @@ export default {
         external: this.isExternal,
       };
     },
+    pullLeft() {
+      return this.isMobile && ' ' || 'pull-left';
+    }
   },
   created() {
     if (this.profileId) {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
@@ -32,7 +32,7 @@
           <v-icon 
             class="mr-3"
             :class="favoriteIconColor"
-            size="16" > 
+            size="16" >
             {{ favoriteIcon }} </v-icon>
           <span class="text-color mt-1">{{ favoriteLabel }}</span>
         </v-list-item> 

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RelativeDateFormat.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RelativeDateFormat.vue
@@ -37,7 +37,7 @@ export default {
     },
     relativeDateLabel() {
       const label = this.date && this.$t(this.relativeDateLabelKey, {0: this.relativeDateLabelValue}) || '';
-      if (this.label) {
+      if (this.label && !this.short) {
         return this.$t(this.label, {0: label});
       } else {
         return label;


### PR DESCRIPTION
This change is going to change to space and user avatar display when using mobile through:

-space avatar behind the user avatar
-space name above the user name
-When browsing a space activity stream The activities should be adjusted so we only see the username. No need to have the space name reminded since we are browsing the space itself
-the alignement of the name and the timestamp in the activity stream are adjusted .
-timestamp is displayed next to the username