### PR TITLE
Fix : Technical label displayed instead of label on people advanced filter button - Meeds-io/meeds#890 - EXO-63060

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
@@ -67,3 +67,4 @@ pepole.advanced.filter.button.confirm=Confirm
 pepole.advanced.filter.button.cancel=Cancel
 pepole.advanced.filter.button.reset=Reset
 pepole.advanced.filter.title=Filter people list
+pepole.advanced.filter.button.title= Filter

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
@@ -41,7 +41,7 @@
           @click="openPeopleAdvancedFilterDrawer()">
           <v-icon small class="primary--text me-lg-1">fa-sliders-h</v-icon>
           <span class="d-none font-weight-regular caption d-lg-inline me-1">
-            {{ $t('profile.label.search.openSearch') }} </span>
+            {{ $t('pepole.advanced.filter.button.title') }} </span>
           <span class="font-weight-regular caption ms-1"> {{ advancedFilterCountDisplay }} </span>
         </v-btn>
       </v-scale-transition>


### PR DESCRIPTION

Prior to this change, it took a few seconds for the advanced filter button label to appear. The problem was that it was using an existing technical label from the gamification resource addon. With this change, a new technical label will be added to the people list application resource and displayed through a computed value.
