### PR TITLE
fix: Post Activity: Same activity was posted multiple times

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -94,7 +94,8 @@ export default {
       activityBodyEdited: false,
       originalBody: '',
       messageEdited: false,
-      activityType: null
+      activityType: null,
+      loading: false
     };
   },
   computed: {


### PR DESCRIPTION
Prior to this change, in the activity drawer when add content and click publish as much as possible, this activity is published multiple times. After this change, this activity posted only once.

(cherry picked from commit e7e1cd9755d8dd3cfc49204856b03de2e1cf37cd)