### PR TITLE
feat: Allow to disable Activity Notifications by plugin - MEED-2290 - Meeds-io/MIPs#50

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/ActivityTypePlugin.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/ActivityTypePlugin.java
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core;
+
+import org.exoplatform.container.component.BaseComponentPlugin;
+import org.exoplatform.container.xml.InitParams;
+
+import lombok.Getter;
+
+/**
+ * A plugin to allow extending A new Activity Type behavior such as enabling
+ * activity/comment type notification.
+ */
+public class ActivityTypePlugin extends BaseComponentPlugin {
+
+  public static final String ENABLE_NOTIFICATION_PARAM = "enableNotification";
+
+  public static final String ACTIVITY_TYPE_PARAM       = "type";
+
+  @Getter
+  protected String           activityType;
+
+  @Getter
+  protected boolean          enableNotification;
+
+  public ActivityTypePlugin(InitParams params) {
+    this.activityType = params.getValueParam(ACTIVITY_TYPE_PARAM).getValue();
+    this.enableNotification = Boolean.parseBoolean(params.getValueParam(ENABLE_NOTIFICATION_PARAM).getValue());
+  }
+
+}

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.ActivityProcessor;
+import org.exoplatform.social.core.ActivityTypePlugin;
 import org.exoplatform.social.core.BaseActivityProcessorPlugin;
 import org.exoplatform.social.core.activity.ActivityFilter;
 import org.exoplatform.social.core.activity.ActivityListenerPlugin;
