### PR TITLE
fix: Deactivating sub attributes of IMs does not work int edit drawer - Meeds-io/meeds#797 - EXO-63174 (#2465)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
@@ -20,7 +20,7 @@
     </div>
     <v-flex v-for="(childProperty, i) in property.children" :key="i">
       <profile-contact-edit-multi-field-select
-        v-if="childProperty.visible && childProperty.active && (childProperty.isNew || childProperty.value)"
+        v-if="childProperty.isNew || childProperty.visible && childProperty.active && childProperty.value"
         :property="childProperty"
         :properties="property.children"
         :multi-valued="property.multiValued"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiFieldSelect.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiFieldSelect.vue
@@ -55,9 +55,9 @@ export default {
   computed: {
     filtredProperties(){
       return this.properties.filter((obj, index, self) =>
-        index === self.findIndex((t) => (
+        obj.isNew && !obj.value || (index === self.findIndex((t) => (
           t.propertyName === obj.propertyName
-        ))
+        )) && obj.visible && obj.active)
       );
     },
   },


### PR DESCRIPTION
prior to this change, displayed add new button is not working since the newly added IMs attribute is not displayed in the user profile's contact info since they are not well restricted from being displayed after this change, add new is now possible