### PR TITLE
fix: Fix Rich Editor Behavior - MEED-2244 - Meeds-io/MIPs#49

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -3,7 +3,7 @@
     <div class="richEditor">
       <div
         v-if="displayPlaceholder"
-        @click="setFocus"
+        @click="setFocus(true)"
         class="caption text-sub-title position-absolute t-0 pa-5 ma-1px full-width">
         {{ placeholder }}
       </div>
@@ -201,7 +201,7 @@ export default {
     initCKEditor(reset, textValue) {
       const self = this;
       window.require(['SHARED/commons-editor', 'SHARED/suggester', 'SHARED/tagSuggester'], function() {
-        self.initCKEditorInstance(reset, textValue);
+        self.initCKEditorInstance(reset, textValue || self.value);
       });
       if (this.$refs.attachmentsInput) {
         this.$refs.attachmentsInput.init();
@@ -287,7 +287,7 @@ export default {
         activityId: this.activityId,
         autoGrow_onStartup: false,
         autoGrow_maxHeight: 300,
-        startupFocus: 'end',
+        startupFocus: this.autofocus && 'end',
         pasteFilter: 'p; a[!href]; strong; i', 
         on: {
           instanceReady: function () {
@@ -301,8 +301,7 @@ export default {
               });
 
             self.setEditorReady();
-
-            if (self.autofocus) {
+            if (this.autofocus) {
               window.setTimeout(() => self.setFocus(), 50);
             }
           },
@@ -335,7 +334,7 @@ export default {
       }
     },
     computePlaceHolderVisibility() {
-      this.displayPlaceholder = this.editor?.status === 'ready' && !this.inputVal && !this.inputVal.trim();
+      this.displayPlaceholder = this.editor?.status === 'ready' && !this.inputVal?.trim()?.length;
     },
     replaceWithSuggesterClass: function(message) {
       const tempdiv = $('<div class=\'temp\'/>').html(message || '');
@@ -372,8 +371,8 @@ export default {
         this.$set(this.editor, 'status', 'ready');
       }, 200);
     },
-    setFocus: function() {
-      if (this.editorReady) {
+    setFocus(force) {
+      if (this.editorReady && (force || this.autofocus)) {
         window.setTimeout(() => {
           this.$nextTick().then(() => this.editor.focus());
         }, 200);


### PR DESCRIPTION
PRior to this change, the Rich Editor doesn't display all time the content to edit when initialized the first time. In addition, the Rich editor is autofocused whether it's enabled or not. This change will fix those behaviors.