### PR TITLE
fix: Profile - Attribute position change not taken into account - EXO-63150

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -905,5 +905,10 @@
             ALTER TABLE SOC_ACTIVITY_TEMPLATE_PARAMS MODIFY COLUMN TEMPLATE_PARAM_KEY NVARCHAR(255) BINARY;
         </sql>
     </changeSet>
+    <changeSet author="social" id="1.0.0-92">
+        <sql>
+            UPDATE SOC_PROFILE_PROPERTY_SETTING SET PROPERTY_ORDER=PROPERTY_SETTING_ID
+        </sql>
+    </changeSet>
 
 </databaseChangeLog>

--- a/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
@@ -601,7 +601,7 @@
                       <boolean>false</boolean>
                     </field>
                     <field  name="order">
-                      <int>12</int>
+                      <int>11</int>
                     </field>
                   </object>
                 </value>
@@ -629,7 +629,7 @@
                       <boolean>false</boolean>
                     </field>
                     <field  name="order">
-                      <int>13</int>
+                      <int>12</int>
                     </field>
                   </object>
                 </value>
@@ -657,7 +657,7 @@
                       <boolean>false</boolean>
                     </field>
                     <field  name="order">
-                      <int>14</int>
+                      <int>13</int>
                     </field>
                   </object>
                 </value>
@@ -688,7 +688,7 @@
                       <string>phones</string>
                     </field>
                     <field  name="order">
-                      <int>15</int>
+                      <int>14</int>
                     </field>
                   </object>
                 </value>
@@ -719,7 +719,7 @@
                       <string>phones</string>
                     </field>
                     <field  name="order">
-                      <int>16</int>
+                      <int>15</int>
                     </field>
                   </object>
                 </value>
@@ -750,7 +750,7 @@
                       <string>phones</string>
                     </field>
                     <field  name="order">
-                      <int>17</int>
+                      <int>16</int>
                     </field>
                   </object>
                 </value>
@@ -779,7 +779,7 @@
                       <boolean>false</boolean>
                     </field>
                     <field  name="order">
-                      <int>18</int>
+                      <int>17</int>
                     </field>
                   </object>
                 </value>
@@ -810,7 +810,7 @@
                       <string>ims</string>
                     </field>
                     <field  name="order">
-                      <int>19</int>
+                      <int>18</int>
                     </field>
                   </object>
                 </value>
@@ -841,7 +841,7 @@
                       <string>ims</string>
                     </field>
                     <field  name="order">
-                      <int>20</int>
+                      <int>19</int>
                     </field>
                   </object>
                 </value>
@@ -872,7 +872,7 @@
                       <string>ims</string>
                     </field>
                     <field  name="order">
-                      <int>21</int>
+                      <int>20</int>
                     </field>
                   </object>
                 </value>
@@ -903,7 +903,7 @@
                       <string>ims</string>
                     </field>
                     <field  name="order">
-                      <int>22</int>
+                      <int>21</int>
                     </field>
                   </object>
                 </value>
@@ -934,7 +934,7 @@
                       <string>ims</string>
                     </field>
                     <field  name="order">
-                      <int>23</int>
+                      <int>22</int>
                     </field>
                   </object>
                 </value>
@@ -962,7 +962,7 @@
                       <boolean>false</boolean>
                     </field>
                     <field  name="order">
-                      <int>24</int>
+                      <int>23</int>
                     </field>
                   </object>
                 </value>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/profileproperty/profile-property-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/profileproperty/profile-property-configuration.xml
@@ -351,7 +351,7 @@
 											<boolean>false</boolean>
 										</field>
 										<field  name="order">
-											<int>12</int>
+											<int>11</int>
 										</field>
 									</object>
 								</value>
@@ -379,7 +379,7 @@
 											<boolean>false</boolean>
 										</field>
 										<field  name="order">
-											<int>13</int>
+											<int>12</int>
 										</field>
 									</object>
 								</value>
@@ -407,7 +407,7 @@
 											<boolean>false</boolean>
 										</field>
 										<field  name="order">
-											<int>14</int>
+											<int>13</int>
 										</field>
 									</object>
 								</value>
@@ -438,7 +438,7 @@
 											<string>phones</string>
 										</field>
 										<field  name="order">
-											<int>15</int>
+											<int>14</int>
 										</field>
 									</object>
 								</value>
@@ -469,7 +469,7 @@
 											<string>phones</string>
 										</field>
 										<field  name="order">
-											<int>16</int>
+											<int>15</int>
 										</field>
 									</object>
 								</value>
@@ -500,7 +500,7 @@
 											<string>phones</string>
 										</field>
 										<field  name="order">
-											<int>17</int>
+											<int>16</int>
 										</field>
 									</object>
 								</value>
@@ -529,7 +529,7 @@
 											<boolean>false</boolean>
 										</field>
 										<field  name="order">
-											<int>18</int>
+											<int>17</int>
 										</field>
 									</object>
 								</value>
@@ -560,7 +560,7 @@
 											<string>ims</string>
 										</field>
 										<field  name="order">
-											<int>19</int>
+											<int>18</int>
 										</field>
 									</object>
 								</value>
@@ -591,7 +591,7 @@
 											<string>ims</string>
 										</field>
 										<field  name="order">
-											<int>20</int>
+											<int>19</int>
 										</field>
 									</object>
 								</value>
@@ -622,7 +622,7 @@
 											<string>ims</string>
 										</field>
 										<field  name="order">
-											<int>21</int>
+											<int>20</int>
 										</field>
 									</object>
 								</value>
@@ -653,7 +653,7 @@
 											<string>ims</string>
 										</field>
 										<field  name="order">
-											<int>22</int>
+											<int>21</int>
 										</field>
 									</object>
 								</value>
@@ -684,7 +684,7 @@
 											<string>ims</string>
 										</field>
 										<field  name="order">
-											<int>23</int>
+											<int>22</int>
 										</field>
 									</object>
 								</value>
@@ -712,7 +712,7 @@
 											<boolean>false</boolean>
 										</field>
 										<field  name="order">
-											<int>24</int>
+											<int>23</int>
 										</field>
 									</object>
 								</value>


### PR DESCRIPTION
prior to this change, the added profile properties from the XML file had the wrong order which lead to duplication of order for some newly added properties after this change, the properties in the XML file are fixed and distinct. A change set was added to fix the already saved ones