### PR TITLE
fix: avoid displaying and indexing user technical properties - EXO-62724 - meeds-io/meeds#762

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -35,7 +35,6 @@ import org.exoplatform.social.core.jpa.storage.dao.ConnectionDAO;
 import org.exoplatform.social.core.jpa.storage.dao.IdentityDAO;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
-import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.relationship.model.Relationship;
 
 /**

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -35,6 +35,7 @@ import org.exoplatform.social.core.jpa.storage.dao.ConnectionDAO;
 import org.exoplatform.social.core.jpa.storage.dao.IdentityDAO;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.relationship.model.Relationship;
 
 /**
@@ -244,9 +245,11 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     }
     Date createdDate = new Date(profile.getCreatedTime());
 
-    for (String propertyName : profilePropertyService.getPropertySettingNames()) {
-      if (!fields.containsKey(propertyName)) {
-        if (profile.getProperty(propertyName) != null && profile.getProperty(propertyName)instanceof String value) {
+    for (ProfilePropertySetting profilePropertySetting : profilePropertyService.getPropertySettings()) {
+      String propertyName = profilePropertySetting.getPropertyName();
+      // We should index only active properties of user profile
+      if (!fields.containsKey(propertyName) && profilePropertySetting.isActive()) {
+        if (profile.getProperty(propertyName) != null && profile.getProperty(propertyName) instanceof String value) {
           if (StringUtils.isNotEmpty(value)) {
             fields.put(propertyName, value);
           }

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
@@ -102,9 +102,9 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
       ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting();
       profilePropertySetting.setPropertyName(propertyName);
       profilePropertySetting.setMultiValued(false);
-      profilePropertySetting.setActive(true);
+      profilePropertySetting.setActive(false);
       profilePropertySetting.setEditable(false);
-      profilePropertySetting.setVisible(true);
+      profilePropertySetting.setVisible(false);
       profilePropertySetting.setParentId(null);
       try {
         profilePropertyService.createPropertySetting(profilePropertySetting);

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImpl.java
@@ -17,6 +17,7 @@
 package org.exoplatform.social.core.listeners;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.*;
@@ -39,8 +41,9 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
 
   private static final Log                     LOG                   =
                                                    ExoLogger.getLogger(SocialUserProfileEventListenerImpl.class);
+  private static final String SOCIAL_PROFILE_EXCLUDED_ATTRIBUTE_LIST = "exo.social.profile.excluded.attributeList";
 
-  private final List<String>                   exlcudedAttributeList = List.of("authenticationAttempts", "latestAuthFailureTime");
+  private final List<String>                   exlcudedAttributeList = new ArrayList<>(List.of("authenticationAttempts", "latestAuthFailureTime"));
 
   private final IdentityManager                identityManager;
 
@@ -50,6 +53,10 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
                                             ProfilePropertyService profilePropertyService) {
     this.identityManager = identityManager;
     this.profilePropertyService = profilePropertyService;
+    String socialProfileExcludedAttributeList = PropertyManager.getProperty(SOCIAL_PROFILE_EXCLUDED_ATTRIBUTE_LIST);
+    if(StringUtils.isNotBlank(socialProfileExcludedAttributeList)) {
+      this.exlcudedAttributeList.addAll(Arrays.asList(socialProfileExcludedAttributeList.split(",")));
+    }
   }
 
   @Override
@@ -102,7 +109,7 @@ public class SocialUserProfileEventListenerImpl extends UserProfileEventListener
       ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting();
       profilePropertySetting.setPropertyName(propertyName);
       profilePropertySetting.setMultiValued(false);
-      profilePropertySetting.setActive(false);
+      profilePropertySetting.setActive(true);
       profilePropertySetting.setEditable(false);
       profilePropertySetting.setVisible(false);
       profilePropertySetting.setParentId(null);

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
@@ -77,7 +78,7 @@ public class SocialUserProfileEventListenerImplTest extends AbstractCoreTest {
   }
   
   private void fakePlugins() throws Exception {
-    if (alreadyAddedPlugins == false) {
+    if (!alreadyAddedPlugins) {
       organizationService.addListenerPlugin(new SocialUserEventListenerImpl());
       organizationService.addListenerPlugin(new SocialUserProfileEventListenerImpl(identityManager,
               profilePropertyService));
@@ -93,7 +94,7 @@ public class SocialUserProfileEventListenerImplTest extends AbstractCoreTest {
     }
     super.tearDown();
   }
-  
+
   /**
    * This testcase what will use for unit testing with scenario to 
    * synchronous profile from Social to Portal's Organization
@@ -269,5 +270,28 @@ public class SocialUserProfileEventListenerImplTest extends AbstractCoreTest {
     Profile profile = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, raulRemoteId).getProfile();
     assertNotNull(profile);
     assertEquals("2100", profile.getProperty("postalCode"));
+  }
+
+  public void testIgnoreExcludedProfileProperties() throws Exception {
+    String raulRemoteId = "raul";
+    UserProfile userProfile = organizationService.getUserProfileHandler().findUserProfileByName(raulRemoteId);
+    userProfile.setAttribute("propertyToIgnore", "value1");
+    userProfile.setAttribute("propertyNotToIgnore", "Yes !");
+    organizationService.getUserProfileHandler().saveUserProfile(userProfile, true);
+
+    Profile profile = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, raulRemoteId).getProfile();
+    assertNotNull(profile);
+
+    // propertyToIgnore should be ignored
+    assertNull(profile.getProperty("propertyToIgnore"));
+
+    // propertyNotToIgnore should not be ignored
+    assertNotNull("Property should not be saved in social profile", profile.getProperty("propertyNotToIgnore"));
+    assertEquals("Yes !", profile.getProperty("propertyNotToIgnore"));
+    assertTrue(profilePropertyService.getPropertySettingNames().contains("propertyNotToIgnore"));
+    ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("propertyNotToIgnore");
+    assertNotNull(profilePropertySetting);
+    assertTrue(profilePropertySetting.isActive());
+    assertFalse(profilePropertySetting.isVisible());
   }
 }

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -655,6 +655,16 @@
     <type>org.exoplatform.social.core.processor.I18NActivityProcessor</type>
   </component>
 
+  <component>
+    <key>social-test-configuration-properties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>social-test-configuration-properties</name>
+        <property name="exo.social.profile.excluded.attributeList" value="propertyToIgnore, propertyToIgnore1, propertyToIgnore2" />
+      </properties-param>
+    </init-params>
+  </component>
   <external-component-plugins>
     <target-component>org.exoplatform.social.metadata.MetadataService</target-component>
     <component-plugin>


### PR DESCRIPTION
When login using openID provider, the related user informations are saved in the user profile an then indexed in ElasticSearch which causes an indexing error. Those properties are also displayed in the user profile while they are technical information that should not be viewed.
The fix sets user properties to inactive (to not display them in the user profile) and do not index them until they are activated by the administrator from the Profile properties settings.
The fix adds the possibility to define properties to ignore when synchronizing both profiles and replaces dot '.' characters with underscore '_' for indexed field names .