### PR TITLE
fix: Profile modified contact field is displayed once edit canceled - EXO-62337 (#2298)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -40,7 +40,6 @@
     <profile-contact-information-drawer
       v-if="owner"
       ref="contactInformationEdit"
-      :properties="properties"
       :upload-limit="uploadLimit"
       @refresh="refresh" />
   </v-app>
@@ -85,7 +84,7 @@ export default {
         .finally(() => this.$root.$applicationLoaded());
     },
     editContactInformation() {
-      this.$refs.contactInformationEdit.open();
+      this.$root.$emit('open-profile-contact-information-drawer', this.properties);
     },
     getResolvedName(item){
       const lang = eXo && eXo.env.portal.language || 'en';

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -64,14 +64,9 @@
 
 <script>
 export default {
-  props: {
-    properties: {
-      type: Array,
-      default: () => null,
-    }
-  },
   data: () => ({
     propertiesToSave: [],
+    properties: [],
     error: null,
     saving: null,
     fieldError: false,
@@ -81,6 +76,9 @@ export default {
       viewMode: 1,
     },
   }),
+  created() {
+    this.$root.$on('open-profile-contact-information-drawer', this.open);
+  },
   methods: {
     
     resetCustomValidity() {
@@ -209,8 +207,11 @@ export default {
       this.refresh();
       this.$refs.profileContactInformationDrawer.close();
     },
-    open() {
+    open(event) {
       this.error = null;
+      if (event) {
+        this.properties = JSON.parse(JSON.stringify(event));
+      }
       this.$refs.profileContactInformationDrawer.open();
     },
     propertyUpdated(item){


### PR DESCRIPTION
prior to this change, after modifying the contact field and then canceling, the modification is displayed instead of the original contact info. After this change, the new modification is displayed only after saving the modifications