### PR TITLE
fix: can not search attributes containg spaces in the field name - EXO-65498 - Meeds-io/meeds#1031

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -520,7 +520,7 @@ public class ProfileSearchConnector {
     Map<String, String> settings = filter.getProfileSettings();
     int settingsCount = 0 ;
     for (Map.Entry<String, String> entry : settings.entrySet()){
-      String inputKey = entry.getKey().replace(" ", "\\\\\\\\ ");
+      String inputKey = entry.getKey().replace(" ", "\\\\ ");
       String inputValue = entry.getValue().replace(StorageUtils.ASTERISK_STR, StorageUtils.EMPTY_STR);
       if (inputValue.startsWith("\"") && inputValue.endsWith("\"")) {
         inputValue = inputValue.replace("\"", "");


### PR DESCRIPTION
Removing extra backslashes that were preventing the correct search of profiles with attributes on their names.