### PR TITLE
feat: Allow to Extend CKEditor configuration by instance Type - MEED-2058 - Meeds-io/MIPs#59

### DIFF
--- a/component/api/src/main/java/io/meeds/social/core/richeditor/RichEditorConfiguration.java
+++ b/component/api/src/main/java/io/meeds/social/core/richeditor/RichEditorConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.core.richeditor;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class RichEditorConfiguration {
+
+  private String filePath;
+
+  private String instanceType;
+
+}

--- a/component/api/src/main/java/io/meeds/social/core/richeditor/RichEditorConfigurationPlugin.java
+++ b/component/api/src/main/java/io/meeds/social/core/richeditor/RichEditorConfigurationPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.core.richeditor;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.exoplatform.container.component.BaseComponentPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ObjectParameter;
+
+import lombok.Getter;
+
+public class RichEditorConfigurationPlugin extends BaseComponentPlugin {
+
+  @Getter
+  private List<RichEditorConfiguration> richEditorConfigurations = new ArrayList<>();
+
+  public RichEditorConfigurationPlugin(InitParams params) {
+    if (params != null) {
+      Iterator<ObjectParameter> objectParamIterator = params.getObjectParamIterator();
+      while (objectParamIterator.hasNext()) {
+        ObjectParameter objectParameter = objectParamIterator.next();
+        if (objectParameter.getObject() instanceof RichEditorConfiguration richEditorConfiguration) {
+          richEditorConfigurations.add(richEditorConfiguration);
+        }
+      }
+    }
+  }
+
+}

--- a/component/api/src/main/java/io/meeds/social/core/richeditor/RichEditorConfigurationService.java
+++ b/component/api/src/main/java/io/meeds/social/core/richeditor/RichEditorConfigurationService.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.core.richeditor;
+
+public interface RichEditorConfigurationService {
+
+  /**
+   * Retrieves the rich editor configuration file for a given instance type
+   * 
+   * @param  instanceType Rich editor instance type
+   * @return              Javascript content of rich Editor configuration
+   */
+  String getRichEditorConfiguration(String instanceType);
+
+  /**
+   * Add a new plugin defining a part of Rich editor instance configuration.
+   * If the plugin contains an Object Parameter that doesn't define instanceType,
+   * the configuration will go to all Rich Editor instances.
+   * 
+   * @param plugin {@link RichEditorConfigurationPlugin}
+   */
+  void addPlugin(RichEditorConfigurationPlugin plugin);
+
+}

