### PR TITLE
fix: After size reduction avatar is pixelized - EXO-61042 - meeds-io/meeds#25

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/common/Utils.java
+++ b/component/api/src/main/java/org/exoplatform/social/common/Utils.java
@@ -115,7 +115,8 @@ public class Utils {
     int[] dimension = new int[2];
     if (size.contains(SIZE_SPLIT_CHAR) && !size.startsWith(SIZE_SPLIT_CHAR)) {
       dimension[0] = Integer.parseInt(size.split(SIZE_SPLIT_CHAR)[0]);
-    } else if (size.contains(SIZE_SPLIT_CHAR) && !size.endsWith(SIZE_SPLIT_CHAR)) {
+    }
+    if (size.contains(SIZE_SPLIT_CHAR) && !size.endsWith(SIZE_SPLIT_CHAR)) {
       dimension[1] = Integer.parseInt(size.split(SIZE_SPLIT_CHAR)[1]);
     }
     return dimension;


### PR DESCRIPTION
Before this fix, in user profil, in stream, avatar is displayed pixelized. But as we are reducing the original image, it should not This problem is due to how we parse the requested avatar size. Before the fix, only one parameter is read. This fix cahnge the behaviour to correctly read 2 parameters of the size