### PR TITLE
fix: Fix Login subtitle hyphenation - MEED-1513 - Meeds-io/meeds#547

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/login-common/components/Introduction.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/login-common/components/Introduction.vue
@@ -43,7 +43,7 @@
               :class="mobile && 'text-wrap text-break' || 'text-no-wrap'">
               <slot name="title"></slot>
             </span>
-            <v-card-subtitle v-if="$slots.subtitle" class="title text-wrap white--text">
+            <v-card-subtitle v-if="$slots.subtitle" class="title text-wrap text-break white--text">
               <slot name="subtitle"></slot>
             </v-card-subtitle>
           </v-card-title>


### PR DESCRIPTION
This change will fix wrong hyphenation on subtitle of non-authenticated pages.