### PR TITLE
fix: Avatar url is malformed when requesting in people page - EXO-61925 - meeds-io/meeds#586

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -95,8 +95,8 @@
     <div class="peopleAvatar">
       <a :href="url">
         <v-img
-          :lazy-src="`${userAvatarUrl}&size=65x65`"
-          :src="`${userAvatarUrl}&size=65x65`"
+          :lazy-src="`${userAvatarUrl}`"
+          :src="`${userAvatarUrl}`"
           transition="none"
           class="mx-auto"
           height="65px"
@@ -261,7 +261,14 @@ export default {
       return this.user && this.user.username === eXo.env.portal.userName;
     },
     userAvatarUrl() {
-      return this.user && this.user.avatar || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.user.username}/avatar`;
+      let userAvatarUrl = this.user && this.user.avatar || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.user.username}/avatar`;
+      if (!userAvatarUrl.includes('?')) {
+        userAvatarUrl += '?';
+      } else {
+        userAvatarUrl += '&';
+      }
+      userAvatarUrl += 'size=65x65';
+      return userAvatarUrl;
     },
     userBannerUrl() {
       return this.user && this.user.banner || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.user.username}/banner`;


### PR DESCRIPTION
Before this fix, some avatar are requested with url like this  : .../avatar&size=65x65 when lastUpdated parameter is not present. This fix add test to add the character ? or & before the size parameter in function of the presence or not of lastUpdate parameter

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
