### PR TITLE
fix: Can't not add a new phone number just after removing the last old one - EXO-62885 - Meeds-io/meeds#788

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
@@ -20,6 +20,7 @@
     </div>
     <v-flex v-for="(childProperty, i) in property.children" :key="i">
       <profile-contact-edit-multi-field-select
+        v-if="childProperty.isNew || childProperty.value"
         :property="childProperty"
         :properties="property.children"
         :multi-valued="property.multiValued"
@@ -39,7 +40,11 @@ export default {
   },
   methods: {
     remove(i) {
-      this.property.children.splice(i, 1);
+      if (this.property.children[i].isNew) {
+        this.property.children.splice(i, 1);
+      } else {
+        this.property.children[i].value = null;
+      }
       this.$emit('propertyUpdated',this.property);
     },
     addNewItem() {


### PR DESCRIPTION
prior to this change, after adding all possible Phone or IMS contact and then removing them all, the add button is no more displayed since the property has no more children to display it as a multi-field so it is displayed as an input field after this change, removing only the value of children from the property or all the children if it is new makes the property always as multi-field