### PR TITLE
fix: Fix renamed space root node label issue - EXO-64817 - Meeds-io/MIPs#51

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -474,7 +474,6 @@ public class SpaceUtils {
       UserNode parentNode = renamedNode.getParent();
       String newNodeLabel = space.getDisplayName();
       String newNodeName = SpaceUtils.cleanString(newNodeLabel);
-      renamedNode.setLabel(newNodeLabel);
       renamedNode.setName(newNodeName);
 
       Page page = layoutService.getPage(renamedNode.getPageRef().format());


### PR DESCRIPTION
Before this fix, when renaming a space, the space user root node label is also renamed with the corresponding space label. After this change, after renaming a spac, we will modify only the space user root node name and keep its label as is.