### PR TITLE
fix: Fix the text size when copy and paste text on description - MEED-1478 - Meeds-io/Meeds#523

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -242,6 +242,7 @@ export default {
         autoGrow_onStartup: false,
         autoGrow_maxHeight: 300,
         startupFocus: 'end',
+        pasteFilter: 'p; a[!href]; strong; i', 
         on: {
           instanceReady: function () {
             self.editor = CKEDITOR.instances[self.ckEditorType];


### PR DESCRIPTION
This change will correct the size of the text in the description area after pasting it from another site.
