### PR TITLE
fix: Fix Updating Profile Job in title right after modifying it - MEED-1697 - Meeds-io/meeds#626

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -145,7 +145,7 @@ export default {
     this.refresh();
     document.addEventListener('userModified', event => {
       if (event && event.detail && event.detail !== this.user) {
-        Object.assign(this.user, event.detail);
+        this.user = Object.assign({}, this.user, event.detail);
         this.$nextTick().then(() => this.$root.$emit('application-loaded'));
       }
     });


### PR DESCRIPTION
Prior to this change, the Profile Header isn't updated after updating the user information from contact Information section. This change ensures to force applying the modifications in Profile Header UI by making an assignment of a variable to let Vue notify components about the change.