### PR TITLE
fix: Fix displaying Space Navigation Arrows - MEED-1971 - Meeds-io/meeds#833

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
@@ -63,6 +63,12 @@ export default {
     displaySpaceNavigations() {
       this.computedSiteBodyMargin();
     },
+    selectedNavigationUri() {
+      this.refreshWindowSize();
+    },
+    navigations() {
+      this.refreshWindowSize();
+    },
   },
   created() {
     document.addEventListener('refreshSpaceNavigations', () => {
@@ -95,7 +101,15 @@ export default {
         window.setTimeout(() => {
           $('#UISiteBody').css('margin-bottom', '70px');
         }, 200);
+      } else {
+        $('#UISiteBody').css('margin-bottom', '');
       }
+      this.refreshWindowSize();
+    },
+    refreshWindowSize() {
+      this.$nextTick().then(() => {
+        window.setTimeout(() => window.dispatchEvent(new Event('resize')), 200);
+      });
     },
   },
 };


### PR DESCRIPTION
Prior to this change, the `v-tabs` slider arrows aren't displayed in a proper way.
This change will fix it by triggering window resize when Space Menu elements changes.