### PR TITLE
Fix Tasks and Notes nodes continue to persist in the space navigationeven after removing both applications from space settings - EXO-62454 Meeds-io/meeds#783

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/DefaultSpaceApplicationHandler.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/DefaultSpaceApplicationHandler.java
@@ -420,7 +420,15 @@ public class DefaultSpaceApplicationHandler implements SpaceApplicationHandler {
       
       UserNode spaceUserNode = SpaceUtils.getSpaceUserNode(space);
       UserNode removedNode = spaceUserNode.getChild(appName);
-      
+      if (removedNode == null){
+        //Try to get the node by the pageRef name and the appId
+        for (UserNode node : spaceUserNode.getChildren()){
+          if (appId.equals(node.getPageRef().getName())){
+            removedNode = spaceUserNode.getChild(node.getName());
+            break;
+          }
+        }
+      }
       if (removedNode == null) {
         // In case of cannot find the removed node, try one more time
         String spaceTemplateName = space.getTemplate();


### PR DESCRIPTION

Prior to this change when notes or tasks applications was added to space and both application were removed from the space settings,the Notes and Tasks node continued to persist on the space navigation .The problem was that we couldn't find the node to be removed by the application name if the application name and saved node name were not the same , for example for the tasks application the saved node name was `tasks` and the application name was `TasksManagement` .
After this change we will attempt to find the node to remove by the node pageRef name and the application id .
