### PR TITLE
fix: Resolve the PostgreSQL error during server startup by adding missing sequences - EXO-62184

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -893,5 +893,9 @@
             ALTER TABLE SOC_ACTIVITY_SHARE_ACTIONS MODIFY COLUMN TITLE longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
         </sql>
     </changeSet>
+    <changeSet author="social" id="1.0.0-90" dbms="postgresql">
+        <createSequence sequenceName="SEQ_SOC_PROPERTY_SETTING_ID" startValue="1"/>
+        <createSequence sequenceName="SEQ_SOC_LABELS_ID" startValue="1"/>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
This change is going to resolve the PostgresSQL error during the server startup by adding the messing sequences. 