### PR TITLE
fix: Fix Expand View of Action drawer - MEED-2373 - Meeds-io/meeds#1034

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -181,6 +181,14 @@ export default {
         this.close();
       }
     },
+    isMobile: {
+      immediate: true,
+      handler: function() {
+        if (this.isMobile && this.expand) {
+          this.expand = false;
+        }
+      }
+    },
     expand() {
       this.$emit('expand-updated', this.expand);
     },
@@ -280,7 +288,9 @@ export default {
       this.loading = false;
     },
     toogleExpand() {
-      this.expand = !this.expand;
+      if (!this.isMobile && this.allowExpand) {
+        this.expand = !this.expand;
+      }
     },
   },
 };


### PR DESCRIPTION
Prior to this change, when using Mobile, the drawer can be toogled to be expanded while it's not supported. This change ensures to not toggle expand view of the drawer in mobile view.