### PR TITLE
fix: Fix Rich Editor content validation - MEED-2238 - Meeds-io/MIPs#49

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -150,8 +150,11 @@ export default {
         this.$emit('input', val);
       }
     },
-    validLength() {
-      this.$emit('validity-updated', this.validLength);
+    validLength: {
+      immediate: true,
+      handler() {
+        this.$emit('validity-updated', this.validLength);
+      },
     },
     editorReady() {
       if (this.editorReady) {


### PR DESCRIPTION
Prior to this change, the Rich Editor component wasn't emitting a validation input after initialization. This change will allow to have Rich Editor validation flag from the beginning of Rich Editor instantiation.