### PR TITLE
fix: Avoid adding Drawers Overlay when standalone page - MEED-1956 - Meeds-io/meeds#755

### DIFF
--- a/webapp/portlet/src/main/webapp/js/BodyScrollListener.js
+++ b/webapp/portlet/src/main/webapp/js/BodyScrollListener.js
@@ -1,35 +1,40 @@
 $(document).ready(installScrollControlListener);
 
 function installScrollControlListener() {
-  const $siteBody = $('#UISiteBody');
-  if (!$siteBody.data('scroll-control')) {
-    $siteBody.data('scroll-control', 'true');
-    const shadowBox = document.createElement('div');
-    shadowBox.id = 'TopBarBoxShadow';
-    shadowBox.style.boxShadow = '0 6px 4px -4px rgb(0 0 0 / 30%)';
-    shadowBox.style.position = 'absolute';
-    shadowBox.style.width = '100vw';
-    shadowBox.style.height = '56px';
-    shadowBox.style.top = 0;
-    shadowBox.style.left = 0;
-    shadowBox.style.right = 0;
-    shadowBox.style.zIndex = -1;
-    shadowBox.style.visibility = 'hidden';
-    document.querySelector('.MiddleToolBarTDContainer .MiddleToolBar').appendChild(shadowBox);
-    $siteBody[0].addEventListener('scroll', controlBodyScrollClass, false);
+  const siteBody = document.querySelector('#UISiteBody') || document.querySelector('#UIPageBody');
+  if (!siteBody.getAttribute('scroll-control')) {
+    siteBody.classList.add('overflow-y-auto');
+    siteBody.style.maxHeight = '100vh';
+    siteBody.setAttribute('scroll-control', 'true');
+    const middleBar = document.querySelector('.MiddleToolBarTDContainer .MiddleToolBar');
+    if (middleBar) {
+      const shadowBox = document.createElement('div');
+      shadowBox.id = 'TopBarBoxShadow';
+      shadowBox.style.boxShadow = '0 6px 4px -4px rgb(0 0 0 / 30%)';
+      shadowBox.style.position = 'absolute';
+      shadowBox.style.width = '100vw';
+      shadowBox.style.height = '56px';
+      shadowBox.style.top = 0;
+      shadowBox.style.left = 0;
+      shadowBox.style.right = 0;
+      shadowBox.style.zIndex = -1;
+      shadowBox.style.visibility = 'hidden';
+      middleBar.appendChild(shadowBox);
+    }
+    siteBody.addEventListener('scroll', controlBodyScrollClass, false);
     controlBodyScrollClass();
   }
 }
 
 function controlBodyScrollClass() {
-  const $siteBody = $('#UISiteBody');
+  const siteBody = document.querySelector('#UISiteBody') || document.querySelector('#UIPageBody');
   const topBarBoxShadow = document.querySelector('#TopBarBoxShadow');
-  if($siteBody.scrollTop()) {
-    if (topBarBoxShadow.style.visibility === 'hidden') {
+  if(siteBody.scrollTop) {
+    if (topBarBoxShadow && topBarBoxShadow.style.visibility === 'hidden') {
       document.querySelector('#TopBarBoxShadow').style.visibility = '';
     }
   } else {
-    if (topBarBoxShadow.style.visibility !== 'hidden') {
+    if (topBarBoxShadow && topBarBoxShadow.style.visibility !== 'hidden') {
       document.querySelector('#TopBarBoxShadow').style.visibility = 'hidden';
     }
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/common/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/main.js
@@ -128,7 +128,7 @@ export function init(i18n) {
         vuetify: Vue.prototype.vuetifyOptions,
         i18n,
       }).$mount('#drawers-overlay');
-    } else { // Needed for anonymous pages (login, register ...)
+    } else if (!document.querySelector('#UIPortalApplication')) { // Needed for anonymous pages (login, register ...)
       const parentDrawersOverlayElement = document.querySelector('#MiddleToolBarChildren') || document.body;
       let drawersOverlayElement = parentDrawersOverlayElement.querySelector('#drawers-overlay');
       if (!drawersOverlayElement) {
@@ -144,9 +144,13 @@ export function init(i18n) {
         }).$mount(drawersOverlayElement);
       }
     }
-    const parentNotificationsElement = document.querySelector('#bottom-all-container') || document.body;
-    let alertNotificationsElement = parentNotificationsElement.querySelector('#alert-notifications');
+    let parentNotificationsElement = document.querySelector('#bottom-all-container');
+    let alertNotificationsElement = parentNotificationsElement?.querySelector('#alert-notifications');
     if (!alertNotificationsElement) {
+      if (!parentNotificationsElement) {
+        parentNotificationsElement = document.createElement('div');
+        document.body.appendChild(parentNotificationsElement);
+      }
       alertNotificationsElement = document.createElement('div');
       alertNotificationsElement.id = 'alert-notifications';
       alertNotificationsElement.class = 'v-application v-application--is-ltr transparent theme--light';


### PR DESCRIPTION
Prior to this change, the VuetifyApp class was added to body element when topbar elements aren't found.
This change will avoid adding the Drawers overlay parent to page when no TopBar is visible only in standalone pages.
In addition, this change will update scrollbar computing to allow it work on standalone pages where the shared layout & site layout are hidden.