### PR TITLE
feat: Add option to Date Picker Component to not allowing Overflow - MEED-2085 - Meeds-io/MIPs#49

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/DatePicker.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/DatePicker.vue
@@ -10,10 +10,10 @@
       :disabled="disabled"
       :top="top"
       :left="left"
+      :attach="attach"
+      :allow-overflow="allowOverflow"
       class="datePickerMenu"
       transition="scale-transition"
-      :attach="attach"
-      allow-overflow
       offset-y
       eager>
       <input
@@ -127,6 +127,12 @@ export default {
       },
     },
     attach: {
+      type: Boolean,
+      default: function() {
+        return true;
+      },
+    },
+    allowOverflow: {
       type: Boolean,
       default: function() {
         return true;


### PR DESCRIPTION
This change will allow to use the option of VMenu of Vuetify 'allow-overflow' in props of Re-usable Common component 'DatePicker'. This will allow to have a better UX of Date Pickers in Drawers, especially when the input exists at the bottom of the form.