### PR TITLE
feat: Improve Drawer and Avatars List Re-usable components - MEED-2179 - Meeds-io/MIPs#49

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -23,7 +23,16 @@
       <v-layout column>
         <template v-if="$slots.title">
           <v-flex class="mx-0 drawerHeader flex-grow-0">
-            <v-list-item class="pe-0">
+            <v-list-item
+              :class="goBackButton && 'ps-1'"
+              class="pe-0">
+              <v-list-item-action v-if="goBackButton" class="drawerIcons me-2">
+                <v-btn icon @click="close()">
+                  <v-icon size="20">
+                    {{ $vuetify.rtl && 'fa fa-arrow-right' || 'fa fa-arrow-left' }}
+                  </v-icon>
+                </v-btn>
+              </v-list-item-action>
               <v-list-item-content class="drawerTitle align-start text-header-title text-truncate">
                 <slot name="title"></slot>
               </v-list-item-content>
@@ -97,6 +106,10 @@ export default {
       default: () => false,
     },
     eager: {
+      type: Boolean,
+      default: () => false,
+    },
+    goBackButton: {
       type: Boolean,
       default: () => false,
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatar.vue
@@ -1,15 +1,19 @@
 <template>
-  <div 
+  <div
     v-if="popover"
-    v-identity-popover="userIdentity"
+    v-identity-popover="popoverIdentity"
     class="profile-popover user-wrapper"
     :class="extraClass">
-    <a 
+    <component
       v-if="avatar"
+      :is="clickable && 'v-btn' || 'a'"
       :id="id"
+      :fab="clickable"
+      :depressed="clickable"
       :href="profileUrl"
+      :class="componentClass"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
-      :class="avatarClass">
+      @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
         :class="pullLeft"
@@ -20,13 +24,17 @@
           loading="lazy"
           role="presentation">
       </v-avatar>
-    </a>
-    <a 
+    </component>
+    <component
       v-else-if="fullname"
+      :is="clickable && 'v-btn' || 'a'"
       :id="id"
+      :fab="clickable"
+      :depressed="clickable"
       :href="profileUrl"
-      :class="pullLeft"
-      class="d-flex align-start text-truncate">
+      :class="componentClass"
+      class="d-flex align-start text-truncate"
+      @click="clickable && $emit('avatar-click', $event)">
       <span
         v-if="userFullname"
         :class="[fullnameStyle, linkStyle && 'primary--text' || '']"
@@ -37,13 +45,17 @@
       <span v-if="$slots.subTitle" class="text-sub-title text-truncate my-auto text-left">
         <slot name="subTitle"></slot>
       </span>
-    </a>
-    <a
+    </component>
+    <component
       v-else
+      :is="clickable && 'v-btn' || 'a'"
       :id="id"
+      :fab="clickable"
+      :depressed="clickable"
       :href="profileUrl"
+      :class="componentClass"
       class="d-flex flex-nowrap flex-grow-1 text-truncate container--fluid"
-      :class="itemsAlignStyle">
+      @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
         class="ma-0">
@@ -68,18 +80,22 @@
       <template v-if="$slots.actions">
         <slot name="actions"></slot>
       </template>
-    </a>
+    </component>
   </div>
   <div 
     v-else
     class="profile-popover user-wrapper"
     :class="extraClass">
-    <a 
+    <component 
       v-if="avatar"
+      :is="clickable && 'v-btn' || 'a'"
       :id="id"
+      :fab="clickable"
+      :depressed="clickable"
       :href="profileUrl"
+      :class="componentClass"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
-      :class="avatarClass">
+      @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
         :class="pullLeft"
@@ -90,13 +106,17 @@
           loading="lazy"
           role="presentation">
       </v-avatar>
-    </a>
-    <a 
+    </component>
+    <component 
       v-else-if="fullname"
+      :is="clickable && 'v-btn' || 'a'"
       :id="id"
+      :fab="clickable"
+      :depressed="clickable"
       :href="profileUrl"
-      :class="pullLeft"
-      class="d-flex align-start text-truncate">
+      :class="componentClass"
+      class="d-flex align-start text-truncate"
+      @click="clickable && $emit('avatar-click', $event)">
       <span
         v-if="userFullname"
         :class="[fullnameStyle, linkStyle && 'primary--text' || '']"
@@ -107,13 +127,17 @@
       <span v-if="$slots.subTitle" class="text-sub-title text-truncate my-auto text-left">
         <slot name="subTitle"></slot>
       </span>
-    </a>
-    <a
+    </component>
+    <component
       v-else
+      :is="clickable && 'v-btn' || 'a'"
       :id="id"
+      :fab="clickable"
+      :depressed="clickable"
       :href="profileUrl"
+      :class="componentClass"
       class="d-flex flex-nowrap flex-grow-1 text-truncate container--fluid"
-      :class="itemsAlignStyle">
+      @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
         class="ma-0">
@@ -138,7 +162,7 @@
       <template v-if="$slots.actions">
         <slot name="actions"></slot>
       </template>
-    </a>
+    </component>
   </div>
 </template>
 
@@ -150,6 +174,10 @@ export default {
     identity: {
       type: Object,
       default: () => null,
+    },
+    clickable: {
+      type: Boolean,
+      default: () => false,
     },
     profileId: {
       type: String,
@@ -227,36 +255,39 @@ export default {
   },
 
   computed: {
+    userIdentity() {
+      return this.retrievedIdentity || this.identity;
+    },
     identityId() {
-      return this.identity?.id || this.retrievedIdentity?.id;
+      return this.userIdentity?.id;
     },
     username() {
-      return this.identity?.username || this.retrievedIdentity?.username || this.profileId;
+      return this.userIdentity?.username ||  this.userIdentity?.userName || this.profileId;
     },
     enabled() {
-      return this.identity?.enabled || this.retrievedIdentity?.enabled;  
+      return this.userIdentity?.enabled;  
     },  
     deleted() {
-      return this.identity?.deleted || this.retrievedIdentity?.deleted;
+      return this.userIdentity?.deleted;
     },    
     userFullname() {
-      return this.identity?.fullname || this.retrievedIdentity?.fullname;
+      return this.userIdentity?.fullname;
     },
     position() {
-      return this.identity?.position || this.retrievedIdentity?.position;
+      return this.userIdentity?.position;
     },
     avatarUrl() {
-      return this.identity?.avatar || this.retrievedIdentity?.avatar || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.username ? this.username : this.profileId}/avatar`;
+      return this.userIdentity?.avatar || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.username ? this.username : this.profileId}/avatar`;
     },
     profileUrl() {
-      if ( this.url ) {
+      if (this.url && !this.clickable) {
         return `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${this.username}`;
       } else {
         return null;
       }
     },
     isExternal() {
-      return this.identity?.external === 'true' || this.retrievedIdentity?.external === 'true';
+      return this.userIdentity?.external === 'true';
     },
     externalTag() {
       return `( ${this.$t('userAvatar.external.label')} )`;
@@ -279,7 +310,7 @@ export default {
         identityId: this.username,        
       };
     },
-    userIdentity() {
+    popoverIdentity() {
       return {
         id: this.identityId,
         username: this.username,
@@ -293,11 +324,25 @@ export default {
     },
     pullLeft() {
       return this.isMobile && ' ' || 'pull-left';
-    }
+    },
+    componentClass() {
+      return `${this.avatarClass || ''} ${this.clickable && 'width-auto height-auto' || ''} ${this.fullname ? this.pullLeft : (!this.avatar && this.itemsAlignStyle || '')}`;
+    },
+    mustRetrieveIdentity() {
+      return !this.identity
+          || !this.identityId
+          || !this.username
+          || !this.userFullname
+          || !this.identity.avatar
+          || !this.identity.hasOwnProperty('enabled')
+          || !this.identity.hasOwnProperty('deleted')
+          || !this.identity.hasOwnProperty('position')
+          || !this.identity.hasOwnProperty('external');
+    },
   },
   created() {
-    if (this.profileId) {
-      this.$userService.getUser(this.profileId)
+    if (this.username && this.mustRetrieveIdentity) {
+      this.$userService.getUser(this.username)
         .then(user => this.retrievedIdentity = user);
     }
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
@@ -1,54 +1,88 @@
 <template>
-  <div v-if="!retrieveExtraInformation" class="d-flex flex-nowrap position-relative">
-    <exo-user-avatar
-      v-for="user in usersToDisplay"
-      :key="user"
-      :identity="user"
-      :size="iconSize"
-      :extra-class="'mx-1'"
-      :popover="popover"
-      avatar />
-    <v-avatar
-      v-if="notDisplayedItems"
-      :size="iconSize"
-      :class="avatarOverlayPosition && 'position-relative' || 'position-absolute'"
-      :style="overlayStyle"
-      class="notDisplayedIdentitiesOverlay clickable"
+  <v-hover>
+    <v-card
+      v-if="!retrieveExtraInformation"
+      slot-scope="{ hover }"
+      :class="hover && clickable && 'light-grey-background'"
+      :ripple="clickable"
+      class="d-flex flex-nowrap position-relative"
+      color="transparent"
+      flat
       @click="$emit('open-detail')">
-      <div class="notDisplayedIdentities d-flex align-center justify-center">
-        +{{ notDisplayedItems }}
-      </div>
-    </v-avatar>
-  </div>
-  <div v-else class="d-flex flex-nowrap position-relative">
-    <exo-user-avatar
-      v-for="user in usersToDisplay"
-      :key="user"
-      :profile-id="user.userName"
-      :size="iconSize"
-      :extra-class="'mx-1'"
-      :popover="popover"
-      avatar />
-    <v-avatar
-      v-if="notDisplayedItems"
-      :size="iconSize"
-      :class="avatarOverlayPosition && 'position-relative' || 'position-absolute'"
-      :style="overlayStyle"
-      class="notDisplayedIdentitiesOverlay clickable"
+      <exo-user-avatar
+        v-for="(user, index) in usersToDisplay"
+        :key="`${user}_${index}`"
+        :identity="user"
+        :size="iconSize"
+        :extra-class="'mx-1'"
+        :popover="popover"
+        :clickable="clickable"
+        avatar
+        @avatar-click="$emit('open-detail', user)" />
+      <v-btn
+        v-if="showMoreAvatarsNumber"
+        :height="iconSize"
+        :width="iconSize"
+        fab
+        depressed>
+        <v-avatar
+          :size="iconSize"
+          class="notDisplayedIdentitiesOverlay"
+          @click="$emit('open-detail')">
+          <div class="notDisplayedIdentities d-flex align-center justify-center caption">
+            +{{ showMoreAvatarsNumber }}
+          </div>
+        </v-avatar>
+      </v-btn>
+    </v-card>
+    <v-card
+      v-else
+      slot-scope="{ hover }"
+      :class="hover && clickable && 'light-grey-background'"
+      :ripple="clickable"
+      class="d-flex flex-nowrap position-relative"
+      color="transparent"
+      flat
       @click="$emit('open-detail')">
-      <div class="notDisplayedIdentities d-flex align-center justify-center">
-        +{{ notDisplayedItems }}
-      </div>
-    </v-avatar>
-  </div>
+      <exo-user-avatar
+        v-for="(user, index) in usersToDisplay"
+        :key="`${user}_${index}`"
+        :profile-id="user.userName"
+        :size="iconSize"
+        :extra-class="'mx-1'"
+        :popover="popover"
+        :clickable="clickable"
+        avatar
+        @avatar-click="$emit('open-detail', user)" />
+      <v-btn
+        v-if="showMoreAvatarsNumber"
+        :height="iconSize"
+        :width="iconSize"
+        fab
+        depressed>
+        <v-avatar
+          :size="iconSize"
+          class="notDisplayedIdentitiesOverlay"
+          @click="$emit('open-detail')">
+          <div class="notDisplayedIdentities d-flex align-center justify-center caption">
+            +{{ showMoreAvatarsNumber }}
+          </div>
+        </v-avatar>
+      </v-btn>
+    </v-card>
+  </v-hover>
 </template>
 
 <script>
 export default {
   props: {
     users: {
-      type: Object,
+      type: Array,
       default: () => null,
+    },
+    clickable: {
+      type: Boolean,
+      default: () => false,
     },
     max: {
       type: Number,
@@ -73,20 +107,26 @@ export default {
     retrieveExtraInformation: {
       type: Boolean,
       default: () => false
-    }
+    },
   },
   computed: {
     usersToDisplay() {
       return this.users && this.users.slice(0, this.max);
     },
-    notDisplayedItems() {
+    totalUsersCount() {
       if (this.defaultLength) {
-        return this.defaultLength > this.max ? this.defaultLength - this.max : 0;
+        return this.defaultLength;
       } else {
-        return this.users && this.users.length > this.max ? this.users.length - this.max : 0;
+        return this.users && this.users.length;
       }
     },
-    overlayStyle(){
+    remainingAvatarsCount() {
+      return this.totalUsersCount > this.max ? this.totalUsersCount - this.max : 0;
+    },
+    showMoreAvatarsNumber() {
+      return this.remainingAvatarsCount > 99 ? 99 : this.remainingAvatarsCount;
+    },
+    overlayStyle() {
       if (!this.avatarOverlayPosition) {
         return `right: ${this.iconSize + 4}px !important`;
       } 


### PR DESCRIPTION
this change will allow to display, in a centralized an re-usable way, a Go-back icon inside an opened drawer. In addition, this change will enhace listing the avatars to aallow clicking on it like a button instead of listing avatars as profile links only.