### PR TITLE
fix: Fix space top bar navigation behavior - EXO-65369 - Meeds-io/MIPs#68

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
@@ -113,11 +113,23 @@ export default {
       });
     },
     urlVerify(url) {
-      if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/)) {
+      if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/) && this.isValidUrl(url) ) {
         url = `//${url}`;
       }
       return url ;
     },
+    isValidUrl(str) {
+      const pattern = new RegExp(
+        '^([a-zA-Z]+:\\/\\/)?' +
+      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' +
+      '((\\d{1,3}\\.){3}\\d{1,3}))' +
+      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' +
+      '(\\?[;&a-z\\d%_.~+=-]*)?' +
+      '(\\#[-a-z\\d_]*)?$',
+        'i'
+      );
+      return pattern.test(str);
+    }
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change, when a new application was added to a space top navigation bar then we access to the added application, a new empty tab is opened. This is due to the fact that the URL of the added application is treated as a link. 
After this change, we have implemented the isValidUrl method to verify that the url is a link.