### PR TITLE
fix: missing activity types values in analytics - EXO-60792

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -194,7 +194,7 @@ public class ActivityManagerImpl implements ActivityManager {
       }
       return;
     }
-
+    setActivityType(newActivity);
     ExoSocialActivity savedActivity = activityStorage.saveActivity(streamOwner, newActivity);
     newActivity.setId(savedActivity.getId());
     activityLifeCycle.saveActivity(newActivity);
@@ -335,6 +335,7 @@ public class ActivityManagerImpl implements ActivityManager {
     // so,
     // as a solution we pass them throw the activity's template params
     String[] previousMentions = getActivity(activityId).getMentionedIds();
+    setActivityType(existingActivity);
     activityStorage.updateActivity(existingActivity);
 
     if (previousMentions.length > 0) {
@@ -944,6 +945,19 @@ public class ActivityManagerImpl implements ActivityManager {
             + space.getDisplayName());
       }
     }
+  }
+
+  private void setActivityType(ExoSocialActivity activity) {
+    String type = activity.getType();
+    if (type == null || type.isEmpty()) {
+      if (activity.getFiles() != null && !activity.getFiles().isEmpty()) {
+        type = ActivityPluginType.FILE.getName();
+      } else if (activity.getTemplateParams() != null && !activity.getTemplateParams().isEmpty()
+              && activity.getTemplateParams().get("link") != null) {
+        type = ActivityPluginType.LINK.getName();
+      }
+    }
+    activity.setType(type);
   }
 
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerRDBMSTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerRDBMSTest.java
@@ -324,6 +324,7 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
     templateParams.put("key1", "value 1");
     templateParams.put("key2", "value 2");
     templateParams.put("key3", "value 3");
+    templateParams.put("link", "http://exoplatform.com?test=<script>");
     activity.setTemplateParams(templateParams);
     activity.setTitle(activityTitle);
     activity.setUserId(userId);
@@ -341,6 +342,8 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
     assertEquals("value 1", gotTemplateParams.get("key1"));
     assertEquals("value 2", gotTemplateParams.get("key2"));
     assertEquals("value 3", gotTemplateParams.get("key3"));
+    assertEquals("http://exoplatform.com?test=<script>", gotTemplateParams.get("link"));
+    assertEquals(ActivityPluginType.LINK.getName(), activity.getType());
 
     //
     assertTrue(activity.isLocked());
@@ -348,7 +351,7 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
   }
 
   /**
-   * Test {@link ActivityManager#saveActivity(ExoSocialActivity)}
+   * Test {@link ActivityManager#saveActivityNoReturn(ExoSocialActivity)}
    * 
    * @throws Exception
    * @since 1.2.0-Beta3
@@ -451,15 +454,22 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
     assertNotNull("activity must not be null", activity);
     assertEquals("activity.getTitle() must return: " + activityTitle, activityTitle, activity.getTitle());
     assertEquals("activity.getUserId() must return: " + userId, userId, activity.getUserId());
-
+    assertNull(activity.getType());
     String newTitle = "new activity title";
     activity.setTitle(newTitle);
+    Map<String, String> templateParams = new LinkedHashMap<String, String>();
+    templateParams.put("link", "http://exoplatform.com?test=<script>");
+    activity.setTemplateParams(templateParams);
     activityManager.updateActivity(activity);
 
     activity = activityManager.getActivity(activity.getId());
     assertNotNull("activity must not be null", activity);
     assertEquals("activity.getTitle() must return: " + newTitle, newTitle, activity.getTitle());
     assertEquals("activity.getUserId() must return: " + userId, userId, activity.getUserId());
+
+    assertEquals(ActivityPluginType.LINK.getName(), activity.getType());
+    Map<String, String> gotTemplateParams = activity.getTemplateParams();
+    assertEquals("http://exoplatform.com?test=<script>", gotTemplateParams.get("link"));
   }
 
   /**

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -196,10 +196,10 @@ export default {
       const message = this.ckEditorInstance.getMessage();
       if (this.activityId) {
         let activityType = this.activityType;
-        if (this.templateParams && this.templateParams.link && !this.activityType) {
+        if (this.files?.length) {
+          activityType = 'DOC_ACTIVITY';
+        } else if (!this.files?.length && this.templateParams && this.templateParams.link && (!this.activityType || !this.activityType.length)) {
           activityType = 'LINK_ACTIVITY';
-        } else if (this.templateParams && this.templateParams.link === '-') {
-          activityType = null;
         }
         this.loading = true;
         this.$activityService.updateActivity(this.activityId, message, activityType, this.files, this.templateParams)
@@ -216,7 +216,9 @@ export default {
           .finally(() => this.loading = false);
       } else {
         let activityType = this.activityType;
-        if (this.templateParams && this.templateParams.link && !this.activityType) {
+        if (this.files?.length) {
+          activityType = 'files:spaces';
+        } else if ( !this.files?.length &&this.templateParams && this.templateParams.link && (!this.activityType || !this.activityType.length)) {
           activityType = 'LINK_ACTIVITY';
         }
         if (this.activityType && this.activityType.length !== 0) {


### PR DESCRIPTION
prior to this change when creating file or link activity its type is not set resulting not indexing the activity type
after this change, the type is set for created activity and are well indexed