### PR TITLE
fix: display Hidden option in a space member's card options list - EXO-64105 - Meeds-io/meeds#950

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -333,6 +333,15 @@ export default {
     publisherRolePromotionFeatureEnabled: eXo.env.portal.PublisherRolePromotionFeatureEnabled,
     bottomMenu: false
   }),
+  watch: {
+    displayActionMenu(newVal) {
+      if (newVal) {
+        document.getElementById(`peopleCardItem${this.user.id}`).style.zIndex = 3;
+      } else {
+        document.getElementById(`peopleCardItem${this.user.id}`).style.zIndex = 0;
+      }
+    },
+  },
   computed: {
     isSameUser() {
       return this.user && this.user.username === eXo.env.portal.userName;

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -12,6 +12,7 @@
             <v-col
               v-for="user in filteredPeople"
               :key="user.id"
+              :id="`peopleCardItem${user.id}`"
               cols="12"
               md="6"
               lg="4"


### PR DESCRIPTION
Prior to this change, when click on the three dots of a card user in a space member and check the display of the list options, this list must contain 6 options but the last option is hidden behind the card below To fix this problem, while clicking on the three dots we increase the z-index of this card. After this change, the list of options is displayed on the card below.

(cherry picked from commit 65466649aba557e3f374a3a3cfeabc86e03dcbcb)