### PR TITLE
fix: Fix Activity Delete ACL - MEED-2313 - Meeds-io/MIPs#50

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerRDBMSTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerRDBMSTest.java
@@ -382,6 +382,7 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
 
     // manager is able to delete other user's activity
     assertTrue(activityManager.isActivityDeletable(activity, admin));
+
     // member is not able to delete other user's activity
     assertFalse(activityManager.isActivityDeletable(activity, mary));
     assertFalse(activityManager.isActivityDeletable(comment, mary));
@@ -403,6 +404,20 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
     assertFalse(activityManager.isActivityDeletable(activity, james));
 
     Mockito.when(james.isMemberOf(acl.getAdminGroups())).thenReturn(true);
+    assertTrue(activityManager.isActivityDeletable(activity, james));
+
+    Map<String, String> templateParams = new HashMap<>();
+    when(activity.getTemplateParams()).thenReturn(templateParams);
+    templateParams.put(ActivityManagerImpl.REMOVABLE, "false");
+    assertFalse(activityManager.isActivityDeletable(activity, owner));
+    assertTrue(activityManager.isActivityDeletable(activity, admin));
+    assertTrue(activityManager.isActivityDeletable(activity, mary));
+    assertTrue(activityManager.isActivityDeletable(activity, james));
+
+    templateParams.put(ActivityManagerImpl.REMOVABLE, "true");
+    assertTrue(activityManager.isActivityDeletable(activity, owner));
+    assertTrue(activityManager.isActivityDeletable(activity, admin));
+    assertTrue(activityManager.isActivityDeletable(activity, mary));
     assertTrue(activityManager.isActivityDeletable(activity, james));
   }
 


### PR DESCRIPTION
Prior to this change, the Activity marked as non REMOVABLE wasn't able to be removed by a space host or a Spaces Administrator. This change will allow for a space Host and space Admin to delete activities, even marked as non-removable.