### PR TITLE
fix: Erroneous number of search results when using advanced people search - EXO-63148 - Meeds-io/meeds#818

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -351,7 +351,7 @@ public class ProfileSearchConnector {
       subQueryEmpty = false;
       appendCommar = true;
     } else if (filter.getExcludedIdentityList() != null && filter.getExcludedIdentityList().size() > 0) {
-      esSubQuery.append("      \"must_not\": [\n");
+      esSubQuery.append("      ,\"must_not\": [\n");
       esSubQuery.append("        {\n");
       esSubQuery.append("          \"ids\" : {\n");
       esSubQuery.append("             \"values\" : [" + buildExcludedIdentities(filter) + "]\n");
@@ -389,7 +389,7 @@ public class ProfileSearchConnector {
     }
 
     esQuery.append(",\"_source\": false\n");
-    esQuery.append(",\"fields\": [\"_id\"]\n");
+    esQuery.append(",\"fields\": [\"userName\"]\n");
     esQuery.append("}\n");
     LOG.debug("Search Query request to ES : {} ", esQuery);
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/UserRestResources.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/UserRestResources.java
@@ -49,7 +49,8 @@ public interface UserRestResources extends SocialRest {
                                     @QueryParam("offset") int offset,
                                     @QueryParam("limit") int limit,
                                     @QueryParam("returnSize") boolean returnSize,
-                                    @QueryParam("expand") String expand) throws Exception;
+                                    @QueryParam("expand") String expand,
+                                    @QueryParam("excludeCurrentUser") boolean excludeCurrentUser) throws Exception;
 
   /**
    * Creates an user

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -263,7 +263,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
           description = "Using the query param \"q\" to filter the target users, ex: \"q=jo*\" returns all the users beginning by \"jo\"."
                 + "Using the query param \"status\" to filter the target users, ex: \"status=online*\" returns the visible online users."
                 + "Using the query params \"status\" and \"spaceId\" together to filter the target users, ex: \"status=online*\" and \"spaceId=1*\" returns the visible online users who are member of space with id=1."
-                + "The params \"status\" and \"spaceId\" cannot be used with \"q\" param since it will falsify the \"limit\" param which is 20 by default. If these 3 parameters are used together, the parameter \"q\" will be ignored")
+                + "The params \"status\" and \"spaceId\" cannot be used with \"q\" param since it will falsify the \"limit\" param which is 20 by default. If these 3 parameters are used together, the parameter \"q\" will be ignored,"
+                + "the current user \"excludeCurrentUser\" will be excluded")
   @ApiResponses(value = {
     @ApiResponse(responseCode = "200", description = "Request fulfilled"),
     @ApiResponse (responseCode = "404", description = "Resource not found"),
@@ -280,7 +281,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
                            @Parameter(description = "Offset") @Schema(defaultValue = "0") @QueryParam("offset") int offset,
                            @Parameter(description = "Limit") @Schema(defaultValue = "20") @QueryParam("limit") int limit,
                            @Parameter(description = "Returning the number of users found or not") @Schema(defaultValue = "false") @QueryParam("returnSize") boolean returnSize,
-                           @Parameter(description = "Asking for a full representation of a specific subresource if any") @QueryParam("expand") String expand) throws Exception {
+                           @Parameter(description = "Asking for a full representation of a specific subresource if any") @QueryParam("expand") String expand,
+                           @Parameter(description = "the current user will be excluded in the list") @Schema(defaultValue = "false") @QueryParam("excludeCurrentUser") boolean excludeCurrentUser) throws Exception {
 
     String userId;
     try {
@@ -315,9 +317,13 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
         identities = getOnlineIdentities(userStateService, userId, limit);
       }
     } else {
+      Identity target = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userId);
       ProfileFilter filter = new ProfileFilter();
       filter.setName(q == null || q.isEmpty() ? "" : q);
       filter.setEnabled(!isDisabled);
+      if (target != null && excludeCurrentUser) {
+        filter.setExcludedIdentityList(Collections.singletonList(target));
+      }
       if (!isDisabled) {
         filter.setUserType(userType);
         filter.setConnected(isConnected != null ? isConnected.equals(CONNECTED) : null);
@@ -447,19 +453,22 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     limit = limit > 0 ? limit : RestUtils.getLimit(uriInfo);
     Identity[] identities;
     int totalSize = 0;
-      ProfileFilter filter = new ProfileFilter();
-      if (filterType.equals("all")) {
-        filter.setEnabled(!isDisabled);
-        if (!isDisabled) {
-          filter.setUserType(userType);
-        }
+    ProfileFilter filter = new ProfileFilter();
+    if (filterType.equals("all")) {
+      filter.setEnabled(!isDisabled);
+      if (!isDisabled) {
+        filter.setUserType(userType);
       }
-      filter.setProfileSettings(settings);
-        ListAccess<Identity> list = filterType.equals("all") ? identityManager.getIdentitiesByProfileFilter(OrganizationIdentityProvider.NAME, filter, true) : relationshipManager.getConnectionsByFilter(target, filter);
-        identities = list.load(offset, limit);
-        if(returnSize) {
-          totalSize = list.getSize();
-        }
+    }
+    if (settings != null) {
+      filter.setExcludedIdentityList(Collections.singletonList(target));
+    }
+    filter.setProfileSettings(settings);
+    ListAccess<Identity> list = filterType.equals("all") ? identityManager.getIdentitiesByProfileFilter(OrganizationIdentityProvider.NAME, filter, true) : relationshipManager.getConnectionsByFilter(target, filter);
+    identities = list.load(offset, limit);
+    if (returnSize) {
+      totalSize = list.getSize();
+    }
     List<DataEntity> profileInfos = new ArrayList<>();
     for (Identity identity : identities) {
       ProfileEntity profileInfo = EntityBuilder.buildEntityProfile(identity.getProfile(), uriInfo.getPath(), expand);

--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -646,7 +646,7 @@ public class PeopleRestService implements ResourceContainer{
    * @throws Exception
    * @LevelAPI Platform
    * @anchor PeopleRestService.suggestUsernames
-   * @deprecated Deprecated from 4.3.x. Replaced by a new API {@link UserRestResourcesV1#getUsers(UriInfo, String, String, String, String, String, boolean, String, int, int, boolean, String)}
+   * @deprecated Deprecated from 4.3.x. Replaced by a new API {@link UserRestResourcesV1#getUsers(UriInfo, String, String, String, String, String, boolean, String, int, int, boolean, String, boolean)}
    * 
    */
   @GET

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -64,8 +64,8 @@ export function getUserByEmail(email) {
   });
 }
 
