### PR TITLE
fix: Fix displaying publisher filter in space members application filters - EXO-62385 - Meeds-io/meeds#694

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
@@ -104,7 +104,7 @@ export default {
   data: () => ({
     filterToChange: null,
     bottomMenu: false,
-    publisherRolePromotionFeatureEnabled: eXo.env.portal.publisherRolePromotionEnabled,
+    publisherRolePromotionFeatureEnabled: eXo.env.portal.PublisherRolePromotionFeatureEnabled,
     startSearchAfterInMilliseconds: 300,
     endTypingKeywordTimeout: 50,
     startTypingKeywordTimeout: 0,


### PR DESCRIPTION

Prior to this fix, publisher filter is not displayed in space members application filters, this is due to the wrong name used for js global variable eXo.env.portal.publisherRolePromotionEnabled containing the publisherRolePromotion FT flag value. After this change, we will fix the js global variable name eXo.env.portal.PublisherRolePromotionFeatureEnabled.