### PR TITLE
fix: Spaces' Members: Root profile displayed twice - EXO-64597 - Meeds-io/meeds#1000 

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-api</artifactId>
   <name>eXo PLF:: Social API</name>

--- a/component/api/src/main/java/org/exoplatform/social/core/identity/SpaceMemberFilterListAccess.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/identity/SpaceMemberFilterListAccess.java
@@ -110,8 +110,9 @@ public class SpaceMemberFilterListAccess implements ListAccess<Identity> {
       profileFilter.setFirstCharFieldName(manager.getFirstCharacterFiltering());
     }
     List<Identity> identities;
-    identities = identityStorage.getSpaceMemberIdentitiesByProfileFilter(space, profileFilter, type, offset, limit);    
-    return identities.toArray(new Identity[identities.size()]);
+    identities = identityStorage.getSpaceMemberIdentitiesByProfileFilter(space, profileFilter, type, offset, limit);
+    List<Identity> filteredIdentities = identities.stream().distinct().toList();
+    return filteredIdentities.toArray(new Identity[filteredIdentities.size()]);
   }
 
   /**

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-common</artifactId>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-core</artifactId>
   <name>eXo PLF:: Social Core Component</name>

--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-notification</artifactId>

--- a/component/oauth-auth/pom.xml
+++ b/component/oauth-auth/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component</artifactId>
   <packaging>pom</packaging>

--- a/component/service/pom.xml
+++ b/component/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-service</artifactId>

--- a/component/webui/pom.xml
+++ b/component/webui/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-webui</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-extension</artifactId>
   <packaging>pom</packaging>

--- a/extension/war/pom.xml
+++ b/extension/war/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-extension</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-extension-war</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social</artifactId>
-  <version>6.5.x-exo-SNAPSHOT</version>
+  <version>6.5.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: Social</name>
   <description>eXo Social - Enterprise Social Networking</description>
@@ -46,8 +46,8 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <org.exoplatform.commons.version>6.5.x-exo-SNAPSHOT</org.exoplatform.commons.version>
-    <org.exoplatform.platform-ui.version>6.5.x-exo-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <org.exoplatform.commons.version>6.5.x-maintenance-SNAPSHOT</org.exoplatform.commons.version>
+    <org.exoplatform.platform-ui.version>6.5.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
 
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp</artifactId>
   <packaging>pom</packaging>

--- a/webapp/portlet/pom.xml
+++ b/webapp/portlet/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp-portlet</artifactId>
   <packaging>war</packaging>

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -336,9 +336,9 @@ export default {
   watch: {
     displayActionMenu(newVal) {
       if (newVal) {
-        document.getElementById(`peopleCardItem${this.user.id}`).style.zIndex = 3;
+        document.getElementById('peopleCard'.concat(this.user.id)).style.zIndex = 3;
       } else {
-        document.getElementById(`peopleCardItem${this.user.id}`).style.zIndex = 0;
+        document.getElementById('peopleCard'.concat(this.user.id)).style.zIndex = 0;
       }
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -336,9 +336,9 @@ export default {
   watch: {
     displayActionMenu(newVal) {
       if (newVal) {
-        document.getElementById('peopleCard'.concat(this.user.id)).style.zIndex = 3;
+        document.getElementById(`peopleCardItem${this.user.id}`).style.zIndex = 3;
       } else {
-        document.getElementById('peopleCard'.concat(this.user.id)).style.zIndex = 0;
+        document.getElementById(`peopleCardItem${this.user.id}`).style.zIndex = 0;
       }
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationPlugin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isEnabledNotifications.length">
+  <div v-if="isEnabledNotifications">
     <v-divider />
 
     <v-list-item dense>
@@ -80,7 +80,7 @@ export default {
       return this.settings && this.settings.channelCheckBoxList && this.settings.channelCheckBoxList.filter(choice => choice.active && choice.channelActive && choice.pluginId === this.plugin.type);
     },
     isEnabledNotifications() {
-      return this.settings && this.settings.channelCheckBoxList && this.settings.channelCheckBoxList.filter(choice => choice.channelActive && choice.pluginId === this.plugin.type);
+      return this.settings && this.settings.channelCheckBoxList && this.settings.channelCheckBoxList.filter(choice => choice.channelActive && choice.pluginId === this.plugin.type).length;
     },
     enabledNotificationLabels() {
       return this.enabledNotifications && this.enabledNotifications.map(plugin => this.settings.channelLabels[plugin.channelId]);


### PR DESCRIPTION
Prior to this change, when admin creates space and opens space members app, this space members app displays admin profile twice. To fix this problem, filter before returning the list of space members by their id so as not to duplicate the profile. after this change,Root profile should be displayed only once space members App.
