### PR TITLE
fix: Fix Space Home Page URL on avatar - MEED-1535 - Meeds-io/meeds#368

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -16,7 +16,7 @@
           v-on="on"
           v-bind="attrs"
           class="d-inline-flex">
-          <a href="portalPath">
+          <a :href="portalPath">
             <v-list-item-avatar 
               v-if="logoPath"
               id="UserHomePortalLink"


### PR DESCRIPTION
Prior to this change, the space URL on avatar in Top Bar is wrong. This change will fix it by introducing the same URL as done for Space Name link in top Bar.