### PR TITLE
fix : Can't like an activity after detaching its attachment - EXO-64057 - Meeds-io/meeds#935 (#2527)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -844,7 +844,9 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
           }
         }
       }
-      activity.getTemplateParams().put("MESSAGE", activity.getTitle());
+      if (activity.getTemplateParams() != null) {
+        activity.getTemplateParams().put("MESSAGE", activity.getTitle());
+      }
     }
   }
 


### PR DESCRIPTION

Prior to this change, detaching an attachment from a posted activity prevented the activity from being liked , due to a null pointer exception that occurred during the 'store activity file' action. This change will address the issue by adding a check to prevent the exception from occurring

