### PR TITLE
fix: Change in profile management field is not applied to profile until the cache is cleared - EXO-62960 -  Meeds-io/meeds#786

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -69,6 +69,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.rest.entity.*;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -205,6 +206,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
 
   private ImageThumbnailService imageThumbnailService;
 
+  private ProfilePropertyService profilePropertyService;
+
   private static final Log LOG = ExoLogger.getLogger(UserRestResourcesV1.class);
 
   private byte[]              defaultUserAvatar = null;
@@ -224,7 +227,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
                              SpaceService spaceService,
                              UploadService uploadService,
                              UserSearchService userSearchService,
-                             ImageThumbnailService imageThumbnailService) {
+                             ImageThumbnailService imageThumbnailService,
+                             ProfilePropertyService profilePropertyService) {
     this.userACL = userACL;
     this.activityRestResourcesV1 = activityRestResourcesV1;
     this.organizationService = organizationService;
@@ -235,6 +239,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     this.uploadService = uploadService;
     this.userSearchService = userSearchService;
     this.imageThumbnailService = imageThumbnailService;
+    this.profilePropertyService = profilePropertyService;
     this.importExecutorService = Executors.newSingleThreadExecutor();
 
     CACHE_CONTROL.setMaxAge(CACHE_IN_SECONDS);
@@ -540,11 +545,17 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     if (identity == null) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
+
     org.exoplatform.services.security.Identity authenticatedUserIdentity = ConversationState.getCurrent().getIdentity();
     String authenticatedUser = authenticatedUserIdentity.getUserId();
 
+    String expandedSettings = expand;
+    if (expand != null && expand.contains("settings")) {
+      expandedSettings = String.valueOf(Objects.hash(profilePropertyService.getPropertySettings()));
+    }
+
     long cacheTime = identity.getCacheTime();
-    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expandedSettings));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -1,5 +1,6 @@
 package org.exoplatform.social.rest.impl.users;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -66,7 +67,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
   private IdentityManager     identityManager;
 
-  private ProfilePropertyService profilePropertyService;
+  private ProfilePropertyService       profilePropertyService;
 
   private UserACL             userACL;
 
@@ -137,7 +138,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                       spaceService,
                                                                       uploadService,
                                                                       userSearchService,
-                                                                      imageThumbnailService);
+                                                                      imageThumbnailService,
+                                                                      profilePropertyService);
     registry(userRestResourcesV1);
   }
 
@@ -218,7 +220,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                     spaceService,
                                                                     uploadService,
                                                                     userSearchService,
-                                                                    imageThumbnailService);
+                                                                    imageThumbnailService,
+                                                                    profilePropertyService);
     registry(userRestResources);
 
     //when
@@ -404,11 +407,25 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
   public void testGetUserById() throws Exception {
     startSessionAs("root");
-    ContainerResponse response = service("GET", getURLResource("users/john"), "", null, null);
+    ContainerResponse response = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
+    String etag = response.getHttpHeaders().get("etag").toString();
     assertNotNull(response);
     assertEquals(200, response.getStatus());
     ProfileEntity userEntity = getBaseEntity(response.getEntity(), ProfileEntity.class);
     assertEquals("john", userEntity.getUsername());
+
+    ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting();
+    profilePropertySetting.setPropertyName(Profile.FIRST_NAME);
+    profilePropertyService.createPropertySetting(profilePropertySetting);
+    ContainerResponse response1 = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
+    String etag1 = response1.getHttpHeaders().get("etag").toString();
+    assertNotNull(response1);
+    assertNotEquals(etag, etag1);
+
+    ContainerResponse response2 = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
+    String etag2 = response2.getHttpHeaders().get("etag").toString();
+    assertNotNull(response2);
+    assertEquals(etag1, etag2);
   }
 
   public void testGetUserProfilePropertiesById() throws Exception {


### PR DESCRIPTION
Before this fix, after changing the value of a field's switch option in profile management, the option was not applied in the user's profile information until the cache was cleared.After this fix, we use the list of property settings in order to calculate the Etag, so that each change in property value force to takes the new value of user's profile information.