### PR TITLE
fix: activity params keys case insensitivity block activity updates -EXO-62802 - Meeds-io/meeds#815

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -900,4 +900,10 @@
         <createSequence sequenceName="SEQ_SOC_LABELS_ID" startValue="1"/>
     </changeSet>
 
+    <changeSet author="social" id="1.0.0-91" dbms="mysql">
+        <sql>
+            ALTER TABLE SOC_ACTIVITY_TEMPLATE_PARAMS MODIFY COLUMN TEMPLATE_PARAM_KEY NVARCHAR(255) BINARY;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, on mysql a the column of activity template params case insensitive by default, this have created an issue when attempting to like a comment activity and an error of duplicated entry exception is thrown.
This PR modifies the affected column by adding the binary keyword to make the column case sensitive

