### PR TITLE
fix: paste menu for post short messages - EXO-65657 - Meeds-io/meeds#1073

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoActivityRichEditor.vue
@@ -1,16 +1,9 @@
 <template>
   <div class="activityRichEditor newEditorToolbar">
-    <div
-      v-if="displayPlaceholder"
-      @click="setFocus"
-      class="caption text-sub-title position-absolute t-0 pa-5 ma-1px full-width">
-      {{ placeholder }}
-    </div>
     <textarea
       ref="editor"
       :id="ckEditorType"
       v-model="inputVal"
-      :placeholder="placeholder"
       cols="30"
       rows="10"
       class="textarea"></textarea>
@@ -91,7 +84,6 @@ export default {
       SMARTPHONE_LANDSCAPE_WIDTH: 768,
       inputVal: null,
       editor: null,
-      displayPlaceholder: true,
       baseUrl: eXo.env.server.portalBaseURL
     };
   },
@@ -114,7 +106,6 @@ export default {
   },
   watch: {
     inputVal(val) {
-      this.computePlaceHolderVisibility();
       if (this.editorReady) {
         this.$emit('input', val);
       }
@@ -124,7 +115,6 @@ export default {
     },
     editorReady() {
       if (this.editorReady) {
-        this.computePlaceHolderVisibility();
         this.$emit('ready');
       } else {
         this.$emit('unloaded');
@@ -177,7 +167,7 @@ export default {
       }
       CKEDITOR.dtd.$removeEmpty['i'] = false;
 
-      let extraPlugins = 'simpleLink,suggester,widget';
+      let extraPlugins = 'simpleLink,suggester,widget,editorplaceholder';
       let removePlugins = 'image,maximize,resize';
       const toolbar = [
         ['Bold', 'Italic', 'BulletedList', 'NumberedList', 'Blockquote'],
@@ -231,6 +221,7 @@ export default {
         customConfig: '/commons-extension/ckeditorCustom/config.js',
         extraPlugins,
         removePlugins,
+        editorplaceholder: this.placeholder,
         toolbar,
         allowedContent: true,
         enterMode: 3, // div
@@ -282,9 +273,6 @@ export default {
       if (this.editor) {
         this.editor.destroy(true);
       }
-    },
-    computePlaceHolderVisibility() {
-      this.displayPlaceholder = this.editor?.status === 'ready' && !this.inputVal && !this.inputVal.trim();
     },
     replaceWithSuggesterClass: function(message) {
       const tempdiv = $('<div class=\'temp\'/>').html(message || '');


### PR DESCRIPTION
Prior to this change, when copy a content(link/text) and click on post short message in spaceX then right click on the editor to paste the content, action menu that permit to paste the content isn't displayed unless at least a char is added. To fix this problem, added the editorplaceholder plugin in ckeditor then replaced the div that replaces the placeholder with the ckeditor config. After this change, action menu permit to paste content is displayed, no need to add chars.

(cherry picked from commit 15f3fad91b37ccbcfc50d143fe500d0f8e2961f0)