### PR TITLE
feat: Add User making the activity like action - MEED-2204 - Meeds-io/MIPs#50

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityLifeCycle.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityLifeCycle.java
@@ -87,20 +87,20 @@ public class ActivityLifeCycle extends AbstractLifeCycle<ActivityListener, Activ
     broadcast(new ActivityLifeCycleEvent(Type.UPDATE_COMMENT, activity));
   }
   
-  public void likeActivity(ExoSocialActivity activity) {
-    broadcast(new ActivityLifeCycleEvent(Type.LIKE_ACTIVITY, activity));
+  public void likeActivity(ExoSocialActivity activity, String userIdentityId) {
+    broadcast(new ActivityLifeCycleEvent(Type.LIKE_ACTIVITY, activity, userIdentityId));
   }
 
-  public void likeComment(ExoSocialActivity activity) {
-    broadcast(new ActivityLifeCycleEvent(Type.LIKE_COMMENT, activity));
+  public void likeComment(ExoSocialActivity activity, String userIdentityId) {
+    broadcast(new ActivityLifeCycleEvent(Type.LIKE_COMMENT, activity, userIdentityId));
   }
 
-  public void deleteLikeActivity(ExoSocialActivity activity, String userId) {
-    broadcast(new ActivityLifeCycleEvent(Type.DELETE_LIKE_ACTIVITY, activity, userId));
+  public void deleteLikeActivity(ExoSocialActivity activity, String userIdentityId) {
+    broadcast(new ActivityLifeCycleEvent(Type.DELETE_LIKE_ACTIVITY, activity, userIdentityId));
   }
 
-  public void deleteLikeComment(ExoSocialActivity activity, String userId) {
-    broadcast(new ActivityLifeCycleEvent(Type.DELETE_LIKE_COMMENT, activity, userId));
+  public void deleteLikeComment(ExoSocialActivity activity, String userIdentityId) {
+    broadcast(new ActivityLifeCycleEvent(Type.DELETE_LIKE_COMMENT, activity, userIdentityId));
   }
 
   public void deleteActivity(ExoSocialActivity activity) {

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -519,9 +519,9 @@ public class ActivityManagerImpl implements ActivityManager {
     //broadcast is false : we don't want to launch update listeners for a like
     updateActivity(existingActivity, false);
     if(existingActivity.isComment()){
-      activityLifeCycle.likeComment(existingActivity);
+      activityLifeCycle.likeComment(existingActivity, identity.getId());
     } else {
-      activityLifeCycle.likeActivity(existingActivity);
+      activityLifeCycle.likeActivity(existingActivity, identity.getId());
     }
   }
 


### PR DESCRIPTION
Prior to this change, the likeComment and likeActivity operations uses the 'Last liker' as user making the action while we can have parallel execution which will lead to erroneous event triggering. This change will add the user identity id making the like action in the transmitted event data to ensure to have a coherent behavior.