### PR TITLE
feat: Remove the default redactor permission to post in a redactional space for publishers of web contributors group - EXO-61216 - Meeds-io/MIPs#35

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -92,8 +92,6 @@ public class SpaceServiceImpl implements SpaceService {
 
   public static final String                   DEFAULT_APP_CATEGORY     = "spacesApplications";
 
-  private final static String                  PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
-
   private IdentityRegistry                     identityRegistry;
 
   private SpaceStorage                         spaceStorage;
@@ -1482,7 +1480,7 @@ public class SpaceServiceImpl implements SpaceService {
   @Override
   public boolean canRedactOnSpace(Space space, org.exoplatform.services.security.Identity viewer) {
     String username = viewer.getUserId();
-    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username) || viewer.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, "publisher")))
+    return (isMember(space, username) && (!hasRedactor(space) || isRedactor(space, username)))
         || isManagerOrSpaceManager(viewer, space);
   }
 


### PR DESCRIPTION
Prior to this change, any publisher of web contributors group can redact in a redactional space even if they he hasn't explicitly redactor role in this space. After this modification, we will remove this implicit permission so the redactor role will be mandatory in order to redact in a redactional space.