### PR TITLE
fix: OpenId connection is KO - EXO-63713 - meeds-io/meeds#894

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/service/impl/OAuthRegistrationServiceImpl.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/service/impl/OAuthRegistrationServiceImpl.java
@@ -102,9 +102,9 @@ public class OAuthRegistrationServiceImpl implements OAuthRegistrationService {
 
     startTransaction();
     try {
-      User user = findUser(email);
+      User user = findUser(username);
       if (user == null) {
-        user = findUser(username);
+        user = findUser(email);
       }
       return user;
     } catch (Exception e) {
@@ -220,10 +220,8 @@ public class OAuthRegistrationServiceImpl implements OAuthRegistrationService {
                                                                       .append(lastname.replaceAll("\\s", ""))
                                                                       .toString()
                                                                       .toLowerCase();
-      return userNameBase;
     } else if (StringUtils.isNotBlank(email)) {
       userNameBase = email.split("@")[0].replaceAll("\\s", "");
-      return userNameBase;
     } else {
       userNameBase = "user1";
     }
@@ -245,7 +243,7 @@ public class OAuthRegistrationServiceImpl implements OAuthRegistrationService {
 
   private User findUser(String usernameOrEmail) throws Exception {
     User user = organizationService.getUserHandler().findUserByName(usernameOrEmail, UserStatus.ANY);
-    if (user == null && usernameOrEmail.contains("@")) {
+    if (user == null && usernameOrEmail != null && usernameOrEmail.contains("@")) {
       Query query = new Query();
       query.setEmail(usernameOrEmail);
       ListAccess<User> list = organizationService.getUserHandler().findUsersByQuery(query, UserStatus.ANY);


### PR DESCRIPTION
Before this fix, when a new user (not known in exo) logs with OIDC, the account fails to be created The code try to find a user by passing a null value for userOrEmail variable which lead to a NPE This fix check the nullity of userOrEmail variable before using it.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
