### PR TITLE
feat: Include modifier username in profile update operation - MEED-2206 - Meeds-io/MIPs#50

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/identity/model/Profile.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/identity/model/Profile.java
@@ -174,30 +174,30 @@ public class Profile {
     BANNER,
     TECHNICAL;
 
-    public void updateActivity(ProfileLifeCycle profileLifeCycle, Profile profile) {
+    public void updateActivity(ProfileLifeCycle profileLifeCycle, Profile profile, String modifierUsername) {
       switch (this) {
       case ABOUT_ME: {
-        profileLifeCycle.aboutMeUpdated(profile.getIdentity().remoteId, profile);
+        profileLifeCycle.aboutMeUpdated(profile.getIdentity().remoteId, profile, modifierUsername);
         break;
       }
       case CONTACT: {
-        profileLifeCycle.contactUpdated(profile.getIdentity().getRemoteId(), profile);
+        profileLifeCycle.contactUpdated(profile.getIdentity().getRemoteId(), profile, modifierUsername);
         break;
       }
       case EXPERIENCES: {
-        profileLifeCycle.experienceUpdated(profile.getIdentity().getRemoteId(), profile);
+        profileLifeCycle.experienceUpdated(profile.getIdentity().getRemoteId(), profile, modifierUsername);
         break;
       }
       case AVATAR: {
-        profileLifeCycle.avatarUpdated(profile.getIdentity().getRemoteId(), profile);
+        profileLifeCycle.avatarUpdated(profile.getIdentity().getRemoteId(), profile, modifierUsername);
         break;
       }
       case BANNER: {
-        profileLifeCycle.bannerUpdated(profile.getIdentity().getRemoteId(), profile);
+        profileLifeCycle.bannerUpdated(profile.getIdentity().getRemoteId(), profile, modifierUsername);
         break;
       }
       case TECHNICAL: {
-        profileLifeCycle.technicalUpdated(profile.getIdentity().getRemoteId(), profile);
+        profileLifeCycle.technicalUpdated(profile.getIdentity().getRemoteId(), profile, modifierUsername);
         break;
       }
       default:

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/IdentityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/IdentityManager.java
@@ -169,6 +169,18 @@ public interface IdentityManager {
   }
 
   /**
+   * Updates a specific profile and broadcast detected changes on profile if
+   * 'broadcastChanges' is turned on
+   *
+   * @param specificProfile The specific profile.
+   * @param modifierUsername modifier username.
+   * @param broadcastChanges whether detect and broadcast changed fields or not
+   */
+  default void updateProfile(Profile specificProfile, String modifierUsername, boolean broadcastChanges) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Gets a list access which contains all identities from a given provider.
    * These identities are filtered by the profile filter.
    * The type of returned result is <code>ListAccess</code> which can be lazy loaded.

--- a/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileLifeCycle.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileLifeCycle.java
@@ -63,40 +63,44 @@ public class ProfileLifeCycle extends AbstractLifeCycle<ProfileListener, Profile
     }
   }
   
-  public void aboutMeUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.ABOUT_ME, username, profile));
+  public void aboutMeUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.ABOUT_ME, profile, username, modifierUsername);
   }
 
-  public void avatarUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.AVATAR_UPDATED, username, profile));
+  public void avatarUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.AVATAR_UPDATED, profile, username, modifierUsername);
   }
 
-  public void bannerUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.BANNER_UPDATED, username, profile));
+  public void bannerUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.BANNER_UPDATED, profile, username, modifierUsername);
   }
 
-  public void technicalUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.TECHNICAL_UPDATED, username, profile));
+  public void technicalUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.TECHNICAL_UPDATED, profile, username, modifierUsername);
   }
 
-  public void basicUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.BASIC_UPDATED, username, profile));
+  public void basicUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.BASIC_UPDATED, profile, username, modifierUsername);
   }
 
-  public void contactUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.CONTACT_UPDATED, username, profile));
+  public void contactUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.CONTACT_UPDATED, profile, username, modifierUsername);
   }
 
-  public void experienceUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.EXPERIENCE_UPDATED, username, profile));
+  public void experienceUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.EXPERIENCE_UPDATED, profile, username, modifierUsername);
   }
 
-  public void headerUpdated(String username, Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.HEADER_UPDATED, username, profile));
+  public void headerUpdated(String username, Profile profile, String modifierUsername) {
+    broadcast(Type.HEADER_UPDATED, profile, username, modifierUsername);
   }
   
   public void createProfile(Profile profile) {
-    broadcast(new ProfileLifeCycleEvent(Type.CREATED, profile.getIdentity().getRemoteId(), profile));
+    broadcast(Type.CREATED, profile, profile.getIdentity().getRemoteId(), null);
+  }
+
+  private void broadcast(Type type, Profile profile, String username, String modifierUsername) {
+    broadcast(new ProfileLifeCycleEvent(type, username, profile, modifierUsername));
   }
 
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileLifeCycleEvent.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileLifeCycleEvent.java
@@ -19,6 +19,8 @@ package org.exoplatform.social.core.profile;
 import org.exoplatform.social.common.lifecycle.LifeCycleEvent;
 import org.exoplatform.social.core.identity.model.Profile;
 
