### PR TITLE
feat: Remove the default redactor permission to post in a redactional space for the publisher of web contributors group - EXO-61216 -  Meeds-io/MIPs#35

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -1482,7 +1482,7 @@ public class SpaceServiceImpl implements SpaceService {
   @Override
   public boolean canRedactOnSpace(Space space, org.exoplatform.services.security.Identity viewer) {
     String username = viewer.getUserId();
-    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username) || viewer.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "publisher")))
+    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username)))
         || isManagerOrSpaceManager(viewer, space);
   }
 


### PR DESCRIPTION

Prior to this change, any publisher of web contributors group can redact in a redactional space even if they he hasn't explicitly redactor role in this space. After this modification, we will remove this implicit permission so the redactor role will be mandatory in order to redact in a redactional space.