### PR TITLE
fix: JS error when trying to edit a shared activity - EXO-61476 (#2209)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -91,8 +91,8 @@ const defaultActivityOptions = {
     return Vue.prototype.$utils.trim(window.decodeURIComponent(templateParams
       && templateParams.default_title
       && templateParams.default_title
-      || (activity.title && activity.title.replaceAll('%', '%25'))
-      || (activity.body && activity.title.replaceAll('%', '%25'))
+      || (activity?.title?.replaceAll('%', '%25'))
+      || (activity?.body?.replaceAll('%', '%25'))
       || ''));
   },
   canShare: () => true,


### PR DESCRIPTION
prior to this change, when trying to edit a shared activity a Js error is thrown " Cannot read properties of undefined (reading 'replaceAll' "and the edit drawer doesn't open.
 after this change, the edit drawer is opened