### PR TITLE
fix: Deactivating sub attributes of IMs does not work int edit drawer - Meeds-io/meeds#797 - EXO-63174

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
@@ -20,7 +20,7 @@
     </div>
     <v-flex v-for="(childProperty, i) in property.children" :key="i">
       <profile-contact-edit-multi-field-select
-        v-if="childProperty.isNew || childProperty.value"
+        v-if="childProperty.visible && childProperty.active && (childProperty.isNew || childProperty.value)"
         :property="childProperty"
         :properties="property.children"
         :multi-valued="property.multiValued"


### PR DESCRIPTION
prior to this change, deactivated and invisible IMs are displayed in the user profile's edit contact info drawer since they are not restricted from being displayed
after this change, deactivated and invisible IMs are not displayed anymore