@@ -382,6 +383,15 @@ public interface ActivityManager {
    */
   void addProcessorPlugin(BaseActivityProcessorPlugin activityProcessorPlugin);
 
+  /**
+   * Adds an Activity Type options such as activity notification enabling
+   * 
+   * @param plugin {@link ActivityTypePlugin}
+   */
+  default void addActivityTypePlugin(ActivityTypePlugin plugin) {
+    // No operation
+  }
+
   void addActivityEventListener(ActivityListenerPlugin activityListenerPlugin);
 
   /**
@@ -463,6 +473,15 @@ public interface ActivityManager {
    * @return true if the activity type is enabled
    */
   default boolean isActivityTypeEnabled(String activityType) {
+    return true;
+  }
+
+  /**
+   * @param  activity {@link ExoSocialActivity}
+   * @return          true if the Activity Type reuses the default activity
+   *                  notifications, else false.
+   */
+  default boolean isNotificationEnabled(ExoSocialActivity activity) {
     return true;
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -32,6 +32,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.ActivityProcessor;
+import org.exoplatform.social.core.ActivityTypePlugin;
 import org.exoplatform.social.core.BaseActivityProcessorPlugin;
 import org.exoplatform.social.core.activity.*;
 import org.exoplatform.social.core.activity.ActivitiesRealtimeListAccess.ActivityType;
@@ -111,6 +112,8 @@ public class ActivityManagerImpl implements ActivityManager {
   public static final String          MANDATORY_USER_IDENTITY_ID     = "userIdentityId is mandatory";
 
   private Set<String>                 systemActivityTypes            = new HashSet<>();
+
+  private List<String>                disabledTypeNotifications      = new ArrayList<>();
 
   private Set<String>                 systemActivityTitleIds         = new HashSet<>(Arrays.asList("has_joined",
                                                                                                    "space_avatar_edited",
@@ -676,6 +679,13 @@ public class ActivityManagerImpl implements ActivityManager {
     this.addProcessor(plugin);
   }
 
+  @Override
+  public void addActivityTypePlugin(ActivityTypePlugin plugin) {
+    if (StringUtils.isNotBlank(plugin.getActivityType()) && !plugin.isEnableNotification()) {
+      disabledTypeNotifications.add(plugin.getActivityType());
+    }
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -831,6 +841,14 @@ public class ActivityManagerImpl implements ActivityManager {
   @Override
   public boolean isActivityTypeEnabled(String activityType) {
     return activityTypesRegistry.get(activityType) == null || activityTypesRegistry.get(activityType);
+  }
+
+  @Override
+  public boolean isNotificationEnabled(ExoSocialActivity activity) {
+    return activity != null
+        && !activity.isHidden()
+        && (StringUtils.isBlank(activity.getType())
+            || !disabledTypeNotifications.contains(activity.getType()));
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -789,7 +789,7 @@ public class SpaceServiceImpl implements SpaceService {
    * {@inheritDoc}
    */
   public boolean isMember(Space space, String userId) {
-    return ArrayUtils.contains(space.getMembers(), userId);
+    return space != null && ArrayUtils.contains(space.getMembers(), userId);
   }
 
   /**
@@ -1484,24 +1484,24 @@ public class SpaceServiceImpl implements SpaceService {
    * {@inheritDoc}
    */
   public boolean isManager(Space space, String userId) {
-    return ArrayUtils.contains(space.getManagers(), userId);
+    return space != null && ArrayUtils.contains(space.getManagers(), userId);
   }
   
   /**
    * {@inheritDoc}
    */
   public boolean isRedactor(Space space, String userId) {
-    return ArrayUtils.contains(space.getRedactors(), userId);
+    return space != null && ArrayUtils.contains(space.getRedactors(), userId);
   }
   
   @Override
   public boolean isPublisher(Space space, String userId) {
-    return ArrayUtils.contains(space.getPublishers(), userId);
+    return space != null && ArrayUtils.contains(space.getPublishers(), userId);
   }
 
   @Override
   public boolean hasRedactor(Space space) {
-    return space.getRedactors() != null && space.getRedactors().length > 0;
+    return space != null && space.getRedactors() != null && space.getRedactors().length > 0;
   }
 
   @Override

--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -30,7 +30,7 @@
   <name>eXo PLF:: Social Notification Component</name>
   <description>eXo Social Notification Component</description>
   <properties>
-    <exo.test.coverage.ratio>0.60</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.61</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -134,17 +134,17 @@ public class Utils {
    * @param receivers The list of users receiving the notification message.
    * @param activityPosterId Id of the activity poster.
    * @param posterId Id of the user who has commented.
+   * @param spaceId Activity space id
    */
-  public static void sendToActivityPoster(Set<String> receivers, String activityPosterId, String posterId , String spaceId) {
+  public static void sendToActivityPoster(Set<String> receivers, String activityPosterId, String posterId, String spaceId) {
+    if (activityPosterId.equals(posterId)) {
+      return;
+    }
     String activityPosterRemoteId = Utils.getUserId(activityPosterId);
     SpaceService spaceService = getSpaceService();
-    Space space = spaceService.getSpaceById(spaceId);
-    boolean isMember = true;
-    if (space != null) {
-      isMember = spaceService.isMember(space, activityPosterRemoteId);
-    }
-    if (!activityPosterId.equals(posterId) && isMember) {
-
+    if (spaceId == null
+        || spaceService.isSuperManager(activityPosterRemoteId)
+        || spaceService.isMember(spaceService.getSpaceById(spaceId), activityPosterRemoteId)) {
       receivers.add(activityPosterRemoteId);
     }
   }
@@ -169,7 +169,7 @@ public class Utils {
       String userName = getUserId(user);
       boolean isMember = true;
       if(space != null) {
-        isMember = spaceService.isMember(space, userName);
+        isMember = spaceService.isMember(space, userName) || spaceService.isSuperManager(userName);
       }
       if (!user.equals(poster) && isMember) {
         destinataires.add(userName);
@@ -218,7 +218,7 @@ public class Utils {
       Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, remoteId, false);
       boolean isMember = true;
       if (space != null) {
-        isMember = spaceService.isMember(space, remoteId);
+        isMember = spaceService.isMember(space, remoteId) || spaceService.isSuperManager(remoteId);
       }
       if (identity != null && !posterRemoteId.equals(remoteId) && isMember) {
         mentioners.add(remoteId);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -16,9 +16,7 @@
  */
 package org.exoplatform.social.notification;
 
-import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -64,14 +62,8 @@ public class Utils {
   
   private static final String styleCSS = " style=\"color: #2f5e92; text-decoration: none;\"";
 
-  /**
-   * Exo property name used for disable news activity notifications
-   */
-  private static final String DISABLED_ACTIVITY_TYPE_NOTIFICATIONS_PROPERTY_NAME = "exo.notifications.activity-type.disabled";
-  
-  @SuppressWarnings("unchecked")
   public static <T> T getService(Class<T> clazz) {
-    return (T) PortalContainer.getInstance().getComponentInstanceOfType(clazz);
+    return PortalContainer.getInstance().getComponentInstanceOfType(clazz);
   }
 
   /**
@@ -310,21 +302,6 @@ public class Utils {
 
   public static RelationshipManager getRelationshipManager() {
     return getService(RelationshipManager.class);
-  }
-
-  /**
-   * Checks if the notification is enabled for activities of type activityType
-   *
-   * @param activityType type of activity to check if their notification is enabled
-   * @return true if the notification is enabled for this Activity Type
-   */
-  public static boolean isActivityNotificationsEnabled(String activityType) {
-    String disabledNotifications = PropertyManager.getProperty(DISABLED_ACTIVITY_TYPE_NOTIFICATIONS_PROPERTY_NAME);
-    if (StringUtils.isNotBlank(disabledNotifications)) {
-      String[] activityTypes = disabledNotifications.split(",");
-      return !Arrays.asList(activityTypes).contains(activityType);
-    }
-    return true;
   }
 
   /**

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -619,21 +619,9 @@ public class MailTemplateProvider extends TemplateProvider {
 
       templateContext.put("PROFILE_URL", LinkProviderUtils.getRedirectUrl("user", identity.getRemoteId()));
       templateContext.put("OPEN_URL", LinkProviderUtils.getOpenLink(activity));
-      String body;
-      if(activity.isComment()) {
-        ExoSocialActivity activityOfComment = Utils.getActivityManager().getParentActivity(activity);
-        templateContext.put("REPLY_ACTION_URL", LinkProviderUtils.getRedirectUrl("reply_activity", activityOfComment.getId()));
-        templateContext.put("VIEW_FULL_DISCUSSION_ACTION_URL", LinkProviderUtils.getRedirectUrl("view_full_activity", activityOfComment.getId()));
-        String commentTitle = getI18N(activity, new Locale(language)).getTitle();
-        commentTitle = SocialNotificationUtils.processImageTitle(commentTitle, imagePlaceHolder);
-        templateContext.put("ACTIVITY", NotificationUtils.processLinkTitle(commentTitle));
-        body = TemplateUtils.processGroovy(templateContext);
-      } else {
-        templateContext.put("REPLY_ACTION_URL", LinkProviderUtils.getRedirectUrl("reply_activity", activity.getId()));
-        templateContext.put("VIEW_FULL_DISCUSSION_ACTION_URL", LinkProviderUtils.getRedirectUrl("view_full_activity", activity.getId()));
-        body = SocialNotificationUtils.getBody(ctx, templateContext, activity);
-      }
-
+      templateContext.put("REPLY_ACTION_URL", LinkProviderUtils.getRedirectUrl("reply_activity", activity.getId()));
+      templateContext.put("VIEW_FULL_DISCUSSION_ACTION_URL", LinkProviderUtils.getRedirectUrl("view_full_activity", activity.getId()));
+      String body = SocialNotificationUtils.getBody(ctx, templateContext, activity);
 
       //binding the exception throws by processing template
       ctx.setException(templateContext.getException());
@@ -690,6 +678,89 @@ public class MailTemplateProvider extends TemplateProvider {
       return true;
     }
 
+  };
+
+  /** Defines the template builder for LikePlugin*/
+  private AbstractTemplateBuilder likeComment = new AbstractTemplateBuilder() {
+    @Override
+    protected MessageInfo makeMessage(NotificationContext ctx) {
+      MessageInfo messageInfo = new MessageInfo();
+
+      NotificationInfo notification = ctx.getNotificationInfo();
+
+      String language = getLanguage(notification);
+      TemplateContext templateContext = new TemplateContext(notification.getKey().getId(), language);
+      SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
+
+      String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
+      ExoSocialActivity activity = Utils.getActivityManager().getActivity(activityId);
+      Identity identity = Utils.getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, notification.getValueOwnerParameter("likersId"), true);
+      if (identity == null) {
+        return null;
+      }
+
+      templateContext.put("USER", Utils.addExternalFlag(identity));
+      String imagePlaceHolder = SocialNotificationUtils.getImagePlaceHolder(language);
+      String title = SocialNotificationUtils.processImageTitle(activity.getTitle(), imagePlaceHolder);
+      String cleanedTitle = StringEscapeUtils.unescapeHtml4(title);
+      templateContext.put("SUBJECT", cleanedTitle);
+      String subject = TemplateUtils.processSubject(templateContext);
+
+      templateContext.put("PROFILE_URL", LinkProviderUtils.getRedirectUrl("user", identity.getRemoteId()));
+      templateContext.put("OPEN_URL", LinkProviderUtils.getOpenLink(activity));
+      ExoSocialActivity activityOfComment = Utils.getActivityManager().getParentActivity(activity);
+      templateContext.put("REPLY_ACTION_URL", LinkProviderUtils.getRedirectUrl("reply_activity", activityOfComment.getId()));
+      templateContext.put("VIEW_FULL_DISCUSSION_ACTION_URL", LinkProviderUtils.getRedirectUrl("view_full_activity", activityOfComment.getId()));
+      String commentTitle = getI18N(activity, new Locale(language)).getTitle();
+      commentTitle = SocialNotificationUtils.processImageTitle(commentTitle, imagePlaceHolder);
+      templateContext.put("ACTIVITY", NotificationUtils.processLinkTitle(commentTitle));
+      String body = TemplateUtils.processGroovy(templateContext);
+
+      //binding the exception throws by processing template
+      ctx.setException(templateContext.getException());
+      return messageInfo.subject(subject).body(body).end();
+    }
+
+    @Override
+    protected boolean makeDigest(NotificationContext ctx, Writer writer) {
+      List<NotificationInfo> notifications = ctx.getNotificationInfos();
+      NotificationInfo first = notifications.get(0);
+      String language = getLanguage(first);
+      TemplateContext templateContext = new TemplateContext(first.getKey().getId(), language);
+      Map<String, List<String>> map = new LinkedHashMap<String, List<String>>();
+      try {
+        for (NotificationInfo message : notifications) {
+          String activityId = message.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
+          ExoSocialActivity activity = Utils.getActivityManager().getActivity(activityId);
+          //
+          if (activity == null) {
+            continue;
+          }
+          if (activity.getPosterId() != null) {
+            Identity identity = Utils.getIdentityManager().getIdentity(activity.getPosterId(), true);
+            if (identity != null) {
+              if (message.getTo() != null && !message.getTo().equals(identity.getRemoteId())) {
+                continue;
+              }
+            }
+          }
+          //
+          String fromUser = message.getValueOwnerParameter("likersId");
+          Identity identityFrom = Utils.getService(IdentityManager.class).getOrCreateIdentity(OrganizationIdentityProvider.NAME, fromUser, false);
+          if (identityFrom == null || !Arrays.asList(activity.getLikeIdentityIds()).contains(identityFrom.getId())) {
+            continue;
+          }
+          //
+          SocialNotificationUtils.processInforSendTo(map, activityId, message.getValueOwnerParameter("likersId"));
+        }
+        writer.append(SocialNotificationUtils.getMessageByIds(map, templateContext));
+      } catch (IOException e) {
+        ctx.setException(e);
+        return false;
+      }
+      return true;
+    }
+    
   };
 
   /** Defines the template builder for NewUserPlugin*/
@@ -1216,7 +1287,7 @@ public class MailTemplateProvider extends TemplateProvider {
     this.templateBuilders.put(PluginKey.key(ActivityReplyToCommentPlugin.ID), replyToComment);
     this.templateBuilders.put(PluginKey.key(ActivityMentionPlugin.ID), mention);
     this.templateBuilders.put(PluginKey.key(LikePlugin.ID), like);
-    this.templateBuilders.put(PluginKey.key(LikeCommentPlugin.ID), like);
+    this.templateBuilders.put(PluginKey.key(LikeCommentPlugin.ID), likeComment);
     this.templateBuilders.put(PluginKey.key(NewUserPlugin.ID), newUser);
     this.templateBuilders.put(PluginKey.key(PostActivityPlugin.ID), postActivity);
     this.templateBuilders.put(PluginKey.key(PostActivitySpaceStreamPlugin.ID), postActivitySpace);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -680,7 +680,7 @@ public class MailTemplateProvider extends TemplateProvider {
 
   };
 
-  /** Defines the template builder for LikePlugin*/
+  /** Defines the template builder for LikeCommentPlugin*/
   private AbstractTemplateBuilder likeComment = new AbstractTemplateBuilder() {
     @Override
     protected MessageInfo makeMessage(NotificationContext ctx) {

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.servlet.ServletContext;
 
@@ -38,7 +37,6 @@ import org.exoplatform.commons.api.notification.service.setting.PluginSettingSer
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.RootContainer.PortalContainerPostInitTask;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -53,7 +51,6 @@ import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
 import org.exoplatform.social.notification.plugin.SpaceWebNotificationPlugin;
 import org.exoplatform.social.notification.service.SpaceWebNotificationService;
 import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 
 @SuppressWarnings("removal")
@@ -231,7 +228,7 @@ public class SpaceWebNotificationServiceImpl implements SpaceWebNotificationServ
     }
     List<String> spacesId = spaceService.getMemberSpacesIds(username, 0, -1);
     if (CollectionUtils.isNotEmpty(spacesId)) {
-      spaceIds = spacesId.stream().map(e -> Long.parseLong(e)).toList();
+      spaceIds = spacesId.stream().map(Long::parseLong).toList();
     }
     return metadataService.countMetadataItemsByMetadataTypeAndSpacesIdAndCreatorId(METADATA_TYPE_NAME,
                                                                                    Long.parseLong(userIdentity.getId()),

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
@@ -16,25 +16,25 @@
  */
 package org.exoplatform.social.notification.plugin;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.notification.Utils;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 
 public class ActivityCommentPlugin extends BaseNotificationPlugin {
 
-  public static final String ID = "ActivityCommentPlugin";
+  public static final String ID           = "ActivityCommentPlugin";
 
-  protected boolean isSubComment = false;
+  protected boolean          isSubComment = false;
 
   public ActivityCommentPlugin(InitParams initParams) {
     super(initParams);
@@ -45,7 +45,7 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
     ExoSocialActivity comment = ctx.value(SocialNotificationUtils.ACTIVITY);
     ExoSocialActivity activity = Utils.getActivityManager().getParentActivity(comment);
     String spaceId = activity.getSpaceId();
-    Set<String> receivers = new HashSet<String>();
+    Set<String> receivers = new HashSet<>();
     if (StringUtils.isNotBlank(comment.getParentCommentId())) {
       ExoSocialActivity parentComment = Utils.getActivityManager().getActivity(comment.getParentCommentId());
       String parentCommentUserPosterId = Utils.getUserId(parentComment.getPosterId());
@@ -53,14 +53,15 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
         // Send notification to parent comment poster
         Utils.sendToActivityPoster(receivers, parentComment.getPosterId(), comment.getPosterId(), spaceId);
       } else {
-        // Send notification to all others users who have commented on this activity
+        // Send notification to all others users who have commented on this
+        // activity
         // except parent comment poster
         Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId(), spaceId);
         Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
         Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId(), spaceId);
         receivers.remove(parentCommentUserPosterId);
         Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId(), spaceId);
-        receivers.remove( Utils.getUserId(comment.getPosterId()));
+        receivers.remove(Utils.getUserId(comment.getPosterId()));
       }
     } else {
       // Send notification to all others users who have comment on this activity
@@ -68,18 +69,16 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
       Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
       Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId(), spaceId);
       Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId(), spaceId);
-      receivers.remove( Utils.getUserId(comment.getPosterId()));
+      receivers.remove(Utils.getUserId(comment.getPosterId()));
 
     }
-    //
     return NotificationInfo.instance()
-           .to(new ArrayList<String>(receivers))
-           .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
-           .with(SocialNotificationUtils.COMMENT_ID.getKey(), comment.getId())
-           .with(SocialNotificationUtils.POSTER.getKey(), Utils.getUserId(comment.getUserId()))
-           .key(getId());
+                           .to(new ArrayList<>(receivers))
+                           .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
+                           .with(SocialNotificationUtils.COMMENT_ID.getKey(), comment.getId())
+                           .with(SocialNotificationUtils.POSTER.getKey(), Utils.getUserId(comment.getUserId()))
+                           .key(getId());
   }
-
 
   @Override
   public String getId() {
@@ -89,18 +88,16 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
   @Override
   public boolean isValid(NotificationContext ctx) {
     ExoSocialActivity comment = ctx.value(SocialNotificationUtils.ACTIVITY);
+    if (!Utils.getActivityManager().isNotificationEnabled(comment)
+        || (isSubComment && comment.getParentCommentId() == null)) {
+      return false;
+    }
     ExoSocialActivity activity = Utils.getActivityManager().getParentActivity(comment);
 
-    if (isSubComment && comment.getParentCommentId() == null) {
-      return false;
-    }
-
-    Identity spaceIdentity = Utils.getIdentityManager().getOrCreateIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner(), false);
-    //if the space is not null and it's not the default activity of space, then it's valid to make notification 
-    if (spaceIdentity != null && activity.getPosterId().equals(spaceIdentity.getId())) {
-      return false;
-    }
-    return true;
+    Identity spaceIdentity = Utils.getIdentityManager().getOrCreateSpaceIdentity(activity.getStreamOwner());
+    // if the space is not null and it's not the default activity of space, then
+    // it's valid to make notification
+    return spaceIdentity == null || !activity.getPosterId().equals(spaceIdentity.getId());
   }
 
 }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
@@ -24,6 +24,7 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.metadata.model.MetadataObject;
+import org.exoplatform.social.notification.Utils;
 import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
 
 public class ActivitySpaceWebNotificationPlugin extends SpaceWebNotificationPlugin {
@@ -41,6 +42,10 @@ public class ActivitySpaceWebNotificationPlugin extends SpaceWebNotificationPlug
   public SpaceWebNotificationItem getSpaceApplicationItem(NotificationInfo notification) {
     String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
     ExoSocialActivity activity = activityManager.getActivity(activityId);
+    if (!Utils.getActivityManager().isNotificationEnabled(activity)) {
+      return null;
+    }
+
     MetadataObject metadataObject;
     if (activity.isComment()) {
       ExoSocialActivity parentActivity = activityManager.getActivity(activity.getParentId());

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
@@ -24,7 +24,6 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.metadata.model.MetadataObject;
-import org.exoplatform.social.notification.Utils;
 import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
 
 public class ActivitySpaceWebNotificationPlugin extends SpaceWebNotificationPlugin {
@@ -42,7 +41,7 @@ public class ActivitySpaceWebNotificationPlugin extends SpaceWebNotificationPlug
   public SpaceWebNotificationItem getSpaceApplicationItem(NotificationInfo notification) {
     String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
     ExoSocialActivity activity = activityManager.getActivity(activityId);
-    if (!Utils.getActivityManager().isNotificationEnabled(activity)) {
+    if (activity == null) {
       return null;
     }
 

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
@@ -1,68 +1,61 @@
 package org.exoplatform.social.notification.plugin;
 
-import org.apache.commons.lang.StringUtils;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.notification.Utils;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 
 public class EditActivityPlugin extends BaseNotificationPlugin {
 
-    public EditActivityPlugin(InitParams initParams) {
-        super(initParams);
+  public EditActivityPlugin(InitParams initParams) {
+    super(initParams);
+  }
+
+  public static final String ID = "EditActivityPlugin";
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  protected boolean isSubComment = false;
+
+  @Override
+  public NotificationInfo makeNotification(NotificationContext ctx) {
+    ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
+    String spaceId = activity.getSpaceId();
+    Set<String> receivers = new HashSet<>();
+    if (activity.getStreamOwner() != null) {
+      Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), activity.getPosterId());
     }
+    // Send notification to all others users who have comment on this activity
+    Utils.sendToCommeters(receivers, activity.getCommentedIds(), activity.getPosterId(), spaceId);
+    Utils.sendToActivityPoster(receivers, activity.getPosterId(), activity.getPosterId(), spaceId);
+    Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId(), spaceId);
+    return NotificationInfo.instance()
+                           .to(new ArrayList<>(receivers))
+                           .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
+                           .with(SocialNotificationUtils.POSTER.getKey(), Utils.getUserId(activity.getUserId()))
+                           .key(getId());
+  }
 
-    public static final String ID = "EditActivityPlugin";
-
-    @Override
-    public String getId() {
-        return ID;
+  @Override
+  public boolean isValid(NotificationContext ctx) {
+    ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
+    if (!Utils.getActivityManager().isNotificationEnabled(activity)) {
+      return false;
     }
-
-    protected boolean isSubComment = false;
-
-    @Override
-    public NotificationInfo makeNotification(NotificationContext ctx) {
-        ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
-        String spaceId = activity.getSpaceId();
-        Set<String> receivers = new HashSet<String>();
-        if (activity.getStreamOwner() != null) {
-            Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), activity.getPosterId());
-        }
-        // Send notification to all others users who have comment on this activity
-        Utils.sendToCommeters(receivers, activity.getCommentedIds(), activity.getPosterId(), spaceId);
-        Utils.sendToActivityPoster(receivers, activity.getPosterId(), activity.getPosterId(), spaceId);
-        Utils.sendToLikers(receivers, activity.getLikeIdentityIds(), activity.getPosterId(), spaceId);
-
-        //
-        return NotificationInfo.instance()
-                .to(new ArrayList<String>(receivers))
-                .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
-                .with(SocialNotificationUtils.POSTER.getKey(), Utils.getUserId(activity.getUserId()))
-                .key(getId());
-    }
-
-
-    @Override
-    public boolean isValid(NotificationContext ctx) {
-        ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
-
-
-
-        Identity spaceIdentity = Utils.getIdentityManager().getOrCreateIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner(), false);
-        //if the space is not null and it's not the default activity of space, then it's valid to make notification
-        if (spaceIdentity != null && activity.getPosterId().equals(spaceIdentity.getId())) {
-            return false;
-        }
-        return true;
-    }
+    Identity spaceIdentity = Utils.getIdentityManager().getOrCreateSpaceIdentity(activity.getStreamOwner());
+    // if the space is not null and it's not the default activity of space, then
+    // it's valid to make notification
+    return spaceIdentity == null || !activity.getPosterId().equals(spaceIdentity.getId());
+  }
 
 }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
@@ -49,9 +49,6 @@ public class EditActivityPlugin extends BaseNotificationPlugin {
   @Override
   public boolean isValid(NotificationContext ctx) {
     ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
-    if (!Utils.getActivityManager().isNotificationEnabled(activity)) {
-      return false;
-    }
     Identity spaceIdentity = Utils.getIdentityManager().getOrCreateSpaceIdentity(activity.getStreamOwner());
     // if the space is not null and it's not the default activity of space, then
     // it's valid to make notification

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditCommentPlugin.java
@@ -69,10 +69,6 @@ public class EditCommentPlugin extends BaseNotificationPlugin {
   @Override
   public boolean isValid(NotificationContext ctx) {
     ExoSocialActivity comment = ctx.value(SocialNotificationUtils.ACTIVITY);
-    if (!Utils.getActivityManager().isNotificationEnabled(comment)) {
-      return false;
-    }
-
     ExoSocialActivity activity = Utils.getActivityManager().getParentActivity(comment);
 
     if (isSubComment && comment.getParentCommentId() == null) {

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikeCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikeCommentPlugin.java
@@ -1,3 +1,20 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.exoplatform.social.notification.plugin;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
@@ -8,9 +25,6 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.notification.Utils;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Notification plugin for Comments Likes
@@ -38,17 +52,14 @@ public class LikeCommentPlugin extends BaseNotificationPlugin {
     String likeTo = Utils.getUserId(activity.getPosterId());
     String spaceId = !activity.isComment() ? activity.getSpaceId()
                                            : Utils.getActivityManager().getParentActivity(activity).getSpaceId();
-    boolean isMember = false;
-
-    if (spaceId != null) {
-      SpaceService spaceService = Utils.getSpaceService();
+    SpaceService spaceService = Utils.getSpaceService();
+    if (spaceId != null && !spaceService.isSuperManager(likeTo)) {
       Space space = spaceService.getSpaceById(spaceId);
-      isMember = spaceService.isMember(space, likeTo);
+      if (!spaceService.isMember(space, likeTo)) {
+        return null;
+      }
     }
 
-    if (spaceId != null && !isMember) {
-      return null;
-    }
     return NotificationInfo.instance()
                            .to(likeTo)
                            .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikePlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/LikePlugin.java
@@ -52,17 +52,15 @@ public class LikePlugin extends BaseNotificationPlugin {
     String likeTo = Utils.getUserId(activity.getPosterId());
     String spaceId = !activity.isComment() ? activity.getSpaceId()
             : Utils.getActivityManager().getParentActivity(activity).getSpaceId();
-    boolean isMember = false;
 
-    if (spaceId != null) {
-      SpaceService spaceService = Utils.getSpaceService();
+    SpaceService spaceService = Utils.getSpaceService();
+    if (spaceId != null && !spaceService.isSuperManager(likeTo)) {
       Space space = spaceService.getSpaceById(spaceId);
-      isMember = spaceService.isMember(space, likeTo);
+      if (!spaceService.isMember(space, likeTo)) {
+        return null;
+      }
     }
 
-    if (spaceId != null && !isMember) {
-      return null;
-    }
     return NotificationInfo.instance()
                                .to(likeTo)
                                .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/PostActivityPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/PostActivityPlugin.java
@@ -25,12 +25,12 @@ import org.exoplatform.social.notification.Utils;
 
 public class PostActivityPlugin extends BaseNotificationPlugin {
 
+  public static final String ID = "PostActivityPlugin";
+
   public PostActivityPlugin(InitParams initParams) {
     super(initParams);
   }
 
-  public static final String ID = "PostActivityPlugin";
-  
   @Override
   public String getId() {
     return ID;
@@ -42,25 +42,25 @@ public class PostActivityPlugin extends BaseNotificationPlugin {
       ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
 
       return NotificationInfo.instance()
-          .to(activity.getStreamOwner())
-          .with(SocialNotificationUtils.POSTER.getKey(), Utils.getUserId(activity.getPosterId()))
-          .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
-          .key(getId()).end();
-      
+                             .to(activity.getStreamOwner())
+                             .with(SocialNotificationUtils.POSTER.getKey(), Utils.getUserId(activity.getPosterId()))
+                             .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), activity.getId())
+                             .key(getId())
+                             .end();
+
     } catch (Exception e) {
       ctx.setException(e);
     }
-    
+
     return null;
   }
 
   @Override
   public boolean isValid(NotificationContext ctx) {
     ExoSocialActivity activity = ctx.value(SocialNotificationUtils.ACTIVITY);
-    if (activity.getStreamOwner().equals(Utils.getUserId(activity.getPosterId())) || Utils.isSpaceActivity(activity)) {
-      return false;
-    }
-    return true;
+    return Utils.getActivityManager().isNotificationEnabled(activity)
+        && !activity.getStreamOwner().equals(Utils.getUserId(activity.getPosterId()))
+        && !Utils.isSpaceActivity(activity);
   }
 
 }

--- a/component/notification/src/test/java/org/exoplatform/social/notification/InitContainerTestSuite.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/InitContainerTestSuite.java
@@ -29,6 +29,7 @@ import org.junit.runners.Suite.SuiteClasses;
   RequestJoinSpaceMailBuilderTest.class,
   SpaceInvitationMailBuilderTest.class,
   LikeMailBuilderTest.class,
+  LikeCommentMailBuilderTest.class,
   LinkProviderUtilsTest.class,
   MailTemplateProviderTest.class,
   WebTemplateProviderTest.class,

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/LikeCommentMailBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/LikeCommentMailBuilderTest.java
@@ -1,0 +1,130 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.social.notification.channel.template;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.channel.AbstractChannel;
+import org.exoplatform.commons.api.notification.channel.ChannelManager;
+import org.exoplatform.commons.api.notification.channel.template.AbstractTemplateBuilder;
+import org.exoplatform.commons.api.notification.model.ChannelKey;
+import org.exoplatform.commons.api.notification.model.MessageInfo;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
+import org.exoplatform.commons.notification.channel.MailChannel;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.notification.AbstractPluginTest;
+import org.exoplatform.social.notification.plugin.LikeCommentPlugin;
+
+public class LikeCommentMailBuilderTest extends AbstractPluginTest {
+  private ChannelManager manager;
+  
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    manager = getService(ChannelManager.class);
+  }
+  
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+  
+
+  @Override
+  public AbstractTemplateBuilder getTemplateBuilder() {
+    AbstractChannel channel = manager.getChannel(ChannelKey.key(MailChannel.ID));
+    assertNotNull(channel);
+    assertTrue(channel.hasTemplateBuilder(PluginKey.key(LikeCommentPlugin.ID)));
+    return channel.getTemplateBuilder(PluginKey.key(LikeCommentPlugin.ID));
+  }
+  
+  @Override
+  public BaseNotificationPlugin getPlugin() {
+    return pluginService.getPlugin(PluginKey.key(LikeCommentPlugin.ID));
+  }
+  
+  public void testSimpleCase() throws Exception {
+    //STEP 1 post activity and comment it
+    ExoSocialActivity activity = makeActivity(rootIdentity, "root post an activity");
+    ExoSocialActivity comment = makeComment(activity, rootIdentity, getName());
+
+    //STEP 2 like activity
+    activityManager.saveLike(comment, demoIdentity);
+
+    assertMadeMailDigestNotifications(1);
+    List<NotificationInfo> list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 1);
+    NotificationInfo likeNotification = list.get(0);
+    
+    //STEP 3 assert Message info
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.setNotificationInfo(likeNotification.setTo("root"));
+    MessageInfo info = buildMessageInfo(ctx);
+    
+    assertSubject(info, getFullName("demo") + " likes your comment testSimpleCase");
+    assertBody(info, "New like on your activity stream");
+  }
+  
+  public void testDigest() throws Exception {
+    ExoSocialActivity activity = makeActivity(rootIdentity, "root post an activity");
+    ExoSocialActivity comment = makeComment(activity, rootIdentity, getName());
+    activityManager.saveLike(comment, maryIdentity);
+    activityManager.saveLike(comment, demoIdentity);
+    activityManager.saveLike(comment, johnIdentity);
+    //
+    assertMadeMailDigestNotifications(3);
+    List<NotificationInfo> list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 3);
+    
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    list.set(0, list.get(0).setTo(rootIdentity.getRemoteId()));
+    ctx.setNotificationInfos(list);
+    Writer writer = new StringWriter();
+    buildDigest(ctx, writer);
+    assertDigest(writer, getFullName("mary") + ", " + getFullName("demo") + ", " + getFullName("john") + " have liked your comment: testDigest");
+  }
+  
+  public void testDigestWithUnLike() throws Exception {
+    // mary post activity on her stream
+    ExoSocialActivity activity = makeActivity(rootIdentity, "root post an activity");
+    ExoSocialActivity comment = makeComment(activity, rootIdentity, getName());
+    notificationService.clearAll();
+
+    assertMadeMailDigestNotifications(0);
+    List<NotificationInfo> list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 0);
+    activityManager.saveLike(comment, demoIdentity);
+    activityManager.saveLike(comment, johnIdentity);
+
+    assertMadeMailDigestNotifications(2);
+    list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 2);
+
+    // john unlike
+    activityManager.deleteLike(comment, johnIdentity);
+
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    list.set(0, list.get(0).setTo(rootIdentity.getRemoteId()));
+    ctx.setNotificationInfos(list);
+    Writer writer = new StringWriter();
+    buildDigest(ctx, writer);
+    assertDigest(writer, getFullName("demo") + " has liked your comment: testDigestWithUnLike");
+  }
+}

--- a/webapp/portlet/.eslintrc.json
+++ b/webapp/portlet/.eslintrc.json
@@ -11,6 +11,7 @@
     "activityComposer": true,
     "socialUIProfile": true,
     "QRCode": true,
+    "DOMPurify": true,
     "ExtendedDomPurify": true,
     "Cropper": true,
     "cCometd": true

--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1288,6 +1288,7 @@
   <portlet>
     <name>TopBarNotification</name>
     <module>
+      <load-group>TopBarNotificationGRP</load-group>
       <script>
         <minify>false</minify>
         <path>/js/topBarNotification.bundle.js</path>
@@ -2032,7 +2033,7 @@
     <name>intranetNotification</name>
     <load-group>webNotificationsGRP</load-group>
     <script>
-      <path>/js/notification/IntranetNotification.js</path>
+      <path>/js/webuiNotification/IntranetNotification.js</path>
     </script>
     <depends>
       <module>webNotifications</module>
@@ -2047,7 +2048,7 @@
     <name>webNotifications</name>
     <load-group>webNotificationsGRP</load-group>
     <script>
-      <path>/js/notification/WebNotification.js</path>
+      <path>/js/webuiNotification/WebNotification.js</path>
     </script>
     <depends>
       <module>jquery</module>

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/NotificationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/NotificationItem.vue
@@ -1,3 +1,23 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
 <template>
   <a
     :id="id"

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/NotificationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/NotificationItem.vue
@@ -1,0 +1,141 @@
+<template>
+  <a
+    :id="id"
+    :href="notifLink"
+    class="notifDrawerItem">
+    <dynamic-html-element :child="bodyElement" />
+  </a>
+</template>
+<script>
+const SLIDE_UP = 300;
+const SLIDE_UP_MORE = 600;
+
+export default {
+  props: {
+    id: {
+      type: String,
+      default: null,
+    },
+    notif: {
+      type: Object,
+      default: null,
+    },
+  },
+  data: () => ({
+    notifLink: null,
+  }),
+  computed: {
+    bodyElement() {
+      const template = DOMPurify.sanitize(this.notif.notification || '', {
+        CUSTOM_ELEMENT_HANDLING: {
+          tagNameCheck: () => true,
+          attributeNameCheck: () => true,
+        },
+      });
+      return {template};
+    },
+  },
+  mounted() {
+    this.applyActions();    
+  },
+  methods: {
+    applyActions() {
+      const self = this;
+      $(`#${this.id}`).find('li').each(function () {
+        let dataLink = $(this).find('.contentSmall:first').data('link');
+        if (!dataLink) {
+          dataLink = $(this).find('.media').children('a').attr('href');
+        }
+        if (dataLink.includes('/portal/g/') || dataLink.includes('/portal/rest/')){
+          dataLink.replace(/\/portal\//,`${eXo.env.portal.context}/`);
+        } else {
+          dataLink.replace(/\/portal\/([a-zA-Z0-9_-]+)\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
+        }
+        const linkId = dataLink.split(`${eXo.env.portal.context}/`);
+        const dataId = $(this).data('id').toString();
+        const dataDetails = $(this).data('details') && $(this).data('details').toString() ? $(this).data('details').toString() : null;
+        if (linkId != null && linkId.length >1 ) {
+          if (linkId[0].includes('/view_full_activity/')) {
+            const id = linkId[0].split('/view_full_activity/')[1];
+            self.notifLink = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity?id=${id}`;
+          } else {
+            self.notifLink = `${eXo.env.portal.context}/${linkId[1]}`;
+          }
+        } else if (dataDetails !== 'notification-details-drawer') {
+          self.notifLink = dataLink.replace(/^\/rest\//,`${eXo.env.portal.context}/rest/`);
+        }
+
+        // ------------- Open details drawer
+        $(this).find('.open-details-drawer').off('click').on('click', function(evt) {
+          evt.preventDefault();
+          evt.stopPropagation();
+          const notificationDetails = $(this).data('notification-details');
+          document.dispatchEvent(new CustomEvent('open-notification-details-drawer', {detail: notificationDetails}));
+          if ($(this).closest('[data-details]').hasClass('unread')) {
+            $(this).closest('[data-details]').removeClass('unread').addClass('read');
+          }
+          Vue.prototype.$notificationService.updateNotification(dataId, 'markAsRead');
+        });
+
+        // ----------------- Mark as read
+        $(this).off('click').on('click', function() {
+          if ($(this).hasClass('unread')) {
+            $(this).removeClass('unread').addClass('read');
+          }
+          Vue.prototype.$notificationService.updateNotification(dataId, 'markAsRead');
+        });
+
+        // ------------- hide notif
+        $(this).find('.remove-item').off('click').on('click', function(evt) {
+          evt.preventDefault();
+          evt.stopPropagation();
+          Vue.prototype.$notificationService.updateNotification(dataId,'hide');
+          $(this).parents('li:first').slideUp(SLIDE_UP);
+        });
+
+        // ------------- Accept request
+        $(this).find('.action-item').off('click').on('click', function(evt) {
+          evt.stopPropagation();
+          evt.preventDefault();
+          let restURl = $(this).data('rest');
+          if (restURl.indexOf('?') >= 0 ) {
+            restURl += '&';
+          } 
+          else {
+            restURl += '?';
+          }
+          restURl += `portal:csrf=${eXo.env.portal.csrfToken}`;
+          if (restURl && restURl.length > 0) {
+            $.ajax(restURl).done(function () {
+              $(document).trigger('exo-invitation-updated');
+            });
+          }
+          Vue.prototype.$notificationService.updateNotification(dataId,'hide');
+          $(this).parents('li:first').slideUp(SLIDE_UP_MORE);
+        });
+
+        // ------------- Refuse request
+        $(this).find('.cancel-item').off('click').on('click', function(evt) {
+          evt.stopPropagation();
+          evt.preventDefault();
+          let restCancelURl = $(this).data('rest');
+          if (restCancelURl.indexOf('?') >= 0 ) {
+            restCancelURl += '&';
+          }
+          else {
+            restCancelURl += '?';
+          }
+          restCancelURl += `portal:csrf=${eXo.env.portal.csrfToken}`;
+          if (restCancelURl && restCancelURl.length > 0) {
+            $.ajax(restCancelURl).done(function () {
+              $(document).trigger('exo-invitation-updated');
+            });
+          }
+          Vue.prototype.$notificationService.updateNotification(dataId,'hide');
+          $(this).parents('li:first').slideUp(SLIDE_UP_MORE);
+        });
+      });
+    },
+  },
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
@@ -1,3 +1,23 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
 <template>
   <v-app id="NotificationPopoverPortlet">
     <v-flex>

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
@@ -34,14 +34,11 @@
           </template>
           <template v-if="notificationsSize" slot="content">
             <div class="notifDrawerItems">
-              <a
+              <top-bar-notification-item
                 v-for="(notif, i) in notifications"
                 :key="i"
                 :id="'notifItem-'+i"
-                v-sanitized-html="notif.notification"
-                class="notifDrawerItem"
-                @mouseenter="applyActions(`notifItem-`+i)">
-              </a>
+                :notif="notif" />
             </div>
           </template>
           <template v-else-if="!loading" slot="content">
@@ -82,9 +79,6 @@
   </v-app>
 </template>
 <script>
-const SLIDE_UP = 300;
-const SLIDE_UP_MORE = 600;
-
 export default {
   data () {
     return {
@@ -157,107 +151,6 @@ export default {
     },
     navigateTo(pagelink) {
       location.href=`${ eXo.env.portal.context }/${ eXo.env.portal.portalName }/${ pagelink }` ;
-    },
-    applyActions(item) {
-      $(`#${item}`).find('li').each(function () {
-        let dataLink = $(this).find('.contentSmall:first').data('link');
-        if (typeof dataLink === 'undefined') {
-          dataLink = $(this).find('.media').children('a').attr('href');
-          
-        }
-        if (dataLink.includes('/portal/g/') || dataLink.includes('/portal/rest/')){
-          dataLink.replace(/\/portal\//,`${eXo.env.portal.context}/`);
-        } else {
-          dataLink.replace(/\/portal\/([a-zA-Z0-9_-]+)\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
-        }
-        const linkId = dataLink.split(`${eXo.env.portal.context}/`);
-        const dataId = $(this).data('id').toString();
-        const dataDetails = $(this).data('details') && $(this).data('details').toString() ? $(this).data('details').toString() : null;
-        if (linkId != null && linkId.length >1 ) {
-          if (linkId[0].includes('/view_full_activity/')) {
-            const id = linkId[0].split('/view_full_activity/')[1];
-            $(this).parent().attr('href', `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity?id=${id}`);
-          } else {
-            $(this).parent().attr('href', `${eXo.env.portal.context}/${linkId[1]}`);
-          }
-        } else if (dataDetails !== 'notification-details-drawer') {
-          $(this).parent().attr('href', dataLink.replace(/^\/rest\//,`${eXo.env.portal.context}/rest/`));
-        }
-
-        // ------------- Open details drawer
-
-        $(this).find('.open-details-drawer').off('click').on('click', function(evt) {
-          evt.preventDefault();
-          evt.stopPropagation();
-          const notificationDetails = $(this).data('notification-details');
-          document.dispatchEvent(new CustomEvent('open-notification-details-drawer', {detail: notificationDetails}));
-          if ($(this).closest('[data-details]').hasClass('unread')) {
-            $(this).closest('[data-details]').removeClass('unread').addClass('read');
-          }
-          Vue.prototype.$notificationService.updateNotification(dataId, 'markAsRead');
-        });
-
-        // ----------------- Mark as read
-        $(this).on('click', function() {
-          if ($(this).hasClass('unread')) {
-            $(this).removeClass('unread').addClass('read');
-          }
-          Vue.prototype.$notificationService.updateNotification(dataId, 'markAsRead');
-        });
-
-        // ------------- hide notif
-        $(this).find('.remove-item').off('click')
-          .on('click', function(evt) {
-            evt.preventDefault();
-            evt.stopPropagation();
-            Vue.prototype.$notificationService.updateNotification(dataId,'hide');
-            $(this).parents('li:first').slideUp(SLIDE_UP);
-          });
-
-        // ------------- Accept request
-
-        $(this).find('.action-item').off('click')
-          .on('click', function(evt) {
-            evt.stopPropagation();
-            let restURl = $(this).data('rest');
-            if (restURl.indexOf('?') >= 0 ) {
-              restURl += '&';
-            } 
-            else {
-              restURl += '?';
-            }
-            restURl += `portal:csrf=${eXo.env.portal.csrfToken}`;
-            if (restURl && restURl.length > 0) {
-              $.ajax(restURl).done(function () {
-                $(document).trigger('exo-invitation-updated');
-              });
-            }
-            Vue.prototype.$notificationService.updateNotification(dataId,'hide');
-            $(this).parents('li:first').slideUp(SLIDE_UP_MORE);
-          });
-
-        // ------------- Refuse request
-
-        $(this).find('.cancel-item').off('click')
-          .on('click', function(evt) {
-            evt.stopPropagation();
-            let restCancelURl = $(this).data('rest');
-            if (restCancelURl.indexOf('?') >= 0 ) {
-              restCancelURl += '&';
-            }
-            else {
-              restCancelURl += '?';
-            }
-            restCancelURl += `portal:csrf=${eXo.env.portal.csrfToken}`;
-            if (restCancelURl && restCancelURl.length > 0) {
-              $.ajax(restCancelURl).done(function () {
-                $(document).trigger('exo-invitation-updated');
-              });
-            }
-            Vue.prototype.$notificationService.updateNotification(dataId,'hide');
-            $(this).parents('li:first').slideUp(SLIDE_UP_MORE);
-          });
-      });
     },
     notificationUpdated(event) {
       if (event && event.detail) {

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/initComponents.js
@@ -1,7 +1,9 @@
-import ExoTopBarNotification from './components/ExoTopBarNotification.vue';
+import TopBarNotification from './components/TopBarNotification.vue';
+import NotificationItem from './components/NotificationItem.vue';
 
 const components = {
-  'exo-top-bar-notification': ExoTopBarNotification,
+  'top-bar-notification': TopBarNotification,
+  'top-bar-notification-item': NotificationItem,
 };
 
 for (const key in components) {

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/main.js
@@ -42,9 +42,10 @@ export function init() {
     .then(() => {
       // init Vue app when locale ressources are ready
       Vue.createApp({
-        template: `<exo-top-bar-notification id="${appId}"></exo-top-bar-notification>`,
+        template: `<top-bar-notification id="${appId}"></top-bar-notification>`,
         vuetify: Vue.prototype.vuetifyOptions,
         i18n: exoi18n.i18n,
       }, `#${appId}`, 'Topbar Notifications');
-    });
+    })
+    .finally(() => Vue.prototype.$utils.includeExtensions('NotificationPopoverExtension'));
 }


### PR DESCRIPTION
Prior to this change, the notifications of activity types were disabled by a property value, which isn't extensible and can't be defined in each addon apart. This change will allow to disable activity notifications by component plugin instead.