### PR TITLE
fix: adjust the size of Favorite action in space popover - EXO-60396

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFavoriteAction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceFavoriteAction.vue
@@ -6,6 +6,7 @@
     :absolute="absolute"
     :top="top"
     :right="right"
+    :small="false"
     type="space"
     type-label="space"
     :entity-type="entityType"


### PR DESCRIPTION
Prior to this fix, the favorite button was not aligned with other buttons in the top-bar space popover
The fix adjusts the sie of the button to fill the space and get the same sie as other actions in the popover