### PR TITLE
fix: fix space and user popover position - EXO-62433 - Meeds-io/meeds#706

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
@@ -27,7 +27,7 @@
     :position-y="offsetY"
     transition="slide-x-transition"
     absolute
-    bottom
+    :top="top"
     content-class="profile-popover-menu pa-1 transparent"
     elevation="0"
     max-width="350"
@@ -42,6 +42,7 @@
 export default {
   data() {
     return {
+      top: true,
       menu: false,
       element: null,
       popoverCloseDelay: 1000,
@@ -80,6 +81,7 @@ export default {
     document.addEventListener('popover-identity-display', event => {
       const data = event?.detail;
       this.identityType = data.identityType;
+      this.top = data.top;
       if (this.isUserIdentity) {
         this.identity = {
           id: data?.id,
@@ -130,8 +132,13 @@ export default {
         $('.profile-popover-menu').css('height', '160px');
       }
     });
+    // Force to close user popover when scrolling
+    document.addEventListener('scroll', this.onScroll, true);
   },
   methods: {
+    onScroll(){
+      this.closePopover(true);
+    },
     registerActivatorElementEvents() {
       if (this.element) {
         $(this.element)

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
@@ -27,7 +27,7 @@
     :position-y="offsetY"
     transition="slide-x-transition"
     absolute
-    top
+    bottom
     content-class="profile-popover-menu pa-1 transparent"
     elevation="0"
     max-width="350"
@@ -160,7 +160,7 @@ export default {
     },
     setPopoverNotHovered() {
       this.isMenuHovered = false;
-      this.closePopover();
+      this.closePopover(true);
     },
     openPopover(immediatly) {
       if (!this.menu) {

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -31,7 +31,8 @@ Vue.directive('identity-popover', (el, binding) => {
     document.dispatchEvent(new CustomEvent('popover-identity-display', {
       detail: Object.assign({
         offsetX: rect.left + window.scrollX,
-        offsetY: rect.bottom + window.scrollY,
+        offsetY: isUser || rect.top > 150 + rect.height ? rect.top : rect.bottom + window.scrollY,
+        top: isUser || rect.top > 150 + rect.height ? true : false, 
         identityType: isUser ? 'User' : 'Space',
         element: el,
       }, identity || {})

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -31,7 +31,7 @@ Vue.directive('identity-popover', (el, binding) => {
     document.dispatchEvent(new CustomEvent('popover-identity-display', {
       detail: Object.assign({
         offsetX: rect.left + window.scrollX,
-        offsetY: rect.top + window.scrollY,
+        offsetY: rect.bottom + window.scrollY,
         identityType: isUser ? 'User' : 'Space',
         element: el,
       }, identity || {})


### PR DESCRIPTION
Prior to this change, the space popover was hiding the space name and when we put the cursor on the space/user popup and then scroll, the popover is always displayed. After this change, we force the popover to close when scrolling and we display the popover under the space name if top space is not enough to display it.