### PR TITLE
fix: Fix npm run lint error on webapp/portlet module with windows - Meeds-io/meeds#693

### DIFF
--- a/webapp/portlet/package.json
+++ b/webapp/portlet/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "watch": "webpack --config webpack.dev.js --progress --color --watch",
-    "lint": "eslint --fix './src/main/webapp/vue-apps/**'",
+    "lint": "eslint --fix \"./src/main/webapp/vue-apps/**\"",
     "eslint-check": "eslint \"./src/main/webapp/**\"",
     "build": "webpack --config webpack.prod.js --mode production"
   },


### PR DESCRIPTION
Prior to this fix, npm run lint on webapp/portlet module is working on for linux and not for windows since the pattern used for lint script is not suitable for windows.
After this change, we ensure to use the pattern \\"./src/main/webapp/vue-apps/**\\" instead of './src/main/webapp/vue-apps/**' which will be suitable for both windows and linux.
