### PR TITLE
fix: Fix Drawer Loading Effect Display - MEED-2550 - Meeds-io/meeds#1113

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -53,7 +53,7 @@
             </v-list-item>
           </v-flex>
           <v-divider :class="!drawerLoading && d-hidden" class="my-0" />
-          <div v-if="drawerLoading" class="position-relative">
+          <div v-if="drawerLoading" class="position-relative z-index-two">
             <v-progress-linear
               indeterminate
               color="primary"


### PR DESCRIPTION
Prior to this change, when the drawer content contains div with relative CSS position property, the loading effect gets hidden. This change ensures to have the loading effect displayed on top of drawer content even when having position relative.