### PR TITLE
fix: bad redirection when accepting a connexion request - EXO-60778 (#2016)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
@@ -117,6 +117,9 @@ public class NotificationsRestService implements ResourceContainer {
   @DeprecatedAPI("The endpoint is deprecated, use RelationshipsRestResourcesV1 instead")
   public Response confirmInvitationToConnect(@PathParam("senderId") String senderId,
                                              @PathParam("receiverId") String receiverId) throws Exception {
+    if (receiverId.contains(JSESSION_ID_PATTERN)) {
+      receiverId = receiverId.substring(0, receiverId.indexOf(JSESSION_ID_PATTERN));
+    }
     checkAuthenticatedUserPermission(receiverId);
 
     Identity sender = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, senderId, true);


### PR DESCRIPTION


prior to this change, when accepting a connexion request without being active for a certain time (no logout) the redirection URL contains a pattern ";jsessionid" which prevents checking authenticated User Permission for the receiver; after this change, when the URL contains the specific pattern with the receiver, it will be removed and the verification of the authenticated user's permission will be performed successfully.

(cherry picked from commit 35ebd320253f8646cc3c03e13a497ba5e06e6208)

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
