### PR TITLE
fix : Incorrect advanced people filter if the searched attribute value ends with a space character - EXO-64041 - Meeds-io/meeds#929 (#2524)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -462,6 +462,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     }
     if (settings != null) {
       filter.setExcludedIdentityList(Collections.singletonList(target));
+      settings.replaceAll((key, value) -> value.trim());
     }
     filter.setProfileSettings(settings);
     ListAccess<Identity> list = filterType.equals("all") ? identityManager.getIdentitiesByProfileFilter(OrganizationIdentityProvider.NAME, filter, true) : relationshipManager.getConnectionsByFilter(target, filter);


### PR DESCRIPTION
Before this change, when we attempted to search for users by filling in any attribute with a value that ended with a space, an incorrect search result was displayed.

This change will trim the searched value in order to correctly match cases where the searched field contains the searched value.

