### PR TITLE
fix: Fix Rich Editor Configuration JS Variables interpretation - MEED-2097 - Meeds-io/meeds#925

### DIFF
--- a/component/core/src/main/java/io/meeds/social/richeditor/RichEditorConfigurationServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/richeditor/RichEditorConfigurationServiceImpl.java
@@ -114,14 +114,14 @@ public class RichEditorConfigurationServiceImpl implements RichEditorConfigurati
         // Avoid interpreting JS variables using JVM properties
         // To do it, replace $ inside `` by ### before interpreting JVM
         // properties
-        content = content.replaceAll("`(.*)\\$(.*)`", "`$1###$2`");
+        content = content.replace("${", "@JSProp{");
+        content = content.replace("@JVMProp", "$");
         content = Deserializer.resolveVariables(content);
-        content = content.replaceAll("`(.*)###(.*)`", "`$1\\$$2`");
+        content = content.replace("@JSProp{", "${");
         fileContent.append(content).append("\n");
       } catch (Exception e) {
         LOG.warn("Error retrieving Rich Editor file content from path {}", richEditorConfiguration.getFilePath(), e);
       }
     });
   }
-
 }

--- a/component/core/src/test/java/io/meeds/social/core/richeditor/RichEditorConfigurationServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/core/richeditor/RichEditorConfigurationServiceTest.java
@@ -15,6 +15,12 @@
  */
 package io.meeds.social.core.richeditor;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+
+import org.exoplatform.container.configuration.ConfigurationManager;
 import org.exoplatform.social.core.test.AbstractCoreTest;
 
 public class RichEditorConfigurationServiceTest extends AbstractCoreTest {
@@ -28,6 +34,27 @@ public class RichEditorConfigurationServiceTest extends AbstractCoreTest {
         // Test Default JS
         // Test Extension JS
         """.trim(), richEditorConfigurationService.getRichEditorConfiguration("test-extension").trim());
+  }
+
+  public void testGetRichEditorConfigurationWithJSVariables() throws IOException, Exception {
+    RichEditorConfigurationService richEditorConfigurationService = getContainer().getComponentInstanceOfType(RichEditorConfigurationService.class);
+    String jsConfiguration = richEditorConfigurationService.getRichEditorConfiguration("js-variable-test");
+    jsConfiguration = jsConfiguration.replace("// Test Default JS\n", "");
+    jsConfiguration = jsConfiguration.replaceAll("\n", "");
+    ConfigurationManager configurationManager = getContainer().getComponentInstanceOfType(ConfigurationManager.class);
+    String expectedConfiguration = IOUtils.toString(configurationManager.getInputStream("jar:/ckeditor-config-js-variable-test.js"), StandardCharsets.UTF_8);
+    assertEquals(expectedConfiguration, jsConfiguration);
+  }
+
+  public void testGetRichEditorConfigurationWithJavaVariables() {
+    String value = "test-value";
+    System.setProperty("io.meeds.test.key", value);
+
+    RichEditorConfigurationService richEditorConfigurationService = getContainer().getComponentInstanceOfType(RichEditorConfigurationService.class);
+    String jsConfiguration = richEditorConfigurationService.getRichEditorConfiguration("java-variable-test");
+    jsConfiguration = jsConfiguration.replace("// Test Default JS\n", "");
+    jsConfiguration = jsConfiguration.replaceAll("\n", "");
+    assertEquals("const javaProp = '" + value + "';", jsConfiguration);
   }
 
 }

--- a/component/core/src/test/resources/ckeditor-config-java-variable-test.js
+++ b/component/core/src/test/resources/ckeditor-config-java-variable-test.js
@@ -1,0 +1,1 @@
+const javaProp = '@JVMProp{io.meeds.test.key:fake-value}';

--- a/component/core/src/test/resources/ckeditor-config-js-variable-test.js
+++ b/component/core/src/test/resources/ckeditor-config-js-variable-test.js
@@ -1,0 +1,1 @@
+const renderMenuItem = '<li data-value="${uid}"><div class="avatarSmall" style="display: inline-block;"><img src="${avatar}"></div>${name} (${uid})</li>';

--- a/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
@@ -67,6 +67,42 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>BaseCKEditorConfiguration</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.social.core.richeditor.RichEditorConfigurationPlugin</type>
+      <init-params>
+        <object-param>
+          <name>BaseCKEditorConfiguration</name>
+          <object type="io.meeds.social.core.richeditor.RichEditorConfiguration">
+            <field name="instanceType">
+              <string>java-variable-test</string>
+            </field>
+            <field name="filePath">
+              <string>jar:/ckeditor-config-java-variable-test.js</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>BaseCKEditorConfiguration</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.social.core.richeditor.RichEditorConfigurationPlugin</type>
+      <init-params>
+        <object-param>
+          <name>BaseCKEditorConfiguration</name>
+          <object type="io.meeds.social.core.richeditor.RichEditorConfiguration">
+            <field name="instanceType">
+              <string>js-variable-test</string>
+            </field>
+            <field name="filePath">
+              <string>jar:/ckeditor-config-js-variable-test.js</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
@@ -25,10 +25,10 @@ CKEDITOR.editorConfig = function(config) {
   CKEDITOR.plugins.addExternal('attachImage', '/commons-extension/eXoPlugins/attachImage/', 'plugin.js');
   CKEDITOR.plugins.addExternal('googleDocPastePlugin', '/commons-extension/eXoPlugins/googleDocPastePlugin/', 'plugin.js')
 
-  const embedBaseApiEndpoint = '${io.meeds.iframely.url://ckeditor.iframe.ly/api/oembed?omit_script=1}'; // Java properties variable
+  const embedBaseApiEndpoint = '@JVMProp{io.meeds.iframely.url://ckeditor.iframe.ly/api/oembed?omit_script=1}';
   CKEDITOR.config.embed_provider = embedBaseApiEndpoint + (embedBaseApiEndpoint.includes('?') ? '&' : '?') + 'url={url}&callback={callback}';
 
-  const iframelyApiKey = '${io.meeds.iframely.key:}'; // Java properties variable
+  const iframelyApiKey = '@JVMProp{io.meeds.iframely.key:}';
   if (iframelyApiKey?.length && embedBaseApiEndpoint.includes('ckeditor.iframe.ly')) {
     CKEDITOR.config.embed_provider += '&api_key=' + iframelyApiKey;
   }


### PR DESCRIPTION
Prio to this change, mentioning JS pattern was interpreted as JVM variable, which leads to a bad suggester Menu display. This change will change the way to define JVM variables inside Rich Editor configurations by using '@JVMProp{...}' instead of '${...}' inside Rich Editor configuration template.