### PR TITLE
feat: Add possibility to choose only managers of a space in suggester- MEED-657 - Meeds-io/MIPs#13

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -625,7 +625,7 @@ public class PeopleRestService implements ResourceContainer{
                                     Space space,
                                     String typeOfRelation,
                                     int order,
-                                    Locale locale) throws SpaceException {
+                                    Locale locale) {
     addSpaceOrUserToList(identities, options, space, typeOfRelation, SpaceMemberFilterListAccess.Type.MEMBER, order, locale);
   }
 
@@ -635,8 +635,7 @@ public class PeopleRestService implements ResourceContainer{
                                     String typeOfRelation,
                                     SpaceMemberFilterListAccess.Type type,
                                     int order,
-                                    Locale locale) throws SpaceException {
-    SpaceService spaceService = getSpaceService(); 
+                                    Locale locale) {
     for (Identity identity : identities) {
       String fullName = identity.getProfile().getFullName();
       if(Util.isExternal(identity.getId())){
@@ -648,23 +647,23 @@ public class PeopleRestService implements ResourceContainer{
         if (type != null) {
           switch (type) {
           case MANAGER:
-            if (!spaceService.isSuperManager(userName)
-                && !spaceService.isManager(space, userName)) {
+            if (!getSpaceService().isSuperManager(userName)
+                && !getSpaceService().isManager(space, userName)) {
               continue;
             }
             break;
           case PENDING:
-            if (!spaceService.isPendingUser(space, userName)) {
+            if (!getSpaceService().isPendingUser(space, userName)) {
               continue;
             }
             break;
           case INVITED:
-            if (!spaceService.isInvitedUser(space, userName)) {
+            if (!getSpaceService().isInvitedUser(space, userName)) {
               continue;
             }
             break;
           default:
-            if (!spaceService.isMember(space, userName)) {
+            if (!getSpaceService().isMember(space, userName)) {
               continue;
             }
             break;
@@ -674,8 +673,8 @@ public class PeopleRestService implements ResourceContainer{
         opt.setValue(userName);
         opt.setText(fullName);
         opt.setAvatarUrl(identity.getProfile() == null ? null : identity.getProfile().getAvatarUrl());
-      } else if (USER_TO_INVITE.equals(typeOfRelation) && (space == null || (!spaceService.isInvitedUser(space, userName)
-                 && !spaceService.isPendingUser(space, userName) && !spaceService.isMember(space, userName)))) {
+      } else if (USER_TO_INVITE.equals(typeOfRelation) && (space == null || (!getSpaceService().isInvitedUser(space, userName)
+                 && !getSpaceService().isPendingUser(space, userName) && !getSpaceService().isMember(space, userName)))) {
         opt.setType("user");
         opt.setValue(userName);
         opt.setText(fullName + " (" + userName + ")");

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
@@ -97,6 +97,9 @@ function searchUsers(filter, items, typeOfRelation, searchOptions) {
     typeOfRelation: typeOfRelation || 'mention_activity_stream',
     currentUser: eXo.env.portal.userName,
   };
+  if (searchOptions?.role) {
+    options.role = searchOptions?.role;
+  }
 
   let params = null;
   let url = null;


### PR DESCRIPTION
Prior to this change, the re-usable suggester component doesn't allow to choose only managers of a space when suggesting users. This change will introduce a new option (role) that will be added in  props of exo-identity-suggester component that will allow to choose the user membership type with chosen space.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
