### PR TITLE
fix: Chat icon should only be displayed for space members - EXO-64806 - Meeds-io/meeds#1069

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -847,8 +847,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
                                 @Parameter(description = "Space id", required = true) @PathParam("id") String id,
                                 @Parameter(description = "User id", required = true) @PathParam("userId") String userId) {
     Space space = spaceService.getSpaceById(id);
-    String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
-    if (space == null || (!spaceService.isMember(space, authenticatedUser) && !spaceService.isSuperManager(authenticatedUser))) {
+    if (space == null) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     boolean isMember = spaceService.isMember(space, userId);

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
@@ -20,6 +20,7 @@
 -->
 <template>
   <v-menu
+    v-if="menu"
     v-model="menu"
     rounded="rounded"
     :close-on-content-click="false"


### PR DESCRIPTION
Prior to this change, when create article in spaceX and publish it on target, create program whose audience spaceX, share activity from spaceX to spaceY and create user1 simple user & user2 admin on plf/ spaces manager not members in spaceX open this article from target and hover on spaceX link, chat icon is visible for none members and opens the drawer. To fix this problem, added to the check if this room enebled another check if this user current is a member of this space in the popverChatButton and to ensure that the chat button only appears for members of this space add one another check during their display in the popver if this user is a member in this space. After this change,chat icon is displayed for spaceX members only.

(cherry picked from commit af6abc84b5007f8d8a48a4b0ad084e87da8dcccc)