### PR TITLE
fix: Fix eTag Usage for authenticated users related information - MEED-1639 - Meeds/meeds#615

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
@@ -338,7 +338,7 @@ public class ActivityRestResourcesV1 implements ResourceContainer {
     }
 
     long cacheTime = computeCacheTime(activity);
-    String eTagValue = StringUtils.isBlank(expand) ? String.valueOf(cacheTime) : String.valueOf(expand.hashCode() + cacheTime);
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
     if (builder == null) {

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/identity/IdentityRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/identity/IdentityRestResourcesV1.java
@@ -124,9 +124,11 @@ public class IdentityRestResourcesV1 implements IdentityRestResources {
     if (identity == null) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
+    org.exoplatform.services.security.Identity authenticatedUserIdentity = ConversationState.getCurrent().getIdentity();
+    String authenticatedUser = authenticatedUserIdentity.getUserId();
 
     long cacheTime = identity.getCacheTime();
-    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(expand.hashCode() + cacheTime);
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
@@ -174,8 +176,11 @@ public class IdentityRestResourcesV1 implements IdentityRestResources {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
 
+    org.exoplatform.services.security.Identity authenticatedUserIdentity = ConversationState.getCurrent().getIdentity();
+    String authenticatedUser = authenticatedUserIdentity.getUserId();
+
     long cacheTime = identity.getCacheTime();
-    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(expand.hashCode() + cacheTime);
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -232,8 +232,8 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       collectionSpace.setSize(listAccess.getSize());
     }
 
-    EntityTag eTag = null;
-    eTag = new EntityTag(Integer.toString(collectionSpace.hashCode()));
+    String eTagValue = String.valueOf(Objects.hash(collectionSpace.hashCode(), authenticatedUser, expand));
+    EntityTag eTag = new EntityTag(eTagValue);
 
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
     if (builder == null) {
@@ -359,7 +359,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     }
 
     long cacheTime = space.getCacheTime();
-    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(authenticatedUser.hashCode() + expand.hashCode() + cacheTime);
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
@@ -407,7 +407,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     long cacheTime = space.getCacheTime();
-    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(expand.hashCode() + cacheTime);
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
@@ -455,7 +455,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     long cacheTime = space.getCacheTime();
-    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(expand.hashCode() + cacheTime);
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
@@ -810,7 +810,9 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     if (returnSize) {
       collectionUser.setSize(spaceIdentitiesListAccess.getSize());
     }
-    EntityTag eTag  = new EntityTag(String.valueOf(collectionUser.hashCode()), true);
+
+    String eTagValue = String.valueOf(Objects.hash(collectionUser.hashCode(), authenticatedUser, expand));
+    EntityTag eTag  = new EntityTag(eTagValue);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
     if (builder == null) {
       builder = Response.ok(collectionUser, MediaType.APPLICATION_JSON);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -483,9 +484,11 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     if (identity == null) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
+    org.exoplatform.services.security.Identity authenticatedUserIdentity = ConversationState.getCurrent().getIdentity();
+    String authenticatedUser = authenticatedUserIdentity.getUserId();
 
     long cacheTime = identity.getCacheTime();
-    String eTagValue = expand == null ? String.valueOf(cacheTime) : String.valueOf(expand.hashCode() + cacheTime);
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
@@ -262,6 +262,55 @@ public void testSpaceDisplayNameUpdateWithDifferentCases () throws Exception {
     assertEquals(1, collections.getEntities().size());
   }
 
+  public void testShouldNotUseUseSameCacheWhenUserChange() throws Exception {
+    getSpaceInstance(1, "root");
+    getSpaceInstance(2, "john");
+    getSpaceInstance(3, "demo");
+
+    startSessionAs("root");
+
+    ContainerResponse response = service("GET", getURLResource("spaces?limit=5&offset=0"), "", null, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    CollectionEntity collections = (CollectionEntity) response.getEntity();
+    assertEquals(3, collections.getEntities().size());
+    EntityTag eTagRoot = (EntityTag) response.getHttpHeaders().getFirst("ETAG");
+    assertNotNull(eTagRoot);
+
+    MultivaluedMap<String,String> headers = new MultivaluedMapImpl();
+    headers.putSingle("If-None-Match", "\"" + eTagRoot.getValue() + "\"");
+    response = service("GET", getURLResource("spaces?limit=5&offset=0"), "", headers, null);
+    assertNotNull(response);
+    assertEquals(304, response.getStatus());
+
+    startSessionAs("john");
+
+    headers.putSingle("If-None-Match", "\"" + eTagRoot.getValue() + "\"");
+    response = service("GET", getURLResource("spaces?limit=5&offset=0"), "", headers, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+
+    EntityTag eTagJohn = (EntityTag) response.getHttpHeaders().getFirst("ETAG");
+    assertNotNull(eTagJohn);
+
+    headers.putSingle("If-None-Match", "\"" + eTagJohn.getValue() + "\"");
+    response = service("GET", getURLResource("spaces?limit=5&offset=0"), "", headers, null);
+    assertNotNull(response);
+    assertEquals(304, response.getStatus());
+
+    startSessionAs("root");
+
+    headers.putSingle("If-None-Match", "\"" + eTagRoot.getValue() + "\"");
+    response = service("GET", getURLResource("spaces?limit=5&offset=0"), "", headers, null);
+    assertNotNull(response);
+    assertEquals(304, response.getStatus());
+
+    headers.putSingle("If-None-Match", "\"" + eTagJohn.getValue() + "\"");
+    response = service("GET", getURLResource("spaces?limit=5&offset=0"), "", headers, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+  }
+
   public void testCreateSpace() throws Exception {
     startSessionAs("root");
     String input = "{\"displayName\":\"social\",\"visibility\":\"hidden\",\"subscription\":\"open\"}";


### PR DESCRIPTION
Prior to this change, retrieving an activity, space of identity using the same browser with two different users (login & logout multiple times), retrieves the same information while those endpoints has privileges information retrieved for current user. This fix will introduce the name of currently authenticated user in the computing of eTag value to fix it.