### PR TITLE
fix: New activity toast appeared despite applying the activity stream filter - EXO-61600 (#2212)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -5,6 +5,7 @@
     <activity-stream-confirm-dialog />
     <activity-stream-updater
       ref="activityUpdater"
+      v-if="showStreamUpdater"
       :space-id="spaceId"
       :activities="activities"
       :standalone="!!activityId"
@@ -100,6 +101,9 @@ export default {
     },
     pinActivityEnabled() {
       return this.spaceId && (this.streamFilter === null || this.streamFilter === 'all_stream') || false;
+    },
+    showStreamUpdater() {
+      return this.streamFilter === 'all_stream' ;
     }
   },
   watch: {


### PR DESCRIPTION
prior to this change, the "New posts" chip is displayed with all stream filter case.
after this change, the "New posts" chips should only be displayed if the filter applied is to "Any Activity" If filtered to any other filter, then no chips at all