### PR TITLE
fix: Apply MOP API Refactoring to Enahance Loading Time of Sites - MEED-1777 - Meeds-io/meeds#660

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
@@ -1,31 +1,11 @@
 package org.exoplatform.social.core.space.impl;
 
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.container.component.RequestLifeCycle;
-import org.exoplatform.portal.application.PortalRequestContext;
-import org.exoplatform.portal.config.DataStorage;
-import org.exoplatform.portal.config.model.Page;
-import org.exoplatform.portal.mop.user.UserNode;
-import org.exoplatform.portal.webui.util.Util;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.Group;
-import org.exoplatform.services.organization.GroupHandler;
-import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.social.core.space.SpaceListenerPlugin;
 import org.exoplatform.social.core.space.SpaceUtils;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
-import org.exoplatform.web.application.RequestContext;
-import org.exoplatform.web.url.navigation.NodeURL;
-import org.exoplatform.container.PortalContainer;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
-
-  private static final Log LOG = ExoLogger.getExoLogger(SpaceRenamedListenerImpl.class);
 
   @Override
   public void spaceAccessEdited(SpaceLifeCycleEvent event) {

--- a/component/core/src/test/java/org/exoplatform/social/core/space/SpaceUtilsTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/SpaceUtilsTest.java
@@ -28,8 +28,6 @@ import org.exoplatform.portal.mop.page.PageService;
 import org.exoplatform.portal.mop.user.UserNode;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.Group;
-import org.exoplatform.services.organization.MembershipType;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.common.Utils;
@@ -81,7 +79,7 @@ public class SpaceUtilsTest extends AbstractCoreTest {
     space1.setVisibility("public");
     space1.setPriority("2");
     String[] manager = new String []{"root"};
-    String[] members = new String []{"demo", "john", "mary"};
+    String[] members = new String []{"root", "demo", "john", "mary"};
     space1.setManagers(manager);
     space1.setMembers(members);
 
@@ -118,20 +116,6 @@ public class SpaceUtilsTest extends AbstractCoreTest {
   public void testRemoveSpecialCharacter() {
     assertEquals("The filter should only filter special characters only","script alert 'Hello' script 100", Utils.removeSpecialCharacterInSpaceFilter("<script>alert('Hello');</script> 100"));
     assertEquals("The filter should keep wildcard *,? and %","% * '?", Utils.removeSpecialCharacterInSpaceFilter("( ) %{ } * [ ] \'? \""));
-    /* I comment this part because unicode String may have problem with Jenkins build.
-    assertEquals("The filter should only filter special characters only","script alert a á à ả ã ạ ă ắ ằ ẳ ẵ ặ â" +
-    		          " ấ ầ ẩ ẫ ậ o ó ò ỏ õ ọ ơ ớ ờ ở ỡ ợ u ú ù ủ ũ ụ ư ứ ừ ử ữ ự đ script 100",
-    		          SpaceUtils.removeSpecialCharacterInSpaceFilter("<script>alert(' a á à ả ã ạ ă ắ ằ ẳ ẵ ặ â" +
-                  " ấ ầ ẩ ẫ ậ o ó ò ỏ õ ọ ơ ớ ờ ở ỡ ợ u ú ù ủ ũ ụ ư ứ ừ ử ữ ự đ');</script> 100"));
-    assertEquals("The filter should keep the unicode characters","ˆáàâäåÁÃÄÅÀÂæÆçÇêéëèÊËÉÈïíîìÍÌÎÏñÑœŒöòõóøÓÔÕØÖÒšŠúüûùÙÚÜÛÿŸýÝžŽÞþƒßµÐºÇüéâäàåçêëèïîìÄÅÉæÆôöòû" +
-    		         "ùÿÖÜáíóúñÑºĈĉĜĝĤĥĴĵŜŝŬŭàâçéèêëîïœôùûÀÂÇÈÉÊËÎÏŒáéíñóúüÁÉÍÑÓÚÜÔÙÛàèìòùÀÈÌÒÙãÃçÇòÒóÓõÕäåæðëöøßþü" +
-    		         "ÿÄÅÆÐËÖØÞÜ",
-    		         SpaceUtils.removeSpecialCharacterInSpaceFilter(
-		             "ˆáàâäåÁÃÄÅÀÂæÆçÇêéëèÊËÉÈïíîìÍÌÎÏñÑœŒöòõóøÓÔÕØÖÒšŠúüûùÙÚÜÛÿŸýÝžŽÞþƒßµÐºÇüéâäàåçêëèïîìÄÅÉæÆôöòû" +
-                 "ùÿÖÜáíóúñÑºĈĉĜĝĤĥĴĵŜŝŬŭàâçéèêëîïœôùûÀÂÇÈÉÊËÎÏŒáéíñóúüÁÉÍÑÓÚÜÔÙÛàèìòùÀÈÌÒÙãÃçÇòÒóÓõÕäåæðëöøßþü" +
-                 "ÿÄÅÆÐËÖØÞÜ"
-                 ));
-    */
   }
   
   public void testGetAppFromPortalContainer() throws Exception {

--- a/component/core/src/test/java/org/exoplatform/social/core/space/mock/MockSpaceApplicationHandler.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/mock/MockSpaceApplicationHandler.java
@@ -19,11 +19,12 @@ package org.exoplatform.social.core.space.mock;
 
 import org.exoplatform.application.registry.Application;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.config.model.PortalConfig;
-import org.exoplatform.portal.mop.page.PageService;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.portal.mop.service.NavigationService;
+import org.exoplatform.portal.mop.storage.PageStorage;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
 import org.exoplatform.social.core.space.impl.DefaultSpaceApplicationHandler;
 import org.exoplatform.social.core.space.model.Space;
@@ -32,10 +33,11 @@ import org.exoplatform.social.core.space.spi.SpaceTemplateService;
 public class MockSpaceApplicationHandler extends DefaultSpaceApplicationHandler {
 
   public MockSpaceApplicationHandler(InitParams params,
-                                     DataStorage dataStorage,
-                                     PageService pageService,
+                                     LayoutService layoutService,
+                                     NavigationService navigationService,
+                                     PageStorage pageStorage,
                                      SpaceTemplateService spaceTemplateService) {
-    super(params, dataStorage, pageService, spaceTemplateService);
+    super(params, layoutService, navigationService, pageStorage, spaceTemplateService);
   }
 
   @Override

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -28,16 +28,16 @@ import org.apache.commons.lang.ArrayUtils;
 import org.exoplatform.application.registry.Application;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.model.ApplicationType;
 import org.exoplatform.portal.config.model.ModelObject;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.mop.navigation.NavigationContext;
-import org.exoplatform.portal.mop.navigation.NavigationService;
 import org.exoplatform.portal.mop.navigation.NodeContext;
 import org.exoplatform.portal.mop.navigation.NodeModel;
 import org.exoplatform.portal.mop.navigation.Scope;
 import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.portal.mop.service.NavigationService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
@@ -3713,8 +3713,8 @@ public class SpaceServiceTest extends AbstractCoreTest {
     PageKey homePageKey = homeNodeContext.getState().getPageRef();
     assertNotNull(homePageKey);
 
-    DataStorage dataStorage = getContainer().getComponentInstanceOfType(DataStorage.class);
-    Page page = dataStorage.getPage(homePageKey.format());
+    LayoutService layoutService = getContainer().getComponentInstanceOfType(LayoutService.class);
+    Page page = layoutService.getPage(homePageKey.format());
     assertNotNull(page);
     assertEquals(5, countPageApplications(page.getChildren(), 0));
 
@@ -3725,7 +3725,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
     assertThrows(IllegalAccessException.class, () -> spaceService.restoreSpacePageLayout(spaceId, "home", new org.exoplatform.services.security.Identity("demo")));
 
     spaceService.restoreSpacePageLayout(spaceId, "home", rootACLIdentity);
-    page = dataStorage.getPage(homePageKey.format());
+    page = layoutService.getPage(homePageKey.format());
     assertNotNull(page);
     assertEquals(2, countPageApplications(page.getChildren(), 0));
   }

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceTemplateServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceTemplateServiceTest.java
@@ -197,7 +197,7 @@ public class SpaceTemplateServiceTest extends AbstractCoreTest {
     valueParam.setName("templateName");
     valueParam.setValue("custom");
     params.addParameter(valueParam);
-    SpaceApplicationHandler applicationHandler = new DefaultSpaceApplicationHandler(params, null, null, null);
+    SpaceApplicationHandler applicationHandler = new DefaultSpaceApplicationHandler(params, null, null, null, null);
     // when
     spaceTemplateService.registerSpaceApplicationHandler(applicationHandler);
     // then

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -16,32 +16,52 @@
  */
 package org.exoplatform.social.rest.impl.space;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.application.registry.Application;
-import org.exoplatform.commons.utils.*;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.IOUtil;
+import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.deprecation.DeprecatedAPI;
-import org.exoplatform.portal.config.DataStorage;
+import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.portal.mop.user.UserNode;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -52,23 +72,42 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.model.*;
+import org.exoplatform.social.core.model.AvatarAttachment;
+import org.exoplatform.social.core.model.BannerAttachment;
+import org.exoplatform.social.core.model.SpaceExternalInvitation;
 import org.exoplatform.social.core.profile.ProfileFilter;
 import org.exoplatform.social.core.search.Sorting;
 import org.exoplatform.social.core.search.Sorting.OrderBy;
 import org.exoplatform.social.core.search.Sorting.SortBy;
 import org.exoplatform.social.core.service.LinkProvider;
-import org.exoplatform.social.core.space.*;
+import org.exoplatform.social.core.space.SpaceException;
+import org.exoplatform.social.core.space.SpaceFilter;
+import org.exoplatform.social.core.space.SpaceUtils;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.metadata.thumbnail.ImageThumbnailService;
-import org.exoplatform.social.rest.api.*;
-import org.exoplatform.social.rest.entity.*;
+import org.exoplatform.social.rest.api.EntityBuilder;
+import org.exoplatform.social.rest.api.RestProperties;
+import org.exoplatform.social.rest.api.RestUtils;
+import org.exoplatform.social.rest.api.SpaceRestResources;
+import org.exoplatform.social.rest.entity.ActivityEntity;
+import org.exoplatform.social.rest.entity.BaseEntity;
+import org.exoplatform.social.rest.entity.CollectionEntity;
+import org.exoplatform.social.rest.entity.DataEntity;
+import org.exoplatform.social.rest.entity.SpaceEntity;
 import org.exoplatform.social.rest.impl.activity.ActivityRestResourcesV1;
 import org.exoplatform.social.service.rest.api.VersionResources;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.web.login.recovery.PasswordRecoveryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 @Path(VersionResources.VERSION_ONE + "/social/spaces")
@@ -689,11 +728,11 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       StringBuilder url = new StringBuilder(uri);
 
       PasswordRecoveryService passwordRecoveryService = CommonsUtils.getService(PasswordRecoveryService.class);
-      DataStorage dataStorage = CommonsUtils.getService(DataStorage.class);
+      LayoutService layoutService = CommonsUtils.getService(LayoutService.class);
       String currentSiteName = CommonsUtils.getCurrentSite().getName();
       Locale locale = null;
       try {
-        String currentSiteLocale = dataStorage.getPortalConfig(currentSiteName).getLocale();
+        String currentSiteLocale = layoutService.getPortalConfig(currentSiteName).getLocale();
         locale = new Locale(currentSiteLocale);
       } catch (Exception e) {
         LOG.error("Failure to retrieve portal config", e);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -38,8 +38,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -75,16 +75,16 @@ import org.json.JSONObject;
 import org.picocontainer.Startable;
 
 import org.exoplatform.common.http.HTTPStatus;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.IOUtil;
 import org.exoplatform.commons.utils.ListAccess;
-import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.deprecation.DeprecatedAPI;
-import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.portal.rest.UserFieldValidator;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -1793,9 +1793,9 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
 
   private void sendOnBoardingEmail(UserImpl user, StringBuilder url) throws Exception {
     PasswordRecoveryService passwordRecoveryService = CommonsUtils.getService(PasswordRecoveryService.class);
-    DataStorage dataStorage = CommonsUtils.getService(DataStorage.class);
+    LayoutService layoutService = CommonsUtils.getService(LayoutService.class);
     String currentSiteName = CommonsUtils.getCurrentSite().getName();
-    String currentSiteLocale = dataStorage.getPortalConfig(currentSiteName).getLocale();
+    String currentSiteLocale = layoutService.getPortalConfig(currentSiteName).getLocale();
     Locale locale = new Locale(currentSiteLocale);
     boolean onBoardingEmailSent = passwordRecoveryService.sendOnboardingEmail(user, locale, url);
     if (onBoardingEmailSent) {

--- a/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -121,24 +121,14 @@ export default {
       if (this.navigations.length) {
         return;
       }
-      const cachedNavigations = window.sessionStorage && window.sessionStorage.getItem(`Administration_Navigations_${eXo.env.server.sessionId}`);
-      if (cachedNavigations) {
-        this.$nextTick().then(() => this.navigations = JSON.parse(cachedNavigations));
-      }
-
       this.loading = true;
-      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/navigations/group?exclude=/spaces.*&${this.visibilityQueryParams}`, {
+      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/navigations/group?${this.visibilityQueryParams}`, {
         method: 'GET',
         credentials: 'include',
       })
         .then(resp => resp && resp.ok && resp.json())
         .then(data => {
           const navigations = data || [];
-          try {
-            window.sessionStorage.setItem(`Administration_Navigations_${eXo.env.server.sessionId}`, JSON.stringify(navigations));
-          } catch (e) {
-            // Expected Quota Exceeded Error
-          }
           this.navigations = navigations;
         })
         .then(() => fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/navigations/categories`, {

--- a/webapp/portlet/src/main/webapp/vue-apps/site-navigation/components/ExoSiteHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/site-navigation/components/ExoSiteHamburgerNavigation.vue
@@ -87,11 +87,6 @@ export default {
     },
   },
   created(){
-    const cacheKey = `Site_Navigations_${eXo.env.portal.portalName}_${eXo.env.server.sessionId}`;
-    const cachedNavigations = window.sessionStorage && window.sessionStorage.getItem(cacheKey);
-    if (cachedNavigations) {
-      this.$nextTick().then(() => this.navigations = JSON.parse(cachedNavigations));
-    }
     fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/navigations/portal/?siteName=${eXo.env.portal.portalName}&scope=${this.navigationScope}&${this.visibilityQueryParams}`, {
       method: 'GET',
       credentials: 'include',
@@ -99,11 +94,6 @@ export default {
       .then(resp => resp && resp.ok && resp.json())
       .then(data => {
         const navigations = data || [];
-        try {
-          window.sessionStorage.setItem(cacheKey, JSON.stringify(navigations));
-        } catch (e) {
-          // Expected Quota Exceeded Error
-        }
         if (!this.navigations || !this.navigations.length) {
           this.navigations = navigations;
         }


### PR DESCRIPTION
This change will avoid using deprecated services in https://github.com/Meeds-io/gatein-portal/pull/535.
Besides, this change will delete the usage of `sessionStorage` for `Site` & `Group` navigation retrieval in Left menu knowing that REST endpoint has become more performant.