### PR TITLE
feat: Resize user avatars depedns on the needed display size - EXO-60290 - Meeds-io/MIPs#25

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/common/Utils.java
+++ b/component/api/src/main/java/org/exoplatform/social/common/Utils.java
@@ -14,6 +14,8 @@ public class Utils {
                                                             +
                                                             "Mark:] Remove; NFC;");
 
+  private static final String         SIZE_SPLIT_CHAR   = "x";
+
   private Utils() {
     // static class, no need to constructor, thus it's 'private'
   }
@@ -109,4 +111,13 @@ public class Utils {
     return cleanedStr.toString().toLowerCase();
   }
 
+  public static int[] parseDimension(String size) {
+    int[] dimension = new int[2];
+    if (size.contains(SIZE_SPLIT_CHAR) && !size.startsWith(SIZE_SPLIT_CHAR)) {
+      dimension[0] = Integer.parseInt(size.split(SIZE_SPLIT_CHAR)[0]);
+    } else if (size.contains(SIZE_SPLIT_CHAR) && !size.endsWith(SIZE_SPLIT_CHAR)) {
+      dimension[1] = Integer.parseInt(size.split(SIZE_SPLIT_CHAR)[1]);
+    }
+    return dimension;
+  }
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/IdentityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/IdentityManager.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.social.core.manager;
 
+import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.social.core.activity.model.ActivityStream;
 import org.exoplatform.social.core.identity.*;
