### PR TITLE
fix: Refresh cache is needed after renaming profile attribute - Meeds-io/meeds#867 - EXO-62875

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -559,7 +559,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
 
     String expandedSettings = expand;
     if (expand != null && expand.contains("settings")) {
-      expandedSettings = String.valueOf(Objects.hash(profilePropertyService.getPropertySettings()));
+      expandedSettings = String.valueOf(Objects.hash(EntityBuilder.buildEntityProfilePropertySettingList(profilePropertyService.getPropertySettings(),profilePropertyService, ProfilePropertyService.LABELS_OBJECT_TYPE)));
     }
 
     long cacheTime = identity.getCacheTime();

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -14,6 +14,8 @@ import javax.imageio.ImageIO;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.social.core.model.ProfileLabel;
+import org.exoplatform.social.core.profilelabel.ProfileLabelService;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.metadata.thumbnail.ImageThumbnailService;
@@ -59,6 +61,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
   private ProfilePropertyService       profilePropertyService;
 
+  private ProfileLabelService profileLabelService ;
+
   private UserACL             userACL;
 
   private RelationshipManager relationshipManager;
@@ -95,6 +99,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     activityManager = getContainer().getComponentInstanceOfType(ActivityManager.class);
     identityManager = getContainer().getComponentInstanceOfType(IdentityManager.class);
     profilePropertyService = getContainer().getComponentInstanceOfType(ProfilePropertyService.class);
+    profileLabelService = getContainer().getComponentInstanceOfType(ProfileLabelService.class);
     userACL = getContainer().getComponentInstanceOfType(UserACL.class);
     relationshipManager = getContainer().getComponentInstanceOfType(RelationshipManager.class);
     spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
@@ -403,10 +408,22 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertNotNull(response1);
     assertNotEquals(etag, etag1);
 
+    ProfileLabel label = new ProfileLabel();
+    label.setLabel("labelTest");
+    label.setLanguage("en");
+    label.setObjectType("profileProperty");
+    label.setObjectId(profilePropertyService.getProfileSettingByName(Profile.FIRST_NAME).getId().toString());
+    profileLabelService.createLabel(label);
     ContainerResponse response2 = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
     String etag2 = response2.getHttpHeaders().get("etag").toString();
     assertNotNull(response2);
-    assertEquals(etag1, etag2);
+    assertNotEquals(etag1, etag2);
+
+    ContainerResponse response3 = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
+    String etag3 = response3.getHttpHeaders().get("etag").toString();
+    assertNotNull(response2);
+    assertEquals(etag2, etag3);
+
   }
 
   public void testGetUserProfilePropertiesById() throws Exception {


### PR DESCRIPTION
Prior to this change , when we retrieved the user by id with the expended settings , we used the ProfilePropertySetting list for the Etag value , because of this we needed to refresh the cache after updating a profile label value as the ProfilePropertySetting did not contain the list of ProfileLabels. After this change, we will use the ProfilePropertySettingEntity for the Etag value, as it contains the ProfileLabel list.