### PR TITLE
fix: Deactivating sub attributes of IMs does not work - Meeds-io/meeds#797 - EXO-63174

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
@@ -31,10 +31,12 @@
           :key="i"
           :title="childProperty.value"
           class="text-no-wrap text-truncate">
-          <span v-if="childProperty.propertyName" class="pe-1 text-capitalize">
-            {{ getResolvedName(childProperty) }}:
-          </span>
-          <span v-autolinker="childProperty.value"></span>
+          <template v-if="childProperty.visible && childProperty.active">
+            <span v-if="childProperty.propertyName" class="pe-1 text-capitalize">
+              {{ getResolvedName(childProperty) }}:
+            </span>
+            <span v-autolinker="childProperty.value"></span>
+          </template>
         </div>
       </div>
     </v-flex>


### PR DESCRIPTION
prior to this change, deactivated and invisible IMs are displayed in the user profile's contact info since they are not restricted from being displayed
after this change, deactivated and invisible IMs are not displayed anymore