### PR TITLE
feat: Display scheduled navigation nodes in top bar navigation menu and  hamburger menu navigation - EXO-63240 - Meeds-io/MIPs#51

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/NavigationService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/NavigationService.js
@@ -24,7 +24,9 @@ export function getNavigations(siteName, siteType, scope, visibility, exclude, n
     formData.append('scope', scope);
   }
   if (visibility) {
-    formData.append('visibility', visibility);
+    visibility.forEach(visibility => {
+      formData.append('visibility', visibility);
+    });
   }
   if (exclude) {
     formData.append('exclude', exclude);

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/HamburgerMenuNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/HamburgerMenuNavigation.vue
@@ -122,6 +122,7 @@ export default {
     interval: null,
     mouseEvent: false,
     allowClosing: true,
+    visibility: ['displayed', 'temporal']
   }),
   computed: {
     allowDisplayLevels() {
@@ -300,11 +301,11 @@ export default {
       window.setTimeout(() => document.dispatchEvent(new CustomEvent('drawerClosed')), 200);
     },
     retrieveSiteNavigations() {
-      return this.$navigationService.getNavigations(eXo.env.portal.portalName, 'portal', 'children', 'displayed')
+      return this.$navigationService.getNavigations(eXo.env.portal.portalName, 'portal', 'children', this.visibility)
         .then(data => this.siteNavigations = data || []);
     },
     retrieveAdministrationNavigations() {
-      return this.$navigationService.getNavigations(null, 'group', null, 'displayed')
+      return this.$navigationService.getNavigations(null, 'group', null, this.visibility)
         .then(data => this.administrationNavigations = data || []);
     },
     retrieveRecentSpaces() {

--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
@@ -69,7 +69,7 @@ export default {
     mobileNavigations: [],
     scope: 'ALL',
     globalScope: 'children',
-    visibility: 'displayed',
+    visibility: ['displayed', 'temporal'],
     siteType: 'PORTAL',
     exclude: 'global',
     tab: null,


### PR DESCRIPTION
Prior to this change, top bar navigation menu and hamburger menu navigation display only visible navigation nodes. After this change, we will allow them to display also scheduled navigation nodes (with temporal visibility) between the start scheduling and end scheduling dates.