### PR TITLE
feat: Images added previously are removed -MEED-2178 - Meeds-io/MIPs#53

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachImageComponent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachImageComponent.vue
@@ -66,7 +66,7 @@ export default {
         const uploadIds = this.images
           .filter((file) => file.progress === 100)
           .map((file) => file.uploadId)
-          .filter((uploadId) => !!uploadId);
+          .filter((uploadId) => !!uploadId).reverse();
         if (!uploadIds?.length) {
           return;
         }

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachImageComponent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachImageComponent.vue
@@ -93,7 +93,10 @@ export default {
               );
             }
           })
-          .finally(() => (this.images = []));
+          .finally(() => {
+            this.images = [];
+            this.$root.$emit('delete-uploaded-files');
+          });
       },
     });
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachedItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachedItem.vue
@@ -3,12 +3,14 @@
     :class="{ 'border-color': !hover }"
     :loading="loading"
     :width="previewWidth"
+    :elevation="hover ? 4 : 0"
     class="attachment-card-item overflow-hidden d-flex flex-column border-box-sizing mx-2"
     height="210px"
     max-height="210px"
     max-width="100%"
-    hover
-    @click="$emit('preview-attachment')">
+    @click="$emit('preview-attachment')"
+    @mouseenter="hover = true"
+    @mouseleave="hover = false">
     <v-card-text class="attachment-card-item-thumbnail d-flex flex-grow-1 pa-0">
       <img
         :src="attachment.thumbnailUrl"
@@ -66,6 +68,7 @@ export default {
   data: () => ({
     loading: false,
     invalid: false,
+    hover: false
   }),
   methods: {
     closeErrorBox(event) {

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachedItems.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/AttachedItems.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="attachmentsCount">
-    <card-carousel parent-class="activity-files-parent mx-n2">
+    <card-carousel parent-class="activity-files-parent">
       <attached-item
         v-for="attachment in attachments"
         :key="attachment.id"

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/FileMultiUploadInput.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/FileMultiUploadInput.vue
@@ -35,15 +35,17 @@ export default {
     },
   },
   data: () => ({
-    filesArray: [],
-    newUpload: false
+    filesArray: []
   }),
   created() {
-    document.addEventListener('open-file-explorer', (event) => {
-      this.newUpload = event?.detail?.additionalUpload ? true : false;
+    document.addEventListener('open-file-explorer', () => {
       this.triggerFileClickEvent();
     });
     this.$root.$on('delete-file', this.removeUplodedFile);
+    this.$root.$on('delete-uploaded-files', () => {
+      this.filesArray = [];
+    });
+
   },
   methods: {
     triggerFileClickEvent() {
@@ -51,9 +53,6 @@ export default {
     },
     uploadFiles(files) {
       this.$root.$emit('close-alert-message');
-      if (!this.newUpload) {
-        this.filesArray = [];
-      }
       const filesArray = Array.from(files);
       if (files.length === 0) {
         return;

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/ImageItems.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/ImageItems.vue
@@ -53,11 +53,7 @@ export default {
   },
   methods: {
     openFileExplorer() {
-      document.dispatchEvent(new CustomEvent('open-file-explorer', {
-        detail: {
-          additionalUpload: true
-        }
-      })); 
+      document.dispatchEvent(new CustomEvent('open-file-explorer')); 
     }
   }
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/CardCarousel.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/CardCarousel.vue
@@ -17,7 +17,7 @@
       </v-btn>
     </v-fab-transition>
     <v-card
-      class="carousel-middle-parent scrollbar-width-none d-flex px-0 pb-4 pt-2 overflow-x-scroll justify-center"
+      class="carousel-middle-parent scrollbar-width-none d-flex px-0 pb-4 pt-2 overflow-x-scroll"
       flat
       @scroll="computeProperties">
       <div :class="parentClass" class="carousel-last-parent d-flex ma-auto">


### PR DESCRIPTION
Prior to this change, when we try to add images before posting an activity,then the previously attached images are removed.
After this change, previously added images remain attached in addition to the new ones.