### PR TITLE
fix: favIcon do not appear in some space Popover - EXO-61430

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/initComponents.js
@@ -1,12 +1,14 @@
 import ExoSpaceLogoBanner from './components/ExoSpaceLogoBanner.vue';
 import SpacePopoverActionComponents from './components/SpacePopoverActionComponents.vue';
 import SpaceHostsDrawer from './components/SpaceHostsDrawer.vue';
+import ExoSpaceFavoriteAction from '../spaces-list/components/ExoSpaceFavoriteAction.vue';
 
 
 const components = {
   'exo-space-logo-banner': ExoSpaceLogoBanner,
   'space-popover-action-component': SpacePopoverActionComponents,
   'space-hosts-drawer': SpaceHostsDrawer,
+  'exo-space-favorite-action': ExoSpaceFavoriteAction
 };
 
 for (const key in components) {


### PR DESCRIPTION
prior to this change, favIcon does not appear in some space Popover since its component is not imported.
after this change, the component is imported and the favicon appears 