### PR TITLE
feat: Resize avatars in space card and people card - EXO-60290 - Meeds-io/MIPs#25

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -60,7 +60,7 @@
         tile>
         <img
           v-if="thumbnail"
-          :src="`${thumbnail}&size=250x150`"
+          :src="thumbnail"
           :alt="title"
           class="object-fit-cover my-auto"
           loading="lazy"

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -85,8 +85,8 @@
     <div class="peopleAvatar">
       <a :href="url">
         <v-img
-          :lazy-src="userAvatarUrl"
-          :src="userAvatarUrl"
+          :lazy-src="`${userAvatarUrl}&size=65x65`"
+          :src="`${userAvatarUrl}&size=65x65`"
           transition="none"
           class="mx-auto"
           height="65px"

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
@@ -84,7 +84,7 @@
     <div class="spaceAvatar">
       <a :href="url">
         <v-img
-          :src="spaceAvatarUrl"
+          :src="`${spaceAvatarUrl}&size=75x75`"
           transition="none"
           class="mx-auto"
           height="75px"


### PR DESCRIPTION
Prior to this change used dimension for avatars in space card is 75x75 and for people card is 65x65 but we request a default 45x45 avatar. This PR adds the size flag for avatar rest endpoint to get the appropriate dimension

