### PR TITLE
fix: Space is not correctly retrieved for space popover actions - EXO-62231

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-navigation/components/SpacePanelHamburgerNavigation.vue
@@ -172,7 +172,7 @@ export default {
     params() {
       return {
         identityType: 'space',
-        identityId: eXo.env.portal.spaceId
+        identityId: this.spaceId
       };
     },
     enabledExtensionComponents() {


### PR DESCRIPTION
Priori to this fix, popover menu actions does not get correctly the space if opened in a page outside a space since it relies on the global variable **exo.env.portal.spaceId** that is present only when a space is opened.
The fix changes the identity id with the local property spaceId instead of the global variable exo.env.portal.spaceId