### PR TITLE
fix: Fix sending Watch notification when Activity isn't of predefined type - MEED-2531 - Meeds-io/MIPs#80

### DIFF
--- a/component/api/src/main/java/io/meeds/social/observe/plugin/ObserverPlugin.java
+++ b/component/api/src/main/java/io/meeds/social/observe/plugin/ObserverPlugin.java
@@ -23,6 +23,7 @@ import org.exoplatform.container.component.BaseComponentPlugin;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.space.model.Space;
 
+import io.meeds.social.observe.model.ObserverObject;
 import io.meeds.social.observe.service.ObserverService;
 
 /**
@@ -66,5 +67,19 @@ public abstract class ObserverPlugin extends BaseComponentPlugin {
    * @throws ObjectNotFoundException thrown when the object doesn't exists
    */
   public abstract long getSpaceId(String objectId) throws ObjectNotFoundException;
+
+  /**
+   * Retrieves a specific Observed Object to watch/unwatch at the same time than
+   * the original content type. Usefull for Activty Stream with Specific
+   * Activity Types for example.
+   * 
+   * @param objectId Object Identifier
+   * @return {@link ObserverObject} if extended by the plugin with the
+   *         identified object, else null
+   * @throws ObjectNotFoundException thrown when the object doesn't exists
+   */
+  public ObserverObject getExtendedObserverObject(String objectId) throws ObjectNotFoundException { // NOSONAR
+    return null;
+  }
 
 }

--- a/component/core/src/main/java/io/meeds/social/observe/plugin/ActivityOberverPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/observe/plugin/ActivityOberverPlugin.java
@@ -29,6 +29,8 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 
+import io.meeds.social.observe.model.ObserverObject;
+
 public class ActivityOberverPlugin extends ObserverPlugin {
 
   public static final String  OBJECT_TYPE                = "activity";
@@ -94,6 +96,18 @@ public class ActivityOberverPlugin extends ObserverPlugin {
       return 0;
     }
     return Long.parseLong(activity.getSpaceId());
+  }
+
+  @Override
+  public ObserverObject getExtendedObserverObject(String objectId) throws ObjectNotFoundException {
+    ExoSocialActivity activity = activityManager.getActivity(objectId);
+    if (activity == null) {
+      throw new ObjectNotFoundException(String.format(ACTIVITY_WITH_ID_NOT_FOUND, objectId));
+    } else if (activity.hasSpecificMetadataObject()) {
+      return new ObserverObject(activity.getMetadataObject());
+    } else {
+      return super.getExtendedObserverObject(objectId);
+    }
   }
 
   private Identity getIdentity(String userId) throws Exception {

--- a/component/core/src/main/java/io/meeds/social/observe/storage/ObserverStorage.java
+++ b/component/core/src/main/java/io/meeds/social/observe/storage/ObserverStorage.java
@@ -71,11 +71,10 @@ public class ObserverStorage {
     long userIdentityId = observer.getIdentityId();
     MetadataKey metadataKey = new MetadataKey(METADATA_TYPE.getName(), String.valueOf(userIdentityId), userIdentityId);
     List<MetadataItem> observers = metadataService.getMetadataItemsByMetadataAndObject(metadataKey, observer.getObject());
-    if (CollectionUtils.isEmpty(observers)) {
-      throw new ObjectNotFoundException("Entity not found for observer " + observer);
-    }
-    for (MetadataItem observerItem : observers) {
-      metadataService.deleteMetadataItem(observerItem.getId(), userIdentityId);
+    if (CollectionUtils.isNotEmpty(observers)) {
+      for (MetadataItem observerItem : observers) {
+        metadataService.deleteMetadataItem(observerItem.getId(), userIdentityId);
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this change, the activity which types disables regular notification, doesn't allow to send notifications to watchers. This change will delete the Notification Enablement check which is useful for AcivityCommentPlugin only.