### PR TITLE
fix: Fix request for publisherRole feature flag activation launched for each users - EXO-61913

### DIFF
--- a/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -67,4 +67,5 @@
      eXo.env.portal.PinActivityEnabled = <%=featureService.isFeatureActiveForUser("PinActivity", userName)%>;
      eXo.env.portal.SpaceWebNotificationsEnabled = <%=featureService.isFeatureActiveForUser("SpaceWebNotifications", userName)%>;
      eXo.env.portal.SpaceHomeLayoutResetEnabled = <%=featureService.isFeatureActiveForUser("SpaceHomeLayoutReset", userName)%>;
+	 eXo.env.portal.PublisherRolePromotionFeatureEnabled = <%=featureService.isFeatureActiveForUser("publisherRolePromotion", userName)%>;
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -299,8 +299,7 @@ export default {
         }, this.waitTimeUntilCloseMenu);
       }
     });
-    this.$featureService.isFeatureEnabled('publisherRolePromotion')
-      .then(enabled => this.publisherRolePromotionFeatureEnabled = enabled);
+    this.publisherRolePromotionFeatureEnabled = eXo.env.portal.PublisherRolePromotionFeatureEnabled;
   },
   methods: {
     connect() {

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
@@ -59,8 +59,7 @@ export default {
     publisherRolePromotionFeatureEnabled: false
   }),
   created() {
-    this.$featureService.isFeatureEnabled('publisherRolePromotion')
-      .then(enabled => this.publisherRolePromotionFeatureEnabled = enabled);
+    this.publisherRolePromotionFeatureEnabled = eXo.env.portal.PublisherRolePromotionFeatureEnabled;
     this.$spaceService.getSpaceById(eXo.env.portal.spaceId)
       .then( space => {
         this.space = space;

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
@@ -189,8 +189,7 @@ export default {
     },
   },
   created() {
-    this.$featureService.isFeatureEnabled('publisherRolePromotion')
-      .then(enabled => this.publisherRolePromotionFeatureEnabled = enabled);
+    this.publisherRolePromotionFeatureEnabled = eXo.env.portal.PublisherRolePromotionFeatureEnabled;
   },
   methods: {
     openBottomMenu() {


### PR DESCRIPTION

Prior to this change, for people page or space members page, the request for publisherRole feature activation is launched for each users which makes a lot of requests and decreases the performance of the corresponding portlets. After this commit, we will ensure to get the status of publisherRole feature flag only once into a global js variable eXo.env.portal.PublisherRolePromotionFeatureEnabled by calling directly featureService.isFeatureActiveForUser service instead of the corresponding rest service. 