### PR TITLE
fix: fix space and user popover position - EXO-62433 - Meeds-io/meeds#706

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -31,8 +31,8 @@ Vue.directive('identity-popover', (el, binding) => {
     document.dispatchEvent(new CustomEvent('popover-identity-display', {
       detail: Object.assign({
         offsetX: rect.left + window.scrollX,
-        offsetY: isUser || rect.top > 150 + rect.height ? rect.top : rect.bottom + window.scrollY,
-        top: isUser || rect.top > 150 + rect.height ? true : false, 
+        offsetY: rect.top > 150 + rect.height ? rect.top : rect.bottom + window.scrollY,
+        top: rect.top > 150 + rect.height ? true : false, 
         identityType: isUser ? 'User' : 'Space',
         element: el,
       }, identity || {})


### PR DESCRIPTION
This fix is going to display the user popover under the user name if top space is not enough to display it.