### PR TITLE
fix: fix space and user popover position - EXO-62433 - Meeds-io/meeds#706

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
@@ -27,7 +27,7 @@
     :position-y="offsetY"
     transition="slide-x-transition"
     absolute
-    top
+    bottom
     content-class="profile-popover-menu pa-1 transparent"
     elevation="0"
     max-width="350"
@@ -160,7 +160,7 @@ export default {
     },
     setPopoverNotHovered() {
       this.isMenuHovered = false;
-      this.closePopover();
+      this.closePopover(true);
     },
     openPopover(immediatly) {
       if (!this.menu) {

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -31,7 +31,7 @@ Vue.directive('identity-popover', (el, binding) => {
     document.dispatchEvent(new CustomEvent('popover-identity-display', {
       detail: Object.assign({
         offsetX: rect.left + window.scrollX,
-        offsetY: rect.top + window.scrollY,
+        offsetY: rect.bottom + window.scrollY,
         identityType: isUser ? 'User' : 'Space',
         element: el,
       }, identity || {})


### PR DESCRIPTION
Prior to this fix, the space and user popover  hide the user or space name and when the popover is displayed and we scroll down or up. The popover remains displayed even if the mouse is no longer on the name of the space because there is waiting time before the popover closes. After this fix, space and user popover is positioned under the user or space name and when we scroll up or down, the popover disappears and closes immediately.