### PR TITLE
fix :fix save button not disabled in profile information drawer when there is no change - EXO-62627 - Meeds-io/meeds#763

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiFieldSelect.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiFieldSelect.vue
@@ -20,7 +20,8 @@
       class="ignore-vuetify-classes align-end flex-grow-1"
       maxlength="2000"
       ref="multiInput"
-      @change="$emit('propertyUpdated')">
+      @change="$emit('propertyUpdated')"
+      @input="$emit('propertyUpdated')">
     <v-icon
       small
       class="removeMultiFieldValue error--text"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -36,7 +36,8 @@
                   maxlength="2000"
                   :required="property.required"
                   :ref="`${property.propertyName}Input`" 
-                  @change="propertyUpdated(property)">
+                  @change="propertyUpdated(property)"
+                  @input="propertyUpdated(property)">
               </v-card-text>
             </v-card-text>
           </div>
@@ -53,7 +54,7 @@
           {{ $t('profileContactInformation.button.cancel') }}
         </v-btn>
         <v-btn
-          :disabled="saving"
+          :disabled="disabled"
           :loading="saving"
           class="btn btn-primary"
           @click="save">
@@ -77,6 +78,7 @@ export default {
       aspectRatio: 1,
       viewMode: 1,
     },
+    disabled: true,
   }),
   created() {
     this.$root.$on('open-profile-contact-information-drawer', this.open);
@@ -159,6 +161,7 @@ export default {
         .catch(this.handleError)
         .finally(() => {
           this.saving = false;
+          this.disabled = true;
           this.$refs.profileContactInformationDrawer.endLoading();
         });
     },
@@ -221,6 +224,7 @@ export default {
       this.$refs.profileContactInformationDrawer.open();
     },
     propertyUpdated(item){
+      this.disabled = false;
       if (!this.propertiesToSave.some(e => e.id === item.id)) {
         this.propertiesToSave.push(item);
       }    


### PR DESCRIPTION
Prior to this change, when we access to edit the profile contact informations without changing anything, the save button is proposed not disabled and not clickable, so the edit drawer cannot be closed. After this fix, the save button is disabled when we open the drawer and no change is detected, and it is enabled when we detect a change in any of the profile information.