--- a/component/core/src/main/java/io/meeds/social/richeditor/RichEditorConfigurationServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/richeditor/RichEditorConfigurationServiceImpl.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.richeditor;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.cache.future.FutureExoCache;
+import org.exoplatform.commons.cache.future.Loader;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.configuration.ConfigurationManager;
+import org.exoplatform.container.xml.Deserializer;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import io.meeds.social.core.richeditor.RichEditorConfiguration;
+import io.meeds.social.core.richeditor.RichEditorConfigurationPlugin;
+import io.meeds.social.core.richeditor.RichEditorConfigurationService;
+
+public class RichEditorConfigurationServiceImpl implements RichEditorConfigurationService {
+
+  private static final Log                             LOG                      =
+                                                           ExoLogger.getLogger(RichEditorConfigurationServiceImpl.class);
+
+  public static final String                           ALL_INSTANCES_KEY        = StringUtils.EMPTY;
+
+  private ConfigurationManager                         configurationManager;
+
+  private Map<String, List<RichEditorConfiguration>>   configurationFilesByType = new HashMap<>();
+
+  private final FutureExoCache<String, String, Object> configurationContentFutureCache;
+
+  private final ExoCache<String, String>               configurationContentCache;
+
+  public RichEditorConfigurationServiceImpl(CacheService cacheService, ConfigurationManager configurationManager) {
+    this.configurationManager = configurationManager;
+    this.configurationContentCache = cacheService.getCacheInstance("social.richEditorConfiguration");
+    this.configurationContentFutureCache = new FutureExoCache<>(new Loader<String, String, Object>() {
+      @Override
+      public String retrieve(Object context, String instanceType) throws Exception {
+        return appendFilesContent(instanceType);
+      }
+    }, configurationContentCache);
+    if (PropertyManager.isDevelopping()) {
+      configurationContentCache.setMaxSize(0);
+    }
+  }
+
+  @Override
+  public String getRichEditorConfiguration(String instanceType) {
+    if (StringUtils.isBlank(instanceType)) {
+      instanceType = ALL_INSTANCES_KEY;
+    }
+    return configurationContentFutureCache.get(null, instanceType);
+  }
+
+  @Override
+  public void addPlugin(RichEditorConfigurationPlugin plugin) {
+    List<RichEditorConfiguration> richEditorConfigurations = plugin.getRichEditorConfigurations();
+    if (richEditorConfigurations != null) {
+      richEditorConfigurations.forEach(richEditorConfiguration -> {
+        String instanceType = richEditorConfiguration.getInstanceType();
+        configurationFilesByType.computeIfAbsent(StringUtils.isBlank(instanceType) ? ALL_INSTANCES_KEY : instanceType,
+                                                 key -> new ArrayList<>())
+                                .addAll(richEditorConfigurations);
+      });
+    }
+  }
+
+  protected String appendFilesContent(String instanceType) {
+    StringBuilder fileContent = new StringBuilder();
+    appendFilesContent(fileContent, ALL_INSTANCES_KEY);
+    if (StringUtils.isNotBlank(instanceType)) {
+      appendFilesContent(fileContent, instanceType);
+    }
+    return fileContent.toString();
+  }
+
+  private void appendFilesContent(StringBuilder fileContent, String instanceType) {
+    List<RichEditorConfiguration> richEditorConfigurations = configurationFilesByType.get(instanceType);
+    if (CollectionUtils.isNotEmpty(richEditorConfigurations)) {
+      appendFilesContent(fileContent, richEditorConfigurations);
+    }
+  }
+
+  private void appendFilesContent(StringBuilder fileContent, List<RichEditorConfiguration> richEditorConfigurations) {
+    richEditorConfigurations.forEach(richEditorConfiguration -> {
+      try {
+        InputStream is = configurationManager.getInputStream(richEditorConfiguration.getFilePath());
+        String content = IOUtils.toString(is, StandardCharsets.UTF_8);
+        // Avoid interpreting JS variables using JVM properties
+        // To do it, replace $ inside `` by ### before interpreting JVM
+        // properties
+        content = content.replaceAll("`(.*)\\$(.*)`", "`$1###$2`");
+        content = Deserializer.resolveVariables(content);
+        content = content.replaceAll("`(.*)###(.*)`", "`$1\\$$2`");
+        fileContent.append(content).append("\n");
+      } catch (Exception e) {
+        LOG.warn("Error retrieving Rich Editor file content from path {}", richEditorConfiguration.getFilePath(), e);
+      }
+    });
+  }
+
+}

