### PR TITLE
fix: check for existence of avatar file before scaling it - EXO-61578- Meeds-io/meeds#499

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/thumbnail/ImageThumbnailServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/thumbnail/ImageThumbnailServiceImpl.java
@@ -95,7 +95,7 @@ public class ImageThumbnailServiceImpl implements ImageThumbnailService {
       try {
         return fileService.getFile(fileId);
       } catch (FileStorageException e) {
-        LOG.error("Error while getting thumbnail, original Image will be returned", e);
+        LOG.warn("Error while getting thumbnail for image of identity {}, original Image will be returned", identity.getId(), e.getMessage());
         return file;
       }
     } else {

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -528,16 +528,19 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       if (builder == null) {
         int[] dimension = Utils.parseDimension(size);
         try {
-          byte[] avatarContent = imageThumbnailService.getOrCreateThumbnail(identityManager.getAvatarFile(identity),
-                          identity,
-                          dimension[0],
-                          dimension[1])
-                  .getAsByte();
+          byte[] avatarContent = null;
+          if(identityManager.getAvatarFile(identity) != null) {
+            avatarContent = imageThumbnailService.getOrCreateThumbnail(identityManager.getAvatarFile(identity),
+                                                                       identity,
+                                                                       dimension[0],
+                                                                       dimension[1])
+                                                 .getAsByte();
+          }
           if (avatarContent != null) {
             builder = Response.ok(avatarContent, "image/png");
           }
         } catch (Exception e) {
-          LOG.error("Error while resizing avatar, original Image will be returned", e);
+          LOG.error("Error while resizing avatar of space identity with Id {}, original Image will be returned", identity.getId(), e);
         }
       }
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -542,13 +542,15 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
           int[] dimension = Utils.parseDimension(size);
           byte[] avatarContent = null;
           try {
-            avatarContent = imageThumbnailService.getOrCreateThumbnail(identityManager.getAvatarFile(identity),
-                                                                       identity,
-                                                                       dimension[0],
-                                                                       dimension[1])
-                                                 .getAsByte();
+            if(identityManager.getAvatarFile(identity) != null) {
+              avatarContent = imageThumbnailService.getOrCreateThumbnail(identityManager.getAvatarFile(identity),
+                              identity,
+                              dimension[0],
+                              dimension[1])
+                      .getAsByte();
+            }
           } catch (Exception e) {
-            LOG.error("Error while resizing avatar, original Image will be returned", e);
+            LOG.error("Error while resizing avatar of user identity with Id {}, original Image will be returned", identity.getId(), e);
           }
           if (avatarContent != null) {
             builder = Response.ok(avatarContent, "image/png");


### PR DESCRIPTION
Before this fix, there is no check if the avatar file exists, which causes NPE. The fix adds the needed check for nullity and improves logging to know which identities have broken avatar files.
