### PR TITLE
feat: Unread activities information Display number of unread activities for a space from the left menu - MEED-700- Meeds-io/MIPs#17

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -299,6 +299,17 @@ public interface MetadataService {
   int countMetadataItemsByMetadataTypeAndCreator (String metadataTypeName, long creatorId);
 
   /**
+   * Count the size of Metadata items to a given {@link Metadata} type,
+   * {@link MetadataItem} creatorId
+   * by a given {@link Space} identifier
+   *
+   * @param metadataTypeName {@link Metadata} type
+   * @param creatorId {@link MetadataItem} creatorId
+   * @param spaceId {@link Space} technical identifier
+   * @return map of Metadata items grouped by objectId {@link MetadataObject}
+   */
+  Map<String, Long> countMetadataItemsByMetadataTypeAndAudienceId(String metadataTypeName, long creatorId, long spaceId);
+  /**
    * Retrieves the list of Metadata items attached to a {@link MetadataKey} and
    * an object identified by its name and identifier
    * 

--- a/component/api/src/main/java/org/exoplatform/social/notification/service/SpaceWebNotificationService.java
+++ b/component/api/src/main/java/org/exoplatform/social/notification/service/SpaceWebNotificationService.java
@@ -19,8 +19,12 @@
 package org.exoplatform.social.notification.service;
 
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
 import org.exoplatform.social.notification.plugin.SpaceWebNotificationPlugin;
+
+import java.util.Map;
 
 public interface SpaceWebNotificationService {
 
@@ -55,5 +59,15 @@ public interface SpaceWebNotificationService {
    * @throws Exception
    */
   void markAsRead(SpaceWebNotificationItem notificationItem) throws Exception;
+
+  /**
+   * Get a list of aunread items per application to a given {@link MetadataItem} creatorId
+   * by a given {@link Space} identifier
+   *
+   * @param creatorId {@link MetadataItem} creatorId
+   * @spaceId spaceId {@link Space} spaceId
+   * @return Map of application and unread items
+   */
+  Map<String, Long> countUnreadItemsByApplication(long creatorId, long spaceId);
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -193,6 +193,21 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     return query.getSingleResult().intValue();
   }
 
