### PR TITLE
fix: Fix duplicated encoded link in activity - EXO-60750 - Meeds-io/meeds#398 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -342,8 +342,7 @@ export default {
           && this.templateParams.link
           && this.templateParams.default_title !== message) {
         this.templateParams.default_title = message;
-        const url = window.encodeURIComponent(this.templateParams.link);
-        const codedMessage = window.encodeURIComponent(message.replace(`<oembed>${url}</oembed>`, ''));
+        const codedMessage = window.encodeURIComponent(message.substring(0, message.indexOf('<oembed>')));
         this.templateParams.comment = window.decodeURIComponent(codedMessage);
       }
     },


### PR DESCRIPTION

Prior to this change when we post an activity with a copied link from Brave browser without "www" generating a preview, the posted activity is displayed with a duplicated encoded link . The problem is caused by missing `www` in the copied link when we copy from brave browser. After this change, we will update the installOmbed method in order to fix this problem.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
