### PR TITLE
fix: bad redirection when accepting a connexion request - EXO-60778 (#2016)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
@@ -117,6 +117,9 @@ public class NotificationsRestService implements ResourceContainer {
   @DeprecatedAPI("The endpoint is deprecated, use RelationshipsRestResourcesV1 instead")
   public Response confirmInvitationToConnect(@PathParam("senderId") String senderId,
                                              @PathParam("receiverId") String receiverId) throws Exception {
+    if (receiverId.contains(JSESSION_ID_PATTERN)) {
+      receiverId = receiverId.substring(0, receiverId.indexOf(JSESSION_ID_PATTERN));
+    }
     checkAuthenticatedUserPermission(receiverId);
 
     Identity sender = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, senderId, true);


### PR DESCRIPTION
prior to this change, when accepting a connexion request without being active for a certain time (no logout) the redirection URL contains a pattern ";jsessionid" which prevents checking authenticated User Permission for the receiver; after this change, when the URL contains the specific pattern with the receiver, it will be removed and the verification of the authenticated user's permission will be performed successfully.
