### PR TITLE
fix: Fix Spaces Application Cards Drawer Width - MEED-1972 - Meeds-io/meeds#834

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/drawer/ExoSpaceAddApplicationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/drawer/ExoSpaceAddApplicationDrawer.vue
@@ -7,20 +7,25 @@
       {{ $t('social.spaces.administration.manageSpaces.applications') }}
     </template>
     <template slot="content">
-      <v-expansion-panels
-        v-model="expanded"
-        accordion
-        flat
-        focusable
-        class="px-4">
-        <exo-space-application-category-card
-          v-for="(category, index) in applicationsByCategory"
-          :key="category.id"
-          :category="category"
-          :expanded="expanded === index"
-          :installed-applications="installedApplications"
-          @addApplication="addApplication" />
-      </v-expansion-panels>
+      <v-card
+        width="420"
+        max-width="100%"
+        flat>
+        <v-expansion-panels
+          v-model="expanded"
+          accordion
+          flat
+          focusable
+          class="px-4">
+          <exo-space-application-category-card
+            v-for="(category, index) in applicationsByCategory"
+            :key="category.id"
+            :category="category"
+            :expanded="expanded === index"
+            :installed-applications="installedApplications"
+            @addApplication="addApplication" />
+        </v-expansion-panels>
+      </v-card>
     </template>
   </exo-drawer>
 </template>


### PR DESCRIPTION
Prior to this change, the Space Applications Drawer takes 100% of Screen width.
This change will force the width of expansion-panels to not exceed the drawer width to be able to display all its elements.