### PR TITLE
fix: Fix Rich Editor Configuration Rest Content Type - MEED-2090 - Meeds-io/meeds#919

### DIFF
--- a/component/service/src/main/java/io/meeds/social/rest/impl/richeditor/RichEditorConfigurationRest.java
+++ b/component/service/src/main/java/io/meeds/social/rest/impl/richeditor/RichEditorConfigurationRest.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Context;
@@ -68,6 +69,7 @@ public class RichEditorConfigurationRest implements ResourceContainer {
   @GET
   @RolesAllowed("users")
   @Operation(summary = "Retrieves rich editor configuration Javascript file", method = "GET", description = "Returns list of tags")
+  @Produces("text/javascript")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Request fulfilled"),
   })


### PR DESCRIPTION
Prior to this change, when adding security HTTP header 'X-Content-Type-Options: nosniff' on HTTP requests, the rich editor wasn't displayed in UI due to error interpreting Rich editor configuration JS content. This change will add explicit content-type with value 'text/javascript' http header on REST endpoint after having Meeds-io/meeds#918 fixed.