### PR TITLE
fix: Fix Dynamic Refresh of Attached images when deleted all - MEED-2038 - Meeds-io/MIPs#53

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityImageAttachments.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityImageAttachments.vue
@@ -67,12 +67,14 @@ export default {
     document.addEventListener('attachments-updated', this.updateActivity);
   },
   beforeDestroy() {
-    document.removeEventListener('attachments-updated', this.updateActivity);
+    window.setTimeout(() => {
+      document.removeEventListener('attachments-updated', this.updateActivity);
+    }, 200);
   },
   methods: {
     updateActivity(event) {
-      if (event?.detail?.objectType === this.metadataObjectType && this.metadataObjectId === event?.detail?.objectId) {
-        document.dispatchEvent(new CustomEvent('activity-updated', {detail: this.activityId}));
+      if (this.attachments && event?.detail?.objectType === this.metadataObjectType && this.metadataObjectId === event?.detail?.objectId) {
+        this.activity.metadatas.attachments = null;
       }
     },
   },


### PR DESCRIPTION
Prior to this change, when deleting the attachments list of an activity, the list isn't updated dynamically to hide the images list. This change ensures to force updating attachments list from REST Endpoint by deleting the automatically provided attachments list in Activity Metadatas.