### PR TITLE
fix: Fix technical nodes labels in space navigation - EXO-62470 - Meeds-io/MIPs#51

### DIFF
--- a/component/service/src/main/resources/locale/social/menu/webui_en.properties
+++ b/component/service/src/main/resources/locale/social/menu/webui_en.properties
@@ -6,3 +6,4 @@ SpaceSettingPortlet.label.name=Settings
 AnswersPortlet.label.name=Answer
 FAQPortlet.label.name=FAQ
 MembersPortlet.label.name=Members
+SpaceActivityStreamPortlet.label.name=Stream


### PR DESCRIPTION
Prior to this change, in the edit navigation management popup the space navigation nodes are displayed with their technical labels because they are not well found in the space resource bundle. After this change, we will retrieve them instead from all shared resource bundles.