### PR TITLE
fix: Check user existence before updating his salt - EXO-65151 - Meeds-io/MIPs#69

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigration.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigration.java
@@ -93,7 +93,7 @@ public class UserPasswordHashMigration extends UpgradeProductPlugin {
         try {
           String saltString = Hex.encodeHexString(generateRandomSalt());
           User user = picketLinkIDMService.getIdentitySession().getPersistenceManager().findUser(userName);
-          if (picketLinkIDMService.getExtendedAttributeManager().getAttribute(userName, PASSWORD_SALT_USER_ATTRIBUTE) == null) {
+          if (user != null && picketLinkIDMService.getExtendedAttributeManager().getAttribute(userName, PASSWORD_SALT_USER_ATTRIBUTE) == null) {
             picketLinkIDMService.getExtendedAttributeManager().addAttribute(userName, PASSWORD_SALT_USER_ATTRIBUTE, saltString);
             picketLinkIDMService.getExtendedAttributeManager().updatePassword(user, passwordHash);
           }

--- a/component/core/src/test/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigrationTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/upgrade/UserPasswordHashMigrationTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.picketlink.idm.api.IdentitySession;
 import org.picketlink.idm.api.PersistenceManager;
+import org.picketlink.idm.api.User;
+import org.picketlink.idm.impl.api.model.SimpleUser;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -104,6 +106,8 @@ public class UserPasswordHashMigrationTest {
 
     IdentitySession identitySession = mock(IdentitySession.class);
     PersistenceManager persistenceManager = mock(PersistenceManager.class);
+    User user = new SimpleUser("userId");
+    when(persistenceManager.findUser(anyString())).thenReturn(user);
     ExtendedAttributeManager extendedAttributeManager = mock(ExtendedAttributeManager.class);
     when(identitySession.getPersistenceManager()).thenReturn(persistenceManager);
     when(picketLinkIDMService.getIdentitySession()).thenReturn(identitySession);


### PR DESCRIPTION
Prior to this change, in some particular cases, the picketlink identity is not found (due to old data). This lead to a null pointer exception for theses users. In order to finish the UP correctly, we add a condition to ignore theses users.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
