### PR TITLE
fix : Fix duplicated encoded link in activity - EXO-60750 - Meeds-io/meeds#398

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -342,7 +342,7 @@ export default {
           && this.templateParams.link
           && this.templateParams.default_title !== message) {
         this.templateParams.default_title = message;
-        const codedMessage = window.encodeURIComponent(message.substring(0,message.indexOf('<oembed>')));
+        const codedMessage = window.encodeURIComponent(message.substring(0, message.indexOf('<oembed>')));
         this.templateParams.comment = window.decodeURIComponent(codedMessage);
       }
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -342,8 +342,7 @@ export default {
           && this.templateParams.link
           && this.templateParams.default_title !== message) {
         this.templateParams.default_title = message;
-        const url = window.encodeURIComponent(this.templateParams.link);
-        const codedMessage = window.encodeURIComponent(message.replace(`<oembed>${url}</oembed>`, ''));
+        const codedMessage = window.encodeURIComponent(message.substring(0,message.indexOf('<oembed>')));
         this.templateParams.comment = window.decodeURIComponent(codedMessage);
       }
     },


### PR DESCRIPTION
Prior to this change when we post an activity with a copied link from Brave browser without "www" generating a preview, the posted activity is displayed with a duplicated encoded link . The problem is caused by missing `www` in the copied link when we copy from brave browser.
After this change, we will update the installOmbed method in order to fix this problem.