### PR TITLE
fix: Fix Space Web Notification NPE - MEED-1796 - Meeds-io/meeds#682

### DIFF
--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -29,7 +29,7 @@
   <name>eXo PLF:: Social Notification Component</name>
   <description>eXo Social Notification Component</description>
   <properties>
-    <exo.test.coverage.ratio>0.59</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.60</exo.test.coverage.ratio>
   </properties>
   <dependencies>
   

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
@@ -240,7 +240,14 @@ public class SpaceWebNotificationServiceImpl implements SpaceWebNotificationServ
                                                              .findFirst()
                                                              .orElse(null);
     if (spaceWebNotification != null) {
-      return spaceWebNotification.getSpaceApplicationItem(notification, username);
+      SpaceWebNotificationItem spaceApplicationItem = spaceWebNotification.getSpaceApplicationItem(notification, username);
+      if (spaceApplicationItem != null
+          && spaceApplicationItem.getSpaceId() > 0
+          && spaceApplicationItem.getUserId() > 0
+          && StringUtils.isNotBlank(spaceApplicationItem.getApplicationItemId())
+          && StringUtils.isNotBlank(spaceApplicationItem.getApplicationName())) {
+        return spaceApplicationItem;
+      }
     }
     return null;
   }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
@@ -48,14 +48,18 @@ public class ActivitySpaceWebNotificationPlugin extends SpaceWebNotificationPlug
     } else {
       metadataObject = activity.getMetadataObject();
     }
-    SpaceWebNotificationItem spaceWebNotificationItem = new SpaceWebNotificationItem(metadataObject.getType(),
-                                                                                     metadataObject.getId(),
-                                                                                     0,
-                                                                                     metadataObject.getSpaceId());
-    if (activity.isComment()) {
-      spaceWebNotificationItem.addApplicationSubItem(activity.getId());
+    if (metadataObject != null && metadataObject.getSpaceId() > 0) {
+      SpaceWebNotificationItem spaceWebNotificationItem = new SpaceWebNotificationItem(metadataObject.getType(),
+                                                                                       metadataObject.getId(),
+                                                                                       0,
+                                                                                       metadataObject.getSpaceId());
+      if (activity.isComment()) {
+        spaceWebNotificationItem.addApplicationSubItem(activity.getId());
+      }
+      return spaceWebNotificationItem;
+    } else {
+      return null;
     }
-    return spaceWebNotificationItem;
   }
 
 }


### PR DESCRIPTION
Prior to this change, when editing a user activity not attached to a space, an NPE is triggered. This change will avoid such a behavior by not dispatching the notification using Space Web Channel.