-export function getUsers(query, offset, limit, expand, signal) {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true`, {
+export function getUsers(query, offset, limit, expand, signal, excludeCurrentUser) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true&excludedIdentity=${excludeCurrentUser || false}`, {
     method: 'GET',
     credentials: 'include',
     signal: signal

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -181,19 +181,12 @@ export default {
           || this.filter === 'publisher') {
         searchUsersFunction = this.$spaceService.getSpaceMembers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.filter, this.spaceId, this.abortController.signal);
       } else {
-        searchUsersFunction = this.$userService.getUsers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.abortController.signal);
+        searchUsersFunction = this.$userService.getUsers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.abortController.signal, true);
       }
       return searchUsersFunction.then(data => {
-        let users = data && data.users || [];
-        if (this.filter === 'all') {
-          users = users.filter(user => user && user.username !== eXo.env.portal.userName);
-        }
-        users = users.slice(0, this.limitToFetch);
-        this.users = users;
+        const users = data && data.users || [];
+        this.users = users.slice(0, this.limitToFetch);
         this.peopleCount = data && data.size && data.size || 0;
-        if (this.peopleCount > 0 && this.filter === 'all' && !this.keyword) {
-          this.peopleCount = this.peopleCount - 1;
-        }
         this.hasPeople = this.hasPeople || this.peopleCount > 0;
         this.$emit('loaded', this.peopleCount);
         return this.$nextTick();
@@ -234,16 +227,9 @@ export default {
         filterUsersFunction = this.$userService.getUsersByAdvancedFilter(profileSettings, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve,this.filter, this.abortController.signal);
       }
       return filterUsersFunction.then(data => {
-        let users = data && data.users || [];
-        if (this.filter === 'all') {
-          users = users.filter(user => user && user.username !== eXo.env.portal.userName);
-        }
-        users = users.slice(0, this.limitToFetch);
-        this.users = users;
+        const users = data && data.users || [];
+        this.users = users.slice(0, this.limitToFetch);
         this.peopleCount = data && data.size && data.size || 0;
-        if (this.peopleCount > 0 && this.filter === 'all' && !this.keyword) {
-          this.peopleCount = this.peopleCount - 1;
-        }
         this.hasPeople = this.hasPeople || this.peopleCount > 0;
         this.$emit('loaded', this.peopleCount);
         return this.$nextTick();


### PR DESCRIPTION
Prior to this change, when go to People page and make an advanced search on a field and confirm, The number of results displayed on the top of the page is less than the real number of cards displayed by 1 card. This problem occurs when the current user is not included in this list. To fix that, it is necessary to calculate the correct size of the list of people in backend by adding the current user in excludedIdentityList of filter.
After this changes, the number of results displayed is the size of the list of all the people who are involved in this search except the current user who should not be applied in this search.