### PR TITLE
fix: Fix instanciating Drawers and Alerts overlays - Meeds-io/MIPs#52 - MEED-1891

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/main.js
@@ -121,7 +121,7 @@ if (!window.drawersOverlayInitialized) {
 }
 
 export function init(i18n) {
-  if (document.readyState === 'interactive' || document.readyState === 'complete' || document.querySelector('#drawers-overlay')) {
+  if ((document.readyState === 'interactive' && document.querySelector('#drawers-overlay')) || document.readyState === 'complete') {
     if (document.querySelector('#drawers-overlay')) {
       new Vue({
         template: '<drawers-overlay id="drawers-overlay" />',


### PR DESCRIPTION
Prior to this change, the Vuetify app class is sometimes added to body element which leads to have WebUI portlets badly displayed. This change will allow to fix this behavior by mounting drawers overlay and alerts parent only when document load is complete or #drawers-overlay element mounted in document.