### PR TITLE
fix: third element in people card menu is invisible - EXO-62230 - Meeds-io/meeds#891

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -71,7 +71,7 @@
           fas fa-ellipsis-v
         </v-icon>
         <v-bottom-sheet v-model="bottomMenu" class="pa-0">
-          <v-sheet class="text-center" height="100">
+          <v-sheet class="text-center">
             <v-list dense>
               <v-list-item 
                 v-if="confirmedUser"


### PR DESCRIPTION
Using Mobile device, the user menu from the People page does not display all items because there were a fixed height attribute defined for the menu.
the fix removes this unneeded CSS rule
