### PR TITLE
fix: Fix Avatars List Remaining Count Display - MEED-2179 - Meeds-io/MIPs#49

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoUserAvatarsList.vue
@@ -113,6 +113,9 @@ export default {
     usersToDisplay() {
       return this.users && this.users.slice(0, this.max);
     },
+    displayedUsersCount() {
+      return this.usersToDisplay?.length || 0;
+    },
     totalUsersCount() {
       if (this.defaultLength) {
         return this.defaultLength;
@@ -121,7 +124,7 @@ export default {
       }
     },
     remainingAvatarsCount() {
-      return this.totalUsersCount > this.max ? this.totalUsersCount - this.max : 0;
+      return this.totalUsersCount > this.displayedUsersCount ? this.totalUsersCount - this.displayedUsersCount : 0;
     },
     showMoreAvatarsNumber() {
       return this.remainingAvatarsCount > 99 ? 99 : this.remainingAvatarsCount;


### PR DESCRIPTION
Prior to this change, when the provided list of avatars to display in ExoUserAvatarsList.vue component is less than the max property value, the remaining number is wrong. This change will fix the computing method to rely on displayed avatars instead of provided max to display property.