### PR TITLE
fix: getting notifications while not member anymore in a space - EXO-61097

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -146,9 +146,9 @@ public class Utils {
    * Checks if a notification message is sent to an activity poster when a new comment is created.
    * @param receivers The list of users receiving the notification message.
    * @param activityPosterId Id of the activity poster.
-   * @param posteId Id of the user who has commented.
+   * @param posterId Id of the user who has commented.
    */
-  public static void sendToActivityPoster(Set<String> receivers, String activityPosterId, String posteId , String spaceId) {
+  public static void sendToActivityPoster(Set<String> receivers, String activityPosterId, String posterId , String spaceId) {
     String activityPosterRemoteId = Utils.getUserId(activityPosterId);
     SpaceService spaceService = getSpaceService();
     Space space = spaceService.getSpaceById(spaceId);
@@ -156,7 +156,7 @@ public class Utils {
     if (space != null) {
       isMember = spaceService.isMember(space, activityPosterRemoteId);
     }
-    if (!activityPosterId.equals(posteId) && isMember) {
+    if (!activityPosterId.equals(posterId) && isMember) {
 
       receivers.add(activityPosterRemoteId);
     }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -116,12 +116,12 @@ public class Utils {
     return (id != null);
   }
   
-  public static void sendToCommeters(Set<String> receivers, String[] commenters, String poster) {
-    receivers.addAll(getDestinataires(commenters, poster));
+  public static void sendToCommeters(Set<String> receivers, String[] commenters, String poster, String spaceId) {
+    receivers.addAll(getDestinataires(commenters, poster, spaceId));
   }
 
-  public static void sendToLikers(Set<String> receivers, String[] likers, String poster) {
-    receivers.addAll(getDestinataires(likers, poster));
+  public static void sendToLikers(Set<String> receivers, String[] likers, String poster, String spaceId) {
+    receivers.addAll(getDestinataires(likers, poster, spaceId));
   }
   
   /**
@@ -148,15 +148,22 @@ public class Utils {
    * @param activityPosterId Id of the activity poster.
    * @param posteId Id of the user who has commented.
    */
-  public static void sendToActivityPoster(Set<String> receivers, String activityPosterId, String posteId) {
+  public static void sendToActivityPoster(Set<String> receivers, String activityPosterId, String posteId , String spaceId) {
     String activityPosterRemoteId = Utils.getUserId(activityPosterId);
-    if (activityPosterId.equals(posteId) == false) {
+    SpaceService spaceService = getSpaceService();
+    Space space = spaceService.getSpaceById(spaceId);
+    boolean isMember = false;
+    if (space != null) {
+      isMember = spaceService.isMember(space, activityPosterRemoteId);
+    }
+    if (!activityPosterId.equals(posteId) && ((isMember && space != null) || (space == null))) {
+
       receivers.add(activityPosterRemoteId);
     }
   }
   
   public static void sendToMentioners(Set<String> receivers, String[] mentioners, String poster) {
-    receivers.addAll(getDestinataires(mentioners, poster));
+    receivers.addAll(getDestinataires(mentioners, poster, null));
   }
   
   /**
@@ -166,12 +173,19 @@ public class Utils {
    * @param poster The user who has posted the activity or comment.
    * @return The remote Ids.
    */
-  private static Set<String> getDestinataires(String[] users, String poster) {
+  private static Set<String> getDestinataires(String[] users, String poster , String spaceId) {
     Set<String> destinataires = new HashSet<String>();
+    Space space = null ;
+    SpaceService spaceService = getSpaceService();
+    space = spaceService.getSpaceById(spaceId);
     for (String user : users) {
       user = user.split("@")[0];
       String userName = getUserId(user);
-      if (! user.equals(poster)) {
+      boolean isMember = false;
+      if(space != null) {
+        isMember = spaceService.isMember(space, userName);
+      }
+      if (!user.equals(poster) && ((isMember && space != null) || ( space == null))) {
         destinataires.add(userName);
       }
     }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -162,8 +162,8 @@ public class Utils {
     }
   }
   
-  public static void sendToMentioners(Set<String> receivers, String[] mentioners, String poster) {
-    receivers.addAll(getDestinataires(mentioners, poster, null));
+  public static void sendToMentioners(Set<String> receivers, String[] mentioners, String poster, String spaceId) {
+    receivers.addAll(getDestinataires(mentioners, poster, spaceId));
   }
   
   /**
@@ -175,9 +175,8 @@ public class Utils {
    */
   private static Set<String> getDestinataires(String[] users, String poster , String spaceId) {
     Set<String> destinataires = new HashSet<String>();
-    Space space = null ;
     SpaceService spaceService = getSpaceService();
-    space = spaceService.getSpaceById(spaceId);
+    Space space = spaceService.getSpaceById(spaceId);
     for (String user : users) {
       user = user.split("@")[0];
       String userName = getUserId(user);
@@ -221,14 +220,19 @@ public class Utils {
    * @param posterId id of the poster
    * @return list of mentioners
    */
-  public static Set<String> getMentioners(String title, String posterId) {
+  public static Set<String> getMentioners(String title, String posterId, String spaceId) {
     String posterRemoteId = getUserId(posterId);
     Set<String> mentioners = new HashSet<String>();
     Matcher matcher = MENTION_PATTERN.matcher(title);
-    while (matcher.find()) {
+    SpaceService spaceService = getSpaceService();
+    Space space = spaceService.getSpaceById(spaceId);    while (matcher.find()) {
       String remoteId = matcher.group(2);
       Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, remoteId, false);
-      if (identity != null && posterRemoteId.equals(remoteId) == false) { 
+      boolean isMember = false;
+      if(space != null) {
+        isMember = spaceService.isMember(space, remoteId);
+      }
+      if (identity != null && !posterRemoteId.equals(remoteId) && ((isMember && space != null) || ( space == null))) {
         mentioners.add(remoteId);
       }
     }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -152,11 +152,11 @@ public class Utils {
     String activityPosterRemoteId = Utils.getUserId(activityPosterId);
     SpaceService spaceService = getSpaceService();
     Space space = spaceService.getSpaceById(spaceId);
-    boolean isMember = false;
+    boolean isMember = true;
     if (space != null) {
       isMember = spaceService.isMember(space, activityPosterRemoteId);
     }
-    if (!activityPosterId.equals(posteId) && ((isMember && space != null) || (space == null))) {
+    if (!activityPosterId.equals(posteId) && isMember) {
 
       receivers.add(activityPosterRemoteId);
     }
@@ -180,11 +180,11 @@ public class Utils {
     for (String user : users) {
       user = user.split("@")[0];
       String userName = getUserId(user);
-      boolean isMember = false;
+      boolean isMember = true;
       if(space != null) {
         isMember = spaceService.isMember(space, userName);
       }
-      if (!user.equals(poster) && ((isMember && space != null) || ( space == null))) {
+      if (!user.equals(poster) && isMember) {
         destinataires.add(userName);
       }
     }
@@ -225,14 +225,15 @@ public class Utils {
     Set<String> mentioners = new HashSet<String>();
     Matcher matcher = MENTION_PATTERN.matcher(title);
     SpaceService spaceService = getSpaceService();
-    Space space = spaceService.getSpaceById(spaceId);    while (matcher.find()) {
+    Space space = spaceService.getSpaceById(spaceId);
+    while (matcher.find()) {
       String remoteId = matcher.group(2);
       Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, remoteId, false);
-      boolean isMember = false;
-      if(space != null) {
+      boolean isMember = true;
+      if (space != null) {
         isMember = spaceService.isMember(space, remoteId);
       }
-      if (identity != null && !posterRemoteId.equals(remoteId) && ((isMember && space != null) || ( space == null))) {
+      if (identity != null && !posterRemoteId.equals(remoteId) && isMember) {
         mentioners.add(remoteId);
       }
     }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
@@ -44,30 +44,30 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
   public NotificationInfo makeNotification(NotificationContext ctx) {
     ExoSocialActivity comment = ctx.value(SocialNotificationUtils.ACTIVITY);
     ExoSocialActivity activity = Utils.getActivityManager().getParentActivity(comment);
-
+    String spaceId = activity.getSpaceId();
     Set<String> receivers = new HashSet<String>();
     if (StringUtils.isNotBlank(comment.getParentCommentId())) {
       ExoSocialActivity parentComment = Utils.getActivityManager().getActivity(comment.getParentCommentId());
       String parentCommentUserPosterId = Utils.getUserId(parentComment.getPosterId());
       if (isSubComment) {
         // Send notification to parent comment poster
-        Utils.sendToActivityPoster(receivers, parentComment.getPosterId(), comment.getPosterId());
+        Utils.sendToActivityPoster(receivers, parentComment.getPosterId(), comment.getPosterId(), spaceId);
       } else {
         // Send notification to all others users who have commented on this activity
         // except parent comment poster
-        Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
+        Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId(), spaceId);
         Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
-        Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
+        Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId(), spaceId);
         receivers.remove(parentCommentUserPosterId);
-        Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId());
+        Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId(), spaceId);
         receivers.remove( Utils.getUserId(comment.getPosterId()));
       }
     } else {
       // Send notification to all others users who have comment on this activity
-      Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
+      Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId(), spaceId);
       Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
-      Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
-      Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId());
+      Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId(), spaceId);
+      Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId(), spaceId);
       receivers.remove( Utils.getUserId(comment.getPosterId()));
 
     }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityMentionPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityMentionPlugin.java
@@ -78,12 +78,9 @@ public class ActivityMentionPlugin extends BaseNotificationPlugin {
     //so the process mention is not correct and no mention is saved to activity
     //We need to process the value stored in the template param of activity with key = comment
     String commentLinkActivity = activity.getTemplateParams().get("comment");
-    if (commentLinkActivity != null && commentLinkActivity.length() > 0 &&
-        Utils.getMentioners(commentLinkActivity, activity.getPosterId(), null).size() > 0) {
-      return true;
-    }
 
-    return false;
+    return commentLinkActivity != null && commentLinkActivity.length() > 0
+        && !Utils.getMentioners(commentLinkActivity, activity.getPosterId(), null).isEmpty();
   }
 
   private String[] getAddedMentions(String[] previousMentions, String[] actualMentions) {

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityMentionPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityMentionPlugin.java
@@ -51,10 +51,12 @@ public class ActivityMentionPlugin extends BaseNotificationPlugin {
     String[] mentionedIds = getAddedMentions(previousMentions, actualMentions);
 
     Set<String> receivers = new HashSet<>();
+    String spaceId = !activity.isComment() ? activity.getSpaceId()
+                                           : Utils.getActivityManager().getParentActivity(activity).getSpaceId();
     if (actualMentions.length > 0) {
-      Utils.sendToMentioners(receivers, mentionedIds, activity.getPosterId());
+      Utils.sendToMentioners(receivers, mentionedIds, activity.getPosterId(), spaceId);
     } else {
-      receivers = Utils.getMentioners(activity.getTemplateParams().get("comment"), activity.getPosterId());
+      receivers = Utils.getMentioners(activity.getTemplateParams().get("comment"), activity.getPosterId(), spaceId);
     }
 
     return NotificationInfo.instance()
@@ -77,7 +79,7 @@ public class ActivityMentionPlugin extends BaseNotificationPlugin {
     //We need to process the value stored in the template param of activity with key = comment
     String commentLinkActivity = activity.getTemplateParams().get("comment");
     if (commentLinkActivity != null && commentLinkActivity.length() > 0 &&
-        Utils.getMentioners(commentLinkActivity, activity.getPosterId()).size() > 0) {
+        Utils.getMentioners(commentLinkActivity, activity.getPosterId(), null).size() > 0) {
       return true;
     }
 

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
@@ -32,15 +32,15 @@ public class EditActivityPlugin extends BaseNotificationPlugin {
     @Override
     public NotificationInfo makeNotification(NotificationContext ctx) {
         ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
-
+        String spaceId = activity.getSpaceId();
         Set<String> receivers = new HashSet<String>();
         if (activity.getStreamOwner() != null) {
             Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), activity.getPosterId());
         }
         // Send notification to all others users who have comment on this activity
-        Utils.sendToCommeters(receivers, activity.getCommentedIds(), activity.getPosterId());
-        Utils.sendToActivityPoster(receivers, activity.getPosterId(), activity.getPosterId());
-        Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId());
+        Utils.sendToCommeters(receivers, activity.getCommentedIds(), activity.getPosterId(), spaceId);
+        Utils.sendToActivityPoster(receivers, activity.getPosterId(), activity.getPosterId(), spaceId);
+        Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId(), spaceId);
 
         //
         return NotificationInfo.instance()

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditCommentPlugin.java
@@ -27,29 +27,29 @@ public class EditCommentPlugin  extends BaseNotificationPlugin {
     public NotificationInfo makeNotification(NotificationContext ctx) {
         ExoSocialActivity comment = ctx.value(SocialNotificationUtils.ACTIVITY);
         ExoSocialActivity activity = Utils.getActivityManager().getParentActivity(comment);
-
+        String spaceId = activity.getSpaceId();
         Set<String> receivers = new HashSet<String>();
         if (StringUtils.isNotBlank(comment.getParentCommentId())) {
             ExoSocialActivity parentComment = Utils.getActivityManager().getActivity(comment.getParentCommentId());
             String parentCommentUserPosterId = Utils.getUserId(parentComment.getPosterId());
             if (isSubComment) {
                 // Send notification to parent comment poster
-                Utils.sendToActivityPoster(receivers, parentComment.getPosterId(), comment.getPosterId());
+                Utils.sendToActivityPoster(receivers, parentComment.getPosterId(), comment.getPosterId(), spaceId);
             } else {
                 // Send notification to all others users who have commented on this activity
                 // except parent comment poster
-                Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
+                Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId(), spaceId);
                 Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
-                Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
-                Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), comment.getPosterId());
+                Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId(), spaceId);
+                Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), comment.getPosterId(), spaceId);
                 receivers.remove(parentCommentUserPosterId);
             }
         } else {
             // Send notification to all others users who have comment on this activity
-            Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
+            Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId(), spaceId);
             Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
-            Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
-            Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), comment.getPosterId());
+            Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId(), spaceId);
+            Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), comment.getPosterId(), spaceId);
         }
         //
         return NotificationInfo.instance()

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikeCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikeCommentPlugin.java
@@ -5,6 +5,8 @@ import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.notification.Utils;
 
 import java.util.ArrayList;
@@ -33,17 +35,26 @@ public class LikeCommentPlugin extends BaseNotificationPlugin {
     String[] likersId = activity.getLikeIdentityIds();
     String liker = Utils.getUserId(likersId[likersId.length - 1]);
 
-    List<String> toUsers = new ArrayList<String>();
-    toUsers.add(Utils.getUserId(activity.getPosterId()));
-    if (Utils.isSpaceActivity(activity) == false && liker.equals(activity.getStreamOwner()) == false) {
-      toUsers.add(activity.getStreamOwner());
+    String likeTo = Utils.getUserId(activity.getPosterId());
+    String spaceId = !activity.isComment() ? activity.getSpaceId()
+                                           : Utils.getActivityManager().getParentActivity(activity).getSpaceId();
+    boolean isMember = false;
+
+    if (spaceId != null) {
+      SpaceService spaceService = Utils.getSpaceService();
+      Space space = spaceService.getSpaceById(spaceId);
+      isMember = spaceService.isMember(space, likeTo);
     }
 
+    if (spaceId != null && !isMember) {
+      return null;
+    }
     return NotificationInfo.instance()
-            .to(Utils.getUserId(activity.getPosterId()))
-            .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
-            .with(SocialNotificationUtils.LIKER.getKey(), liker)
-            .key(getId()).end();
+                           .to(likeTo)
+                           .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
+                           .with(SocialNotificationUtils.LIKER.getKey(), liker)
+                           .key(getId())
+                           .end();
   }
 
   @Override

--- a/component/notification/src/test/java/org/exoplatform/social/notification/LinkProviderUtilsTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/LinkProviderUtilsTest.java
@@ -145,4 +145,15 @@ public class LinkProviderUtilsTest extends AbstractCoreTest {
     String openUrl2 = LinkProviderUtils.getOpenLink(comment2);
     assertEquals(expected, openUrl2);
   }
+
+  public void testGetWebNotificationRestUrl() {
+    String object1 = "demo", object2 = "root";
+    String expected = "/rest/notification/demo/root";
+    assertEquals(expected, LinkProviderUtils.getWebNotificationRestUrl("notification", object1, object2));
+  }
+  public void testGetWebNotificationRestUrlWithJsonFile() {
+    String object1 = "demo", object2 = "root", notifificationId = "12", jsonFile = "jsonFile";
+    String expected = "/rest/notification/demo/root/12/jsonFile";
+    assertEquals(expected, LinkProviderUtils.getWebNotificationRestUrl("notification", object1, object2, notifificationId, jsonFile));
+  }
 }

--- a/component/notification/src/test/java/org/exoplatform/social/notification/UtilsTestCase.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/UtilsTestCase.java
@@ -1,14 +1,37 @@
 package org.exoplatform.social.notification;
 
-import junit.framework.TestCase;
 
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.social.core.space.impl.DefaultSpaceApplicationHandler;
+import org.exoplatform.social.core.space.model.Space;
 
-public class UtilsTestCase extends TestCase {
-  
+import java.util.HashSet;
+import java.util.Set;
+
+public class UtilsTestCase extends AbstractCoreTest {
+
+  Space space ;
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    space = new Space();
+    space.setDisplayName("my space");
+    space.setPrettyName(space.getDisplayName());
+    space.setRegistration(Space.OPEN);
+    space.setDescription("new space ");
+    space.setType(DefaultSpaceApplicationHandler.NAME);
+    space.setVisibility(Space.PUBLIC);
+    space.setRegistration(Space.VALIDATION);
+    space.setPriority(Space.INTERMEDIATE_PRIORITY);
+    space.setGroupId("/space/space");
+    String[] managers = new String[] {rootIdentity.getRemoteId()};
+    String[] members = new String[] { rootIdentity.getRemoteId(), demoIdentity.getRemoteId(), johnIdentity.getRemoteId() };
+    space.setManagers(managers);
+    space.setMembers(members);
+    space.setUrl(space.getPrettyName());
+    space.setAvatarLastUpdated(System.currentTimeMillis());
+    space = spaceService.createSpace(space, rootIdentity.getRemoteId());
+    tearDownSpaceList.add(space);
     System.setProperty(CommonsUtils.CONFIGURED_DOMAIN_URL_KEY, "http://exoplatform.com");
   }
 
@@ -21,5 +44,67 @@ public class UtilsTestCase extends TestCase {
     assertEquals("Shared a document <a href=\"http://exoplatform.com/portal/rest/Do_Thanh_Tung/Public/New+design.+eXo+in+Smart+Watch.jpg\" style=\"color: #2f5e92; text-decoration: none;\">New design. eXo in Smart Watch.jpg</a>", Utils.processLinkTitle(title));
     title = "Shared a document <a href=\"/portal/rest/Do_Thanh_Tung/Public/New+design.+eXo+in+Smart+Watch.jpg\">New design. eXo in Smart Watch.jpg</a>";
     assertEquals("Shared a document <a href=\"http://exoplatform.com/portal/rest/Do_Thanh_Tung/Public/New+design.+eXo+in+Smart+Watch.jpg\" style=\"color: #2f5e92; text-decoration: none;\">New design. eXo in Smart Watch.jpg</a>", Utils.processLinkTitle(title));
+  }
+
+  public void testGetMentioners() {
+    String mentionTitle ="<a href=\"/portal/dw/profile/demo\"> " + demoIdentity.getProfile().getFullName() + " </a>";
+    Set<String> receivers = Utils.getMentioners(mentionTitle, rootIdentity.getId(), space.getId());
+    assertEquals(1, receivers.size());
+    mentionTitle ="<a href=\"/portal/dw/profile/root\"> "+ rootIdentity.getProfile().getFullName() + " </a>";
+    receivers = Utils.getMentioners(mentionTitle, rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
+    mentionTitle ="<a href=\"/portal/dw/profile/ghost\"> "+ ghostIdentity.getProfile().getFullName() + " </a>";
+    receivers = Utils.getMentioners(mentionTitle, rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
+  }
+
+
+  public void testSendToCommenters() {
+    Set<String> receivers = new HashSet<>();
+    ;
+    String[] commenters = new String[] { demoIdentity.getId()};
+    Utils.sendToCommeters(receivers, commenters, rootIdentity.getId(), space.getId());
+    assertEquals(1, receivers.size());
+
+    receivers = new HashSet<>();
+    commenters = new String[] { rootIdentity.getId()};
+    Utils.sendToCommeters(receivers, commenters, rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
+
+    receivers = new HashSet<>();
+    commenters = new String[] {ghostIdentity.getId()};
+    Utils.sendToCommeters(receivers, commenters, rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
+  }
+
+  public void testSendToLikers() {
+    Set<String> receivers = new HashSet<>();
+    String[] likers = new String[] { demoIdentity.getId()};
+    Utils.sendToLikers(receivers, likers, rootIdentity.getId(), space.getId());
+    assertEquals(1, receivers.size());
+
+    receivers = new HashSet<>();
+    likers = new String[] { rootIdentity.getId()};
+    Utils.sendToLikers(receivers, likers, rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
+
+    receivers = new HashSet<>();
+    likers = new String[] {ghostIdentity.getId()};
+    Utils.sendToLikers(receivers, likers, rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
+  }
+
+  public void testSendToActivityPoster() {
+    Set<String> receivers = new HashSet<>();
+    Utils.sendToActivityPoster(receivers, demoIdentity.getId(), rootIdentity.getId(), space.getId());
+    assertEquals(1, receivers.size());
+
+    receivers = new HashSet<>();
+    Utils.sendToActivityPoster(receivers, rootIdentity.getId(), rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
+
+    receivers = new HashSet<>();
+    Utils.sendToActivityPoster(receivers, ghostIdentity.getId(), rootIdentity.getId(), space.getId());
+    assertEquals(0, receivers.size());
   }
 }


### PR DESCRIPTION
before this change, users continue to receive notifications of activities they have already commented on or liked even though they are no longer members.
after this change, notification receivers are filtered by whether they are members of the space or not.