### PR TITLE
fix: Reset Style of all CKEditor Contents to have WYSIWYG effect after editing - MEED-2534 - Meeds-io/meeds#1102

### DIFF
--- a/webapp/portlet/src/main/webapp/js/sanitize-html-directive.js
+++ b/webapp/portlet/src/main/webapp/js/sanitize-html-directive.js
@@ -33,6 +33,9 @@
         }
       }
     }
+    if (!el.classList.contains('reset-style-box')) {
+      el.classList.add('reset-style-box');
+    }
     el.innerHTML = content && ExtendedDomPurify.purify(content) || '';
   });
   window.Vue.directive('sanitized-html-no-embed', function (el, binding) {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -4,7 +4,7 @@
     :child="bodyElement"
     :element="element"
     :class="bodyClass"
-    class="reset-style-box text-break overflow-hidden"
+    class="reset-style-box rich-editor-content text-break overflow-hidden"
     dir="auto" />
 </template>
 

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -103,7 +103,7 @@
           :child="summaryElement"
           :title="summaryTooltip"
           :class="useEllipsisOnSummary && 'text-light-color text-truncate-3' || 'text-color'"
-          class="caption text-wrap text-break rich-editor-content reset-style-box"
+          class="caption text-wrap text-break reset-style-box rich-editor-content"
           dir="auto" />
       </div>
     </template>


### PR DESCRIPTION
This change will define 'reset-style-box' CSS class to add to all contents displayed in paged that will use 'v-sanitized-html' directive. By adding this class, HTML contents will be reverted to its original CSS content to have exactly the same content as in Rich Editor.