### PR TITLE
fix: Issue with cursor icon when hovering over a notification text -EXO-63933 - Meeds-io/meeds#1064.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-notifications/components/UserSettingNotificationDrawer.vue
@@ -21,6 +21,7 @@
               v-model="channels[pluginOption.channelId]"
               :name="pluginOption.channelId"
               :disabled="!pluginOption.channelActive"
+              :id="pluginOption.channelId"
               hide-details
               dense
               class="mt-0" />


### PR DESCRIPTION
Prior to this change, when open the edition drawer of any notification and hover over the text of the one of the 3 options , the cursor icon changes to hand icon but no action can be done by clicking on the text After this change, the cursor should remain with the text icon.