### PR TITLE
fix: Search result are replaced by original request because it is tool ong to execute - EXO-61970 - Meeds-io/meeds#758 (#2358)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SpaceService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SpaceService.js
@@ -13,10 +13,11 @@ export function getSpaceTemplates() {
   });
 }
 
-export function getSpaceMembers(query, offset, limit, expand, role, spaceId) {
+export function getSpaceMembers(query, offset, limit, expand, role, spaceId, signal) {
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/${spaceId}/users?role=${role}&q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true`, {
     method: 'GET',
     credentials: 'include',
+    signal: signal
   }).then(resp => {
     if (!resp || !resp.ok) {
       throw new Error('Response code indicates a server error', resp);

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -64,10 +64,11 @@ export function getUserByEmail(email) {
   });
 }
 
-export function getUsers(query, offset, limit, expand) {
+export function getUsers(query, offset, limit, expand, signal) {
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true`, {
     method: 'GET',
     credentials: 'include',
+    signal: signal
   }).then(resp => {
     if (!resp || !resp.ok) {
       throw new Error('Response code indicates a server error', resp);
@@ -76,7 +77,7 @@ export function getUsers(query, offset, limit, expand) {
     }
   });
 }
-export function getUsersByAdvancedFilter(settings, offset, limit, expand,filterType) {
+export function getUsersByAdvancedFilter(settings, offset, limit, expand,filterType, signal) {
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/advancedfilter?offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&filterType=${filterType || 'all'}&returnSize=true`, {
     method: 'POST',
     headers: {
@@ -84,6 +85,7 @@ export function getUsersByAdvancedFilter(settings, offset, limit, expand,filterT
       'Content-Type': 'application/json',
     },
     credentials: 'include',
+    signal: signal,
     body: JSON.stringify(settings),
   }).then(resp => {
     if (!resp || !resp.ok) {
@@ -107,10 +109,11 @@ export function getUsersByStatus(query, offset, limit, status) {
   });
 }
 
-export function getConnections(query, offset, limit, expand) {
+export function getConnections(query, offset, limit, expand, signal) {
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${eXo.env.portal.userName}/connections?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true`, {
     method: 'GET',
     credentials: 'include',
+    signal: signal
   }).then(resp => {
     if (!resp || !resp.ok) {
       throw new Error('Response code indicates a server error', resp);

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -103,6 +103,7 @@ export default {
     users: [],
     limitToFetch: 0,
     originalLimitToFetch: 0,
+    abortController: null,
   }),
   computed: {
     profileActionExtensions() {
@@ -131,7 +132,7 @@ export default {
         this.searchPeople();
         return;
       }
-      this.waitForInitializing();
+      this.searchPeople();
 
     },
     limitToFetch() {
@@ -140,7 +141,7 @@ export default {
     filter() {
       this.searchPeople();
     },
-  },
+  }, 
   created() {
     this.originalLimitToFetch = this.limitToFetch = this.limit;
 
@@ -165,18 +166,22 @@ export default {
       this.loadingPeople = true;
       // Using 'limitToFetch + 1' to retrieve current user and then delete it from result
       // to finally let only 'limitToFetch' users
+      if (this.abortController) {
+        this.abortController.abort();
+      }
+      this.abortController = new AbortController();
       let searchUsersFunction;
       if (this.filter === 'connections') {
-        searchUsersFunction = this.$userService.getConnections(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve);
+        searchUsersFunction = this.$userService.getConnections(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.abortController.signal);
       } else if (this.filter === 'member'
           || this.filter === 'manager'
           || this.filter === 'invited'
           || this.filter === 'pending'
           || this.filter === 'redactor'
           || this.filter === 'publisher') {
-        searchUsersFunction = this.$spaceService.getSpaceMembers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.filter, this.spaceId);
+        searchUsersFunction = this.$spaceService.getSpaceMembers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.filter, this.spaceId, this.abortController.signal);
       } else {
-        searchUsersFunction = this.$userService.getUsers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve);
+        searchUsersFunction = this.$userService.getUsers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.abortController.signal);
       }
       return searchUsersFunction.then(data => {
         let users = data && data.users || [];
@@ -204,6 +209,7 @@ export default {
           }
           this.loadingPeople = false;
           this.initialized = true;
+          this.abortController = null;
         });
     },
     resetSearch() {
@@ -219,9 +225,13 @@ export default {
       this.loadingPeople = true;
       // Using 'limitToFetch + 1' to retrieve current user and then delete it from result
       // to finally let only 'limitToFetch' users
+      if (this.abortController) {
+        this.abortController.abort();
+      }
+      this.abortController = new AbortController();
       let filterUsersFunction;
       if (this.filter) {
-        filterUsersFunction = this.$userService.getUsersByAdvancedFilter(profileSettings, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve,this.filter);
+        filterUsersFunction = this.$userService.getUsersByAdvancedFilter(profileSettings, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve,this.filter, this.abortController.signal);
       }
       return filterUsersFunction.then(data => {
         let users = data && data.users || [];
@@ -249,17 +259,9 @@ export default {
           }
           this.loadingPeople = false;
           this.initialized = true;
+          this.abortController = null;
         });
 
-    },
-    waitForInitializing() {
-      window.setTimeout(() => {
-        if (this.initialized) {
-          this.searchPeople();
-        } else {
-          this.waitForInitializing();
-        }
-      }, 50);
     }
   }
 };


### PR DESCRIPTION
prior to this change, the Search result of users is replaced by the original request because it takes too long to retrieve the result after this change when searching people the first fetch is aborted