### PR TITLE
fix: New multi valued profile attribute not saved - Meeds-io/meeds#889 - EXO-63578 

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1034,9 +1034,9 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
             default:
               List<Map<String, String>> maps = new ArrayList<>();
               profileProperty.getChildren().stream().forEach(profilePropertySettingEntity -> {
-                if (profilePropertySettingEntity.getValue() != null && profilePropertySettingEntity.getPropertyName() != null
-                    && !profilePropertySettingEntity.getPropertyName().isBlank()
-                    && !profilePropertySettingEntity.getValue().isBlank()) {
+                if (profilePropertySettingEntity.getValue() != null && !profilePropertySettingEntity.getValue().isBlank()
+                && (profilePropertySettingEntity.getPropertyName() != null && !profilePropertySettingEntity.getPropertyName().isBlank()
+                || profileProperty.isMultiValued())) {
                   Map<String, String> childrenMap = new HashMap<>();
                   childrenMap.put("key", profilePropertySettingEntity.getPropertyName());
                   childrenMap.put("value", profilePropertySettingEntity.getValue());

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactEditMultiField.vue
@@ -20,7 +20,7 @@
     </div>
     <v-flex v-for="(childProperty, i) in property.children" :key="i">
       <profile-contact-edit-multi-field-select
-        v-if="childProperty.isNew || childProperty.visible && childProperty.active && childProperty.value"
+        v-if="childProperty.isNew || (childProperty.visible && childProperty.active && childProperty.value) || (property.multiValued && property.active && property.visible && childProperty.value)"
         :property="childProperty"
         :properties="property.children"
         :multi-valued="property.multiValued"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
@@ -31,7 +31,7 @@
           :key="i"
           :title="childProperty.value"
           class="text-no-wrap text-truncate">
-          <template v-if="childProperty.value && childProperty.visible && childProperty.active">
+          <template v-if="(childProperty.value && childProperty.visible && childProperty.active) || (property.multiValued && property.active && property.visible && childProperty.value)">
             <span v-if="childProperty.propertyName" class="pe-1 text-capitalize">
               {{ getResolvedName(childProperty) }}:
             </span>


### PR DESCRIPTION
Prior to this change, newly added multi-valued profile attributes were not being saved. The issue was that the UserRestResourceV1 was unable to save a property without a name. However, in the case of multi-valued properties, there is no need for the children property to have a name because they will be displayed under the parent property's name. The same applies to the visibility check. There is no need to check if the value is visible when we have a visible attribute.

Finally, in the case of multi-valued profile properties, the child value property is considered as the value of the parent property. Therefore, there is no need to check the name and visibility of the children since these are already checked for the parent.

After this change, multi-valued profile properties can be saved and edited from the profile contact information drawer.
