### PR TITLE
fix: duplicated content in shared activity - EXO-61994

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -75,9 +75,9 @@ const defaultActivityOptions = {
     icon: 'fa fa-link',
   },
   getBody: activity => {
-    return (activity.templateParams && activity.templateParams.comment)
-           || (activity && activity.title)
-           || (activity && activity.body)
+    return ( activity?.templateParams?.comment)
+           || activity?.title
+           || (!activity?.originalActivity && activity?.body)
            || '';
   },
   getBodyToEdit: activity => {
@@ -92,7 +92,7 @@ const defaultActivityOptions = {
       && templateParams.default_title
       && templateParams.default_title
       || (activity?.title?.replaceAll('%', '%25'))
-      || (activity?.body?.replaceAll('%', '%25'))
+      || (!activity?.originalActivity && activity?.body?.replaceAll('%', '%25'))
       || ''));
   },
   canShare: () => true,


### PR DESCRIPTION
prior to this change, when displaying a shared activity that does not
contain a title the original body is duplicated
after this change, we avoid displaying the body when it is a shared
activity