### PR TITLE
fix: allow importing custom & multivalued properties with csv - EXO-65669 - Meeds-io/meeds#1070

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
@@ -49,6 +49,14 @@ public interface ProfilePropertyService {
    *
    * @return {@link ProfilePropertySetting} if exist or null if not
    */
+  ProfilePropertySetting getProfileSettingById(Long id);
+
+  /**
+   * Retrieves the ProfileProperty item with given {@link ProfilePropertySetting}
+   * propertyName
+   *
+   * @return {@link ProfilePropertySetting} if exist or null if not
+   */
   ProfilePropertySetting getProfileSettingByName(String name);
 
   /**

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
@@ -75,6 +75,11 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   }
 
   @Override
+  public ProfilePropertySetting getProfileSettingById(Long id) {
+    return profileSettingStorage.getProfileSettingById(id);
+  }
+
+  @Override
   public ProfilePropertySetting createPropertySetting(ProfilePropertySetting profilePropertySetting) throws ObjectAlreadyExistsException {
     if (profilePropertySetting == null) {
       throw new IllegalArgumentException("Profile property setting Item Object is mandatory");

--- a/component/service/src/test/resources/users-with-profile-settings.csv
+++ b/component/service/src/test/resources/users-with-profile-settings.csv
@@ -1,0 +1,2 @@
+userName,firstName,lastName,email,password,groups,aboutMe,timeZone,company,position,phones.work,custom-single-property,custom-multi-property.first-property
+jack.nipper,Jack,Nipper,jack.nipper0@nasa.gov,Pass@123456,*:/platform/users;member:/spaces/spaceone,aboutMe1,timeZone1,company1,position1,777777,test,first property value


### PR DESCRIPTION
When importing users from a CSV file, the custom profile properties were ignored and they are not added to the imported user profile.
The fix generify the code to allow importing users with all custom properties including multi valued ones. 