+import lombok.Getter;
+
 
 /**
  * event propagated along the {@link org.exoplatform.social.core.profile.ProfileLifeCycle}
@@ -30,7 +32,16 @@ public class ProfileLifeCycleEvent extends LifeCycleEvent<String, Profile> {
 
   public enum Type {ABOUT_ME, AVATAR_UPDATED, BASIC_UPDATED, CONTACT_UPDATED, EXPERIENCE_UPDATED, HEADER_UPDATED, CREATED, BANNER_UPDATED, TECHNICAL_UPDATED}
 
-  private Type type;
+  private Type   type;
+
+  @Getter
+  private String modifierUsername;
+
+  public ProfileLifeCycleEvent(Type type, String user, Profile profile, String modifierUsername) {
+    super(user, profile);
+    this.type = type;
+    this.modifierUsername = modifierUsername;
+  }
 
   public ProfileLifeCycleEvent(Type type, String user, Profile profile) {
     super(user, profile);

--- a/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileListener.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileListener.java
@@ -44,14 +44,6 @@ public interface ProfileListener extends LifeCycleListener<ProfileLifeCycleEvent
   public void bannerUpdated(ProfileLifeCycleEvent event) ;
 
   /**
-   * basic account info of the profile are updated
-   * @param event
-   * @deprecated not used anymore. Will be removed in next major version release.
-   */
-  @Deprecated
-  public void basicInfoUpdated(ProfileLifeCycleEvent event);
-
-  /**
    * contact information of the profile is updated
    * @param event
    */
@@ -64,14 +56,6 @@ public interface ProfileListener extends LifeCycleListener<ProfileLifeCycleEvent
   public void experienceSectionUpdated(ProfileLifeCycleEvent event);
 
   /**
-   * header section of the profile is updated
-   * @param event
-   * @deprecated not used anymore. Will be removed in next major version release.
-   */
-  @Deprecated
-  public void headerSectionUpdated(ProfileLifeCycleEvent event) ;
-  
-  /**
    * new profile created
    * @param event
    */
@@ -83,6 +67,25 @@ public interface ProfileListener extends LifeCycleListener<ProfileLifeCycleEvent
    */
   public void technicalUpdated(ProfileLifeCycleEvent event);
 
