### PR TITLE
feat: Implement an upgrade plugin to update passwords hashing algorithm - EXO-65151 - Meeds-io/MIPs#69

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigration.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigration.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2023 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.social.core.upgrade;
+
+import org.apache.commons.codec.binary.Hex;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.idm.PicketLinkIDMService;
+import org.exoplatform.web.security.security.SecureRandomService;
+import org.picketlink.idm.api.User;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class UserPasswordHashMigration extends UpgradeProductPlugin {
+
+  private static final Log           LOG                          = ExoLogger.getExoLogger(UserPasswordHashMigration.class);
+
+  private final EntityManagerService entityManagerService;
+
+  private final PicketLinkIDMService picketLinkIDMService;
+
+  private final SecureRandomService  secureRandomService;
+
+  private static final String        PASSWORD_SALT_USER_ATTRIBUTE = "passwordSalt128";
+
+  private static final String        DEFAULT_ENCODER              = "org.exoplatform.web.security.hash.Argon2IdPasswordEncoder";
+
+  private boolean                    hasErrors                    = false;
+
+  public UserPasswordHashMigration(EntityManagerService entityManagerService,
+                                   PicketLinkIDMService picketLinkIDMService,
+                                   SecureRandomService secureRandomService,
+                                   InitParams initParams) {
+    super(initParams);
+    this.entityManagerService = entityManagerService;
+    this.picketLinkIDMService = picketLinkIDMService;
+    this.secureRandomService = secureRandomService;
+  }
+
+  @Override
+  public void processUpgrade(String s, String s1) {
+    LOG.info("Start upgrade of users passwords hashing algorithm");
+    long startupTime = System.currentTimeMillis();
+
+    PortalContainer container = PortalContainer.getInstance();
+    RequestLifeCycle.begin(container);
+    AtomicInteger updatedPasswords = new AtomicInteger();
+    EntityManager entityManager = this.entityManagerService.getEntityManager();
+    try {
+      String sqlString = "SELECT jbid_io.NAME, jbid_io_creden.TEXT  FROM"
+          + " (jbid_io_creden INNER JOIN jbid_io ON jbid_io_creden.IDENTITY_OBJECT_ID = jbid_io.ID)"
+          + " INNER JOIN (SELECT jbid_io_attr.IDENTITY_OBJECT_ID FROM jbid_io_attr"
+          + " WHERE jbid_io_attr.IDENTITY_OBJECT_ID NOT IN (SELECT jbid_io_attr.IDENTITY_OBJECT_ID FROM jbid_io_attr WHERE NAME = 'passwordSalt128')"
+          + " GROUP BY jbid_io_attr.IDENTITY_OBJECT_ID) jia ON jbid_io_creden.IDENTITY_OBJECT_ID  = jia.IDENTITY_OBJECT_ID;";
+
+      Query nativeQuery = entityManager.createNativeQuery(sqlString);
+      List<Object[]> result = nativeQuery.getResultList();
+      result.forEach(item -> {
+        String userName = (String) item[0];
+        String passwordHash = (String) item[1];
+        try {
+          String saltString = Hex.encodeHexString(generateRandomSalt());
+          User user = picketLinkIDMService.getIdentitySession().getPersistenceManager().findUser(userName);
+          picketLinkIDMService.getExtendedAttributeManager().addAttribute(userName, PASSWORD_SALT_USER_ATTRIBUTE, saltString);
+          picketLinkIDMService.getExtendedAttributeManager().updatePassword(user, passwordHash);
+          int count = updatedPasswords.incrementAndGet();
+          if (count % 50 == 0 || count == result.size()) {
+            LOG.info("{}/{} passwords have been updated", count, result.size());
+          }
+        } catch (Exception e) {
+          hasErrors = true;
+          LOG.error("Error while creating attribute salt and updating password hash for user : {}", userName, e);
+        }
+      });
+      if (hasErrors) {
+        throw new IllegalStateException("UserPasswordHashMigration upgrade failed due to previous errors");
+      }
+    } catch (Exception e) {
+      LOG.error("Error while getting old users passwords hash", e);
+      throw new IllegalStateException("UserPasswordHashMigration upgrade failed due to previous errors");
+    } finally {
+      RequestLifeCycle.end();
+    }
+    LOG.info("End upgrade of users passwords hashing algorithm. {} passwords has been updated. It took {} ms",
+             updatedPasswords.get(),
+             (System.currentTimeMillis() - startupTime));
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion,
+                                        String previousGroupVersion,
+                                        UpgradePluginExecutionContext previousUpgradePluginExecution) {
+    try {
+      return picketLinkIDMService.getExtendedAttributeManager()
+                                 .getDefaultCredentialEncoder()
+                                 .getClass()
+                                 .getName()
+                                 .equals(DEFAULT_ENCODER)
+          && super.shouldProceedToUpgrade(newVersion, previousGroupVersion, previousUpgradePluginExecution);
+    } catch (Exception e) {
+      LOG.error("Error while checking current default credential encoder", e);
+      return false;
+    }
+  }
+
+  private byte[] generateRandomSalt() {
+    SecureRandom secureRandom = secureRandomService.getSecureRandom();
+    byte[] salt = new byte[16];
+    secureRandom.nextBytes(salt);
+    return salt;
+  }
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.social.core.jpa.test;
 
+import org.exoplatform.social.core.upgrade.UserPasswordHashMigrationTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runners.Suite.SuiteClasses;
@@ -100,6 +101,7 @@ import org.exoplatform.social.core.binding.spi.RDBMSGroupSpaceBindingStorageTest
   ImageThumbnailServiceImplTest.class,
   RichEditorConfigurationServiceTest.class,
   TranslationServiceTest.class,
+  UserPasswordHashMigrationTest.class
 })
 @ConfigTestCase(AbstractCoreTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/core/src/test/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigrationTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2023 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.social.core.upgrade;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.organization.idm.PicketLinkIDMService;
+import org.exoplatform.web.security.hash.Argon2IdPasswordEncoder;
+import org.exoplatform.web.security.security.SecureRandomService;
+import org.gatein.portal.idm.impl.store.attribute.ExtendedAttributeManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.picketlink.idm.api.IdentitySession;
+import org.picketlink.idm.api.PersistenceManager;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserPasswordHashMigrationTest {
+
+  @Mock
+  private EntityManagerService      entityManagerService;
+
+  @Mock
+  private PicketLinkIDMService      picketLinkIDMService;
+
+  private SecureRandomService       secureRandomService;
+
+  private PortalContainer           container;
+
+  private UserPasswordHashMigration userPasswordHashMigration;
+
+  @Before
+  public void setUp() {
+    container = PortalContainer.getInstance();
+    secureRandomService = container.getComponentInstanceOfType(SecureRandomService.class);
+    InitParams initParams = new InitParams();
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.platform");
+    ValueParam valueParamVersion = new ValueParam();
+    valueParamVersion.setName("plugin.upgrade.target.version");
+    valueParamVersion.setValue("6.5.0");
+    ValueParam oldAppNamevalueParam = new ValueParam();
+    oldAppNamevalueParam.setName("plugin.execution.order");
+    oldAppNamevalueParam.setValue("100");
+    ValueParam oldAppIdvalueParam = new ValueParam();
+    oldAppIdvalueParam.setName("plugin.upgrade.execute.once");
+    oldAppIdvalueParam.setValue("true");
+    ValueParam newAppIdvalueParam = new ValueParam();
+    newAppIdvalueParam.setName("plugin.upgrade.async.execution");
+    newAppIdvalueParam.setValue("true");
+    initParams.addParameter(valueParam);
+    initParams.addParameter(valueParamVersion);
+    initParams.addParameter(oldAppNamevalueParam);
+    initParams.addParameter(oldAppIdvalueParam);
+    initParams.addParameter(newAppIdvalueParam);
+    userPasswordHashMigration = new UserPasswordHashMigration(entityManagerService,
+                                                              picketLinkIDMService,
+                                                              secureRandomService,
+                                                              initParams);
+  }
+
+  @Test
+  public void tesProcessUpgrade() throws Exception {
+    List<Object[]> result = new ArrayList<>();
+    result.add(new String[] { "user", "passwordHash" });
+    EntityManager entityManager = mock(EntityManager.class);
+    Query query = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(query);
+    when(query.getResultList()).thenReturn(result);
+    when(entityManagerService.getEntityManager()).thenReturn(entityManager);
+
+    IdentitySession identitySession = mock(IdentitySession.class);
+    PersistenceManager persistenceManager = mock(PersistenceManager.class);
+    ExtendedAttributeManager extendedAttributeManager = mock(ExtendedAttributeManager.class);
+    when(identitySession.getPersistenceManager()).thenReturn(persistenceManager);
+    when(picketLinkIDMService.getIdentitySession()).thenReturn(identitySession);
+    when(picketLinkIDMService.getExtendedAttributeManager()).thenReturn(extendedAttributeManager);
+    userPasswordHashMigration.processUpgrade(null, null);
+    verify(extendedAttributeManager, times(1)).updatePassword(any(), anyString());
+    verify(extendedAttributeManager, times(1)).addAttribute(anyString(), anyString(), anyString());
+
+    when(extendedAttributeManager.getDefaultCredentialEncoder()).thenReturn(new Argon2IdPasswordEncoder());
+    boolean proceedToUpgrade = userPasswordHashMigration.shouldProceedToUpgrade(null, null, null);
+    assertFalse(proceedToUpgrade);
+
+    UpgradePluginExecutionContext upgradePluginExecutionContext = new UpgradePluginExecutionContext("6.4.0", 0);
+    proceedToUpgrade = userPasswordHashMigration.shouldProceedToUpgrade("6.5.0", "6.4.0", upgradePluginExecutionContext);
+    assertTrue(proceedToUpgrade);
+    // Case of exceptions existing during upgrade
+    doThrow(new RuntimeException()).when(picketLinkIDMService).getIdentitySession();
+    Throwable exception = assertThrows(IllegalStateException.class, () -> userPasswordHashMigration.processUpgrade(null, null));
+    assertEquals("UserPasswordHashMigration upgrade failed due to previous errors", exception.getMessage());
+  }
+}

--- a/extension/war/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -28,6 +28,7 @@
   <import>war:/conf/social-extension/portal/resource-bundle-configuration.xml</import>
   <import>war:/conf/social-extension/portal/dynamic-container-configuration.xml</import>
   <import>war:/conf/social-extension/portal/application-registry-configuration.xml</import>
+  <import>war:/conf/social-extension/portal/upgrade-plugins-configuration.xml</import>
   <import>war:/conf/social-extension/social/social-configuration.xml</import>
   <import>war:/conf/social-extension/social/spaces-templates-configuration.xml</import>
   <import>war:/conf/social-extension/social/component-plugins-configuration.xml</import>
@@ -47,5 +48,4 @@
   <import>war:/conf/social-extension/portal/navigation-categories-configuration.xml</import>
 
   <import>war:/conf/social-extension/social/profileproperty/profile-property-configuration.xml</import>
-
 </configuration>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/upgrade-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/upgrade-plugins-configuration.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2023 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+               xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+    <external-component-plugins>
+        <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+        <component-plugin>
+            <name>UserPasswordHashMigration</name>
+            <set-method>addUpgradePlugin</set-method>
+            <type>org.exoplatform.social.core.upgrade.UserPasswordHashMigration</type>
+            <description>Update users passwords hash algorithm</description>
+            <init-params>
+                <value-param>
+                    <name>product.group.id</name>
+                    <description>The groupId of the product</description>
+                    <value>org.exoplatform.platform</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.target.version</name>
+                    <description>
+                        The plugin target version (will not be executed if previous version is equal or higher than
+                        6.3.1)
+                    </description>
+                    <value>6.5.0</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.execution.order</name>
+                    <description>The plugin execution order</description>
+                    <value>100</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.execute.once</name>
+                    <description>The plugin must be executed only once</description>
+                    <value>true</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.async.execution</name>
+                    <description>The plugin will be executed in an asynchronous mode</description>
+                    <value>true</value>
+                </value-param>
+            </init-params>
+        </component-plugin>
+    </external-component-plugins>
+</configuration>


### PR DESCRIPTION
Prior to this change, As a part of the upgrade mechanism of old hashed passwords we need to create an UP to re-hash old passwords by the new hash algo. This PR creates an UP which has to update the old passwords hash by the new algo by re-hashing and adding the needed salt attribute.