### PR TITLE
fix:  Attribute options in edit mode not updating according to the position - EXO-63127 - Meeds-io/meeds#827 (#2439)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ProfilePropertySettingDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ProfilePropertySettingDAO.java
@@ -48,4 +48,11 @@ public class ProfilePropertySettingDAO extends GenericDAOJPAImpl<ProfileProperty
                                                                                        ProfilePropertySettingEntity.class);
     return query.getResultList();
   }
+
+  public List<ProfilePropertySettingEntity> findOrderedSettings() {
+    TypedQuery<ProfilePropertySettingEntity> query =
+                                                   getEntityManager().createNamedQuery("SocProfileSettingEntity.findOrderedSettings",
+                                                                                       ProfilePropertySettingEntity.class);
+    return query.getResultList();
+  }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 
 @NamedQuery(name = "SocProfileSettingEntity.findProfileSettingByName", query = "SELECT c FROM SocProfileSettingEntity c WHERE propertyName = :name")
 @NamedQuery(name = "SocProfileSettingEntity.findSynchronizedSettings", query = "SELECT c FROM SocProfileSettingEntity c WHERE isGroupSynchronized = true")
+@NamedQuery(name = "SocProfileSettingEntity.findOrderedSettings", query = "SELECT c FROM SocProfileSettingEntity c order by c.order")
 
 public class ProfilePropertySettingEntity implements Serializable {
 

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
@@ -35,7 +35,7 @@ public class ProfileSettingStorage {
   }
 
   public List<ProfilePropertySetting> getPropertySettings() {
-    return profilePropertySettingDAO.findAll().stream().map(this::convertFromEntity).toList();
+    return profilePropertySettingDAO.findOrderedSettings().stream().map(this::convertFromEntity).toList();
   }
 
   public List<ProfilePropertySetting> getSynchronizedPropertySettings() {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/test/AbstractCoreTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/test/AbstractCoreTest.java
@@ -65,6 +65,7 @@ import java.util.List;
  */
 @ConfiguredBy({
   @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/exo.social.component.core-local-root-configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.social.component.core-dependencies-configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.social.component.core-local-configuration.xml"),

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/test/BaseCoreTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/test/BaseCoreTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.*;
  */
 @ConfiguredBy({
   @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/exo.social.component.core-local-root-configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.social.component.core-dependencies-configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.social.component.core-local-configuration.xml"),

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/SocialUserProfileEventListenerImplTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
@@ -52,7 +51,6 @@ public class SocialUserProfileEventListenerImplTest extends AbstractCoreTest {
   private ProfilePropertyService profilePropertyService;
   private Identity paul;
   private Identity raul;
-  private boolean alreadyAddedPlugins = false;
 
   public SocialUserProfileEventListenerImplTest() {
     setForceContainerReload(true);
@@ -63,7 +61,6 @@ public class SocialUserProfileEventListenerImplTest extends AbstractCoreTest {
     identityManager = (IdentityManager) getContainer().getComponentInstanceOfType(IdentityManager.class);
     organizationService = (OrganizationService) getContainer().getComponentInstanceOfType(OrganizationService.class);
     profilePropertyService = getContainer().getComponentInstanceOfType(ProfilePropertyService.class);
-    fakePlugins();
     cacheService = getContainer().getComponentInstanceOfType(SocialStorageCacheService.class);
     cacheService.getIdentityCache().clearCache();
     cacheService.getIdentityIndexCache().clearCache();
@@ -75,16 +72,6 @@ public class SocialUserProfileEventListenerImplTest extends AbstractCoreTest {
     tearDownIdentityList.add(raul);
     org.exoplatform.services.security.Identity identity = getService(IdentityRegistry.class).getIdentity("root");
     ConversationState.setCurrent(new ConversationState(identity));
-  }
-  
-  private void fakePlugins() throws Exception {
-    if (!alreadyAddedPlugins) {
-      organizationService.addListenerPlugin(new SocialUserEventListenerImpl());
-      organizationService.addListenerPlugin(new SocialUserProfileEventListenerImpl(identityManager,
-              profilePropertyService));
-      alreadyAddedPlugins = true;
-    }
-    
   }
 
   public void tearDown() throws Exception {

--- a/component/core/src/test/java/org/exoplatform/social/core/test/AbstractCoreTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/AbstractCoreTest.java
@@ -48,6 +48,7 @@ import junit.framework.AssertionFailedError;
  */
 @ConfiguredBy({
   @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/exo.social.component.core-local-root-configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.social.component.core-dependencies-configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.social.component.core-local-configuration.xml"),

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -655,16 +655,6 @@
     <type>org.exoplatform.social.core.processor.I18NActivityProcessor</type>
   </component>
 
-  <component>
-    <key>social-test-configuration-properties</key>
-    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
-    <init-params>
-      <properties-param>
-        <name>social-test-configuration-properties</name>
-        <property name="exo.social.profile.excluded.attributeList" value="propertyToIgnore, propertyToIgnore1, propertyToIgnore2" />
-      </properties-param>
-    </init-params>
-  </component>
   <external-component-plugins>
     <target-component>org.exoplatform.social.metadata.MetadataService</target-component>
     <component-plugin>

--- a/component/core/src/test/resources/conf/exo.social.component.core-local-root-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-local-root-configuration.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<configuration
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+    xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+  <component>
+    <key>social-test-configuration-properties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>social-test-configuration-properties</name>
+        <property name="exo.social.profile.excluded.attributeList" value="propertyToIgnore, propertyToIgnore1, propertyToIgnore2" />
+      </properties-param>
+    </init-params>
+  </component>
+</configuration>

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettingsTable.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettingsTable.vue
@@ -25,12 +25,8 @@
     :items="settings"
     :items-per-page="pageSize"
     :loading="loading"
-    :options.sync="options"
     :locale="lang"
-    :disable-sort="isMobile"
-    :loading-text="loadingLabel"
-    :class="loadingClass"
-    :sort-by="sortBy"
+    :sort-by.sync="sortBy"
     hide-default-footer
     disable-pagination
     disable-filtering
@@ -58,7 +54,6 @@
 
 <script>
 export default {
-
   props: {
     settings: {
       type: Object,
@@ -91,6 +86,7 @@ export default {
   },
   data: () => ({
     waitTimeUntilCloseMenu: 200,
+    lang: eXo.env.portal.language,
   }),
   computed: {
     headers() {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/menu/ProfileSettingsActionMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/menu/ProfileSettingsActionMenu.vue
@@ -83,11 +83,11 @@ export default {
     },
     canMoveUp()
     {
-      return this.index > 0 ?  true : false;
+      return this.index > 0;
     },
     canMoveDown()
     {
-      return this.index < this.settings.length-1 ?  true : false;
+      return this.index < this.settings.length - 1;
     }, 
   },
   methods: {


### PR DESCRIPTION
Prior to this change, when moving attribute up or down and refresh the page, the proposed move options are not consistent with actual attribute order position. due to getting unordered list of attributes each time we update the attributes order.
This PR ensures to get an order attribute list depends on the order field and adjust the used options in the data-table including non used ones.

(cherry picked from commit 011165b7db6514e8f185c8fb52e87e8fda27e5f4)