### PR TITLE
fix: Hide expand icon when using mobile - MEED-1376

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -151,7 +151,7 @@ export default {
       return this.expand && '100%' || this.drawerWidth;
     },
     isMobile() {
-      return this.$vuetify && this.$vuetify.breakpoint && this.$vuetify.breakpoint.name === 'xs';
+      return this.$vuetify?.breakpoint?.smAndDown;
     },
     expandIcon() {
       return this.expand && 'mdi-arrow-collapse' || 'mdi-arrow-expand';


### PR DESCRIPTION
This change will hide the expand icon used in drawer when using mobile.