### PR TITLE
fix: avoid displaying and indexing user technical properties - EXO-62724 - meeds-io/meeds#762

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -35,6 +35,7 @@ import org.exoplatform.social.core.jpa.storage.dao.ConnectionDAO;
 import org.exoplatform.social.core.jpa.storage.dao.IdentityDAO;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.relationship.model.Relationship;
 
 /**
@@ -244,9 +245,11 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     }
     Date createdDate = new Date(profile.getCreatedTime());
 
-    for (String propertyName : profilePropertyService.getPropertySettingNames()) {
-      if (!fields.containsKey(propertyName)) {
-        if (profile.getProperty(propertyName) != null && profile.getProperty(propertyName)instanceof String value) {
+    for (ProfilePropertySetting profilePropertySetting : profilePropertyService.getPropertySettings()) {
+      String propertyName = profilePropertySetting.getPropertyName();
+      // We should index only active properties of user profile
+      if (!fields.containsKey(propertyName) && profilePropertySetting.isActive()) {
+        if (profile.getProperty(propertyName) != null && profile.getProperty(propertyName) instanceof String value) {
           if (StringUtils.isNotEmpty(value)) {
             fields.put(propertyName, value);
           }

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
@@ -109,9 +109,9 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
       ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting();
       profilePropertySetting.setPropertyName(propertyName);
       profilePropertySetting.setMultiValued(false);
-      profilePropertySetting.setActive(true);
+      profilePropertySetting.setActive(false);
       profilePropertySetting.setEditable(false);
-      profilePropertySetting.setVisible(true);
+      profilePropertySetting.setVisible(false);
       profilePropertySetting.setParentId(null);
       try {
         profilePropertyService.createPropertySetting(profilePropertySetting);


### PR DESCRIPTION
When login using openID provider, the related user informations are saved in the user profile an then indexed in ElasticSearch which causes an indexing error. Those properties are also displayed in the user profile while they are technical information that should not be viewed.
The fix sets user properties to inactive (to not display them in the user profile) and do not index them until they are activated by the administrator from the Profile properties settings.