### PR TITLE
feat: Hide attach option from other composer than activity MEED-2133- Meeds-io/MIPs#53

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -21,7 +21,6 @@
           suggestor-type-of-relation="mention_comment"
           use-extra-plugins
           autofocus
-          :attachment-enabled="false"
           @ready="handleEditorReady" />
         <extension-registry-components
           :params="extensionParams"

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -87,7 +87,7 @@ export default {
     },
     attachmentEnabled: {
       type: Boolean,
-      default: true
+      default: false
     },
   },
   data() {


### PR DESCRIPTION
This change allows to put the default value of enable attachment in rich editor to false for all instance, to activate it you need to add property attachment-enabled to the ckeditor instance (Right now we enable The attach image plugin only for activity composer).