### PR TITLE
fix: Profile admin modified contact field is displayed empty on edit mode - EXO-62451 (#2304)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/menu/ProfileSettingsActionMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/menu/ProfileSettingsActionMenu.vue
@@ -92,7 +92,7 @@ export default {
   },
   methods: {
     edit(){
-      this.$root.$emit('open-settings-edit-drawer', this.setting);
+      this.$root.$emit('open-settings-edit-drawer', JSON.parse(JSON.stringify( this.setting)));
     },
     moveUp(){
       this.$root.$emit('move-up-setting', this.setting);


### PR DESCRIPTION
prior to this change, after modifying the contact field and then canceling, the modification is displayed instead of the original contact info since the setting object is linked to the original setting object resulting that the changes will be bidirectional. After this change, the new modification is displayed only after saving the modifications by creating a copy of the setting object with no reference to objects linked to the original one