### PR TITLE
fix : Work experience values are empty after migrating from 5 to 6.4 - EXO-63059 - Meeds-io/meeds#848

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
@@ -1,5 +1,8 @@
 const DIGIT_PATTERN = /^[1-9]\d*$/g;
 
+//Regex to check date with format: dd/MM/yyyy 
+const DD_MM_YYYY_REGEX = /^\d{2}\/\d{2}\/\d{4}$/;
+
 /**
  * Return Date object from string value.
  * The string value can of type:
@@ -16,6 +19,11 @@ export function getDateObjectFromString(value, isISOString) {
   value = String(value).trim();
   if (new RegExp(DIGIT_PATTERN).test(value)) {
     return new Date(parseInt(value));
+
+  } else if (new RegExp(DD_MM_YYYY_REGEX).test(value)) {
+    const [date, month, year] = value.trim().split('/');
+    return new Date(year, parseInt(month) -1, date);
+    
   } else if (isISOString) {
     if (value.length > 10) {
       // long ISO format
@@ -28,9 +36,6 @@ export function getDateObjectFromString(value, isISOString) {
       // in user timezone, the day can change
       return new Date(`${value}T00:00:00`);
     }
-  } else if (String(value).indexOf('/') >= 0) {
-    const [date, month, year] = value.trim().split('/');
-    return new Date(year, parseInt(month) -1, date);
   } else {
     return new Date(value);
   }


### PR DESCRIPTION


Before to this change when we migrating from 5.3 to 6.4 user work experience value were empty and a console error would appear stating an invalid Time error , The problem was that the start work experience was stored with the format DD/MM/YYYY and the getDateObjectFromString method would always return a new date assuming the provided string was an ISO string, causing an error before checking if the stored date format is DD/MM/YYYY.
With this change, we will first check the stored digit pattern , and then return the correct date value."


