### PR TITLE
fix: Notification read display - EXO-66167 - Meeds-io/meeds#1103

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-api</artifactId>
   <name>eXo PLF:: Social API</name>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-common</artifactId>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-core</artifactId>
   <name>eXo PLF:: Social Core Component</name>

--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component-notification</artifactId>
   <name>eXo PLF:: Social Notification Component</name>

--- a/component/oauth-auth/pom.xml
+++ b/component/oauth-auth/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-component</artifactId>
   <packaging>pom</packaging>

--- a/component/service/pom.xml
+++ b/component/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-service</artifactId>

--- a/component/webui/pom.xml
+++ b/component/webui/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-component</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social-component-webui</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-extension</artifactId>
   <packaging>pom</packaging>

--- a/extension/war/pom.xml
+++ b/extension/war/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-extension</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-extension-war</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>org.exoplatform.social</groupId>
   <artifactId>social</artifactId>
-  <version>6.5.x-exo-SNAPSHOT</version>
+  <version>6.5.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: Social</name>
   <description>eXo Social - Enterprise Social Networking</description>
@@ -46,8 +46,8 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <org.exoplatform.commons.version>6.5.x-exo-SNAPSHOT</org.exoplatform.commons.version>
-    <org.exoplatform.platform-ui.version>6.5.x-exo-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <org.exoplatform.commons.version>6.5.x-maintenance-SNAPSHOT</org.exoplatform.commons.version>
+    <org.exoplatform.platform-ui.version>6.5.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
 
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>social</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp</artifactId>
   <packaging>pom</packaging>

--- a/webapp/portlet/pom.xml
+++ b/webapp/portlet/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>social-webapp</artifactId>
     <groupId>org.exoplatform.social</groupId>
-    <version>6.5.x-exo-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>social-webapp-portlet</artifactId>
   <packaging>war</packaging>

--- a/webapp/portlet/src/main/webapp/groovy/social/portlet/UIIntranetNotificationsPortlet.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/portlet/UIIntranetNotificationsPortlet.gtmpl
@@ -41,3 +41,25 @@ jsManager.require("SHARED/jquery", "jq")
 	</div>
   <div class="bottomContainer"></div>
 </div>
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    var contentElements = document.querySelectorAll(".unread");
+    if (contentElements.length) {
+      contentElements.forEach(function(element) {
+        var elmt = element.querySelectorAll(".contentSmall");
+        var notificationId = element.getAttribute("data-id");
+        elmt[0].addEventListener("click", function(event) {
+          var restPath = "/portal/rest/notifications/webNotifications/"+notificationId;
+          fetch(restPath, {
+            headers: {
+              "Content-Type": "text/plain",
+              credentials: "include",
+            },
+            method: "PATCH",
+            body: "markAsRead"
+          });
+        });
+      });
+    }
+});
+</script>

--- a/webapp/portlet/src/main/webapp/skin/less/common/Notification/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/common/Notification/Style.less
@@ -105,6 +105,7 @@ li {
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
+    width: 100%;
 
     .contentSmall {
       .status {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -203,7 +203,7 @@
           {{ $t('profileSettings.button.cancel') }}
         </v-btn>
         <v-btn
-          :disabled="saving"
+          :disabled="isSaveButtonDisabled || saving"
           :loading="saving"
           class="btn btn-primary"
           @click="saveSetting">
@@ -238,6 +238,9 @@ export default {
     labels: [],
     changes: false,
     labelsObjectType: 'profileProperty',
+    initialSetting: {},
+    initialLabels: [],
+    areLabelsChanged: false
   }),
   computed: {
     title() {
@@ -246,6 +249,12 @@ export default {
       } else {
         return this.$t('profileSettings.drawer.title.editSetting');
       }
+    },
+    isSaveButtonDisabled() {
+      if (!this.newSetting) {
+        return !this.areLabelsChanged && this.areSettingsEqual(this.initialSetting, this.setting);
+      }
+      return false;
     }
   },
   watch: {
@@ -262,6 +271,20 @@ export default {
       } else {
         this.$refs.profileSettingFormDrawer.close();
       }
+    },
+    labels: {
+      immediate: true,
+      deep: true,
+      handler(newItems) {
+        const areEqualsLabels = this.initialLabels.length === newItems.length && this.initialLabels.every((item, index) => {
+          return item.id === newItems[index].id && item.label === newItems[index].label && item.language === newItems[index].language;
+        });
+        if (!areEqualsLabels) {
+          this.areLabelsChanged = true;
+        } else {
+          this.areLabelsChanged = false;
+        }
+      },
     },
   },
   created() {
@@ -296,6 +319,8 @@ export default {
       this.drawer = true;
     },
     editSetting(setting) {
+      this.initialSetting = {...setting};
+      this.initialLabels = JSON.parse(JSON.stringify(setting.labels));
       this.setting = { ...setting};
       this.parents = Object.assign([], this.settings);
       this.parents = !(Array.isArray(this.setting?.children) && this.setting?.children.length) && this.parents.filter(setting => setting.id !== this.setting.id && !setting.parentId) || [];
@@ -378,6 +403,19 @@ export default {
         this.changes= false;
       } 
     },
+    areSettingsEqual(initialSetting, setting) {
+      const fields = ['id', 'parentId', 'active', 'groupSynchronized', 'multiValued', 'visible', 'required', 'editable'
+      ];
+      for (const field of fields) {
+        if (field === 'parentId' && setting[field] === '') {
+          setting[field] = null;
+        }
+        if (initialSetting[field] !== setting[field]) {
+          return false;
+        }
+      }
+      return true;
+    }
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change, when open notif drawer, click on see all button, click on any notif unread and check notif in drawer or on full page, notif colored in blue as if it was unread. To fix this problem, added a script to trigger the rest of the change to read after clicking on this notif. After this change, this notif is colored white and marked as read.