### PR TITLE
fix: performance problem when accessing to space members page - EXO-61104 - meeds-io/meeds#448

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -1784,10 +1784,10 @@ public class SpaceServiceImpl implements SpaceService {
     if (identity == null) {
       //user is not already loggued, and identity not present in identityRegistry
       //so we dont load it, and check only concerned membershipEntry
-      return superManagersMemberships.parallelStream()
+      return superManagersMemberships.stream()
                                          .anyMatch(membershipEntry -> isUserInGroup(userId, membershipEntry));
     } else {
-      return superManagersMemberships.parallelStream()
+      return superManagersMemberships.stream()
                                      .anyMatch(identity::isMemberOf);
     }
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -199,7 +199,6 @@ public class EntityBuilder {
   public static ProfileEntity buildEntityProfile(Space space, Profile profile, String path, String expand) {
     ProfileEntity entity = buildEntityProfile(profile, path, expand);
     String userId = profile.getIdentity().getRemoteId();
-    entity.setIsSpacesManager(spaceService.isSuperManager(userId));
     entity.setIsManager(spaceService.isManager(space, userId));
     entity.setIsSpaceRedactor(spaceService.isRedactor(space, userId));
     entity.setIsMember(spaceService.isMember(space, userId));

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
@@ -261,15 +261,6 @@ public class ProfileEntity extends BaseEntity {
     return (Boolean) getProperty("isManager");
   }
 
-  public ProfileEntity setIsSpacesManager(boolean isSpacesManager) {
-    setProperty("isSpacesManager", isSpacesManager);
-    return this;
-  }
-
-  public Boolean getIsSpacesManager() {
-    return (Boolean) getProperty("isSpacesManager");
-  }
-
   public ProfileEntity setIsSpaceRedactor(boolean isSpaceRedactor) {
     setProperty("isSpaceRedactor", isSpaceRedactor);
     return this;


### PR DESCRIPTION
Before this fix, in some particuler cases, the page space members take long time to display, and sature idm pool connexion This problem is due to the fact we check, for each displayed users (20 is the page is full), if he is spacesManager (manager of all spaces). For that, with use a combination of parallelStream and anyMatch. As the anyMatch stops others thread of parallelStream when finding, the connexion to idm database seems to stay opened. This commit comes back to a simple sequential stream. As the stream is on only few elements (one by group configured in spaces management), the parallel stream is not more efficient than sequential stream

In addition, this commit also remove the parameter isSpacesManagers when computing entityProfile when requesting spaces members, as it is not used on front level. I was used few month ago, but removed only at front level.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
