### PR TITLE
fix: Fix edited activity link and its preview still displayed after removing the link - EXO-60760 - Meeds-io/meeds#417

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -763,7 +763,7 @@ public class EntityBuilder {
     while (entries.hasNext()) {
       Map.Entry<String, String> entry = entries.next();
       if (entry != null && (StringUtils.isBlank(entry.getValue()) || StringUtils.equals(entry.getValue(), "-"))) {
-        entries.remove();
+        entry.setValue("");
       }
     }
     activity.setTemplateParams(currentTemplateParams);

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
@@ -590,6 +590,35 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     assertEquals(4, result.getTemplateParams().size());
   }
 
+  public void testUpdateLinkActivityById() throws Exception {
+    startSessionAs("root");
+
+    ExoSocialActivity rootActivity = new ExoSocialActivityImpl();
+    rootActivity.setTitle("test activity");
+    rootActivity.setType("LINK_ACTIVITY");
+    Map<String, String> templateParams = new HashMap<String, String>();
+    templateParams.put("link", "https://www.linkedin.com/");
+    rootActivity.setTemplateParams(templateParams);
+    activityManager.saveActivityNoReturn(rootIdentity, rootActivity);
+    ContainerResponse response = service("GET",
+            "/" + VersionResources.VERSION_ONE + "/social/activities/" + rootActivity.getId(), "", null, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    ActivityEntity result = getBaseEntity(response.getEntity(), ActivityEntity.class);
+    assertEquals("test activity", result.getTitle());
+    assertEquals("https://www.linkedin.com/", result.getTemplateParams().get("link"));
+
+    String input = "{\"title\":\"updated title\",\"templateParams\":{\"link\":\"-\"}}";
+
+    response = getResponse("PUT", "/" + VersionResources.VERSION_ONE + "/social/activities/" + rootActivity.getId(), input);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    result = getBaseEntity(response.getEntity(), ActivityEntity.class);
+    assertEquals("updated title", result.getTitle());
+    rootActivity = activityManager.getActivity(rootActivity.getId());
+    assertEquals("", rootActivity.getTemplateParams().get("link"));
+  }
+
   public void testHideActivityById() throws Exception {
     startSessionAs("root");
 

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -197,6 +197,8 @@ export default {
         let activityType = this.activityType;
         if (this.templateParams && this.templateParams.link && !this.activityType) {
           activityType = 'LINK_ACTIVITY';
+        } else if (this.templateParams && this.templateParams.link === '-') {
+          activityType = null;
         }
         this.loading = true;
         this.$activityService.updateActivity(this.activityId, message, activityType, this.files, this.templateParams)


### PR DESCRIPTION
Prior to this change, when we modify an activity containing a link with its corresponding preview by deleting the link and the corresponding preview and adding a simple text, the link and the corresponding preview are still displayed. The problem is that the updated activity templateParams related to the link will be deleted, so when we put the template params of the updated activity to those of the old one, the deleted link template params of the updated activity will persist with the old activity ones. After this modification, we will ensure to persist the link template params of the updated activity in order to update the activity without link and corresponding preview.