### PR TITLE
fix: Fix Refresh Space Navigation on Hamburger Menu - MEED-1889 - Meeds-io/meeds#780

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
@@ -225,7 +225,11 @@ export default {
       immediate: true,
       handler(newVal, oldVal) {
         if (newVal !== oldVal) {
-          this.refreshExtensions();
+          if (this.spaceId) {
+            this.spaceNavigations = [];
+            this.retrieveSpaceNavigations(this.spaceId)
+              .then(() => this.refreshExtensions());
+          }
         }
       },
     },


### PR DESCRIPTION
Prior to this change, when switching the selected space from hamburger menu, the list of applications isn't refreshed. This fix will retrieve the new navigations to space when switching from a space to another.