### PR TITLE
feat: Allow to change default Language through REST API call - MEED-2260 - Meeds-io/meeds#994

### DIFF
--- a/component/service/src/main/java/io/meeds/social/translation/rest/TranslationRest.java
+++ b/component/service/src/main/java/io/meeds/social/translation/rest/TranslationRest.java
@@ -27,8 +27,10 @@ import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -103,17 +105,19 @@ public class TranslationRest implements ResourceContainer {
     return builder.build();
   }
 
-  private Map<String, String> getSupportedLocales(Locale defaultLocale) {
-    return localeConfigService.getLocalConfigs() == null ? Collections.singletonMap(defaultLocale.toLanguageTag(),
-                                                                                    getLocaleDisplayName(defaultLocale,
-                                                                                                         defaultLocale))
-                                                         : localeConfigService.getLocalConfigs()
-                                                                              .stream()
-                                                                              .filter(localeConfig -> !StringUtils.equals(localeConfig.getLocaleName(),
-                                                                                                                          "ma"))
-                                                                              .collect(Collectors.toMap(LocaleConfig::getLocaleName,
-                                                                                                        localeConfig -> getLocaleDisplayName(defaultLocale,
-                                                                                                                                             localeConfig.getLocale())));
+  @PUT
+  @Path("configuration/defaultLanguage")
+  @RolesAllowed("administrators")
+  @Operation(summary = "Saves new default language for product", method = "PUT", description = "Saves new default language for product")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Request fulfilled"),
+  })
+  public Response saveDefaultLanguage(
+                                      @Parameter(description = "Default language to save", required = true)
+                                      @FormParam("lang")
+                                      String lang) {
+    localeConfigService.saveDefaultLocaleConfig(lang);
+    return Response.noContent().build();
   }
 
   @GET
@@ -209,6 +213,19 @@ public class TranslationRest implements ResourceContainer {
     } catch (ObjectNotFoundException e) {
       return Response.status(Response.Status.NOT_FOUND).entity(e.getMessage()).build();
     }
