### PR TITLE
fix: Avoid sending uploaded images with reverse order - MEED-2358 - Meeds-io/MIPs#53

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
@@ -25,7 +25,8 @@
       @delete="deleteImage" />
     <attachments-image-input-multi-upload
       ref="uploadInput"
-      :images.sync="images" />
+      :images.sync="images"
+      @delete="deleteImage" />
   </div>
 </template>
 <script>
@@ -95,11 +96,11 @@ export default {
       const uploadIds = this.images
         .filter((file) => file.progress === 100)
         .map((file) => file.uploadId)
-        .filter((uploadId) => !!uploadId)
-        .reverse();
+        .filter((uploadId) => !!uploadId);
       const fileIds = this.attachments
         .filter(file => file.id)
         .map(file => file.id);
+      fileIds.sort((a1, a2) => Number(a1.id) - Number(a2.id));
 
       return this.$fileAttachmentService.saveAttachments({
         objectType: this.objectType,

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputItem.vue
@@ -32,6 +32,15 @@
       color="primary">
       {{ imageUploadProgress }}%
     </v-progress-circular>
+    <v-card-actions class="position-absolute t-0 r-0">
+      <v-btn
+        class="ml-0"
+        fab
+        x-small
+        @click="deleteFile">
+        <v-icon class="error-color" small>fa-trash</v-icon>
+      </v-btn>
+    </v-card-actions>
   </v-card> 
   <v-card 
     v-else 

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/preview/ImagePreviewDialog.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/preview/ImagePreviewDialog.vue
@@ -60,7 +60,7 @@
           hide-delimiters   
           class="AttachmentCarouselPreview white border-radius">
           <v-carousel-item
-            v-for="attachment in attachmentsToDisplay"
+            v-for="attachment in sortedAttachments"
             :key="attachment.id"
             :value="attachment.id"
             reverse-transition="fade-transition"
@@ -94,8 +94,10 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'md';
     },
-    attachmentsToDisplay() {
-      return this.attachments?.length && this.attachments.slice() || [];
+    sortedAttachments() {
+      const sortedAttachments = this.attachments?.length && this.attachments.slice() || [];
+      sortedAttachments.sort((a1, a2) => Number(a1.id) - Number(a2.id));
+      return sortedAttachments;
     },
   },
   watch: {

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/view/ImageItems.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/view/ImageItems.vue
@@ -20,7 +20,7 @@
   <div v-if="attachmentsCount">
     <card-carousel parent-class="attachments-image-parent">
       <attachments-image-item
-        v-for="attachment in imageAttachments"
+        v-for="attachment in sortedAttachments"
         :key="attachment.id"
         :attachment="attachment"
         :object-type="objectType"
@@ -66,6 +66,11 @@ export default {
     },
     attachmentsCount() {
       return this.imageAttachments?.length || 0;
+    },
+    sortedAttachments() {
+      const sortedAttachments = this.attachmentsCount && this.imageAttachments.slice() || [];
+      sortedAttachments.sort((a1, a2) => Number(a1.id) - Number(a2.id));
+      return sortedAttachments;
     },
   },
   created() {


### PR DESCRIPTION
This change will avoid sending Uploaded files in reverse order.
In addition, this will allow to delete files when upload still in progress.
In addition, this will delete uploading files and display error when the upload process is interrupted.