### PR TITLE
fix: fix email in contact information should be a link mailto format - EXO-62136 - Meeds-io/meeds#798

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -29,7 +29,7 @@
             <div class="align-start text-no-wrap font-weight-bold me-3">
               {{ getResolvedName(property) }}
             </div>
-            <div :title="property.value" class="align-end flex-grow-1 text-truncate text-end">
+            <div v-autolinker="property.value" class="align-end flex-grow-1 text-truncate text-end">
               {{ property.value }}
             </div>
           </v-flex>


### PR DESCRIPTION
After this fix, the email in the contact information is displayed in a mailto format by adding autolinker to the property value.