### PR TITLE
feat: display Field Translation in readonly mode instead of I18N Key - MEED-2012 - Meeds-io/meeds#863

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/portlet/GeneralSettings/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/GeneralSettings/Style.less
@@ -20,4 +20,4 @@
 
 @import "../../variables.less"; 
 @import "../../mixins.less";
-@import (css) "../../../component/ImageCropper/cropper.min.css";
+@import (css) "/platform-ui/skin/css/component/ImageCropper/cropper.min.css";

--- a/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationTextField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationTextField.vue
@@ -19,6 +19,27 @@
 <template>
   <div class="translation-text-field">
     <v-text-field
+      v-if="isI18N"
+      :id="id"
+      :name="id"
+      :placeholder="placeholder"
+      :value="$t(defaultLanguageValue)"
+      class="border-box-sizing pt-0"
+      type="text"
+      outlined
+      readonly
+      dense>
+      <template #append>
+        <v-btn
+          class="mt-n2 pt-2px"
+          icon
+          @click="defaultLanguageValue = null">
+          <v-icon :color="iconColor">far fa-times-circle</v-icon>
+        </v-btn>
+      </template>
+    </v-text-field>
+    <v-text-field
+      v-else
       v-model="defaultLanguageValue"
       :id="id"
       :name="id"
@@ -85,6 +106,9 @@ export default {
     valuesPerLanguage: {},
   }),
   computed: {
+    isI18N() {
+      return this.$te(this.defaultLanguageValue);
+    },
     translationsCount() {
       return Object.keys(this.valuesPerLanguage).length;
     },


### PR DESCRIPTION
Prior to this change, the TranslationTextField component was displaying the I18N key inside the text field. This change will display the field value in a readonly text is it's about an I18N Key to avoid displaying.