### PR TITLE
fix: ignore openId properties while synchronize user profile - EXO-62724 - meeds-io/meeds#762

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -248,7 +248,7 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     for (ProfilePropertySetting profilePropertySetting : profilePropertyService.getPropertySettings()) {
       String propertyName = profilePropertySetting.getPropertyName();
       // We should index only active properties of user profile
-      if (!fields.containsKey(propertyName) && profilePropertySetting.isActive()) {
+      if (!fields.containsKey(propertyName)) {
         if (profile.getProperty(propertyName) != null && profile.getProperty(propertyName) instanceof String value) {
           if (StringUtils.isNotEmpty(value)) {
             fields.put(propertyName, value);

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -245,23 +245,22 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     }
     Date createdDate = new Date(profile.getCreatedTime());
 
-    for (ProfilePropertySetting profilePropertySetting : profilePropertyService.getPropertySettings()) {
-      String propertyName = profilePropertySetting.getPropertyName();
-      // We should index only active properties of user profile
-      if (!fields.containsKey(propertyName)) {
-        if (profile.getProperty(propertyName) != null && profile.getProperty(propertyName) instanceof String value) {
+    for (String profilePropertySettingName : profilePropertyService.getPropertySettingNames()) {
+      if (!fields.containsKey(profilePropertySettingName)) {
+        if (profile.getProperty(profilePropertySettingName) != null && profile.getProperty(profilePropertySettingName) instanceof String value) {
           if (StringUtils.isNotEmpty(value)) {
-            fields.put(propertyName, value);
+            // Avoid having dots in field names in ES, otherwise properties with String values may be converted in Objects in some cases
+            fields.put(profilePropertySettingName.replace(".", "_"), value);
           }
         } else {
-          List<Map<String, String>> multiValues = (List<Map<String, String>>) profile.getProperty(propertyName);
+          List<Map<String, String>> multiValues = (List<Map<String, String>>) profile.getProperty(profilePropertySettingName);
           if (CollectionUtils.isNotEmpty(multiValues)) {
             String value = multiValues.stream()
                 .filter(property -> property.get("value") != null)
                 .map(property -> property.get("value"))
                 .collect(Collectors.joining(",", "", ""));
             if (StringUtils.isNotEmpty(value)) {
-              fields.put(propertyName, removeAccents(value));
+              fields.put(profilePropertySettingName.replace(".", "_"), removeAccents(value));
             }
           }
         }

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
@@ -17,6 +17,7 @@
 package org.exoplatform.social.core.listeners;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -24,8 +25,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.*;
@@ -41,8 +44,9 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
 
   private static final Log                     LOG                   =
                                                    ExoLogger.getLogger(SocialUserProfileEventListenerImpl.class);
+  private static final String SOCIAL_PROFILE_EXCLUDED_ATTRIBUTE_LIST = "exo.social.profile.excluded.attributeList";
 
-  private final List<String>                   exlcudedAttributeList = List.of("authenticationAttempts", "latestAuthFailureTime");
+  private final List<String>                   exlcudedAttributeList = new ArrayList<>(List.of("authenticationAttempts", "latestAuthFailureTime"));
 
   private final IdentityManager                identityManager;
 
@@ -52,6 +56,10 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
                                             ProfilePropertyService profilePropertyService) {
     this.identityManager = identityManager;
     this.profilePropertyService = profilePropertyService;
+    String socialProfileExcludedAttributeList = PropertyManager.getProperty(SOCIAL_PROFILE_EXCLUDED_ATTRIBUTE_LIST);
+    if(StringUtils.isNotBlank(socialProfileExcludedAttributeList)) {
+      this.exlcudedAttributeList.addAll(Arrays.asList(socialProfileExcludedAttributeList.split(",")));
+    }
   }
 
   @Override
@@ -109,7 +117,7 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
       ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting();
       profilePropertySetting.setPropertyName(propertyName);
       profilePropertySetting.setMultiValued(false);
-      profilePropertySetting.setActive(false);
+      profilePropertySetting.setActive(true);
       profilePropertySetting.setEditable(false);
       profilePropertySetting.setVisible(false);
       profilePropertySetting.setParentId(null);

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
@@ -95,12 +95,6 @@ public class SocialUserProfileEventListenerImplTest extends AbstractCoreTest {
     super.tearDown();
   }
 
-  @Override
-  protected void beforeRunBare() {
-    PropertyManager.getProperties().putIfAbsent("exo.social.profile.excluded.attributeList", "propertyToIgnore, propertyToIgnore1, propertyToIgnore2");
-    super.beforeRunBare();
-  }
-
   /**
    * This testcase what will use for unit testing with scenario to 
    * synchronous profile from Social to Portal's Organization

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -655,6 +655,16 @@
     <type>org.exoplatform.social.core.processor.I18NActivityProcessor</type>
   </component>
 
+  <component>
+    <key>social-test-configuration-properties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>social-test-configuration-properties</name>
+        <property name="exo.social.profile.excluded.attributeList" value="propertyToIgnore, propertyToIgnore1, propertyToIgnore2" />
+      </properties-param>
+    </init-params>
+  </component>
   <external-component-plugins>
     <target-component>org.exoplatform.social.metadata.MetadataService</target-component>
     <component-plugin>


### PR DESCRIPTION
Some technical properties saved in Portal user profile are used for technical purposes and not intended to be shared with the social user profile. Those properties contain DOT  '.' character which may cause problems when indexing those properties.
The fix adds the possibility to define properties to ignore when synchronizing both profiles and replaces dot '.' characters with underscore '_' for indexed filed names .