### PR TITLE
 feat: AttachImage- Stabilize Social Build -MEED-2231 - Meeds-io/MIPs#53

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/FileAttachmentListenerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/FileAttachmentListenerTest.java
@@ -172,12 +172,12 @@ public class FileAttachmentListenerTest extends AbstractCoreTest {
     assertNotNull(fileService.getFile(attachFileId));
 
     activityManager.deleteActivity(activity);
+    restartTransaction();
 
     attachmentList = attachmentService.getAttachments("activity", activity.getId(), userAclIdentity);
     assertTrue(attachmentList.getAttachments().isEmpty());
 
     assertTrue(fileService.getFile(attachFileId).getFileInfo().isDeleted());
-    restartTransaction();
   }
 
   private InitParams newParam(long id, String name) {


### PR DESCRIPTION
Prior to this changes, testDeleteActivity method is randomly fail on CI but work fine on local, this change allows to execute the restartTransaction() after the activity delete method, to ensure that the activity is deleted before testing if the attached file ids are marked as deleted also.