### PR TITLE
Fix :The full name isn't updated after updating multiple profile properties including the first name or the last name - EXO-65382 - Meeds-io/meeds#1050

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1025,6 +1025,9 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
       try {
         if (!(profileProperty.isMultiValued() || !profileProperty.getChildren().isEmpty())) {
           updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), true);
+          if (profileProperty.getPropertyName().equals(Profile.FIRST_NAME) || profileProperty.getPropertyName().equals(Profile.LAST_NAME) ) {
+            profile = getUserIdentity(username).getProfile();
+          }
         } else {
           switch (profileProperty.getPropertyName()) {
             case Profile.CONTACT_PHONES:


### PR DESCRIPTION
Prior to this change, after updating multiple profile properties including the first name or the last name, the full name was not being updated. This issue occurred because the full name property was only updated when either the first name or the last name was changed. In the case of updating multiple properties at once, we need to fetch the newly updated profile to utilize the new value of the full name.