### PR TITLE
fix: broken links in all notifications page - EXO-64278 - Meeds-io/meeds#1023

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -2003,7 +2003,7 @@
     <name>intranetNotification</name>
     <load-group>webNotificationsGRP</load-group>
     <script>
-      <path>/js/notification/IntranetNotification.js</path>
+      <path>/js/webuiNotification/IntranetNotification.js</path>
     </script>
     <depends>
       <module>webNotifications</module>
@@ -2018,7 +2018,7 @@
     <name>webNotifications</name>
     <load-group>webNotificationsGRP</load-group>
     <script>
-      <path>/js/notification/WebNotification.js</path>
+      <path>/js/webuiNotification/WebNotification.js</path>
     </script>
     <depends>
       <module>jquery</module>

--- a/webapp/portlet/src/main/webapp/skin/less/common/Notification/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/common/Notification/Style.less
@@ -105,6 +105,7 @@ li {
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
+    width: 100%;
 
     .contentSmall {
       .status {


### PR DESCRIPTION
When clicking on notifications on All notifications page, nothing happens.
This will fix the wrong URL on JS files and adds a style to make the whole notification line clickable.