### PR TITLE
fix: Group Suggestor : double suggestion for same space - EXO-61750 (#2152)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SuggesterService.js
@@ -63,7 +63,7 @@ function searchGroups(filter, groupMember, groupType, items, allGroupsForAdmin, 
   formData.append('groupMember', groupMember);
   formData.append('groupType', groupType);
   formData.append('allGroupsForAdmin', allGroupsForAdmin);
-  formData.append('excludeParentGroup', '/space');
+  formData.append('excludeParentGroup', '/spaces');
   formData.append('excludeParentGroup', '/');
   const params = new URLSearchParams(formData).toString();
 


### PR DESCRIPTION
prior to this change, space and group space are suggested together since the group of space is not excluded because of the wrong type name. after this change, group space fixed to excluded not needed groups