-  ;
+  /**
+   * basic account info of the profile are updated
+   * 
+   * @param      event
+   * @deprecated       Use {@link #contactSectionUpdated(ProfileLifeCycleEvent)}
+   *                   instead. not used anymore. Will be removed in next major
+   *                   version release.
+   */
+  @Deprecated(forRemoval = true, since = "1.5.0")
+  default void basicInfoUpdated(ProfileLifeCycleEvent event) {}
+
+  /**
+   * header section of the profile is updated
+   * @param event
+   * @deprecated       Use {@link #contactSectionUpdated(ProfileLifeCycleEvent)}
+   *                   instead. not used anymore. Will be removed in next major
+   *                   version release.
+   */
+  @Deprecated(forRemoval = true, since = "1.5.0")
+  default void headerSectionUpdated(ProfileLifeCycleEvent event) {}
 
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileListenerPlugin.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileListenerPlugin.java
@@ -22,7 +22,7 @@ import org.exoplatform.social.common.lifecycle.AbstractListenerPlugin;
 /**
  * Convenience class to write and wire {@link ProfileListener} plugin. <br>
  * This base class is a valid {@link ComponentPlugin} and implements {@link ProfileListener}.
- * @see org.exoplatform.social.core.manager.IdentityManager#registerProfileListener(ProfileListener)
+ * @see org.exoplatform.social.core.manager.IdentityManager#registerProfileListener(ProfileListenerPlugin)
  */
 public abstract class ProfileListenerPlugin extends AbstractListenerPlugin implements ProfileListener {
 
@@ -34,41 +34,31 @@ public abstract class ProfileListenerPlugin extends AbstractListenerPlugin imple
   /**
    * {@inheritDoc}
    */
-  public abstract void avatarUpdated(ProfileLifeCycleEvent event);
+  public void avatarUpdated(ProfileLifeCycleEvent event) {}
 
   /**
    * {@inheritDoc}
    */
-  public abstract void bannerUpdated(ProfileLifeCycleEvent event);
+  public void bannerUpdated(ProfileLifeCycleEvent event) {}
 
   /**
    * {@inheritDoc}
    */
-  public void basicInfoUpdated(ProfileLifeCycleEvent event) {}
+  public void contactSectionUpdated(ProfileLifeCycleEvent event) {}
 
   /**
    * {@inheritDoc}
    */
-  public abstract void contactSectionUpdated(ProfileLifeCycleEvent event);
+  public void experienceSectionUpdated(ProfileLifeCycleEvent event) {}
 
   /**
    * {@inheritDoc}
    */
-  public abstract void experienceSectionUpdated(ProfileLifeCycleEvent event);
+  public void createProfile(ProfileLifeCycleEvent event) {}
 
   /**
    * {@inheritDoc}
    */
-  public void headerSectionUpdated(ProfileLifeCycleEvent event) {}
-  
-  /**
-   * {@inheritDoc}
-   */
-  public abstract void createProfile(ProfileLifeCycleEvent event);
-
-  /**
-   * {@inheritDoc}
-   */
-  public void technicalUpdated(ProfileLifeCycleEvent event) {};
+  public void technicalUpdated(ProfileLifeCycleEvent event) {}
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/application/ProfileUpdatesPublisher.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/application/ProfileUpdatesPublisher.java
@@ -112,12 +112,6 @@ public class ProfileUpdatesPublisher extends ProfileListenerPlugin {
     LOG.debug("Profile banner of user {} has been updated", event.getProfile().getIdentity().getId());
   }
 
-
-  @Override
-  public void basicInfoUpdated(ProfileLifeCycleEvent event) {
-    publishActivity(event, BASIC_INFO_UPDATED);
-  }
-
   @Override
   public void contactSectionUpdated(ProfileLifeCycleEvent event) {
     publishActivity(event, CONTACT_UPDATED);
@@ -128,11 +122,6 @@ public class ProfileUpdatesPublisher extends ProfileListenerPlugin {
     publishActivity(event, EX_SECTION_UPDATED);
   }
 
-  @Override
-  public void headerSectionUpdated(ProfileLifeCycleEvent event) {
-    publishActivity(event, POSITION_TITLE_ID);
-  }
-  
   private ExoSocialActivity createComment(String title, String titleId, Identity identity, String position) {
     ExoSocialActivityImpl comment = new ExoSocialActivityImpl();
     comment.setTitle(title);

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/listener/ProfileESListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/listener/ProfileESListenerImpl.java
@@ -33,16 +33,6 @@ public class ProfileESListenerImpl extends ProfileListenerPlugin {
   private static final Log LOG = ExoLogger.getLogger(ProfileESListenerImpl.class);
 
   @Override
-  public void headerSectionUpdated(ProfileLifeCycleEvent event) {
-    IndexingService indexingService = CommonsUtils.getService(IndexingService.class);
-    String id = event.getProfile().getIdentity().getId();
-
-    LOG.debug("Notifying indexing service for profile header information update id={}", id);
-
-    indexingService.reindex(ProfileIndexingServiceConnector.TYPE, id);
-  }
-
-  @Override
   public void avatarUpdated(ProfileLifeCycleEvent event) {
     IndexingService indexingService = CommonsUtils.getService(IndexingService.class);
     String id = event.getProfile().getIdentity().getId();
@@ -55,16 +45,6 @@ public class ProfileESListenerImpl extends ProfileListenerPlugin {
   @Override
   public void bannerUpdated(ProfileLifeCycleEvent event) {
     LOG.debug("Profile banner of user {} has been updated", event.getProfile().getIdentity().getId());
-  }
-
-  @Override
-  public void basicInfoUpdated(ProfileLifeCycleEvent event) {
-    IndexingService indexingService = CommonsUtils.getService(IndexingService.class);
-    String id = event.getProfile().getIdentity().getId();
-
-    LOG.debug("Notifying indexing service for the basic information update id={}", id);
-
-    indexingService.reindex(ProfileIndexingServiceConnector.TYPE, id);
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
@@ -246,12 +246,17 @@ public class IdentityManagerImpl implements IdentityManager {
   }
 
   @Override
-  public void updateProfile(Profile specificProfile, boolean broadcastChanges) {
+  public void updateProfile(Profile profile, boolean broadcastChanges) {
+    updateProfile(profile, null, broadcastChanges);
+  }
+
+  @Override
+  public void updateProfile(Profile specificProfile, String modifierUsername, boolean broadcastChanges) {
     if (broadcastChanges) {
       detectChanges(specificProfile);
     }
     identityStorage.updateProfile(specificProfile);
-    broadcastUpdateProfileEvent(specificProfile);
+    broadcastUpdateProfileEvent(specificProfile, modifierUsername);
     this.getIdentityProvider(specificProfile.getIdentity().getProviderId()).onUpdateProfile(specificProfile);
   }
 
@@ -666,18 +671,6 @@ public class IdentityManagerImpl implements IdentityManager {
     return this.identityStorage;
   }
 
-  /**
-   * Broadcasts update profile event depending on type of update. 
-   * 
-   * @param profile
-   * @since 1.2.0-GA
-   */
-  protected void broadcastUpdateProfileEvent(Profile profile) {
-    for (UpdateType type : profile.getListUpdateTypes()) {
-      type.updateActivity(profileLifeCycle, profile);
-    }
-  }
-
   @Override
   public void processEnabledIdentity(String remoteId, boolean isEnable) {
     Identity identity = getOrCreateIdentity(OrganizationIdentityProvider.NAME, remoteId, false);
@@ -710,6 +703,19 @@ public class IdentityManagerImpl implements IdentityManager {
                                      String sortField,
                                      String sortDirection) {
     return sortIdentities(identityRemoteIds, firstCharacterFieldName, firstCharacter, sortField, sortDirection, true);
+  }
+
+  /**
+   * Broadcasts update profile event depending on type of update. 
+   * 
+   * @param profile
+   * @param modifierUsername 
+   * @since 1.2.0-GA
+   */
+  protected void broadcastUpdateProfileEvent(Profile profile, String modifierUsername) {
+    for (UpdateType type : profile.getListUpdateTypes()) {
+      type.updateActivity(profileLifeCycle, profile, modifierUsername);
+    }
   }
 
   private String getValue(String value) {

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/ProfileNotificationImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/ProfileNotificationImpl.java
@@ -42,22 +42,12 @@ public class ProfileNotificationImpl extends ProfileListenerPlugin {
   }
 
   @Override
-  public void basicInfoUpdated(ProfileLifeCycleEvent event) {
-
-  }
-
-  @Override
   public void contactSectionUpdated(ProfileLifeCycleEvent event) {
 
   }
 
   @Override
   public void experienceSectionUpdated(ProfileLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void headerSectionUpdated(ProfileLifeCycleEvent event) {
 
   }
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -872,7 +872,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
         profile.setListUpdateTypes(Arrays.asList(UpdateType.BANNER));
         profile.setBannerUrl("DEFAULT_BANNER");
         profile.removeProperty(name);
-        identityManager.updateProfile(profile, true);
+        identityManager.updateProfile(profile, getCurrentUser(), true);
       } else{
         updateProfileField(profile, fieldName, value, true);
       }
@@ -1743,7 +1743,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
         String fieldName = ProfileEntity.getFieldName(name);
         updateProfileField(profile, fieldName, value, false);
       }
-      identityManager.updateProfile(profile, true);
+      identityManager.updateProfile(profile, getCurrentUser(), true);
     }
   }
 
@@ -1863,7 +1863,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
         }
         profile.setProperty(name, attachment);
         if (save) {
-          identityManager.updateProfile(profile, true);
+          identityManager.updateProfile(profile, getCurrentUser(), true);
         }
       } finally {
         uploadService.removeUploadResource(value.toString());
@@ -1890,7 +1890,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
       }
 
       if (save) {
-        identityManager.updateProfile(profile, true);
+        identityManager.updateProfile(profile, getCurrentUser(), true);
       }
     } else if (Profile.CONTACT_PHONES.equals(name)) {
       @SuppressWarnings("unchecked")
@@ -1914,7 +1914,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
       }
 
       if (save) {
-        identityManager.updateProfile(profile, true);
+        identityManager.updateProfile(profile, getCurrentUser(), true);
       }
     } else if (Profile.CONTACT_URLS.equals(name)) {
       @SuppressWarnings("unchecked")
@@ -1936,7 +1936,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
       }
 
       if (save) {
-        identityManager.updateProfile(profile, true);
+        identityManager.updateProfile(profile, getCurrentUser(), true);
       }
     } else if (Profile.EXPERIENCES.equals(name)) {
       @SuppressWarnings("unchecked")
@@ -1960,12 +1960,12 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
         profile.setProperty(Profile.EXPERIENCES, experienceMaps);
       }
       if (save) {
-        identityManager.updateProfile(profile, true);
+        identityManager.updateProfile(profile, getCurrentUser(), true);
       }
     } else {
       profile.setProperty(name, value);
       if (save) {
-        identityManager.updateProfile(profile, true);
+        identityManager.updateProfile(profile, getCurrentUser(), true);
       }
     }
   }


### PR DESCRIPTION
This change will include modifier username in triggered event of profile update when it's made using REST API.
At the same time, this will deprecate two unused and un-triggered profile listener methods.