### PR TITLE
fix: Fix last edited activity text persists when creating a new activity - EXO-60727 - Meeds-io/meeds#404

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -202,6 +202,9 @@ export default {
         this.$activityService.updateActivity(this.activityId, message, activityType, this.files, this.templateParams)
           .then(() => {
             document.dispatchEvent(new CustomEvent('activity-updated', {detail: this.activityId}));
+            if (localStorage.getItem('activity-message-activityComposer')) {
+              localStorage.removeItem('activity-message-activityComposer');
+            }
             this.close();
           })
           .catch(error => {


### PR DESCRIPTION
Prior to this change, when we edit a post, the last edited activity text persists when creating a new activity. After this change, we ensure to reset the post activity text area when we create a new activity by removing the value of local storage item 'activity-message-activityComposer'.