### PR TITLE
fix: Unable to add new IMs when updating the field - EXO-62687 - Meds-io/meeds#761

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -411,9 +411,9 @@ public class EntityBuilder {
     for (ProfilePropertySetting property : subProperties) {
       if (!parents.contains(property.getParentId())) {
         ProfilePropertySettingEntity profilePropertySettingEntity =
-                buildEntityProfilePropertySetting(property,
-                        profilePropertyService,
-                        ProfilePropertyService.LABELS_OBJECT_TYPE);
+                                                                  buildEntityProfilePropertySetting(property,
+                                                                                                    profilePropertyService,
+                                                                                                    ProfilePropertyService.LABELS_OBJECT_TYPE);
         profilePropertySettingEntity.setValue((String) profile.getProperty(property.getPropertyName()));
         profilePropertySettingEntity.setInternal(internal);
         ProfilePropertySettingEntity parentProperty = properties.get(property.getParentId());
@@ -421,6 +421,26 @@ public class EntityBuilder {
         children.add(profilePropertySettingEntity);
         parentProperty.setChildren(children);
         properties.put(parentProperty.getId(), parentProperty);
+      } else {
+        ProfilePropertySettingEntity parent = properties.get(property.getParentId());
+        ProfilePropertySettingEntity profilePropertySettingEntity =
+                                                                  parent.getChildren()
+                                                                        .stream()
+                                                                        .filter(child -> property.getPropertyName()
+                                                                                                 .equals(child.getPropertyName()))
+                                                                        .findAny()
+                                                                        .orElse(null);
+        if (profilePropertySettingEntity == null) {
+          profilePropertySettingEntity = buildEntityProfilePropertySetting(property,
+                                                                           profilePropertyService,
+                                                                           ProfilePropertyService.LABELS_OBJECT_TYPE);
+          profilePropertySettingEntity.setValue((String) profile.getProperty(property.getPropertyName()));
+          profilePropertySettingEntity.setInternal(internal);
+          List<ProfilePropertySettingEntity> children = parent.getChildren();
+          children.add(profilePropertySettingEntity);
+          parent.setChildren(children);
+          properties.put(parent.getId(), parent);
+        }
       }
     }
     return new ArrayList<>(properties.values());

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiFieldSelect.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiFieldSelect.vue
@@ -6,7 +6,7 @@
       class="ignore-vuetify-classes align-start flex-grow-0 half-width text-capitalize"
       @change="$emit('propertyUpdated')">
       <option
-        v-for="item in properties"
+        v-for="item in filtredProperties"
         :key="item.propertyName"
         :value="item.propertyName"
         class="text-capitalize">
@@ -51,6 +51,15 @@ export default {
   created() {
     this.$root.$on('non-valid-url-input', this.showError);
     this.$root.$on('reset-custom-validity', this.resetCustomValidity);
+  },
+  computed: {
+    filtredProperties(){
+      return this.properties.filter((obj, index, self) =>
+        index === self.findIndex((t) => (
+          t.propertyName === obj.propertyName
+        ))
+      );
+    },
   },
   methods: {
     getResolvedName(item){


### PR DESCRIPTION
Prior to this change when the user tries to edit ims or phones property in his profile, only already filled options are displayed After this modification all options are displayed in the edit drawer of profile for IMS and Phones properties