### PR TITLE
fix: Fix Retrieving Administration Menu without Meeds-io/meeds#660 and Meeds-io/MIPs#42 on develop - MEED-1882

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/hamburgerMenu.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/hamburgerMenu.jsp
@@ -18,7 +18,6 @@
   PortalHttpServletResponseWrapper responseWrapper = (PortalHttpServletResponseWrapper) rcontext.getResponse();
 
   responseWrapper.addHeader("Link", "</portal/rest/v1/navigations/portal?siteName=" + rcontext.getPortalOwner() + "&scope=children&visibility=displayed>; rel=preload; as=fetch; crossorigin=use-credentials", false);
-  responseWrapper.addHeader("Link", "</portal/rest/v1/navigations/group?visibility=displayed>; rel=preload; as=fetch; crossorigin=use-credentials", false);
   responseWrapper.addHeader("Link", "</portal/rest/v1/social/spaces?q=&offset=0&limit=7&filterType=lastVisited&returnSize=true&expand=member,managers,favorite,unread>; rel=preload; as=fetch; crossorigin=use-credentials", false);
 %>
 <div class="VuetifyApp">

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/HamburgerMenuNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/HamburgerMenuNavigation.vue
@@ -261,7 +261,7 @@ export default {
         .then(data => this.siteNavigations = data || []);
     },
     retrieveAdministrationNavigations() {
-      return this.$navigationService.getNavigations(null, 'group', null, 'displayed')
+      return this.$navigationService.getNavigations(null, 'group', null, 'displayed', '/spaces/.*')
         .then(data => this.administrationNavigations = data || []);
     },
   },


### PR DESCRIPTION
The improvements made in Meeds-io/meeds#660 aren't in develop yet because of Meeds-io/MIPs#42 which is under review. This change will be applied on develop only to fix retrieving Administration Manu navigation using the old way (By collecting all groups of current user and then exclude /spaces/*). Prior to this change, the administration endpoint retrieves all group navigations of current user (including spaces). This change will apply a manual exclusion on /spaces/* until Meeds-io/meeds#660 gets merged on develop.