### PR TITLE
fix: updating activities mentions when username changes - MEED-1186

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -835,4 +835,22 @@
         </addColumn>
     </changeSet>
 
+    <changeSet author="social" id="1.0.0-85">
+        <createTable tableName="SOC_ACTIVITY_MENTIONS">
+            <column name="ACTIVITY_ID" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="ACTIVITY_TYPE" type="NVARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="MENTIONED_ID" type="NVARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="ACTIVITY_ID" constraintName="PK_SOC_ACTIVITY_MENTIONS_01" tableName="SOC_ACTIVITY_MENTIONS"/>
+        <createIndex tableName="SOC_ACTIVITY_MENTIONS" indexName="IDX_SOC_ACTIVITY_MENTIONS_01">
+            <column name="ACTIVITY_ID"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
this change is going to create a new table to link the activities depending on their type with activities mentions