### PR TITLE
feat: Delete related metadata when updating user avatar - EXO-60290 - Meeds-io/MIPs#25

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/FileActionListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/FileActionListener.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.listeners;
+
+import org.exoplatform.commons.file.model.FileInfo;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.thumbnail.model.ThumbnailObject;
+
+public class FileActionListener extends Listener<FileInfo, Object> {
+
+  private static final String   FILE_UPDATED_EVENT      = "file.updated";
+
+  private static final String   FILE_DELETED_EVENT      = "file.deleted";
+
+  private static final String   THUMBNAIL_METADATA_NAME = "thumbnail";
+
+  private static final String   THUMBNAIL_OBJECT_TYPE   = "file";
+
+  private final MetadataService metadataService;
+
+  public FileActionListener(MetadataService metadataService) {
+    this.metadataService = metadataService;
+  }
+
+  @Override
+  public void onEvent(Event<FileInfo, Object> event) throws Exception {
+    String eventName = event.getEventName();
+    FileInfo fileInfo = event.getSource();
+    if (eventName.equals(FILE_UPDATED_EVENT) || eventName.equals(FILE_DELETED_EVENT)) {
+      ThumbnailObject thumbnailObject = new ThumbnailObject(THUMBNAIL_OBJECT_TYPE, Long.toString(fileInfo.getId()));
+      metadataService.deleteMetadataItemsByMetadataTypeAndObject(THUMBNAIL_METADATA_NAME, thumbnailObject);
+    }
+  }
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/FileActionListenerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/FileActionListenerTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.listeners;
+
+import org.exoplatform.commons.file.model.FileInfo;
+import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.thumbnail.model.ThumbnailObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileActionListenerTest {
+
+  @Mock
+  private MetadataService    metadataService;
+  
+  private FileActionListener fileActionListener;
+
+  @Before
+  public void setUp() throws Exception {
+    fileActionListener = new FileActionListener(metadataService);
+  }
+
+  @Test
+  public void testOnEvent() throws Exception {
+    ThumbnailObject thumbnailObject = new ThumbnailObject("file", "1");
+    FileItem fileItem = new FileItem(1L,
+                                     "test",
+                                     "image/png",
+                                     "social",
+                                     "test".getBytes().length,
+                                     new Date(),
+                                     "user",
+                                     false,
+                                     new ByteArrayInputStream("test".getBytes()));
+    Event<FileInfo, Object> updateFile = new Event<>("file.updated", fileItem.getFileInfo(), null);
+    fileActionListener.onEvent(updateFile);
+    verify(metadataService, times(1)).deleteMetadataItemsByMetadataTypeAndObject("thumbnail", thumbnailObject);
+    Event<FileInfo, Object> deleteFile = new Event<>("file.deleted", fileItem.getFileInfo(), null);
+    fileActionListener.onEvent(deleteFile);
+    verify(metadataService, times(2)).deleteMetadataItemsByMetadataTypeAndObject("thumbnail", thumbnailObject);
+  }
+}

--- a/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
@@ -131,6 +131,25 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>file.created</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>file.updated</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>file.deleted</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+    </component-plugin>
+  </external-component-plugins>
+
   <remove-configuration>org.exoplatform.portal.resource.SkinResourceRequestHandler</remove-configuration>
   <remove-configuration>org.exoplatform.web.WebAppController</remove-configuration>
   <remove-configuration>org.exoplatform.services.scheduler.JobSchedulerService</remove-configuration>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -849,6 +849,25 @@
     </external-component-plugins>
 
     <external-component-plugins>
+        <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+        <component-plugin>
+            <name>file.created</name>
+            <set-method>addListener</set-method>
+            <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+        </component-plugin>
+        <component-plugin>
+            <name>file.updated</name>
+            <set-method>addListener</set-method>
+            <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+        </component-plugin>
+        <component-plugin>
+            <name>file.deleted</name>
+            <set-method>addListener</set-method>
+            <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+        </component-plugin>
+    </external-component-plugins>
+
+    <external-component-plugins>
         <target-component>org.exoplatform.services.scheduler.JobSchedulerService</target-component>
         <component-plugin profiles="all">
             <name>AddCronJob</name>


### PR DESCRIPTION
Prior to this change, when updating user avatar, the thumbnail remains the same without getting updated too, which cause the display of the old avatar always.
This PR should make sure to drop related metadata when the avatar was updated
