### PR TITLE
fix: Fix Tab Bar Site Navigation Mobile Margin - MEED-1590 - Meeds-io/meeds#571 - Meeds-io/meeds#561

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
@@ -77,9 +77,11 @@ export default {
     this.getActiveTab();
   },
   watch: {
-    isMobile(mobile) {
-      if (mobile) {
+    isMobile() {
+      if (this.isMobile) {
         this.refreshMobileNavigations();
+      } else {
+        this.computeSiteBodyMargin();
       }
     },
   },
@@ -135,6 +137,7 @@ export default {
       } else {
         this.mobileNavigations = this.navigations;
       }
+      this.computeSiteBodyMargin();
     },
     getActiveTab() {
       const siteName = eXo.env.portal.portalName;
@@ -147,7 +150,16 @@ export default {
       if (pathname !== this.tab && !pathname.startsWith(this.tab)) {
         this.tab = pathname;
       }
-    }
+    },
+    computeSiteBodyMargin() {
+      if (this.isMobile) {
+        window.setTimeout(() => {
+          $('#UISiteBody').css('margin-bottom', '70px');
+        }, 200);
+      } else {
+        $('#UISiteBody').css('margin-bottom', '');
+      }
+    },
   }
 };
 </script>


### PR DESCRIPTION
Prior to this change, in Mobile View in sites Pages (where the new Tab Bar is displayed), the Tab Bar hides actions of applications in bottom of the page. This change will ensure to add a margin to site's layout (as done for Space Menu Bottom Tab Bar) when in mobile view.