--- a/component/core/src/test/java/io/meeds/social/core/richeditor/RichEditorConfigurationServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/core/richeditor/RichEditorConfigurationServiceTest.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.core.richeditor;
+
+import org.exoplatform.social.core.test.AbstractCoreTest;
+
+public class RichEditorConfigurationServiceTest extends AbstractCoreTest {
+
+  public void testGetRichEditorConfiguration() {
+    RichEditorConfigurationService richEditorConfigurationService = getContainer().getComponentInstanceOfType(RichEditorConfigurationService.class);
+    assertEquals("// Test Default JS\n", richEditorConfigurationService.getRichEditorConfiguration(""));
+    assertEquals("// Test Default JS\n", richEditorConfigurationService.getRichEditorConfiguration(null));
+    assertEquals("// Test Default JS\n", richEditorConfigurationService.getRichEditorConfiguration("not-extended-config"));
+    assertEquals("""
+        // Test Default JS
+        // Test Extension JS
+        """.trim(), richEditorConfigurationService.getRichEditorConfiguration("test-extension").trim());
+  }
+
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
@@ -47,6 +47,9 @@ import org.exoplatform.social.core.space.spi.SpaceTemplateServiceTest;
 import org.exoplatform.social.metadata.MetadataServiceTest;
 import org.exoplatform.social.metadata.favorite.FavoriteServiceTest;
 import org.exoplatform.social.metadata.tag.TagServiceTest;
+
+import io.meeds.social.core.richeditor.RichEditorConfigurationServiceTest;
+
 import org.exoplatform.social.core.application.SpaceActivityPublisherTest;
 import org.exoplatform.social.core.binding.spi.GroupSpaceBindingServiceTest;
 import org.exoplatform.social.core.binding.spi.RDBMSGroupSpaceBindingStorageTest;
@@ -94,6 +97,7 @@ import org.exoplatform.social.core.binding.spi.RDBMSGroupSpaceBindingStorageTest
   ActivityTagMetadataListenerTest.class,
   MetadataActivityProcessorTest.class,
   ImageThumbnailServiceImplTest.class,
+  RichEditorConfigurationServiceTest.class,
 })
 @ConfigTestCase(AbstractCoreTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/core/src/test/resources/ckeditor-config-extension-test.js
+++ b/component/core/src/test/resources/ckeditor-config-extension-test.js
@@ -1,0 +1,1 @@
+// Test Extension JS

--- a/component/core/src/test/resources/ckeditor-config-test.js
+++ b/component/core/src/test/resources/ckeditor-config-test.js
@@ -1,0 +1,1 @@
+// Test Default JS

--- a/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
@@ -23,6 +23,52 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <component>
+    <key>io.meeds.social.core.richeditor.RichEditorConfigurationService</key>
+    <type>io.meeds.social.richeditor.RichEditorConfigurationServiceImpl</type>
+  </component>
+
+  <external-component-plugins>
+    <target-component>io.meeds.social.core.richeditor.RichEditorConfigurationService</target-component>
+    <component-plugin>
+      <name>BaseCKEditorConfiguration</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.social.core.richeditor.RichEditorConfigurationPlugin</type>
+      <init-params>
+        <object-param>
+          <name>BaseCKEditorConfiguration</name>
+          <object type="io.meeds.social.core.richeditor.RichEditorConfiguration">
+            <field name="instanceType">
+              <string></string>
+            </field>
+            <field name="filePath">
+              <string>jar:/ckeditor-config-test.js</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>BaseCKEditorConfiguration</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.social.core.richeditor.RichEditorConfigurationPlugin</type>
+      <init-params>
+        <object-param>
+          <name>BaseCKEditorConfiguration</name>
+          <object type="io.meeds.social.core.richeditor.RichEditorConfiguration">
+            <field name="instanceType">
+              <string>test-extension</string>
+            </field>
+            <field name="filePath">
+              <string>jar:/ckeditor-config-extension-test.js</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
   <external-component-plugins>
     <target-component>org.exoplatform.social.metadata.MetadataService</target-component>
     <component-plugin>

--- a/component/service/src/main/java/io/meeds/social/rest/impl/richeditor/RichEditorConfigurationRest.java
+++ b/component/service/src/main/java/io/meeds/social/rest/impl/richeditor/RichEditorConfigurationRest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.rest.impl.richeditor;
+
+import java.util.Date;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.services.rest.resource.ResourceContainer;
+
+import io.meeds.social.core.richeditor.RichEditorConfigurationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Path("richeditor/configuration")
+@Tag(name = "richeditor/configuration", description = "Retrieves Rich Editor configurations")
+public class RichEditorConfigurationRest implements ResourceContainer {
+
+  private static final CacheControl      CACHE_CONTROL             = new CacheControl();
+
+  private static final Date              DEFAULT_LAST_MODIFED      = new Date();
+
+  private static final long              DEFAULT_LAST_MODIFED_HASH = DEFAULT_LAST_MODIFED.getTime();
+
+  // 365 days
+  private static final int               CACHE_IN_SECONDS          = 365 * 86400;
+
+  private static final int               CACHE_IN_MILLI_SECONDS    = CACHE_IN_SECONDS * 1000;
+
+  private RichEditorConfigurationService richEditorConfigurationService;
+
+  private boolean                        useCache;
+
+  public RichEditorConfigurationRest(RichEditorConfigurationService richEditorConfigurationService) {
+    this.richEditorConfigurationService = richEditorConfigurationService;
+    this.useCache = !PropertyManager.isDevelopping();
+  }
+
+  @GET
+  @RolesAllowed("users")
+  @Operation(summary = "Retrieves rich editor configuration Javascript file", method = "GET", description = "Returns list of tags")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+  })
+  public Response getRichEditorConfiguration(
+                                             @Context
+                                             Request request,
+                                             @Parameter(description = "Rich Editor Type")
+                                             @QueryParam("type")
+                                             String type,
+                                             @Parameter(description = "The value of v parameter will determine whether the query should be cached by browser or not. If not set, no 'expires HTTP Header will be sent'")
+                                             @QueryParam("v")
+                                             String version) {
+    EntityTag eTag = new EntityTag(String.valueOf(DEFAULT_LAST_MODIFED_HASH));
+    Response.ResponseBuilder builder = this.useCache ? request.evaluatePreconditions(eTag) : null;
+    if (builder == null) {
+      String richEditorConfiguration = this.richEditorConfigurationService.getRichEditorConfiguration(type);
+      builder = Response.ok(richEditorConfiguration);
+    }
+    if (this.useCache) {
+      builder.tag(eTag);
+      builder.lastModified(DEFAULT_LAST_MODIFED);
+      builder.cacheControl(CACHE_CONTROL);
+      // If the query has a lastModified parameter, it means that the client
+      // will change the lastModified entry when it really changes
+      // Which means that we can cache the image in browser side
+      // for a long time
+      if (StringUtils.isNotBlank(version)) {
+        builder.expires(new Date(System.currentTimeMillis() + CACHE_IN_MILLI_SECONDS));
+      }
+    }
+    return builder.build();
+  }
+
+}