@@ -679,6 +680,16 @@ public interface IdentityManager {
    */
   default Identity getOrCreateUserIdentity(String username) {
     return getOrCreateIdentity(ActivityStream.ORGANIZATION_PROVIDER_ID, username);
+  }
+
+  /**
+   * Retrieves user avatar file by a given identity
+   *
+   * @param identity User social identity
+   * @return {@link FileItem}
+   */
+  default FileItem getAvatarFile(Identity identity) {
+    throw new UnsupportedOperationException();
   }
 
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/storage/api/IdentityStorage.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/storage/api/IdentityStorage.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
 
+import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.social.core.identity.SpaceMemberFilterListAccess;
 import org.exoplatform.social.core.identity.model.ActiveIdentityFilter;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -479,6 +480,16 @@ public interface IdentityStorage {
    * @param imageUploadLimit upload limit in MB, default is 2 MB
    */
   default void setImageUploadLimit(int imageUploadLimit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Retrieves user avatar file by a given identity
+   *
+   * @param identity User social identity
+   * @return {@link FileItem}
+   */
+  default FileItem getAvatarFile(Identity identity) {
     throw new UnsupportedOperationException();
   }
 

--- a/component/api/src/main/java/org/exoplatform/social/metadata/thumbnail/ImageThumbnailService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/thumbnail/ImageThumbnailService.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.metadata.thumbnail;
+
+import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.social.core.identity.model.Identity;
+
+public interface ImageThumbnailService {
+
+    /**
+     * Retrieves a thumbnail by given width and height or creates a thumbnail image and get it
+     * if not exist
+     * @param file Image file
+     * @param identity User social identity
+     * @param width target thumbnail width
+     * @param height target thumbnail height
+     * @return {@link FileItem}
+     */
+    FileItem getOrCreateThumbnail(FileItem file, Identity identity, int width, int height) throws Exception;
+}

--- a/component/api/src/main/java/org/exoplatform/social/metadata/thumbnail/model/ThumbnailObject.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/thumbnail/model/ThumbnailObject.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.metadata.thumbnail.model;
+
+import org.exoplatform.social.metadata.model.MetadataObject;
+
+public class ThumbnailObject extends MetadataObject {
+
+  public ThumbnailObject(String type, String id) {
+    super(type, id);
+  }
+
+  public ThumbnailObject(String type, String id, String parentId) {
+    super(type, id, parentId);
+  }
+}

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -284,6 +284,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.imgscalr</groupId>
+      <artifactId>imgscalr-lib</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
@@ -996,25 +996,26 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
   
   @Override
   public InputStream getAvatarInputStreamById(Identity identity) throws IOException {
+    FileItem fileItem = getAvatarFile(identity);
+    if (fileItem != null) {
+      return fileItem.getAsStream();
+    }
+    return null;
+  }
+
+  @Override
+  public FileItem getAvatarFile(Identity identity) {
     FileItem file = null;
-    IdentityEntity entity = identityDAO.findByProviderAndRemoteId(identity.getProviderId(), identity.getRemoteId());
-    if (entity == null) {
-      return null;
+    IdentityEntity entity = identityDAO.findByProviderAndRemoteId(identity.getProviderId(),
+                                                                  identity.getRemoteId());
+    if (entity != null && entity.getAvatarFileId() != null) {
+      try {
+        file = fileService.getFile(entity.getAvatarFileId());
+      } catch (FileStorageException e) {
+        return null;
+      }
     }
-    Long avatarId = entity.getAvatarFileId();
-    if (avatarId == null) {
-      return null;
-    }
-    try {
-      file = fileService.getFile(avatarId);
-    } catch (FileStorageException e) {
-      return null;
-    }
-  
-    if (file == null) {
-      return null;
-    }
-    return file.getAsStream();
+    return file;
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/FileActionListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/FileActionListener.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.listeners;
+
+import org.exoplatform.commons.file.model.FileInfo;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.thumbnail.model.ThumbnailObject;
+
+public class FileActionListener extends Listener<FileInfo, Object> {
+
+  private static final String   FILE_UPDATED_EVENT      = "file.updated";
+
+  private static final String   FILE_DELETED_EVENT      = "file.deleted";
+
+  private static final String   THUMBNAIL_METADATA_NAME = "thumbnail";
+
+  private static final String   THUMBNAIL_OBJECT_TYPE   = "file";
+
+  private final MetadataService metadataService;
+
+  public FileActionListener(MetadataService metadataService) {
+    this.metadataService = metadataService;
+  }
+
+  @Override
+  public void onEvent(Event<FileInfo, Object> event) throws Exception {
+    String eventName = event.getEventName();
+    FileInfo fileInfo = event.getSource();
+    if (eventName.equals(FILE_UPDATED_EVENT) || eventName.equals(FILE_DELETED_EVENT)) {
+      ThumbnailObject thumbnailObject = new ThumbnailObject(THUMBNAIL_OBJECT_TYPE, Long.toString(fileInfo.getId()));
+      metadataService.deleteMetadataItemsByMetadataTypeAndObject(THUMBNAIL_METADATA_NAME, thumbnailObject);
+    }
+  }
+}

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
@@ -22,6 +22,7 @@ import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.xml.InitParams;
@@ -210,13 +211,24 @@ public class IdentityManagerImpl implements IdentityManager {
   /**
    * {@inheritDoc}
    */
+  @Override
+  public FileItem getAvatarFile(Identity identity) {
+    if (identity == null) {
+      return null;
+    }
+    return identityStorage.getAvatarFile(identity);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public InputStream getBannerInputStream(Identity identity) throws IOException {
     if (identity == null) {
       return null;
     }
     return identityStorage.getBannerInputStreamById(identity);
   }
-  
+
   /**
    * {@inheritDoc}
    */

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/thumbnail/ImageThumbnailServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/thumbnail/ImageThumbnailServiceImpl.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.metadata.thumbnail;
+
+import org.apache.commons.io.IOUtils;
+import org.exoplatform.commons.file.model.FileInfo;
+import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.commons.file.services.FileStorageException;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.thumbnail.ImageResizeService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
+import org.exoplatform.social.metadata.model.MetadataType;
+import org.exoplatform.social.metadata.thumbnail.ImageThumbnailService;
+import org.exoplatform.social.metadata.thumbnail.model.ThumbnailObject;
+
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ImageThumbnailServiceImpl implements ImageThumbnailService {
+
+  private static final Log          LOG                       = ExoLogger.getExoLogger(ImageThumbnailServiceImpl.class);
+
+  private static final MetadataType THUMBNAIL_METADATA_TYPE   = new MetadataType(5, "thumbnail");
+
+  private static final String       SOCIAL_NAME_SPACE         = "social";
+
+  private static final String       THUMBNAIL_OBJECT_TYPE     = "file";
+
+  private static final String       THUMBNAIL_WIDTH_PROPERTY  = "width";
+
+  private static final String       THUMBNAIL_HEIGHT_PROPERTY = "height";
+
+  private final MetadataService     metadataService;
+
+  private final FileService         fileService;
+
+  private final ImageResizeService  imageResizeService;
+
+  public ImageThumbnailServiceImpl(MetadataService metadataService,
+                                   FileService fileService,
+                                   ImageResizeService imageResizeService) {
+    this.metadataService = metadataService;
+    this.fileService = fileService;
+    this.imageResizeService = imageResizeService;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public FileItem getOrCreateThumbnail(FileItem file, Identity identity, int width, int height) throws Exception {
+    if (file == null) {
+      throw new IllegalArgumentException("file argument is mandatory");
+    }
+    if (width == 0 && height == 0) {
+      return file;
+    }
+    FileInfo fileInfo = file.getFileInfo();
+    ThumbnailObject thumbnailObject = new ThumbnailObject(THUMBNAIL_OBJECT_TYPE, Long.toString(fileInfo.getId()));
+    List<MetadataItem> metadataItemList = metadataService.getMetadataItemsByMetadataTypeAndObject(THUMBNAIL_METADATA_TYPE.getName(),
+                                                                                                thumbnailObject);
+    List<MetadataItem> items = metadataItemList.stream()
+                                               .filter(metadataItem -> metadataItem.getProperties() != null
+                                                   && metadataItem.getProperties()
+                                                                  .get(THUMBNAIL_WIDTH_PROPERTY)
+                                                                  .equals(String.valueOf(width))
+                                                   && metadataItem.getProperties()
+                                                                  .get(THUMBNAIL_HEIGHT_PROPERTY)
+                                                                  .equals(String.valueOf(height)))
+                                               .collect(Collectors.toList());
+    if (!items.isEmpty()) {
+      long fileId = Long.parseLong(items.get(0).getParentObjectId());
+      try {
+        return fileService.getFile(fileId);
+      } catch (FileStorageException e) {
+        LOG.error("Error while getting thumbnail, original Image will be returned", e);
+        return file;
+      }
+    } else {
+      byte[] imageContent = imageResizeService.scaleImage(IOUtils.toByteArray(file.getAsStream()), width, height, false, false);
+      FileItem thumbnail = new FileItem(null,
+                                        fileInfo.getName(),
+                                        fileInfo.getMimetype(),
+                                        SOCIAL_NAME_SPACE,
+                                        imageContent.length,
+                                        new Date(),
+                                        fileInfo.getUpdater(),
+                                        false,
+                                        new ByteArrayInputStream(imageContent));
+      FileItem thumbnailFileItem = fileService.writeFile(thumbnail);
+      FileInfo thumbnailFileInfo = thumbnailFileItem.getFileInfo();
+      ThumbnailObject thumbnailMetadataObject = new ThumbnailObject(THUMBNAIL_OBJECT_TYPE,
+                                                                    Long.toString(fileInfo.getId()),
+                                                                    Long.toString(thumbnailFileInfo.getId()));
+      MetadataKey metadataKey = new MetadataKey(THUMBNAIL_METADATA_TYPE.getName(), THUMBNAIL_METADATA_TYPE.getName(), 0);
+      Map<String, String> properties = new HashMap<>();
+      properties.put(THUMBNAIL_WIDTH_PROPERTY, String.valueOf(width));
+      properties.put(THUMBNAIL_HEIGHT_PROPERTY, String.valueOf(height));
+      metadataService.createMetadataItem(thumbnailMetadataObject, metadataKey, properties, Long.parseLong(identity.getId()));
+      return thumbnailFileItem;
+    }
+  }
+}

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.cache.future.FutureExoCache;
+import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.cache.ExoCache;
@@ -700,6 +701,14 @@ public class CachedIdentityStorage implements IdentityStorage {
   @Override
   public InputStream getAvatarInputStreamById(Identity identity) throws IOException {
     return storage.getAvatarInputStreamById(identity);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public FileItem getAvatarFile(Identity identity) {
+    return storage.getAvatarFile(identity);
   }
 
   /**

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/FileActionListenerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/FileActionListenerTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.listeners;
+
+import org.exoplatform.commons.file.model.FileInfo;
+import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.thumbnail.model.ThumbnailObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileActionListenerTest {
+
+  @Mock
+  private MetadataService    metadataService;
+  
+  private FileActionListener fileActionListener;
+
+  @Before
+  public void setUp() throws Exception {
+    fileActionListener = new FileActionListener(metadataService);
+  }
+
+  @Test
+  public void testOnEvent() throws Exception {
+    ThumbnailObject thumbnailObject = new ThumbnailObject("file", "1");
+    FileItem fileItem = new FileItem(1L,
+                                     "test",
+                                     "image/png",
+                                     "social",
+                                     "test".getBytes().length,
+                                     new Date(),
+                                     "user",
+                                     false,
+                                     new ByteArrayInputStream("test".getBytes()));
+    Event<FileInfo, Object> updateFile = new Event<>("file.updated", fileItem.getFileInfo(), null);
+    fileActionListener.onEvent(updateFile);
+    verify(metadataService, times(1)).deleteMetadataItemsByMetadataTypeAndObject("thumbnail", thumbnailObject);
+    Event<FileInfo, Object> deleteFile = new Event<>("file.deleted", fileItem.getFileInfo(), null);
+    fileActionListener.onEvent(deleteFile);
+    verify(metadataService, times(2)).deleteMetadataItemsByMetadataTypeAndObject("thumbnail", thumbnailObject);
+  }
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/metadata/thumbnail/ImageThumbnailServiceImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/metadata/thumbnail/ImageThumbnailServiceImplTest.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.metadata.thumbnail;
+
+import org.exoplatform.commons.file.model.FileInfo;
+import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.services.thumbnail.ImageResizeService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.test.AbstractCoreTest;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataType;
+import org.exoplatform.social.metadata.thumbnail.model.ThumbnailObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Date;
+import java.util.List;
+
+public class ImageThumbnailServiceImplTest extends AbstractCoreTest {
+
+  private MetadataService           metadataService;
+
+  private FileService               fileService;
+
+  private ImageResizeService        imageResizeService;
+
+  private ImageThumbnailServiceImpl imageThumbnailService;
+
+  private IdentityManager           identityManager;
+
+  private Identity                  userIdentity;
+
+  public void setUp() throws Exception {
+    super.setUp();
+    metadataService = getContainer().getComponentInstanceOfType(MetadataService.class);
+    fileService = getContainer().getComponentInstanceOfType(FileService.class);
+    imageResizeService = getContainer().getComponentInstanceOfType(ImageResizeService.class);
+    identityManager = getContainer().getComponentInstanceOfType(IdentityManager.class);
+    imageThumbnailService = new ImageThumbnailServiceImpl(metadataService, fileService, imageResizeService);
+    userIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john");
+  }
+
+  public void testGetOrCreateThumbnail() throws Exception {
+    MetadataType metadataType = new MetadataType(5, "thumbnail");
+    File file = new File(getClass().getClassLoader().getResource("test.png").getFile());
+    byte[] content = Files.readAllBytes(file.toPath());
+    FileItem fileThumbnail = new FileItem(null,
+                                          "testAvatar",
+                                          "image/png",
+                                          "social",
+                                          content.length,
+                                          new Date(),
+                                          userIdentity.getRemoteId(),
+                                          false,
+                                          new ByteArrayInputStream(content));
+    fileThumbnail = fileService.writeFile(fileThumbnail);
+    FileInfo fileInfo = fileThumbnail.getFileInfo();
+    ThumbnailObject thumbnailObject = new ThumbnailObject("file", Long.toString(fileInfo.getId()));
+    List<MetadataItem> metadataItemList = metadataService.getMetadataItemsByMetadataTypeAndObject(metadataType.getName(),
+                                                                                                  thumbnailObject);
+    assertEquals(0, metadataItemList.size());
+    FileItem thumbnail = imageThumbnailService.getOrCreateThumbnail(fileThumbnail, userIdentity, 45, 45);
+    assertNotNull(thumbnail);
+
+    metadataItemList = metadataService.getMetadataItemsByMetadataTypeAndObject(metadataType.getName(),
+            thumbnailObject);
+    assertEquals(1, metadataItemList.size());
+
+    thumbnail = imageThumbnailService.getOrCreateThumbnail(fileThumbnail, userIdentity, 45, 45);
+    assertNotNull(thumbnail);
+    metadataItemList = metadataService.getMetadataItemsByMetadataTypeAndObject(metadataType.getName(),
+            thumbnailObject);
+    assertEquals(1, metadataItemList.size());
+  }
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/test/InitContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/InitContainerTestSuite.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.social.core.test;
 
+import org.exoplatform.social.core.metadata.thumbnail.ImageThumbnailServiceImplTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runners.Suite.SuiteClasses;
@@ -88,6 +89,7 @@ import org.exoplatform.social.metadata.tag.TagServiceTest;
     ActivityMetadataListenerTest.class,
     ActivityTagMetadataListenerTest.class,
     MetadataActivityProcessorTest.class,
+    ImageThumbnailServiceImplTest.class
 })
 @ConfigTestCase(AbstractCoreTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -405,6 +405,11 @@
   </component>
 
   <component>
+    <key>org.exoplatform.social.metadata.thumbnail.ImageThumbnailService</key>
+    <type>org.exoplatform.social.core.metadata.thumbnail.ImageThumbnailServiceImpl</type>
+  </component>
+
+  <component>
     <key>org.exoplatform.social.core.manager.IdentityManager</key>
     <type>org.exoplatform.social.core.manager.IdentityManagerImpl</type>
     <component-plugins>
@@ -668,6 +673,29 @@
             </field>
             <field name="name">
               <string>tags</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>ThumbnailMetadataPlugin</name>
+      <set-method>addMetadataTypePlugin</set-method>
+      <type>org.exoplatform.social.metadata.MetadataTypePlugin</type>
+      <init-params>
+        <value-param>
+          <name>allowMultipleItemsPerObject</name>
+          <description>Whether to allow adding the same object to the same Metadata or not</description>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>metadataType</name>
+          <object type="org.exoplatform.social.metadata.model.MetadataType">
+            <field name="id">
+              <int>5</int>
+            </field>
+            <field name="name">
+              <string>thumbnail</string>
             </field>
           </object>
         </object-param>

--- a/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
@@ -131,6 +131,25 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>file.created</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>file.updated</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>file.deleted</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+    </component-plugin>
+  </external-component-plugins>
+
   <remove-configuration>org.exoplatform.portal.resource.SkinResourceRequestHandler</remove-configuration>
   <remove-configuration>org.exoplatform.web.WebAppController</remove-configuration>
   <remove-configuration>org.exoplatform.services.scheduler.JobSchedulerService</remove-configuration>

--- a/component/service/pom.xml
+++ b/component/service/pom.xml
@@ -207,6 +207,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.imgscalr</groupId>
+      <artifactId>imgscalr-lib</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-testing</artifactId>
       <scope>test</scope>

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
@@ -31,6 +31,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.space.spi.SpaceTemplateService;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
+import org.exoplatform.social.metadata.thumbnail.ImageThumbnailService;
 import org.exoplatform.social.mock.MockUploadService;
 import org.exoplatform.social.rest.entity.CollectionEntity;
 import org.exoplatform.social.rest.entity.DataEntity;
@@ -43,21 +44,31 @@ import org.exoplatform.upload.UploadService;
 import org.json.JSONObject;
 
 public class SpaceRestResourcesTest extends AbstractResourceTest {
-  private IdentityManager identityManager;
-  private OrganizationService organizationService;
-  private UserACL userACL;
-  private ActivityManager activityManager;
-  private SpaceService spaceService;
+  private IdentityManager       identityManager;
 
-  private SpaceRestResourcesV1 spaceRestResources;
+  private OrganizationService   organizationService;
 
-  private Identity rootIdentity;
-  private Identity johnIdentity;
-  private Identity maryIdentity;
-  private Identity demoIdentity;
-  private Identity externalUserIdentity;
+  private UserACL               userACL;
 
-  private MockUploadService    uploadService;
+  private ActivityManager       activityManager;
+
+  private SpaceService          spaceService;
+
+  private SpaceRestResourcesV1  spaceRestResources;
+
+  private Identity              rootIdentity;
+
+  private Identity              johnIdentity;
+
+  private Identity              maryIdentity;
+
+  private Identity              demoIdentity;
+
+  private Identity              externalUserIdentity;
+
+  private ImageThumbnailService imageThumbnailService;
+
+  private MockUploadService     uploadService;
 
   public void setUp() throws Exception {
     super.setUp();
@@ -69,16 +80,19 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
     spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
     organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
     uploadService = (MockUploadService) getContainer().getComponentInstanceOfType(UploadService.class);
-
+    imageThumbnailService = getContainer().getComponentInstanceOfType(ImageThumbnailService.class);
+    
     rootIdentity = identityManager.getOrCreateIdentity("organization", "root");
     johnIdentity = identityManager.getOrCreateIdentity("organization", "john");
     maryIdentity = identityManager.getOrCreateIdentity("organization", "mary");
     demoIdentity = identityManager.getOrCreateIdentity("organization", "demo");
 
-    spaceRestResources = new SpaceRestResourcesV1(new ActivityRestResourcesV1(activityManager, identityManager, spaceService, null),
-                                                  spaceService,
-                                                  identityManager,
-                                                  uploadService);
+    spaceRestResources =
+                       new SpaceRestResourcesV1(new ActivityRestResourcesV1(activityManager, identityManager, spaceService, null),
+                                                spaceService,
+                                                identityManager,
+                                                uploadService,
+                                                imageThumbnailService);
     registry(spaceRestResources);
 
     SpaceTemplatesRestResourcesV1 spaceTemplatesRestResourcesV1 = new SpaceTemplatesRestResourcesV1(getContainer().getComponentInstanceOfType(SpaceTemplateService.class), getContainer().getComponentInstanceOfType(ConfigurationManager.class));

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -11,6 +11,8 @@ import java.util.*;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.services.thumbnail.ImageResizeService;
+import org.exoplatform.social.metadata.thumbnail.ImageThumbnailService;
 import org.json.JSONObject;
 import org.mortbay.cometd.continuation.EXoContinuationBayeux;
 
@@ -64,6 +66,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
   private MockUploadService   uploadService;
 
   private UserSearchService   userSearchService;
+  
+  private ImageThumbnailService imageThumbnailService;
 
   private Identity            rootIdentity;
 
@@ -88,6 +92,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     uploadService = (MockUploadService) getContainer().getComponentInstanceOfType(UploadService.class);
     organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
     userSearchService = getContainer().getComponentInstanceOfType(UserSearchService.class);
+    imageThumbnailService = getContainer().getComponentInstanceOfType(ImageThumbnailService.class);
     rootIdentity = new Identity(OrganizationIdentityProvider.NAME, "root");
     johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
     maryIdentity = new Identity(OrganizationIdentityProvider.NAME, "mary");
@@ -110,7 +115,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                       userStateService,
                                                                       spaceService,
                                                                       uploadService,
-                                                                      userSearchService);
+                                                                      userSearchService,
+                                                                      imageThumbnailService);
     registry(userRestResourcesV1);
   }
 
@@ -175,7 +181,11 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
     when(identityManager.getIdentitiesByProfileFilter(anyString(), any(), anyBoolean())).thenReturn(identityListAccess);
 
-    UserRestResourcesV1 userRestResources = new UserRestResourcesV1(new ActivityRestResourcesV1(activityManager, identityManager, spaceService, null),
+    UserRestResourcesV1 userRestResources = new UserRestResourcesV1(
+                                                                    new ActivityRestResourcesV1(activityManager,
+                                                                                                identityManager,
+                                                                                                spaceService,
+                                                                                                null),
                                                                     userACL,
                                                                     organizationService,
                                                                     identityManager,
@@ -183,7 +193,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                     userStateService,
                                                                     spaceService,
                                                                     uploadService,
-                                                                    userSearchService);
+                                                                    userSearchService,
+                                                                    imageThumbnailService);
     registry(userRestResources);
 
     //when

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -414,6 +414,11 @@
     </component>
 
     <component>
+        <key>org.exoplatform.social.metadata.thumbnail.ImageThumbnailService</key>
+        <type>org.exoplatform.social.core.metadata.thumbnail.ImageThumbnailServiceImpl</type>
+    </component>
+
+    <component>
         <key>org.exoplatform.social.core.processor.I18NActivityProcessor</key>
         <type>org.exoplatform.social.core.processor.I18NActivityProcessor</type>
         <component-plugins>
@@ -840,6 +845,25 @@
             <set-method>addListener</set-method>
             <type>org.exoplatform.social.core.listeners.SynchronizedUsersListenerImpl</type>
             <description>Edit external store user listener.</description>
+        </component-plugin>
+    </external-component-plugins>
+
+    <external-component-plugins>
+        <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+        <component-plugin>
+            <name>file.created</name>
+            <set-method>addListener</set-method>
+            <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+        </component-plugin>
+        <component-plugin>
+            <name>file.updated</name>
+            <set-method>addListener</set-method>
+            <type>org.exoplatform.social.core.listeners.FileActionListener</type>
+        </component-plugin>
+        <component-plugin>
+            <name>file.deleted</name>
+            <set-method>addListener</set-method>
+            <type>org.exoplatform.social.core.listeners.FileActionListener</type>
         </component-plugin>
     </external-component-plugins>
 

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/metadata-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/metadata-plugins-configuration.xml
@@ -77,6 +77,29 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>ThumbnailMetadataPlugin</name>
+      <set-method>addMetadataTypePlugin</set-method>
+      <type>org.exoplatform.social.metadata.MetadataTypePlugin</type>
+      <init-params>
+        <value-param>
+          <name>allowMultipleItemsPerObject</name>
+          <description>Whether to allow adding the same object to the same Metadata or not</description>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>metadataType</name>
+          <object type="org.exoplatform.social.metadata.model.MetadataType">
+            <field name="id">
+              <int>5</int>
+            </field>
+            <field name="name">
+              <string>thumbnail</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -20,7 +20,7 @@
           tile>
           <img
             v-if="thumbnail"
-            :src="thumbnail"
+            :src="`${thumbnail}&size=250x150`"
             :alt="title"
             class="object-fit-cover my-auto"
             loading="lazy"

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -85,8 +85,8 @@
     <div class="peopleAvatar">
       <a :href="url">
         <v-img
-          :lazy-src="userAvatarUrl"
-          :src="userAvatarUrl"
+          :lazy-src="`${userAvatarUrl}&size=65x65`"
+          :src="`${userAvatarUrl}&size=65x65`"
           transition="none"
           class="mx-auto"
           height="65px"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderAvatar.vue
@@ -4,8 +4,8 @@
     :size="size"
     class="align-start flex-grow-0 ms-3 my-3 profileHeaderAvatar">
     <v-img
-      :lazy-src="(avatarData || user && user.avatar) || ''" 
-      :src="(avatarData || user && user.avatar) || ''" 
+      :lazy-src="(avatarData || user && `${user.avatar}&size=165x165`) || ''"
+      :src="(avatarData || user && `${user.avatar}&size=165x165`) || ''"
       transition="none"
       eager
       role="presentation" />

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingFormDrawer.vue
@@ -16,7 +16,7 @@
           <space-setting-avatar
             ref="spaceAvatar"
             v-model="space.avatarId"
-            :avatar-url="space.avatarUrl"
+            :avatar-url="`${space.avatarUrl}&size=165x165`"
             :max-upload-size="maxUploadSize"
             class="mx-auto mb-6 mt-2"
             hover

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -44,7 +44,7 @@
               height="60">
               <v-img
                 class="object-fit-cover"
-                :src="logoPath" />
+                :src="`${logoPath}&size=60x60`" />
             </v-list-item-avatar>
             <v-list-item-content class="pb-0 pt-0">
               <v-list-item-title>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
@@ -84,7 +84,7 @@
     <div class="spaceAvatar">
       <a :href="url">
         <v-img
-          :src="spaceAvatarUrl"
+          :src="`${spaceAvatarUrl}&size=75x75`"
           transition="none"
           class="mx-auto"
           height="75px"


### PR DESCRIPTION
Prior to this change, avatars are displayed and fetched with their original size, which affects the perf and leading to a critical loading time in the stream page because of the number of the enormous loaded images.
This PR:
1 - Use the ResizeImageService and applying a resize step on avatars (users and spaces) on server side before rendering it on the page which enhance the perf on the stream page and the images load time. The resized image in store by using Metadata Service
2 - Make sure to drop related metadata when the avatar was updated to recreate it when resize the new uploaded image.
