### PR TITLE
fix: Fix displaying likers list - MEED-2268 - Meeds-io/meeds#998

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="likers.length" class="likers-list">
     <activity-liker-item
-      v-for="(liker , i) in likers"
-      :key="i"
+      v-for="liker in likers"
+      :key="liker.id"
       :liker="liker" />
   </div>
 </template>


### PR DESCRIPTION
Prior to this change, the displayed likers list of an activity is intertwined with likers of previously displayed activity. This is due to the usage of wrong key used in v-for loop that identifies a displayed Vue child element, which was, the index position of the element in the list. Knowing that each time, the list changes, the element for a given index will change, but the Vue cache will not be aware of that change due to the fact that the used key is independent from element itself but just using the index. This change will make sure that the Vue cache uses the correct Cache Key using the identity id as key instead of index.