### PR TITLE
fix: Fix Drawer Overlay Parent Element initialization - MEED-1696 - Meeds-io/meeds#625

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/dynamic-container-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/dynamic-container-configuration.xml
@@ -440,7 +440,54 @@
           <value>MiddleToolBar</value>
         </value-param>
         <object-param>
-          <name>MiddleToolBar</name>
+          <name>Drawers Overlay</name>
+          <description></description>
+          <object type="org.exoplatform.commons.addons.PortletModel">
+            <field name="contentId">
+              <string>social-portlet/DrawersOverlay</string>
+            </field>
+            <field name="permissions">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>*:/platform/users</string>
+                </value>
+                <value>
+                  <string>*:/platform/externals</string>
+                </value>
+              </collection>
+            </field>
+            <field name="title">
+              <string>Drawers Overlay</string>
+            </field>
+            <field name="showInfoBar">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationState">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationMode">
+              <boolean>false</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>addPlugin</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
+      <description></description>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <value>30</value>
+        </value-param>
+        <value-param>
+          <name>containerName</name>
+          <value>MiddleToolBar</value>
+        </value-param>
+        <object-param>
+          <name>Space Topbar Menu</name>
           <description></description>
           <object type="org.exoplatform.commons.addons.PortletModel">
             <field name="contentId">

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -876,4 +876,21 @@
     </portlet-preferences>
   </portlet>
 
+  <portlet>
+    <portlet-name>DrawersOverlay</portlet-name>
+    <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
+    <init-param>
+      <name>portlet-view-dispatched-file-path</name>
+      <value>/html/drawersOverlay.html</value>
+    </init-param>
+    <expiration-cache>-1</expiration-cache>
+    <cache-scope>PUBLIC</cache-scope>
+    <supports>
+      <mime-type>text/html</mime-type>
+    </supports>
+    <portlet-info>
+      <title>Technical Drawers Overlay Portlet</title>
+    </portlet-info>
+  </portlet>
+
 </portlet-app>

--- a/webapp/portlet/src/main/webapp/html/drawersOverlay.html
+++ b/webapp/portlet/src/main/webapp/html/drawersOverlay.html
@@ -1,0 +1,3 @@
+<div class="VuetifyApp">
+  <div id="drawers-overlay"></div>
+</div>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/main.js
@@ -104,47 +104,34 @@ const urls = [
   `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.social.SpacesListApplication-${lang}.json`,
 ];
 
-exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
-  const parentDrawersOverlayElement = document.querySelector('#MiddleToolBarChildren') || document.body;
-  let drawersOverlayElement = parentDrawersOverlayElement.querySelector('#drawers-overlay');
-  if (!drawersOverlayElement) {
-    drawersOverlayElement = document.createElement('div');
-    drawersOverlayElement.id = 'drawers-overlay';
-    drawersOverlayElement.class = 'v-application v-application--is-ltr transparent theme--light';
-    parentDrawersOverlayElement.appendChild(drawersOverlayElement);
-    parentDrawersOverlayElement.classList.add('VuetifyApp');
-    new Vue({
-      created() {
-        this.$userPopupLabels = Vue.prototype.$userPopupLabels = {
-          CancelRequest: this.$t('UserProfilePopup.label.CancelRequest'),
-          Confirm: this.$t('UserProfilePopup.label.Confirm'),
-          Connect: this.$t('UserProfilePopup.label.Connect'),
-          Ignore: this.$t('UserProfilePopup.label.Ignore'),
-          RemoveConnection: this.$t('UserProfilePopup.label.RemoveConnection'),
-          StatusTitle: this.$t('UserProfilePopup.label.Loading'),
-          External: this.$t('UserProfilePopup.label.External'),
-          Disabled: this.$t('UserProfilePopup.label.Disabled'),
-          Loading: this.$t('UserProfilePopup.label.Loading'),
-        };
-        this.$spacePopupLabels = Vue.prototype.$spacePopupLabels = {
-          CancelRequest: this.$t('UserProfilePopup.label.CancelRequest'),
-          Confirm: this.$t('UserProfilePopup.label.Confirm'),
-          Connect: this.$t('UserProfilePopup.label.Connect'),
-          Ignore: this.$t('UserProfilePopup.label.Ignore'),
-          RemoveConnection: this.$t('UserProfilePopup.label.RemoveConnection'),
-          StatusTitle: this.$t('UserProfilePopup.label.Loading'),
-          External: this.$t('UserProfilePopup.label.External'),
-          join: this.$t('spacesList.button.join'),
-          leave: this.$t('spacesList.button.leave'),
-          members: this.$t('spacesList.label.SpaceMembers'),
-        };
-      },
-      template: '<drawers-overlay id="drawers-overlay" />',
-      vuetify: Vue.prototype.vuetifyOptions,
-      i18n,
-    }).$mount(drawersOverlayElement);
-  }
-});
+if (!window.drawersOverlayInitialized) {
+  window.drawersOverlayInitialized = true;
+  exoi18n.loadLanguageAsync(lang, urls)
+    .then(i18n => {
+      if (document.querySelector('#drawers-overlay')) {
+        new Vue({
+          template: '<drawers-overlay id="drawers-overlay" />',
+          vuetify: Vue.prototype.vuetifyOptions,
+          i18n,
+        }).$mount('#drawers-overlay');
+      } else { // Needed for anonymous pages (login, register ...)
+        const parentDrawersOverlayElement = document.querySelector('#MiddleToolBarChildren') || document.body;
+        let drawersOverlayElement = parentDrawersOverlayElement.querySelector('#drawers-overlay');
+        if (!drawersOverlayElement) {
+          drawersOverlayElement = document.createElement('div');
+          drawersOverlayElement.id = 'drawers-overlay';
+          drawersOverlayElement.class = 'v-application v-application--is-ltr transparent theme--light';
+          parentDrawersOverlayElement.appendChild(drawersOverlayElement);
+          parentDrawersOverlayElement.classList.add('VuetifyApp');
+          new Vue({
+            template: '<drawers-overlay id="drawers-overlay" />',
+            vuetify: Vue.prototype.vuetifyOptions,
+            i18n,
+          }).$mount(drawersOverlayElement);
+        }
+      }
+    });
+}
 
 const parentNotificationsElement = document.querySelector('#bottom-all-container') || document.body;
 let alertNotificationsElement = parentNotificationsElement.querySelector('#alert-notifications');


### PR DESCRIPTION
Prior to this change, the drawers overlay sometimes is displayed on top of drawers due to its position where it's added in bottom of the page. This change will ensure the add the dedicated element of the drawers overlay definition when the initial DOM is retrieved from server by injecting the adequate div element in place using a Dynamic container.