### PR TITLE
fix: Fix user avatar border applied on name - MEED-2383 - Meeds-io/meeds#1041

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -16,6 +16,7 @@
       @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
+        :class="avatarClass"
         class="ma-0 flex-shrink-0">
         <img
           :src="avatarUrl"
@@ -58,6 +59,7 @@
       @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
+        :class="avatarClass"
         class="ma-0">
         <img
           :src="avatarUrl"
@@ -99,6 +101,7 @@
       @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
+        :class="avatarClass"
         class="ma-0 flex-shrink-0">
         <img
           :src="avatarUrl"
@@ -141,6 +144,7 @@
       @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
         :size="size"
+        :class="avatarClass"
         class="ma-0">
         <img
           :src="avatarUrl"
@@ -327,7 +331,7 @@ export default {
       };
     },
     componentClass() {
-      return `${this.avatarClass || ''} ${this.clickable && 'width-auto height-auto' || ''} ${this.fullname ? '' : (!this.avatar && this.itemsAlignStyle || '')}`;
+      return `${this.clickable && 'width-auto height-auto' || ''} ${this.fullname ? '' : (!this.avatar && this.itemsAlignStyle || '')}`;
     },
     mustRetrieveIdentity() {
       return !this.identity

--- a/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
@@ -1,7 +1,7 @@
 import ExoDrawer from './components/ExoDrawer.vue';
 import ExoConfirmDialog from './components/ExoConfirmDialog.vue';
 import ExoUserAvatarsList from './components/ExoUserAvatarsList.vue';
-import ExoUserAvatar from './components/ExoUserAvatar.vue';
+import UserAvatar from './components/UserAvatar.vue';
 import SpaceAvatar from './components/SpaceAvatar.vue';
 import ExoIdentitySuggester from './components/ExoIdentitySuggester.vue';
 import RichEditor from './components/RichEditor.vue';
@@ -28,9 +28,11 @@ import RippleHoverButton from './components/RippleHoverButton.vue';
 const components = {
   'card-carousel': CardCarousel,
   'exo-user-avatars-list': ExoUserAvatarsList,
-  'exo-user-avatar': ExoUserAvatar,
+  // FIXME should be deleted, deprecated, use user-avatar instead
+  'exo-user-avatar': UserAvatar,
   // FIXME should be deleted, deprecated, use space-avatar instead
   'exo-space-avatar': SpaceAvatar,
+  'user-avatar': UserAvatar,
   'space-avatar': SpaceAvatar,
   'exo-drawer': ExoDrawer,
   'activity-share-drawer': ActivityShareDrawer,


### PR DESCRIPTION
Prior to this change, the user name has a new border applied on it. This change will move the usage of avatar classes on avatar only and avoid using it on all 'user-avatar' component.