### PR TITLE
fix: random unit test fail - EXO-61283

### DIFF
--- a/component/notification/src/test/java/org/exoplatform/social/notification/web/template/EditCommentWebBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/web/template/EditCommentWebBuilderTest.java
@@ -79,7 +79,7 @@ public class EditCommentWebBuilderTest extends AbstractPluginTest {
         ctx.setNotificationInfo(editNotification.setTo("root"));
         MessageInfo info = buildMessageInfo(ctx);
         assertBody(info, "edited comment");
-        assertBody(info, "data-link=\"/portal/classic/activity?id=" + activity.getId() + "#comment-comment72\"");
+        assertBody(info, "data-link=\"/portal/classic/activity?id=" + activity.getId() + "#comment-" + comment.getId() + "\"");
     }
 
 }


### PR DESCRIPTION
before this change, a random unit test failure is reproduced because of the static comment id added to the assertion
after this change, a unit test passes because the id added to the assertion is added from the created comment