### PR TITLE
fix: fix user full name and popover after updating user contact in kudos activity - EXO-59990

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
@@ -155,7 +155,7 @@ public class CachedActivityStorage implements ActivityStorage {
   /**
    * Build the ids from the activity list.
    *
-   * @param activities activities
+   * @param ids  activities ids
    * @return ids
    */
   private ListActivitiesData buildActivityIds(List<String> ids) {
@@ -2161,4 +2161,7 @@ public class CachedActivityStorage implements ActivityStorage {
     }
   }
 
+  public void clearAllActivityCache() {
+    activityCache.clear();
+  }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
@@ -51,18 +51,8 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.storage.IdentityStorageException;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
 import org.exoplatform.social.core.storage.cache.loader.ServiceContext;
-import org.exoplatform.social.core.storage.cache.model.data.ActiveIdentitiesData;
-import org.exoplatform.social.core.storage.cache.model.data.IdentityData;
-import org.exoplatform.social.core.storage.cache.model.data.IntegerData;
-import org.exoplatform.social.core.storage.cache.model.data.ListIdentitiesData;
-import org.exoplatform.social.core.storage.cache.model.data.ProfileData;
-import org.exoplatform.social.core.storage.cache.model.key.ActiveIdentityKey;
-import org.exoplatform.social.core.storage.cache.model.key.IdentityCompositeKey;
-import org.exoplatform.social.core.storage.cache.model.key.IdentityFilterKey;
-import org.exoplatform.social.core.storage.cache.model.key.IdentityKey;
-import org.exoplatform.social.core.storage.cache.model.key.ListIdentitiesKey;
-import org.exoplatform.social.core.storage.cache.model.key.ListSpaceMembersKey;
-import org.exoplatform.social.core.storage.cache.model.key.SpaceKey;
+import org.exoplatform.social.core.storage.cache.model.data.*;
+import org.exoplatform.social.core.storage.cache.model.key.*;
 import org.exoplatform.social.core.storage.cache.selector.IdentityCacheSelector;
 
 /**
@@ -92,6 +82,9 @@ public class CachedIdentityStorage implements IdentityStorage {
 
   private final IdentityStorage storage;
   private CachedRelationshipStorage cachedRelationshipStorage;
+
+  private CachedActivityStorage cachedActivityStorage;
+
 
   void clearCache() {
 
@@ -424,7 +417,7 @@ public class CachedIdentityStorage implements IdentityStorage {
     IdentityKey key = new IdentityKey(new Identity(profile.getIdentity().getId()));
     exoIdentityCache.remove(key);
     exoProfileCache.remove(key);
-
+    getCachedActivityStorage().clearAllActivityCache();
     clearCache();
   }
 
@@ -802,5 +795,12 @@ public class CachedIdentityStorage implements IdentityStorage {
 
   public IdentityStorage getStorage() {
     return storage;
+  }
+  
+  public CachedActivityStorage getCachedActivityStorage() {
+    if (cachedActivityStorage == null) {
+      cachedActivityStorage = PortalContainer.getInstance().getComponentInstanceOfType(CachedActivityStorage.class);
+    }
+    return cachedActivityStorage;
   }
 }


### PR DESCRIPTION
prior to this change, when the user had updated his contact info (his name or job title), the user popover in the kudos activity still displayed old user info, since the activity is cached
prior to this change, after updated user contact, activity cache is cleared