### PR TITLE
fix: Fix Spaces Loading Effect when typing and searching - MEED-1647

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesCardList.vue
@@ -145,6 +145,11 @@ export default {
     filter() {
       this.searchSpaces();
     },
+    typing() {
+      if (this.typing) {
+        this.$emit('loading-spaces', true);
+      }
+    },
   }, 
   created() {
     this.originalLimitToFetch = this.limitToFetch = this.limit;
@@ -157,7 +162,7 @@ export default {
       this.profileActionExtensions = extensionRegistry.loadExtensions('profile-extension', 'action') || [];
     },
     searchSpaces() {
-      this.loadingSpaces = true;
+      this.$emit('loading-spaces', true);
       const expand = this.filter === 'requests' ? 'pending,favorite' : 'managers,favorite';
       return this.$spaceService.getSpaces(this.keyword, this.offset, this.limitToFetch, this.filter, expand)
         .then(data => {
@@ -172,7 +177,7 @@ export default {
             this.limitToFetch += this.pageSize;
           }
         })
-        .finally(() => this.loadingSpaces = false);
+        .finally(() => this.$emit('loading-spaces', false));
     },
     resetSearch() {
       if (this.limitToFetch !== this.originalLimitToFetch) {

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesList.vue
@@ -13,6 +13,7 @@
       :filter="filter"
       :loading-spaces="loadingSpaces"
       :spaces-size="spacesSize"
+      @loading-spaces="loadingSpaces = $event"
       @loaded="spacesLoaded" />
 
     <exo-space-managers-drawer />

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesToolbar.vue
@@ -9,7 +9,7 @@
       <v-btn
         v-else
         id="addNewSpaceButton"
-        class="btn btn-primary px-0 mx-2 mx-sm-0 addNewSpaceButton"
+        class="btn btn-primary px-2 mx-2 mx-sm-0 addNewSpaceButton"
         :small="isMobile"
         :large="!isMobile"
         @click="$root.$emit('addNewSpace')">


### PR DESCRIPTION
Prior to this change, the spaces loading effet was deleted when the user is typing or searching on a space due to the fact that a Vue props is modified instead of a Vue data which didn't triggers the loading effect. In addition to bad UX, this loading is used in automatic tests to know when the spaces are refreshed with user search results.