### PR TITLE
fix: The thumbnail url contains twice the size in activity - EXO-61893 - meeds-io/meeds#580

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -20,7 +20,7 @@
           tile>
           <img
             v-if="thumbnail"
-            :src="`${thumbnail}&size=250x150`"
+            :src="`${thumbnail}`"
             :alt="title"
             class="object-fit-cover my-auto"
             loading="lazy"


### PR DESCRIPTION
Before this fix, the size of thumbnail is added in activity display, but is also provided by extensions like news. So, the size is added twice. This fix remove the not needed size

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
