### PR TITLE
fix: Deactivating sub attributes of IMs does not work int edit drawer- Meeds-io/meeds#797 - EXO-63174 (#2427)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
@@ -20,7 +20,7 @@
     </div>
     <v-flex v-for="(childProperty, i) in property.children" :key="i">
       <profile-contact-edit-multi-field-select
-        v-if="childProperty.isNew || childProperty.value"
+        v-if="childProperty.visible && childProperty.active && (childProperty.isNew || childProperty.value)"
         :property="childProperty"
         :properties="property.children"
         :multi-valued="property.multiValued"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
@@ -31,10 +31,12 @@
           :key="i"
           :title="childProperty.value"
           class="text-no-wrap text-truncate">
-          <span v-if="childProperty.propertyName" class="pe-1 text-capitalize">
-            {{ getResolvedName(childProperty) }}:
-          </span>
-          <span v-autolinker="childProperty.value"></span>
+          <template v-if="childProperty.visible && childProperty.active">
+            <span v-if="childProperty.propertyName" class="pe-1 text-capitalize">
+              {{ getResolvedName(childProperty) }}:
+            </span>
+            <span v-autolinker="childProperty.value"></span>
+          </template>
         </div>
       </div>
     </v-flex>


### PR DESCRIPTION
prior to this change, deactivated and invisible IMs are displayed in the user profile's edit contact info drawer since they are not restricted from being displayed after this change, deactivated and invisible IMs are not displayed anymore

(cherry picked from commit 1f47b9bdb6fb4ad329969f120bf6ab9e4df462bf)