### PR TITLE
fix:  Attribute options in edit mode not updating according to the position - EXO-63127 - Meeds-io/meeds#827

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ProfilePropertySettingDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ProfilePropertySettingDAO.java
@@ -48,4 +48,11 @@ public class ProfilePropertySettingDAO extends GenericDAOJPAImpl<ProfileProperty
                                                                                        ProfilePropertySettingEntity.class);
     return query.getResultList();
   }
+
+  public List<ProfilePropertySettingEntity> findOrderedSettings() {
+    TypedQuery<ProfilePropertySettingEntity> query =
+                                                   getEntityManager().createNamedQuery("SocProfileSettingEntity.findOrderedSettings",
+                                                                                       ProfilePropertySettingEntity.class);
+    return query.getResultList();
+  }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 
 @NamedQuery(name = "SocProfileSettingEntity.findProfileSettingByName", query = "SELECT c FROM SocProfileSettingEntity c WHERE propertyName = :name")
 @NamedQuery(name = "SocProfileSettingEntity.findSynchronizedSettings", query = "SELECT c FROM SocProfileSettingEntity c WHERE isGroupSynchronized = true")
+@NamedQuery(name = "SocProfileSettingEntity.findOrderedSettings", query = "SELECT c FROM SocProfileSettingEntity c order by c.order")
 
 public class ProfilePropertySettingEntity implements Serializable {
 

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
@@ -35,7 +35,7 @@ public class ProfileSettingStorage {
   }
 
   public List<ProfilePropertySetting> getPropertySettings() {
-    return profilePropertySettingDAO.findAll().stream().map(this::convertFromEntity).toList();
+    return profilePropertySettingDAO.findOrderedSettings().stream().map(this::convertFromEntity).toList();
   }
 
   public List<ProfilePropertySetting> getSynchronizedPropertySettings() {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettingsTable.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettingsTable.vue
@@ -25,12 +25,8 @@
     :items="settings"
     :items-per-page="pageSize"
     :loading="loading"
-    :options.sync="options"
     :locale="lang"
-    :disable-sort="isMobile"
-    :loading-text="loadingLabel"
-    :class="loadingClass"
-    :sort-by="sortBy"
+    :sort-by.sync="sortBy"
     hide-default-footer
     disable-pagination
     disable-filtering
@@ -58,7 +54,6 @@
 
 <script>
 export default {
-
   props: {
     settings: {
       type: Object,
@@ -91,6 +86,7 @@ export default {
   },
   data: () => ({
     waitTimeUntilCloseMenu: 200,
+    lang: eXo.env.portal.language,
   }),
   computed: {
     headers() {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/menu/ProfileSettingsActionMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/menu/ProfileSettingsActionMenu.vue
@@ -83,11 +83,11 @@ export default {
     },
     canMoveUp()
     {
-      return this.index > 0 ?  true : false;
+      return this.index > 0;
     },
     canMoveDown()
     {
-      return this.index < this.settings.length-1 ?  true : false;
+      return this.index < this.settings.length - 1;
     }, 
   },
   methods: {


### PR DESCRIPTION
Prior to this change, when moving attribute up or down and refresh the page, the proposed move options are not consistent with actual attribute order position. due to getting unordered list of attributes each time we update the attributes order. 
This PR ensures to get an order attribute list depends on the order field and adjust the used options in the data-table including non used ones.
