### PR TITLE
fix: Work experience: Missing indication for required fields - EXO-62858 - meeds-io/meeds#814  (#2420)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperienceEditItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperienceEditItem.vue
@@ -10,7 +10,7 @@
     </v-expansion-panel-header>
     <v-expansion-panel-content>
       <v-card-text class="d-flex flex-grow-1 text-no-wrap text-left font-weight-bold pt-0 pb-2">
-        {{ $t('profileWorkExperiences.company') }}
+        {{ $t('profileWorkExperiences.company') }} *
       </v-card-text>
       <v-card-text class="d-flex py-0">
         <input
@@ -23,7 +23,7 @@
           required>
       </v-card-text>
       <v-card-text class="d-flex flex-grow-1 text-no-wrap text-left font-weight-bold pb-2">
-        {{ $t('profileWorkExperiences.jobTitle') }}
+        {{ $t('profileWorkExperiences.jobTitle') }} *
       </v-card-text>
       <v-card-text class="d-flex py-0">
         <input


### PR DESCRIPTION
prior to this change, There isn't any indication of required fields in the section "Work experience" after this change, An indication for the "Organization" and "Job title" fields was added