+  public List<Tuple> countMetadataItemsByMetadataTypeAndAudienceId(long metadataType, long creatorId, long spaceId) {
+    TypedQuery<Tuple> query =
+        getEntityManager().createNamedQuery("SocMetadataItemEntity.countMetadataItemsByMetadataTypeAndAudienceId",
+            Tuple.class);
+    query.setParameter(METADATA_TYPE_PARAM, metadataType);
+    query.setParameter(CREATOR_ID, creatorId);
+    query.setParameter(SPACE_ID, spaceId);
+    List<Tuple> result = query.getResultList();
+    if (CollectionUtils.isEmpty(result)) {
+      return Collections.emptyList();
+    } else {
+      return result;
+    }
+  }
+
   public List<String> getMetadataObjectIds(long metadataType,
                                            String metadataName,
                                            String objectType,

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -135,6 +135,17 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         + " AND mi.metadata.audienceId = :audienceId"
 )
 @NamedNativeQuery(
+    name = "SocMetadataItemEntity.countMetadataItemsByMetadataTypeAndAudienceId",
+    query = "SELECT item.object_type, COUNT(DISTINCT item.metadata_item_id) FROM SOC_METADATA_ITEMS item "
+        + " INNER JOIN SOC_METADATAS sm"
+        + " ON item.metadata_id = sm.metadata_id "
+        + " AND sm.type = :metadataType "
+        + " AND sm.audience_id = :creatorId "
+        + " WHERE item.space_id = :spaceId "
+        + " GROUP BY item.object_type"
+)
+
+@NamedNativeQuery(
     name = "SocMetadataItemEntity.getMetadataItemsByMetadataNameAndTypeAndObjectAndMetadataItemProperty",
     query = "SELECT DISTINCT sm.*  FROM SOC_METADATA_ITEMS sm"
         + " INNER JOIN SOC_METADATAS sm_"

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -378,6 +378,17 @@ public class MetadataServiceImpl implements MetadataService, Startable {
     return this.metadataStorage.countMetadataItemsByMetadataTypeAndCreator(metadataType.getId(), creatorId);
   }
 
+  public Map<String, Long> countMetadataItemsByMetadataTypeAndAudienceId(String metadataTypeName, long creatorId, long spaceId) {
+    MetadataType metadataType = getMetadataTypeByName(metadataTypeName);
+    if (metadataType == null) {
+      throw new IllegalArgumentException("Metadata Type " + metadataType + " is not registered as a plugin");
+    }
+    if (creatorId <= 0) {
+      throw new IllegalArgumentException("creatorId is mandatory.");
+    }
+    return this.metadataStorage.countMetadataItemsByMetadataTypeAndAudienceId(metadataType.getId(), creatorId, spaceId);
+  }
+
   @Override
   public Set<String> getMetadataNamesByObject(MetadataObject object) {
     return this.metadataStorage.getMetadataNamesByObject(object);

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
@@ -15,12 +15,8 @@
  */
 package org.exoplatform.social.core.metadata.storage;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.math.BigInteger;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -36,6 +32,8 @@ import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataKey;
 import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.metadata.model.MetadataType;
+
+import javax.persistence.Tuple;
 
 public class MetadataStorage {
 
@@ -136,6 +134,16 @@ public class MetadataStorage {
 
   public int countMetadataItemsByMetadataTypeAndCreator(long metadataType, long creatorId) {
     return metadataItemDAO.countMetadataItemsByMetadataTypeAndCreator(metadataType, creatorId);
+  }
+
+  public Map<String, Long> countMetadataItemsByMetadataTypeAndAudienceId(long metadataType, long creatorId, long spaceId) {
+    List<Tuple> metadataItemsTuple =
+                                   metadataItemDAO.countMetadataItemsByMetadataTypeAndAudienceId(metadataType, creatorId, spaceId);
+    Map<String, Long> metadataItemsMap = new HashMap<>();
+    for (Tuple tuple : metadataItemsTuple) {
+      metadataItemsMap.put((String) tuple.get(0), ((BigInteger) tuple.get(1)).longValue());
+    }
+    return metadataItemsMap;
   }
 
   public List<MetadataItem> getMetadataItemsByMetadataNameAndTypeAndObject(String metadataName,

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
@@ -20,6 +20,7 @@ package org.exoplatform.social.notification.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
 
@@ -121,6 +122,11 @@ public class SpaceWebNotificationServiceImpl implements SpaceWebNotificationServ
       }
       listenerService.broadcast(NOTIFICATION_READ_EVENT_NAME, userIdentityId, notificationItem);
     }
+  }
+
+  @Override
+  public Map<String, Long> countUnreadItemsByApplication(long creatorId, long spaceId) {
+    return metadataService.countMetadataItemsByMetadataTypeAndAudienceId(METADATA_TYPE_NAME, creatorId, spaceId);
   }
 
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -63,6 +63,7 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.social.metadata.favorite.model.Favorite;
 import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.notification.service.SpaceWebNotificationService;
 import org.exoplatform.social.rest.entity.*;
 import org.exoplatform.social.service.rest.Util;
 import org.exoplatform.social.service.rest.api.VersionResources;
@@ -476,10 +477,25 @@ public class EntityBuilder {
         }
 
         if (expandFields.contains(RestProperties.FAVORITE)) {
-          FavoriteService favoriteService = ExoContainerContext.getService(FavoriteService.class);
           Identity userIdentity = identityManager.getOrCreateUserIdentity(userId);
-          boolean isFavorite = favoriteService.isFavorite(new Favorite(Space.DEFAULT_SPACE_METADATA_OBJECT_TYPE, space.getId(), null, Long.parseLong(userIdentity.getId())));
+          FavoriteService favoriteService = ExoContainerContext.getService(FavoriteService.class);
+          boolean isFavorite = favoriteService.isFavorite(new Favorite(Space.DEFAULT_SPACE_METADATA_OBJECT_TYPE,
+                                                                       space.getId(),
+                                                                       null,
+                                                                       Long.parseLong(userIdentity.getId())));
           spaceEntity.setIsFavorite(String.valueOf(isFavorite));
+        }
+
+        if (expandFields.contains(RestProperties.UNREAD)) {
+          Identity userIdentity = identityManager.getOrCreateUserIdentity(userId);
+          SpaceWebNotificationService spaceWebNotificationService =
+                                                                  ExoContainerContext.getService(SpaceWebNotificationService.class);
+          Map<String, Long> unreadItems =
+                                        spaceWebNotificationService.countUnreadItemsByApplication(Long.parseLong(userIdentity.getId()),
+                                                                                                     Long.parseLong(space.getId()));
+          if (MapUtils.isNotEmpty(unreadItems)) {
+            spaceEntity.setUnreadItems(unreadItems);
+          }
         }
       }
       boolean isManager = spaceService.isManager(space, userId);

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/RestProperties.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/RestProperties.java
@@ -67,4 +67,6 @@ public class RestProperties {
 
   public static final String FAVORITE      = "favorite";
 
+  public static final String UNREAD        = "unread";
+
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/SpaceRestResources.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/SpaceRestResources.java
@@ -46,7 +46,6 @@ public interface SpaceRestResources extends SocialRest {
  * @param sort
  * @param order
  * @param returnSize
- * @param favorites
  * @param expand
  * @return
  * @throws Exception
@@ -61,7 +60,6 @@ public interface SpaceRestResources extends SocialRest {
                                      @QueryParam("sort") String sort,
                                      @QueryParam("order") String order,
                                      @QueryParam("returnSize") boolean returnSize,
-                                     @QueryParam("favorites") boolean favorites,
                                      @QueryParam("expand") String expand) throws Exception;
 
   /**

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/SpaceEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/SpaceEntity.java
@@ -18,6 +18,7 @@
 package org.exoplatform.social.rest.entity;
 
 import java.util.List;
+import java.util.Map;
 
 import org.exoplatform.social.core.identity.model.Identity;
 
@@ -327,6 +328,15 @@ public class SpaceEntity extends BaseEntity {
 
   public SpaceEntity setIsFavorite(String isFavorite) {
     setProperty("isFavorite", isFavorite);
+    return this;
+  }
+
+  public Map<String, Long> getUnreadItems() {
+    return (Map<String, Long>) getProperty("unreadActivitiesCount");
+  }
+
+  public SpaceEntity setUnreadItems(Map<String, Long> getUnreadItems) {
+    setProperty("unreadActivitiesCount", getUnreadItems);
     return this;
   }
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -145,8 +145,6 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
                             @Parameter(description = "Order", required = false) @QueryParam("order") String order,
                             @Parameter(description = "Returning the number of spaces found or not")
                             @Schema(defaultValue = "false")  @QueryParam("returnSize") boolean returnSize,
-                            @Parameter(description = "Returning the favorite spaces of current user not not")
-                            @Schema(defaultValue = "false")  @QueryParam("favorites") boolean favorites,
                             @Parameter(description = "Asking for a full representation of a specific subresource, ex: members or managers", required = false) @QueryParam("expand") String expand) throws Exception {
 
     offset = offset > 0 ? offset : RestUtils.getOffset(uriInfo);
@@ -171,8 +169,9 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
         }
         spaceFilter.setSorting(new Sorting(sortBy, orderBy));
     }
-    spaceFilter.setIsFavorite(favorites);
-
+    if (StringUtils.isNotBlank(expand)) {
+      spaceFilter.setIsFavorite(Arrays.asList(StringUtils.split(expand, ",")).contains(RestProperties.FAVORITE));
+    }
     String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
     if (StringUtils.equalsIgnoreCase(SPACE_FILTER_TYPE_ALL, filterType)) {
       listAccess = spaceService.getVisibleSpacesWithListAccess(authenticatedUser, spaceFilter);

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -400,7 +400,7 @@
     </init-param>
     <init-param>
       <name>prefetch.resource.rest</name>
-      <value><![CDATA[/portal/rest/v1/social/spaces?q=&offset=0&limit=7&filterType=lastVisited&returnSize=true&expand=member,managers,favorite]]></value>
+      <value><![CDATA[/portal/rest/v1/social/spaces?q=&offset=0&limit=7&filterType=lastVisited&returnSize=true&expand=member,managers,favorite,unread]]></value>
     </init-param>
     <init-param>
       <name>separator</name>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/ExoSpacesNavigationContent.vue
@@ -115,7 +115,7 @@ export default {
   },
   methods: {
     searchSpaces() {
-      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces?q=&offset=${this.offset}&limit=${this.limitToFetch}&filterType=lastVisited&returnSize=true&expand=member,managers,favorite`, {
+      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces?q=&offset=${this.offset}&limit=${this.limitToFetch}&filterType=lastVisited&returnSize=true&expand=member,managers,favorite,unread`, {
         method: 'GET',
         credentials: 'include',
       })

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpaceNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpaceNavigationItem.vue
@@ -62,16 +62,30 @@
         </v-icon>
       </v-btn>
     </v-list-item-icon>
+    <v-list-item-icon
+      v-if="!toggleArrow && spaceUnreadActivities && !this.SpaceWebNotificationsEnabled"
+      class="me-2 align-center">
+      <v-btn
+        class="error-color-background white--text"
+        width="22"
+        height="22"
+        depressed
+        fab>
+        {{ spaceUnreadActivities }}
+      </v-btn>
+    </v-list-item-icon>
   </v-list-item>
 </template>
 <script>
+
 export default {
   data () {
     return {
       secondLevelVueInstancee: null,
       secondeLevel: false,
       showItemActions: false,
-      arrowIcon: 'fa-arrow-right'
+      arrowIcon: 'fa-arrow-right',
+      SpaceWebNotificationsEnabled: eXo.env.portal.SpaceWebNotificationsEnabled
     };
   },
   props: {
@@ -101,6 +115,9 @@ export default {
     },
     spaceDisplayName() {
       return this.space?.displayName;
+    },
+    spaceUnreadActivities() {
+      return this.space?.unreadActivitiesCount?.activity;
     },
     toggleArrow() {
       return this.showItemActions || this.secondeLevel;


### PR DESCRIPTION
This Task allows to add a badge of the number of unread items per application to the recent viewed spaces from the left navigation menu. For now this information will be retrieve only when the value "unread" is added to "&expand=...,unread" Path parameter.