### PR TITLE
fix: fix error while sharing an activity with title containing emojis - EXO-62213 (#2294)

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -835,4 +835,10 @@
         </addColumn>
     </changeSet>
 
+  <changeSet author="social" id="1.0.0-89" dbms="mysql">
+    <sql>
+      ALTER TABLE SOC_ACTIVITY_SHARE_ACTIONS MODIFY COLUMN TITLE longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
prior to this change, while sharing an activity with a title containing emojis, an error occurs since the title type doesn't accept emojis after this change, the Title type is changed to utf8mb4 so it accepts emojis and the activity is shared successfully