### PR TITLE
 fix: error 500 when login with Openid - EXO-62366 - Meeds-io/meeds#750

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.*;
@@ -54,44 +56,49 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
 
   @Override
   public void postSave(UserProfile userProfile, boolean isNew) throws Exception {
-    Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userProfile.getUserName());
-    Profile profile = identity.getProfile();
-    String uGender = userProfile.getAttribute(UserProfile.PERSONAL_INFO_KEYS[4]);// "user.gender"
-    String uPosition = userProfile.getAttribute(UserProfile.PERSONAL_INFO_KEYS[7]);// user.jobtitle
-    String pGender = (String) profile.getProperty(Profile.GENDER);
-    String pPosition = (String) profile.getProperty(Profile.POSITION);
+    RequestLifeCycle.begin(PortalContainer.getInstance());
+    try {
+      Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userProfile.getUserName());
+      Profile profile = identity.getProfile();
+      String uGender = userProfile.getAttribute(UserProfile.PERSONAL_INFO_KEYS[4]);// "user.gender"
+      String uPosition = userProfile.getAttribute(UserProfile.PERSONAL_INFO_KEYS[7]);// user.jobtitle
+      String pGender = (String) profile.getProperty(Profile.GENDER);
+      String pPosition = (String) profile.getProperty(Profile.POSITION);
 
-    AtomicBoolean hasUpdated = new AtomicBoolean(false);
-    Map<String, String> properties = userProfile.getUserInfoMap();
-    exlcudedAttributeList.forEach(properties.keySet()::remove);
-    properties.forEach((name, value) -> {
-      updateProfilePropertySettings(name, profilePropertyService);
-      if (isNew) {
-        profile.setProperty(name, value);
-      } else if (!StringUtils.equals((String) profile.getProperty(name), userProfile.getAttribute(name))) {
-        profile.setProperty(name, value);
+      AtomicBoolean hasUpdated = new AtomicBoolean(false);
+      Map<String, String> properties = userProfile.getUserInfoMap();
+      exlcudedAttributeList.forEach(properties.keySet()::remove);
+      properties.forEach((name, value) -> {
+        updateProfilePropertySettings(name, profilePropertyService);
+        if (isNew) {
+          profile.setProperty(name, value);
+        } else if (!StringUtils.equals((String) profile.getProperty(name), userProfile.getAttribute(name))) {
+          profile.setProperty(name, value);
+          hasUpdated.set(true);
+        }
+      });
+
+      if (!StringUtils.equals(uGender, pGender)) {
+        profile.setProperty(Profile.GENDER, uGender);
         hasUpdated.set(true);
       }
-    });
+      if (!StringUtils.equals(uPosition, pPosition)) {
+        profile.setProperty(Profile.POSITION, uPosition);
+        hasUpdated.set(true);
+      }
 
-    if (!StringUtils.equals(uGender, pGender)) {
-      profile.setProperty(Profile.GENDER, uGender);
-      hasUpdated.set(true);
-    }
-    if (!StringUtils.equals(uPosition, pPosition)) {
-      profile.setProperty(Profile.POSITION, uPosition);
-      hasUpdated.set(true);
-    }
+      if (hasUpdated.get()) {
+        List<Profile.UpdateType> updateTypes = new ArrayList<>();
+        updateTypes.add(Profile.UpdateType.CONTACT);
+        profile.setListUpdateTypes(updateTypes);
+      }
 
-    if (hasUpdated.get()) {
-      List<Profile.UpdateType> updateTypes = new ArrayList<>();
-      updateTypes.add(Profile.UpdateType.CONTACT);
-      profile.setListUpdateTypes(updateTypes);
-    }
-
-    if (hasUpdated.get() || isNew) {
-      IdentityStorage identityStorage = CommonsUtils.getService(IdentityStorage.class);
-      identityStorage.updateProfile(profile);
+      if (hasUpdated.get() || isNew) {
+        IdentityStorage identityStorage = CommonsUtils.getService(IdentityStorage.class);
+        identityStorage.updateProfile(profile);
+      }
+    } finally {
+      RequestLifeCycle.end();
     }
 
   }


### PR DESCRIPTION
Prior to this fix, with Openid authentication configured, when logging on Meeds server an error page (HTTP 500) is displayed. The SocialUserProfileEventListenerImpl was retrieving services from the Root container and a NullPointerException was thrown. The fix will encapsulate the code executed in the
SocialUserProfileEventListenerImpl inside a requestlifecycle with the correct Portal container.
