### PR TITLE
feat: Allow to accept/deny notification to a subset of activity receivers by plugin - MEED-1650 - Meeds-io/meeds#576

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/ActivityTypePlugin.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/ActivityTypePlugin.java
@@ -68,6 +68,19 @@ public class ActivityTypePlugin extends BaseComponentPlugin {
   }
 
   /**
+   * Makes a check whether the activity notification is enabled for a given user
+   * or not.
+   * 
+   * @param  activity {@link ExoSocialActivity}
+   * @param  username {@link org.exoplatform.social.core.identity.model.Identity}
+   *                    remote id
+   * @return true if enabled, else false
+   */
+  public boolean isEnableNotification(ExoSocialActivity activity, String username) {
+    return isEnableNotification();
+  }
+
+  /**
    * Return whether an activity is viewable by a user or not
    * 
    * @param  activity        {@link ExoSocialActivity}

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -486,6 +486,16 @@ public interface ActivityManager {
   }
 
   /**
+   * @param  activity {@link ExoSocialActivity}
+   * @param  username User for whom the notification will be sent
+   * @return          true if the Activity Notification is enabled for a given
+   *                  user
+   */
+  default boolean isNotificationEnabled(ExoSocialActivity activity, String username) {
+    return true;
+  }
+
+  /**
    * Checks whether a user can post an activity in a specific stream of user Or
    * Space
    * 

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -112,8 +112,6 @@ public class ActivityManagerImpl implements ActivityManager {
 
   private Set<String>                     systemActivityTypes            = new HashSet<>();
 
-  private List<String>                    disabledTypeNotifications      = new ArrayList<>();
-
   private Map<String, ActivityTypePlugin> activityTypePlugins            = new HashMap<>();
 
   private Set<String>                     systemActivityTitleIds         = new HashSet<>(Arrays.asList("has_joined",
@@ -692,9 +690,6 @@ public class ActivityManagerImpl implements ActivityManager {
 
   @Override
   public void addActivityTypePlugin(ActivityTypePlugin plugin) {
-    if (StringUtils.isNotBlank(plugin.getActivityType()) && !plugin.isEnableNotification()) {
-      disabledTypeNotifications.add(plugin.getActivityType());
-    }
     activityTypePlugins.put(plugin.getActivityType(), plugin);
   }
 
@@ -881,10 +876,25 @@ public class ActivityManagerImpl implements ActivityManager {
 
   @Override
   public boolean isNotificationEnabled(ExoSocialActivity activity) {
-    return activity != null
-        && !activity.isHidden()
-        && (StringUtils.isBlank(activity.getType())
-            || !disabledTypeNotifications.contains(activity.getType()));
+    if (activity == null || activity.isHidden()) {
+      return false;
+    }
+    if (StringUtils.isBlank(activity.getType())) {
+      return true;
+    }
+    ActivityTypePlugin activityTypePlugin = getActivityTypePlugin(activity.getType());
+    return activityTypePlugin == null
+        || activityTypePlugin.isEnableNotification();
+  }
+
+  @Override
+  public boolean isNotificationEnabled(ExoSocialActivity activity, String username) {
+    if (!isNotificationEnabled(activity)) {
+      return false;
+    }
+    ActivityTypePlugin activityTypePlugin = getActivityTypePlugin(activity.getType());
+    return activityTypePlugin == null
+        || activityTypePlugin.isEnableNotification(activity, username);
   }
 
   @Override

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerRDBMSTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerRDBMSTest.java
@@ -314,17 +314,21 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
     addActivityTypePlugin(activityManager, activityType2, true);
 
     assertFalse(activityManager.isNotificationEnabled(null));
+    assertFalse(activityManager.isNotificationEnabled(null, null));
 
     ExoSocialActivity activity = mock(ExoSocialActivity.class);
     assertTrue(activityManager.isNotificationEnabled(activity));
+    assertTrue(activityManager.isNotificationEnabled(activity, null));
     when(activity.getType()).thenReturn(activityType);
-    assertFalse(activityManager.isNotificationEnabled(activity));
+    assertFalse(activityManager.isNotificationEnabled(activity, null));
     when(activity.getType()).thenReturn(activityType2);
-    assertTrue(activityManager.isNotificationEnabled(activity));
+    assertTrue(activityManager.isNotificationEnabled(activity, null));
+    assertFalse(activityManager.isNotificationEnabled(activity, "root3"));
+    assertTrue(activityManager.isNotificationEnabled(activity, "root2"));
     when(activity.getType()).thenReturn(activityType3);
-    assertTrue(activityManager.isNotificationEnabled(activity));
+    assertTrue(activityManager.isNotificationEnabled(activity, null));
     when(activity.isHidden()).thenReturn(true);
-    assertFalse(activityManager.isNotificationEnabled(activity));
+    assertFalse(activityManager.isNotificationEnabled(activity, null));
   }
 
   public void testActivityDeletable() {
@@ -1697,7 +1701,12 @@ public class ActivityManagerRDBMSTest extends AbstractCoreTest {
     param.setName(ActivityTypePlugin.ENABLE_NOTIFICATION_PARAM);
     param.setValue(String.valueOf(enabled));
     params.addParameter(param);
-    activityManager.addActivityTypePlugin(new ActivityTypePlugin(params));
+    activityManager.addActivityTypePlugin(new ActivityTypePlugin(params) {
+      @Override
+      public boolean isEnableNotification(ExoSocialActivity activity, String username) {
+        return !StringUtils.equals(username, "root3") && super.isEnableNotification();
+      }
+    });
   }
 
 }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -199,6 +199,9 @@ public class MailTemplateProvider extends TemplateProvider {
         LOG.debug("Comment of activity with id '{}' was removed but the notification with id'{}' is remaining", commentId, notification.getId());
         return null;
       }
+      if (!Utils.getActivityManager().isNotificationEnabled(comment, notification.getTo())) {
+        return null;
+      }
       Identity identity = Utils.getIdentityManager().getIdentity(comment.getPosterId(), true);
 
       TemplateContext templateContext = new TemplateContext(notification.getKey().getId(), language);
@@ -850,6 +853,9 @@ public class MailTemplateProvider extends TemplateProvider {
 
       String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
       ExoSocialActivity activity = Utils.getActivityManager().getActivity(activityId);
+      if (activity == null || !Utils.getActivityManager().isNotificationEnabled(activity, notification.getTo())) {
+        return null;
+      }
       Identity identity = Utils.getIdentityManager().getIdentity(activity.getPosterId(), true);
 
 
@@ -916,6 +922,9 @@ public class MailTemplateProvider extends TemplateProvider {
       String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
       String originalTitle = notification.getValueOwnerParameter(SocialNotificationUtils.ORIGINAL_TITLE.getKey());
       ExoSocialActivity activity = Utils.getActivityManager().getActivity(activityId);
+      if (activity == null || !Utils.getActivityManager().isNotificationEnabled(activity, notification.getTo())) {
+        return null;
+      }
       Identity identity = Utils.getIdentityManager().getIdentity(activity.getPosterId(), true);
 
       Identity spaceIdentity = Utils.getIdentityManager().getOrCreateIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner(), true);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/WebTemplateProvider.java
@@ -300,6 +300,9 @@ public class WebTemplateProvider extends TemplateProvider {
         LOG.debug("Comment of activity with id '{}' was removed but the notification with id'{}' is remaining", commentId, notification.getId());
         return null;
       }
+      if (!Utils.getActivityManager().isNotificationEnabled(comment, notification.getTo())) {
+        return null;
+      }
       String pluginId = notification.getKey().getId();
       
       TemplateContext templateContext = TemplateContext.newChannelInstance(getChannelKey(), pluginId, language);
@@ -661,6 +664,9 @@ public class WebTemplateProvider extends TemplateProvider {
         LOG.debug("Activity with id '{}' doesn't exist. The related notification will be ignored", activityId);
         return null;
       }
+      if (!Utils.getActivityManager().isNotificationEnabled(activity, notification.getTo())) {
+        return null;
+      }
       Identity identity = Utils.getIdentityManager().getIdentity(activity.getPosterId(), true);
       Profile profile = identity.getProfile();
       templateContext.put("isIntranet", "true");
@@ -752,6 +758,9 @@ public class WebTemplateProvider extends TemplateProvider {
       ExoSocialActivity activity = Utils.getActivityManager().getActivity(activityId);
       if (activity == null) {
         LOG.debug("Notification related to activity with id '{}' couldn't be found. The related notification will be ignored", activityId);
+        return null;
+      }
+      if (!Utils.getActivityManager().isNotificationEnabled(activity, notification.getTo())) {
         return null;
       }
       Identity identity = Utils.getIdentityManager().getIdentity(activity.getPosterId(), true);


### PR DESCRIPTION
This change will allow to specify by ActivityNotificationPlugin whether to send to a given user the notification or not.