+  }
+
+  private Map<String, String> getSupportedLocales(Locale defaultLocale) {
+    return localeConfigService.getLocalConfigs() == null ? Collections.singletonMap(defaultLocale.toLanguageTag(),
+                                                                                    getLocaleDisplayName(defaultLocale,
+                                                                                                         defaultLocale))
+                                                         : localeConfigService.getLocalConfigs()
+                                                                              .stream()
+                                                                              .filter(localeConfig -> !StringUtils.equals(localeConfig.getLocaleName(),
+                                                                                                                          "ma"))
+                                                                              .collect(Collectors.toMap(LocaleConfig::getLocaleName,
+                                                                                                        localeConfig -> getLocaleDisplayName(defaultLocale,
+                                                                                                                                             localeConfig.getLocale())));
   }
 
   private String getLocaleDisplayName(Locale defaultLocale, Locale locale) {

--- a/component/service/src/test/java/io/meeds/social/translation/rest/TranslationRestResourcesTest.java
+++ b/component/service/src/test/java/io/meeds/social/translation/rest/TranslationRestResourcesTest.java
@@ -1,11 +1,16 @@
 package io.meeds.social.translation.rest;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
 import org.exoplatform.social.service.test.AbstractResourceTest;
 
 import io.meeds.social.translation.model.TranslationConfiguration;
@@ -122,6 +127,61 @@ public class TranslationRestResourcesTest extends AbstractResourceTest {
     assertNotNull(responseEntity);
     assertNotNull(responseEntity.getDefaultLanguage());
     assertNotNull(responseEntity.getSupportedLanguages());
+  }
+
+  public void testSaveDefaultLanguageConfiguration() throws Exception {
+    startSessionAs(username);
+    setTranslationPlugin(false, false, spaceId, audienceId);
+
+    ContainerResponse response = getResponse("GET", getConfigurationUrl(), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+
+    TranslationConfiguration responseEntity = (TranslationConfiguration) response.getEntity();
+    assertNotNull(responseEntity);
+    assertEquals("en", responseEntity.getDefaultLanguage());
+
+    response = saveDefaultLocale("fr");
+    assertNotNull(response);
+    assertEquals(204, response.getStatus());
+
+    response = getResponse("GET", getConfigurationUrl(), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+
+    responseEntity = (TranslationConfiguration) response.getEntity();
+    assertNotNull(responseEntity);
+    assertEquals("fr", responseEntity.getDefaultLanguage());
+
+    response = saveDefaultLocale("");
+    assertNotNull(response);
+    assertEquals(204, response.getStatus());
+
+    response = getResponse("GET", getConfigurationUrl(), null);
+    responseEntity = (TranslationConfiguration) response.getEntity();
+    assertNotNull(responseEntity);
+    assertEquals("en", responseEntity.getDefaultLanguage());
+
+    response = saveDefaultLocale("en");
+    assertNotNull(response);
+    assertEquals(204, response.getStatus());
+
+    response = getResponse("GET", getConfigurationUrl(), null);
+    responseEntity = (TranslationConfiguration) response.getEntity();
+    assertNotNull(responseEntity);
+    assertEquals("en", responseEntity.getDefaultLanguage());
+  }
+
+  private ContainerResponse saveDefaultLocale(String locale) throws UnsupportedEncodingException, Exception {
+    ContainerResponse response;
+    byte[] formDataInput = ("lang=" + locale).getBytes("UTF-8");
+
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    h.putSingle("content-type", MediaType.APPLICATION_FORM_URLENCODED);
+    h.putSingle("content-length", "" + formDataInput.length);
+
+    response = service("PUT", getConfigurationUrl() + "/defaultLanguage", "", h, formDataInput);
+    return response;
   }
 
   private String getConfigurationUrl() {

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -31,6 +31,7 @@ import org.exoplatform.services.cache.CacheService;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.organization.search.UserSearchService;
+import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.rest.impl.ContainerResponse;
 import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
 import org.exoplatform.services.user.UserStateService;
@@ -58,6 +59,7 @@ import org.exoplatform.social.rest.impl.user.UserRestResourcesV1;
 import org.exoplatform.social.service.test.AbstractResourceTest;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
+import org.exoplatform.web.login.recovery.PasswordRecoveryService;
 
 public class UserRestResourcesTest extends AbstractResourceTest {
 
@@ -84,8 +86,12 @@ public class UserRestResourcesTest extends AbstractResourceTest {
   private MockUploadService   uploadService;
 
   private UserSearchService   userSearchService;
-  
-  private ImageThumbnailService imageThumbnailService;
+
+  private ImageThumbnailService        imageThumbnailService;
+
+  private PasswordRecoveryService      passwordRecoveryService;
+
+  private LocaleConfigService          localeConfigService;
 
   private Identity            rootIdentity;
 
@@ -116,6 +122,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
     userSearchService = getContainer().getComponentInstanceOfType(UserSearchService.class);
     imageThumbnailService = getContainer().getComponentInstanceOfType(ImageThumbnailService.class);
+    passwordRecoveryService = getContainer().getComponentInstanceOfType(PasswordRecoveryService.class);
+    localeConfigService = getContainer().getComponentInstanceOfType(LocaleConfigService.class);
     rootIdentity = new Identity(OrganizationIdentityProvider.NAME, "root");
     johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
     maryIdentity = new Identity(OrganizationIdentityProvider.NAME, "mary");
@@ -140,7 +148,9 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                       uploadService,
                                                                       userSearchService,
                                                                       imageThumbnailService,
-                                                                      profilePropertyService);
+                                                                      profilePropertyService,
+                                                                      passwordRecoveryService,
+                                                                      localeConfigService);
     registry(userRestResourcesV1);
   }
 
@@ -222,7 +232,9 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                     uploadService,
                                                                     userSearchService,
                                                                     imageThumbnailService,
-                                                                    profilePropertyService);
+                                                                    profilePropertyService,
+                                                                    passwordRecoveryService,
+                                                                    localeConfigService);
     registry(userRestResources);
 
     //when

--- a/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/js/TranslationService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/js/TranslationService.js
@@ -64,3 +64,18 @@ export function saveTranslations(objectType, objectId, fieldName, labels) {
     }
   });
 }
+
+export function saveDefaultLanguage(lang) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/social/translations/configuration/defaultLanguage`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: `lang=${lang}`,
+  }).then((resp) => {
+    if (!resp?.ok) {
+      throw new Error(`Error when saving default language '${lang}' configuration`);
+    }
+  });
+}


### PR DESCRIPTION
this change will allow to store new Default Global Language for platform using LocaleConfigService. This service is used to retrieve global Default Locale for operations that can't retrieve a preferred locale for a user, such as onboarding email content.