### PR TITLE
 feat: Prevent the default event when clicking to delete an attached image - MEED-2036 - Meeds-io/MIPs#53

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputItem.vue
@@ -64,7 +64,7 @@
         class="ml-0" 
         fab 
         x-small
-        @click="deleteFile">
+        @click.prevent.stop="deleteFile">
         <v-icon class="error-color" small>fa-trash</v-icon>
       </v-btn>
     </v-card-actions>


### PR DESCRIPTION
Prior to this change when clicking to delete an attached image, the click event is propagated. This change will avoid to propagate this event.