### PR TITLE
feat: Allow to add embedded content in Rich Editor contents - MEED-2439 - Meeds-io/meeds#1082

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -2115,14 +2115,7 @@
     <name>purifyVue</name>
     <load-group>purifyGRP</load-group>
     <script>
-      <minify>false</minify>
-      <adapter>
-        (function() {
-          Vue.directive('sanitized-html', function (el, binding) {
-            el.innerHTML = ExtendedDomPurify.purify(binding.value);
-          })
-        })();
-      </adapter>
+      <path>/js/sanitize-html-directive.js</path>
     </script>
     <depends>
       <module>ExtendedDomPurify</module>

--- a/webapp/portlet/src/main/webapp/js/sanitize-html-directive.js
+++ b/webapp/portlet/src/main/webapp/js/sanitize-html-directive.js
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+(function() {
+  window.Vue.directive('sanitized-html', function (el, binding) {
+    let content = binding.value;
+    if (content && content.includes('<oembed>') && content.includes('</oembed>')) {
+      content = content.replace(/<oembed>(.*)<\/oembed>/g, '');
+    }
+    if (content && content.includes('<div><![CDATA[') && content.includes(']]></div>')) {
+      try {
+        content = content.replace(/<div><!\[CDATA\[(.*)]]><\/div>/g, window.decodeURIComponent(content.match(/<div><!\[CDATA\[(.*)]]><\/div>/i)[1]));
+      } catch(e) {
+        content = content.replace(/<div><!\[CDATA\[(.*)]]><\/div>/g, content.match(/<div><!\[CDATA\[(.*)]]><\/div>/i)[1]);
+      }
+    }
+    el.innerHTML = content && ExtendedDomPurify.purify(content) || '';
+  });
+})();

--- a/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationDrawer.vue
@@ -111,6 +111,7 @@
             :value="translations[language]"
             :max-length="maxLength"
             :tag-enabled="false"
+            :oembed="richEditorOembed"
             autofocus
             @input="updateValue(language, $event)" />
         </v-col>
@@ -178,6 +179,10 @@ export default {
       default: false,
     },
     richEditor: {
+      type: Boolean,
+      default: false,
+    },
+    richEditorOembed: {
       type: Boolean,
       default: false,
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationTextField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationTextField.vue
@@ -99,6 +99,7 @@
       :back-icon="backIcon"
       :max-length="maxlength"
       :rich-editor="richEditor"
+      :rich-editor-oembed="richEditorOembed"
       :no-expand-icon="noExpandIcon"
       @input="emitUpdateValues" />
   </div>
@@ -159,6 +160,10 @@ export default {
       default: false,
     },
     richEditor: {
+      type: Boolean,
+      default: false,
+    },
+    richEditorOembed: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
Prior to this change, it was possible to embed content from external sites only in Activity stream using TemplateParams. This change will allow to store the html of embedded content inside the saved content itself so this can be genralized in all content that are based on 'rich-editor' component.