### PR TITLE
fix: Fix disabling Apply button on Hub Access when no modifications

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/registration/HubAccess.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/registration/HubAccess.vue
@@ -320,9 +320,9 @@ export default {
         return false;
       }
       const newSettings = {
-        type: this.accessType,
         externalUser: this.accessType === 'OPEN' ? this.externalUserOpenRegistration : this.externalUserRestrictedRegistration,
         extraGroupIds: this.defaultSpaceIds,
+        type: this.accessType,
       };
       return JSON.stringify(newSettings) !== JSON.stringify(this.registrationSettings);
     },


### PR DESCRIPTION
Prior to this change, the Hub Access apply button wasn't disabled when no change is made on UI yet.