### PR TITLE
fix: fix UI glitch when clicking on bottom menu item - EXO-62219 - Meeds-io/meeds#751

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/mobile/NavigationMobileMenuItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/mobile/NavigationMobileMenuItem.vue
@@ -56,6 +56,7 @@
       </v-tab>
     </template>
     <navigation-mobile-menu-sub-item
+      v-if="hasChildren"
       :navigation="navigation.children"
       :base-site-uri="baseSiteUri"
       :show-menu="showMenu"


### PR DESCRIPTION
prior to this change, in mobile view and clicking on an element of the bottom menu, there is a white line that appears, which is the sub-menu component that displays the list of sub-menus in case the navigation has children. in case it doesn't have children it is displayed empty after this change, the sub-menu component is displayed only when it has children