### PR TITLE
fix : Can't save edited profile attributes without additional actions- Meeds-io/meeds#795 - EXO-63095

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfilePropertyLabels.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfilePropertyLabels.vue
@@ -71,7 +71,7 @@ export default {
 
   methods: {
     addNewLabel() {
-      this.propertylabels.push( {language: '', label: '', objectId: this.id, objectType: this.labelsObjectType});
+      this.propertylabels.push( {language: eXo.env.portal.language, label: '', objectId: this.id, objectType: this.labelsObjectType});
     },
     deleteLabel(propertylabel) {
       this.propertylabels.splice(this.propertylabels.findIndex(v => v.language === propertylabel.language), 1);

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -302,9 +302,6 @@ export default {
       this.parents.unshift({resolvedLabel: ''});
       this.newSetting = false;
       this.labels = JSON.parse(JSON.stringify(this.setting.labels));
-      if (this.labels.length === 0){
-        this.labels.push( {language: 'en', label: '', objectId: this.setting.id, objectType: this.labelsObjectType});
-      }
       this.changes= false;
       this.drawer = true;     
     },


### PR DESCRIPTION


Before to this change we were unable to save any edited property of a profile attribute due of the required text filed label. I don't think there is a need to display an empty text filed when there is no label property value to edit on the edit profile attribute drawer. After this change we will display the text filed label property when we have a value to edit , if that is'n the case we display only the add property label button to use it if we want to add an new property during the editing of an attribute .