--- a/extension/war/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2003-2011 eXo Platform SAS.
+  This file is part of the Meeds project (https://meeds.io/).
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  Copyright (C) 2023 Meeds Association contact@meeds.io
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 -->
 <configuration
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
-   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
-
+   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
   <import>war:/conf/social-extension/organization/organization-configuration.xml</import>
   <import>war:/conf/social-extension/portal/social-portal-configuration.xml</import>
@@ -31,8 +31,6 @@
   <import>war:/conf/social-extension/social/social-configuration.xml</import>
   <import>war:/conf/social-extension/social/spaces-templates-configuration.xml</import>
   <import>war:/conf/social-extension/social/component-plugins-configuration.xml</import>
-
-  <!-- Comes from config module -->
   <import>war:/conf/social-extension/social/cache-configuration.xml</import>
   <import>war:/conf/social-extension/social/common-configuration.xml</import>
   <import>war:/conf/social-extension/social/core-configuration.xml</import>
@@ -42,6 +40,7 @@
   <import>war:/conf/social-extension/social/search-configuration.xml</import>
   <import>war:/conf/social-extension/social/websocket-configuration.xml</import>
   <import>war:/conf/social-extension/social/metadata-plugins-configuration.xml</import>
+  <import>war:/conf/social-extension/social/ckeditor-configuration.xml</import>
 
   <import>war:/conf/social-extension/social/notification-configuration.xml</import>
   <import>war:/conf/social-extension/social/notification-plugins-configuration.xml</import>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
@@ -1,0 +1,148 @@
+﻿// force env when using the eXo Android app (the eXo Android app uses a custom user agent which
+// is not known by CKEditor and which makes it not initialize the editor)
+var userAgent = navigator.userAgent.toLowerCase();
+if (userAgent != null && userAgent.indexOf('exo/') == 0 && userAgent.indexOf('(android)') > 0) {
+  CKEDITOR.env.mobile = true;
+  CKEDITOR.env.chrome = true;
+  CKEDITOR.env.gecko = false;
+  CKEDITOR.env.webkit = true;
+}
+
+CKEDITOR.editorConfig = function(config) {
+
+  // The configuration options below are needed when running CKEditor from source files.
+  config.plugins = 'dialogui,dialog,about,a11yhelp,basicstyles,blockquote,panel,floatpanel,button,toolbar,enterkey,entities,popup,filebrowser,floatingspace,listblock,richcombo,format,horizontalrule,htmlwriter,wysiwygarea,indent,indentlist,fakeobjects,list,maximize,removeformat,showborders,sourcearea,specialchar,scayt,stylescombo,tab,table,notification,notificationaggregator,filetools,undo,wsc,panelbutton,colorbutton,autogrow,confighelper,uploadwidget,imageresize,confirmBeforeReload,autoembed,embedsemantic';
+
+  CKEDITOR.plugins.addExternal('simpleLink', '/commons-extension/eXoPlugins/simpleLink/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('simpleImage', '/commons-extension/eXoPlugins/simpleImage/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('suggester', '/commons-extension/eXoPlugins/suggester/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('hideBottomToolbar', '/commons-extension/eXoPlugins/hideBottomToolbar/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('confirmBeforeReload', '/commons-extension/eXoPlugins/confirmBeforeReload/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('autoembed', '/commons-extension/eXoPlugins/autoembed/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('embedsemantic', '/commons-extension/eXoPlugins/embedsemantic/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('tagSuggester', '/commons-extension/eXoPlugins/tagSuggester/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('formatOption', '/commons-extension/eXoPlugins/formatOption/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('attachImage', '/commons-extension/eXoPlugins/attachImage/', 'plugin.js');
+  CKEDITOR.plugins.addExternal('googleDocPastePlugin', '/commons-extension/eXoPlugins/googleDocPastePlugin/', 'plugin.js')
+
+  const embedBaseApiEndpoint = '${io.meeds.iframely.url://ckeditor.iframe.ly/api/oembed?omit_script=1}'; // Java properties variable
+  CKEDITOR.config.embed_provider = embedBaseApiEndpoint + (embedBaseApiEndpoint.includes('?') ? '&' : '?') + 'url={url}&callback={callback}';
+
+  const iframelyApiKey = '${io.meeds.iframely.key:}'; // Java properties variable
+  if (iframelyApiKey?.length && embedBaseApiEndpoint.includes('ckeditor.iframe.ly')) {
+    CKEDITOR.config.embed_provider += '&api_key=' + iframelyApiKey;
+  }
+
+  config.extraPlugins = 'simpleLink,suggester,hideBottomToolbar';
+  config.skin = 'moono-exo,/commons-extension/ckeditor/skins/moono-exo/';
+
+  // Define changes to default configuration here.
+  // For complete reference see:
+  // http://docs.ckeditor.com/#!/api/CKEDITOR.config
+
+  // The toolbar groups arrangement.
+  config.toolbarGroups = [
+    { name: 'basicstyles', groups: ['basicstyles', 'cleanup'] },
+    { name: 'paragraph', groups: ['list', 'indent', 'blocks', 'align', 'bidi', 'paragraph'] }
+  ];
+
+  // Remove some buttons provided by the standard plugins, which are
+  // not needed in the Standard(s) toolbar.
+  config.removeButtons = 'Subscript,Superscript,Cut,Copy,Paste,PasteText,PasteFromWord,Undo,Redo,Scayt,Unlink,Anchor,Table,HorizontalRule,SpecialChar,Maximize,Source,Strike,Outdent,Indent,Format,BGColor,About';
+
+  config.uploadUrl = eXo.env.server.context + '/upload?action=upload&uploadId=';
+
+  // Enable the browser native spell checker
+  config.disableNativeSpellChecker = false;
+
+  // Set the most common block elements.
+  config.format_tags = 'p;h1;h2;h3;pre';
+
+  // Simplify the dialog windows.
+  config.removeDialogTabs = 'image:advanced;link:advanced';
+
+  // Move toolbar below the test area
+  config.toolbarLocation = 'bottom';
+
+  // Remove "More colors..." button
+  config.colorButton_enableMore = false;
+
+  // style inside the editor
+  config.contentsCss = [];
+  document.querySelectorAll('[skin-type=portal-skin]').forEach(link => config.contentsCss.push(link.href))
+  config.contentsCss.push('/commons-extension/ckeditorCustom/contents.css'); // load last
+
+  config.toolbar = [
+    ['Bold', 'Italic', 'RemoveFormat',],
+    ['-', 'NumberedList', 'BulletedList', 'Blockquote'],
+    ['-', 'simpleLink'],
+  ];
+
+  config.height = 110;
+
+  config.autoGrow_onStartup = true;
+  config.autoGrow_minHeight = 110;
+
+  config.language = eXo.env.portal.language || 'en';
+
+  // image2 config of align classes
+  config.image2_alignClasses = ['pull-left', 'text-center', 'pull-right'];
+
+  // remove the white mask on dialog
+  config.dialog_backgroundCoverColor = 'transparent';
+  config.dialog_backgroundCoverOpacity = 1;
+
+  // Here is configure for suggester
+  var peopleSearchCached = {};
+  var lastNoResultQuery = false;
+  config.suggester = {
+    suffix: '\u00A0',
+    renderMenuItem: '<li data-value="${uid}"><div class="avatarSmall" style="display: inline-block;"><img src="${avatar}"></div>${name} (${uid})</li>',
+    renderItem: '<span class="exo-mention">${name}<a href="#" class="remove"><i class="uiIconClose uiIconLightGray"></i></a></span>',
+    sourceProviders: ['exo:people'],
+    providers: {
+      'exo:people': function(query, callback) {
+        if (lastNoResultQuery && query.length > lastNoResultQuery.length) {
+          if (query.substr(0, lastNoResultQuery.length) === lastNoResultQuery) {
+            callback.call(this, []);
+            return;
+          }
+        }
+        if (peopleSearchCached[query]) {
+          callback.call(this, peopleSearchCached[query]);
+        } else {
+          require(['SHARED/jquery'], function($) {
+            var userName = eXo.env.portal.userName;
+            var activityId = CKEDITOR.currentInstance.config.activityId;
+            var typeOfRelation = CKEDITOR.currentInstance.config.typeOfRelation;
+            var spaceURL = CKEDITOR.currentInstance.config.spaceURL;
+            var url = window.location.protocol + '//' + window.location.host + eXo.env.portal.context + '/' + eXo.env.portal.rest + '/social/people/suggest.json?nameToSearch=' + query + '&currentUser=' + userName + '&typeOfRelation=' + typeOfRelation + '&spaceURL=' + spaceURL;
+            if (CKEDITOR.currentInstance.config.activityId) {
+              url += '&activityId=' + activityId;
+            }
+            $.getJSON(url, function(responseData) {
+              var result = [];
+              for (var i = 0; i < responseData.length; i++) {
+                var d = responseData[i];
+                var item = {
+                  uid: d.id.substr(1),
+                  name: d.name,
+                  avatar: d.avatar
+                };
+                result.push(item);
+              }
+
+              peopleSearchCached[query] = result;
+              if (peopleSearchCached[query].length == 0) {
+                lastNoResultQuery = query;
+              } else {
+                lastNoResultQuery = false;
+              }
+              callback.call(this, peopleSearchCached[query]);
+            });
+          });
+        }
+      }
+    }
+  };
+};

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/ckeditor-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/ckeditor-configuration.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<configuration
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <component>
+    <key>io.meeds.social.core.richeditor.RichEditorConfigurationService</key>
+    <type>io.meeds.social.richeditor.RichEditorConfigurationServiceImpl</type>
+  </component>
+
+  <component>
+    <type>io.meeds.social.rest.impl.richeditor.RichEditorConfigurationRest</type>
+  </component>
+
+  <external-component-plugins>
+    <target-component>io.meeds.social.core.richeditor.RichEditorConfigurationService</target-component>
+    <component-plugin>
+      <name>BaseCKEditorConfiguration</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.social.core.richeditor.RichEditorConfigurationPlugin</type>
+      <init-params>
+        <object-param>
+          <name>BaseCKEditorConfiguration</name>
+          <object type="io.meeds.social.core.richeditor.RichEditorConfiguration">
+            <field name="instanceType">
+              <string></string>
+            </field>
+            <field name="filePath">
+              <string>war:/conf/social-extension/ckeditor/config.js</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -111,6 +111,9 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
+    ckEditorConfigUrl() {
+      return `${eXo.env.portal.context}/${eXo.env.portal.rest}/richeditor/configuration?type=${this.ckEditorType || 'default'}&v=${eXo.env.client.assetsVersion}`;
+    },
   },
   watch: {
     inputVal(val) {
@@ -238,7 +241,7 @@ export default {
       CKEDITOR.basePath = '/commons-extension/ckeditor/';
       const self = this;
       $(this.$refs.editor).ckeditor({
-        customConfig: '/commons-extension/ckeditorCustom/config.js',
+        customConfig: this.ckEditorConfigUrl,
         extraPlugins,
         removePlugins,
         toolbar,


### PR DESCRIPTION
This change will allow to extend CKEditor configurations to select it per instance and per installed addons. In addition, this will allow to add JVM properties inside CKEditor JS configuration files, such as made per default for Iframely URL & API Key. (Reminder : Iframely is a service that is used by embedbase CKEDitor plugin to generate a thumbnail of external URLs inside CKEditor content)

Two properties can be used to customize URL of Iframely oembed API:

* `io.meeds.iframely.key` : used to change Iframely API Key
* `io.meeds.iframely.url` : used to change Iframely oembed API URL, useful especially when having a self-hosted Iframely instance. ( Default value = //ckeditor.iframe.ly/api/oembed?omit_script=1 )