### PR TITLE
fix: Profile - username and Position not updated directly in the profile's header after add/edit  - EXO-62664 - Meeds-io/meeds#756 

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -327,6 +327,9 @@ public class EntityBuilder {
         }
       }
     }
+    if (expandAttributes.contains("settings")) {
+      userEntity.setProperties(EntityBuilder.buildProperties(profile));
+    }
     return userEntity;
   }
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
@@ -403,6 +403,15 @@ public class ProfileEntity extends BaseEntity {
     return getString("connectionsInCommonCount");
   }
 
+  public String getProperties() {
+    return getString("properties");
+  }
+
+  public ProfileEntity setProperties(List<ProfilePropertySettingEntity> properties) {
+    setProperty("properties", properties);
+    return this;
+  }
+
   public void setPhones(List<PhoneEntity> phones) {
     setProperty(PHONES, phones);
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -548,12 +548,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
     if (builder == null) {
-      if (StringUtils.isNotBlank(expand) && expand.equals("settings")) {
-        builder = Response.ok(EntityBuilder.buildProperties(identity.getProfile()), MediaType.APPLICATION_JSON);
-      } else {
-        ProfileEntity profileInfo = EntityBuilder.buildEntityProfile(identity.getProfile(), uriInfo.getPath(), expand);
-        builder = Response.ok(profileInfo.getDataEntity(), MediaType.APPLICATION_JSON);
-      }
+      ProfileEntity profileInfo = EntityBuilder.buildEntityProfile(identity.getProfile(), uriInfo.getPath(), expand);
+      builder = Response.ok(profileInfo.getDataEntity(), MediaType.APPLICATION_JSON);
       builder.tag(eTag);
       builder.lastModified(new Date(cacheTime));
       builder.expires(new Date(cacheTime));

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -407,7 +407,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     ContainerResponse response = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
     assertNotNull(response);
     assertEquals(200, response.getStatus());
-    ArrayList collections = (ArrayList) response.getEntity();
+    DataEntity dataEntity = (DataEntity) response.getEntity();
+    ArrayList collections = (ArrayList) dataEntity.get("properties");
     assertEquals(3, collections.size());
   }
 

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -205,7 +205,7 @@ export default {
     },
     refresh() {
       this.propertiesToSave = [];
-      document.dispatchEvent(new CustomEvent('userModified'));
+      document.dispatchEvent(new CustomEvent('userPropertiesModified'));
     }, 
     cancel() {
       this.refresh();


### PR DESCRIPTION
prior to this change, after saving/editing the username or user position are not updated directly in the profile's header
since the data from the event 'userModified' in this case is null
after this change, the modification is well displayed by refreshing the user properties