### PR TITLE
fix: stabilize social build for SocialUserProfileEventListenerImplTest - EXO-63065

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-api</artifactId>
   <name>eXo PLF:: Social API</name>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-common</artifactId>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-core</artifactId>
   <name>eXo PLF:: Social Core Component</name>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -340,6 +340,9 @@
           <excludes>
             <exclude>**/*TestIT.java</exclude>
           </excludes>
+          <systemPropertyVariables>
+            <exo.social.profile.excluded.attributeList>propertyToIgnore, propertyToIgnore1, propertyToIgnore2</exo.social.profile.excluded.attributeList>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -654,17 +654,7 @@
     <key>org.exoplatform.social.core.processor.I18NActivityProcessor</key>
     <type>org.exoplatform.social.core.processor.I18NActivityProcessor</type>
   </component>
-
-  <component>
-    <key>social-test-configuration-properties</key>
-    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
-    <init-params>
-      <properties-param>
-        <name>social-test-configuration-properties</name>
-        <property name="exo.social.profile.excluded.attributeList" value="propertyToIgnore, propertyToIgnore1, propertyToIgnore2" />
-      </properties-param>
-    </init-params>
-  </component>
+  
   <external-component-plugins>
     <target-component>org.exoplatform.social.metadata.MetadataService</target-component>
     <component-plugin>

--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-notification</artifactId>

--- a/component/oauth-auth/pom.xml
+++ b/component/oauth-auth/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component</artifactId>
   <packaging>pom</packaging>

--- a/component/search/pom.xml
+++ b/component/search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.social</groupId>
     <artifactId>social-component</artifactId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-search</artifactId>
   <packaging>jar</packaging>

--- a/component/service/pom.xml
+++ b/component/service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-service</artifactId>

--- a/component/webui/pom.xml
+++ b/component/webui/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-webui</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-extension</artifactId>
   <packaging>pom</packaging>

--- a/extension/war/pom.xml
+++ b/extension/war/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-extension</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-extension-war</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social</artifactId>
-  <version>6.5.x-exo-SNAPSHOT</version>
+  <version>6.5.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: Social</name>
   <description>eXo Social - Enterprise Social Networking</description>
@@ -46,7 +46,7 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <org.exoplatform.commons.version>6.5.x-exo-SNAPSHOT</org.exoplatform.commons.version>
+    <org.exoplatform.commons.version>6.5.x-maintenance-SNAPSHOT</org.exoplatform.commons.version>
 
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp</artifactId>
   <packaging>pom</packaging>

--- a/webapp/portlet/pom.xml
+++ b/webapp/portlet/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-webapp-portlet</artifactId>

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -31,8 +31,8 @@ Vue.directive('identity-popover', (el, binding) => {
     document.dispatchEvent(new CustomEvent('popover-identity-display', {
       detail: Object.assign({
         offsetX: rect.left + window.scrollX,
-        offsetY: isUser || rect.top > 150 + rect.height ? rect.top : rect.bottom + window.scrollY,
-        top: isUser || rect.top > 150 + rect.height ? true : false, 
+        offsetY: rect.top > 150 + rect.height ? rect.top : rect.bottom + window.scrollY,
+        top: rect.top > 150 + rect.height ? true : false, 
         identityType: isUser ? 'User' : 'Space',
         element: el,
       }, identity || {})


### PR DESCRIPTION
Unit test `SocialUserProfileEventListenerImplTest#testIgnoreExcludedProfileProperties` fails sometimes randomly, the JPM system properties are sometimes added after initiation of the listener causing failure for asserted expression.
The fix includes the testsing system property in the surefire test configuration instead of the kernel internal mechanism using using ExtendedPropertyConfigurator 