### PR TITLE
fix: Erroneous number of search results when using advanced people search - EXO-63148 - Meeds-io/meeds#818

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -351,7 +351,7 @@ public class ProfileSearchConnector {
       subQueryEmpty = false;
       appendCommar = true;
     } else if (filter.getExcludedIdentityList() != null && filter.getExcludedIdentityList().size() > 0) {
-      esSubQuery.append("      \"must_not\": [\n");
+      esSubQuery.append("      ,\"must_not\": [\n");
       esSubQuery.append("        {\n");
       esSubQuery.append("          \"ids\" : {\n");
       esSubQuery.append("             \"values\" : [" + buildExcludedIdentities(filter) + "]\n");
@@ -389,7 +389,7 @@ public class ProfileSearchConnector {
     }
 
     esQuery.append(",\"_source\": false\n");
-    esQuery.append(",\"fields\": [\"_id\"]\n");
+    esQuery.append(",\"fields\": [\"userName\"]\n");
     esQuery.append("}\n");
     LOG.debug("Search Query request to ES : {} ", esQuery);
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/UserRestResources.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/UserRestResources.java
@@ -49,7 +49,8 @@ public interface UserRestResources extends SocialRest {
                                     @QueryParam("offset") int offset,
                                     @QueryParam("limit") int limit,
                                     @QueryParam("returnSize") boolean returnSize,
-                                    @QueryParam("expand") String expand) throws Exception;
+                                    @QueryParam("expand") String expand,
+                                    @QueryParam("excludeCurrentUser") boolean excludeCurrentUser) throws Exception;
 
   /**
    * Creates an user

--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -646,7 +646,7 @@ public class PeopleRestService implements ResourceContainer{
    * @throws Exception
    * @LevelAPI Platform
    * @anchor PeopleRestService.suggestUsernames
-   * @deprecated Deprecated from 4.3.x. Replaced by a new API {@link UserRestResourcesV1#getUsers(UriInfo, String, String, String, String, String, boolean, String, int, int, boolean, String)}
+   * @deprecated Deprecated from 4.3.x. Replaced by a new API {@link UserRestResourcesV1#getUsers(UriInfo, String, String, String, String, String, boolean, String, int, int, boolean, String, boolean)}
    * 
    */
   @GET

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -65,7 +65,7 @@ export function getUserByEmail(email) {
 }
 
 export function getUsers(query, offset, limit, expand, signal, excludeCurrentUser) {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true&excludedIdentity=${excludeCurrentUser || false}`, {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true&excludeCurrentUser=${excludeCurrentUser || false}`, {
     method: 'GET',
     credentials: 'include',
     signal: signal

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -64,8 +64,8 @@ export function getUserByEmail(email) {
   });
 }
 
-export function getUsers(query, offset, limit, expand, signal) {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true`, {
+export function getUsers(query, offset, limit, expand, signal, excludeCurrentUser) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users?q=${query || ''}&offset=${offset || 0}&limit=${limit|| 0}&expand=${expand || ''}&returnSize=true&excludedIdentity=${excludeCurrentUser || false}`, {
     method: 'GET',
     credentials: 'include',
     signal: signal

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -181,19 +181,12 @@ export default {
           || this.filter === 'publisher') {
         searchUsersFunction = this.$spaceService.getSpaceMembers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.filter, this.spaceId, this.abortController.signal);
       } else {
-        searchUsersFunction = this.$userService.getUsers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.abortController.signal);
+        searchUsersFunction = this.$userService.getUsers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.abortController.signal, true);
       }
       return searchUsersFunction.then(data => {
-        let users = data && data.users || [];
-        if (this.filter === 'all') {
-          users = users.filter(user => user && user.username !== eXo.env.portal.userName);
-        }
-        users = users.slice(0, this.limitToFetch);
-        this.users = users;
+        const users = data && data.users || [];
+        this.users = users.slice(0, this.limitToFetch);
         this.peopleCount = data && data.size && data.size || 0;
-        if (this.peopleCount > 0 && this.filter === 'all' && !this.keyword) {
-          this.peopleCount = this.peopleCount - 1;
-        }
         this.hasPeople = this.hasPeople || this.peopleCount > 0;
         this.$emit('loaded', this.peopleCount);
         return this.$nextTick();
@@ -234,16 +227,9 @@ export default {
         filterUsersFunction = this.$userService.getUsersByAdvancedFilter(profileSettings, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve,this.filter, this.abortController.signal);
       }
       return filterUsersFunction.then(data => {
-        let users = data && data.users || [];
-        if (this.filter === 'all') {
-          users = users.filter(user => user && user.username !== eXo.env.portal.userName);
-        }
-        users = users.slice(0, this.limitToFetch);
-        this.users = users;
+        const users = data && data.users || [];
+        this.users = users.slice(0, this.limitToFetch);
         this.peopleCount = data && data.size && data.size || 0;
-        if (this.peopleCount > 0 && this.filter === 'all' && !this.keyword) {
-          this.peopleCount = this.peopleCount - 1;
-        }
         this.hasPeople = this.hasPeople || this.peopleCount > 0;
         this.$emit('loaded', this.peopleCount);
         return this.$nextTick();


### PR DESCRIPTION
Prior to this change, when go to People page and make an advanced search on a field and confirm, The number of results displayed on the top of the page is less than the real number of cards displayed by 1 card. This problem occurs when the current user is not included in this list. To fix that, it is necessary to calculate the correct size of the list of people in backend by adding the current user in excludedIdentityList of filter.
After this changes, the number of results displayed is the size of the list of all the people who are involved in this search except the current user who should not be applied in this search.
(cherry-picked from [commit](https://github.com/Meeds-io/social/pull/d95149d618ebbf08135df4eac57cf908944a45f9) & [commit](https://github.com/Meeds-io/social/pull/d95149d618ebbf08135df4eac57cf908944a45f9) )