### PR TITLE
fix: can not search attributes containg spaces in the field name - EXO-65498 - Meeds-io/meeds#1031

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -520,6 +520,7 @@ public class ProfileSearchConnector {
     Map<String, String> settings = filter.getProfileSettings();
     int settingsCount = 0 ;
     for (Map.Entry<String, String> entry : settings.entrySet()){
+      String inputKey = entry.getKey().replace(" ", "\\\\ ");
       String inputValue = entry.getValue().replace(StorageUtils.ASTERISK_STR, StorageUtils.EMPTY_STR);
       if (inputValue.startsWith("\"") && inputValue.endsWith("\"")) {
         inputValue = inputValue.replace("\"", "");
@@ -531,11 +532,11 @@ public class ProfileSearchConnector {
           if (i != 0 ) {
             esExp.append(" AND ") ;
           }
-          esExp.append(entry.getKey()+":").append(StorageUtils.ASTERISK_STR).append(removeAccents(splittedValue[i])).append(StorageUtils.ASTERISK_STR);
+          esExp.append(inputKey+":").append(StorageUtils.ASTERISK_STR).append(removeAccents(splittedValue[i])).append(StorageUtils.ASTERISK_STR);
         }
         esExp.append(")");
       } else {
-        esExp.append("( "+entry.getKey()+":").append(StorageUtils.ASTERISK_STR).append(removeAccents(inputValue)).append(StorageUtils.ASTERISK_STR);
+        esExp.append("( "+inputKey+":").append(StorageUtils.ASTERISK_STR).append(removeAccents(inputValue)).append(StorageUtils.ASTERISK_STR);
         esExp.append(")");
       }
       if ( settingsCount != settings.size()- 1 ) esExp.append(" AND ") ;


### PR DESCRIPTION
When a profile attribute has a space in its name, filtering with that attribute does not return results.
The space in the attribute should be escaped to perform correctly the search
