### PR TITLE
fix: Fix Activity Not Found Placeholder Style - MEED-2494 - Meeds-io/meeds#1095

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityNotFound.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityNotFound.vue
@@ -10,9 +10,9 @@
       {{ $t('UIUserActivitiesDisplay.label.activityNotFound') }}
     </div>
     <v-card
-      class="text-color mt-6 d-none d-sm-inline title"
+      class="text-color mt-6 mx-2 d-none d-sm-inline title"
       max-width="80%"
-      min-width="50vw"
+      width="80%"
       flat>
       {{ $t('activity.notFound.message') }}
     </v-card>


### PR DESCRIPTION
Prior to this change, the 'Activity Not Found' message overflows the app box size. This change ensures to use relative width proportions to not let the text exceeds the parent box size.