### PR TITLE
Notification administration : disabled notifs should be hidden to users - EXO-64634 - Meeds-io/meeds#951

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationDrawer.vue
@@ -111,7 +111,7 @@ export default {
       this.group = group;
       this.emailChannel = this.settings && this.settings.emailChannel;
 
-      this.listChannelOptions = this.settings?.channelCheckBoxList?.filter(channelChoice => channelChoice.allowed && channelChoice.pluginId === this.plugin.type)
+      this.listChannelOptions = this.settings?.channelCheckBoxList?.filter(channelChoice => channelChoice.channelActive && channelChoice.allowed && channelChoice.pluginId === this.plugin.type)
         .map(channelChoice => JSON.parse(JSON.stringify(channelChoice))) || [];
 
       const digestChoice = this.settings && this.settings.emailDigestChoices && this.settings.emailDigestChoices.find(choice => choice && choice.channelActive && choice.channelId === this.emailChannel && choice.pluginId === this.plugin.type);

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationGroup.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="manageNotification" class="border-radius border-color ma-4">
+  <div v-if="manageNotification && isEnabledNotificationGroup" class="border-radius border-color ma-4">
     <v-list-item dense>
       <v-list-item-content>
         <v-list-item-title class="text-color font-weight-bold subtitle-1">
@@ -34,6 +34,9 @@ export default {
       default: false,
     },
   },
+  data: () => ({
+    isEnabledNotificationGroup: true,
+  }),
   computed: {
     label() {
       return this.settings && this.settings.groupsLabels && this.settings.groupsLabels[this.group.groupId];
@@ -42,6 +45,20 @@ export default {
       return this.group && this.group.pluginInfos && this.group.pluginInfos.length ;
     },
   },
+  created() {
+    this.init();
+  },
+  methods: {
+    init() {
+      const listPlugins = [];
+      this.group?.pluginInfos?.forEach(plugin => {
+        if (this.settings && this.settings.channelCheckBoxList && this.settings.channelCheckBoxList.filter(choice => choice.channelActive && choice.pluginId === plugin.type).length) {
+          listPlugins.push(plugin);
+        }
+      });
+      this.isEnabledNotificationGroup = listPlugins && listPlugins.length;
+    }
+  }
 };
 </script>
 

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="isEnabledNotifications.length">
     <v-divider />
 
     <v-list-item dense>
@@ -78,6 +78,9 @@ export default {
     },
     enabledNotifications() {
       return this.settings && this.settings.channelCheckBoxList && this.settings.channelCheckBoxList.filter(choice => choice.active && choice.channelActive && choice.pluginId === this.plugin.type);
+    },
+    isEnabledNotifications() {
+      return this.settings && this.settings.channelCheckBoxList && this.settings.channelCheckBoxList.filter(choice => choice.channelActive && choice.pluginId === this.plugin.type);
     },
     enabledNotificationLabels() {
       return this.enabledNotifications && this.enabledNotifications.map(plugin => this.settings.channelLabels[plugin.channelId]);


### PR DESCRIPTION
Prior to this change, when administrator disable any notification for any option and user displays his notification settings. To fix this problem, show only editable notifications even in the drawer to modify the notification parameters by adding a condition on channel Active when filtering the display options and hidden the group that has none of the notifications has their options activated by adding an init function that will check the existence of the group . in the same option this option will also be disabled even for groups.

(cherry picked from commit 68797cfb74118ed1e643f9e64cdbf652f83c78d9)