### PR TITLE
fix: Fix Server Error Logs for Image Attachments - MEED-2284 - Meeds-io/MIPs#53

### DIFF
--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -29,7 +29,7 @@
   <name>eXo PLF:: Social Core Component</name>
   <description>eXo Social Core Component: People and Space</description>
   <properties>
-    <exo.test.coverage.ratio>0.65</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.66</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <!-- These dependency is required to compile but reported as useless by mvn dependency:analyze -->

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
@@ -504,7 +504,9 @@ public class IdentityManagerImpl implements IdentityManager {
         return result;
       }
     } else {
-      if (identityFoundByRemoteProvider == null && !result.isDeleted()) {
+      if (identityFoundByRemoteProvider == null
+          && !result.isDeleted()
+          && (System.currentTimeMillis() - result.getCacheTime()) > 1000) {
         LOG.warn("Identity with remoteId " + remoteId + " not found in remote provider " + providerId
             + " but his social identity is not marked as deleted",
                  new IllegalStateException("Identity with provider '" + providerId + "' and remoteId '" + remoteId

--- a/component/core/src/main/java/org/exoplatform/social/core/processor/AttachmentActivityProcessor.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/processor/AttachmentActivityProcessor.java
@@ -27,7 +27,6 @@ import org.exoplatform.social.attachment.AttachmentService;
 import org.exoplatform.social.attachment.model.ObjectAttachmentDetail;
 import org.exoplatform.social.core.BaseActivityProcessorPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
-import org.exoplatform.social.core.plugin.ActivityAttachmentPlugin;
 import org.exoplatform.social.metadata.model.MetadataItem;
 
 public class AttachmentActivityProcessor extends BaseActivityProcessorPlugin {
@@ -45,9 +44,15 @@ public class AttachmentActivityProcessor extends BaseActivityProcessorPlugin {
       List<MetadataItem> attachmentMetadataItems = activity.getMetadatas().get(AttachmentService.METADATA_TYPE.getName());
       attachmentMetadataItems.forEach(metadataItem -> {
         String fileId = metadataItem.getMetadata().getName();
-        ObjectAttachmentDetail attachment = attachmentService.getAttachment(ActivityAttachmentPlugin.ACTIVITY_ATTACHMENT_TYPE, activity.getId(), fileId);
+        String objectId = activity.getMetadataObjectId();
+        String objectType = activity.getMetadataObjectType();
+        ObjectAttachmentDetail attachment = attachmentService.getAttachment(objectType, objectId, fileId);
+        if (attachment == null) {
+          return;
+        }
+
         Map<String, String> properties = metadataItem.getMetadata().getProperties();
-        if (MapUtils.isEmpty(properties)) {
+        if (properties == null) {
           properties = new HashMap<>();
           metadataItem.setProperties(properties);
         }


### PR DESCRIPTION
Prior to this change an NPE is triggered in AttachmentActivityProcessor when the attachment metadata exists but not the file. This change will replace a Mock Test with an integration Test to ensure to not have such error. Besides, this will avoid logging an error while the user identity isn't flushed in IDM store yet (happens when async operations are executed at the same time: User Creation + Social Identity retrieval). This change will ensure to not log the error when those operations happens at the same time (less than 1 second of User Creation/Modification).