### PR TITLE
fix: Set Home Node selected when displaying Site Home Page - MEED-1589 - Meeds-io/meeds#557

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
@@ -138,13 +138,14 @@ export default {
     },
     getActiveTab() {
       const siteName = eXo.env.portal.portalName;
-      if (location.pathname.endsWith(siteName)) {
-        this.updateNavigationState(`${location.pathname}/home`);
+      let pathname = location.pathname;
+      if (pathname === `${eXo.env.portal.context}/${siteName}/`) {
+        pathname = `${eXo.env.portal.context}/${siteName}/${eXo.env.portal.selectedNodeUri}`;
+        this.updateNavigationState(pathname);
       }
       this.tab = sessionStorage.getItem(this.navigationTabState);
-      if (location.pathname !== this.tab && !location.pathname.startsWith(this.tab)
-          && !location.pathname.endsWith(siteName)) {
-        this.tab = location.pathname;
+      if (pathname !== this.tab && !pathname.startsWith(this.tab)) {
+        this.tab = pathname;
       }
     }
   }


### PR DESCRIPTION
Prior to this change, the Top Navigation menu doesn't set the home page node as selected when accessing the site home page with URL '/portal/meeds'.