### PR TITLE
fix: Profile new multi field sub attributes are not saved in profile - Meeds-io/meeds#801 - EXO-63188 (#2410)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/EntityConverterUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/EntityConverterUtils.java
@@ -152,25 +152,32 @@ public class EntityConverterUtils {
       for (Entry<String, String> entry : properties.entrySet()) {
         String key = entry.getKey();
         String value = entry.getValue();
-
-        if (Profile.CONTACT_IMS.equals(key) || Profile.CONTACT_PHONES.equals(key) || Profile.CONTACT_URLS.equals(key)) {
+        boolean isJsonArray = false ;
+        JSONArray arr = null ;
+        try {
+          arr = new JSONArray(value);
+          isJsonArray = true;
+        } catch (Exception ex) {
+          // Ignore this exception
+        }
+        if (Profile.CONTACT_IMS.equals(key) || Profile.CONTACT_PHONES.equals(key) || Profile.CONTACT_URLS.equals(key) || isJsonArray) {
           List<Map<String, String>> list = new ArrayList<>();
-          try {
-            JSONArray arr = new JSONArray(value);
-            for (int i = 0 ; i < arr.length(); i++) {
-              Map<String, String> map = new HashMap<>();
-              JSONObject json = arr.getJSONObject(i);
-              Iterator<String> keys = json.keys();
-              while (keys.hasNext()) {
-                String k = keys.next();
-                map.put(k, json.optString(k));
+          if (arr != null) {
+            try {
+              for (int i = 0; i < arr.length(); i++) {
+                Map<String, String> map = new HashMap<>();
+                JSONObject json = arr.getJSONObject(i);
+                Iterator<String> keys = json.keys();
+                while (keys.hasNext()) {
+                  String k = keys.next();
+                  map.put(k, json.optString(k));
+                }
+                list.add(map);
               }
-              list.add(map);
+            } catch (JSONException ex) {
+              // Ignore this exception
             }
-          } catch (JSONException ex) {
-            // Ignore this exception
           }
-
           props.put(key, list);
 
         } else if (!Profile.URL.equals(key)) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
@@ -277,7 +277,7 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
         }
       } else if (Profile.CONTACT_IMS.equals(profileProperty.getKey())
               || Profile.CONTACT_PHONES.equals(profileProperty.getKey())
-              || Profile.CONTACT_URLS.equals(profileProperty.getKey())) {
+              || Profile.CONTACT_URLS.equals(profileProperty.getKey()) || properties.get(profileProperty.getKey()) instanceof ArrayList<?>) {
 
         List<Map<String, String>> list = (List<Map<String, String>>) profileProperty.getValue();
         JSONArray arr = new JSONArray();

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
@@ -1112,6 +1112,16 @@ public class IdentityStorageTest extends AbstractCoreTest {
     assertNotNull(identity.getProfile());
     assertEquals("male", identity.getProfile().getGender());
     assertEquals(null, identity.getProfile().getPosition());
+
+
+    profile.setProperty("multi-field", Collections.singletonList("new field"));
+    identityStorage.updateProfile(profile);
+
+    identity = identityStorage.findIdentity(OrganizationIdentityProvider.NAME, userName);
+    assertNotNull(identity);
+    assertNotNull(identity.getProfile());
+    assertNotNull(identity.getProfile().getProperty("multi-field"));
+    assertTrue(identity.getProfile().getProperty("multi-field") instanceof ArrayList<?>);
   }
   
   /**

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1022,11 +1022,19 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
               }
               break;
             default:
-              List<String> childrenValues = profileProperty.getChildren()
-                      .stream()
-                      .map(ProfilePropertySettingEntity::getValue)
-                      .toList();
-              updateProfileField(profile, profileProperty.getPropertyName(), StringUtils.join(childrenValues, ','), true);
+              List<Map<String, String>> maps = new ArrayList<>();
+              profileProperty.getChildren().stream().forEach(profilePropertySettingEntity -> {
+                if (profilePropertySettingEntity.getValue() != null && profilePropertySettingEntity.getPropertyName() != null
+                    && !profilePropertySettingEntity.getPropertyName().isBlank()
+                    && !profilePropertySettingEntity.getValue().isBlank()) {
+                  Map<String, String> childrenMap = new HashMap<>();
+                  childrenMap.put("key", profilePropertySettingEntity.getPropertyName());
+                  childrenMap.put("value", profilePropertySettingEntity.getValue());
+                  maps.add(childrenMap);
+                }
+                return;
+              });
+              updateProfileField(profile, profileProperty.getPropertyName(), maps, true);
           }
         }
       } catch (IllegalAccessException e) {

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -14,12 +14,11 @@ import javax.imageio.ImageIO;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.ObjectAlreadyExistsException;
-import org.exoplatform.services.thumbnail.ImageResizeService;
-import org.exoplatform.social.core.jpa.storage.dao.jpa.ProfilePropertySettingDAO;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.metadata.thumbnail.ImageThumbnailService;
+import org.exoplatform.social.rest.entity.ProfilePropertySettingEntity;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mortbay.cometd.continuation.EXoContinuationBayeux;
 
@@ -1174,6 +1173,22 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                  400,
                  response.getStatus());
     data.put(ProfileEntity.LASTNAME, "Test");
+  }
+
+  public void testUpdateUserNewMultiProperties() throws Exception {
+    startSessionAs("root");
+    ProfilePropertySettingEntity profilePropertySettingEntity = new ProfilePropertySettingEntity();
+    profilePropertySettingEntity.setPropertyName("new ArrayField");
+    profilePropertySettingEntity.setMultiValued(false);
+    ProfilePropertySettingEntity profilePropertySettingEntityChild = new ProfilePropertySettingEntity();
+    profilePropertySettingEntityChild.setPropertyName("subField");
+    profilePropertySettingEntityChild.setValue("subfield value");
+    profilePropertySettingEntity.setChildren(Collections.singletonList(profilePropertySettingEntityChild));
+    ArrayList< ProfilePropertySettingEntity > profilePropertySettingEntityList =  new ArrayList<>();
+    profilePropertySettingEntityList.add(profilePropertySettingEntity);
+    ContainerResponse response = getResponse("PATCH", "/v1/social/users/root/profile/properties", new JSONArray(profilePropertySettingEntityList).toString());
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
   }
 
   private Space getSpaceInstance(int number, String creator) throws Exception {


### PR DESCRIPTION
prior to this change, after editing a newly added attribute profile with sub-attributes, the changes are not displayed since the parent was saved as a simple attribute ( their children have null value) after this change, the newly added attribute is treated as a parent attribute with children, and the edit and displayed are well saved