### PR TITLE
fix: Fix Mail Notification Subject Label for watched activity - MEED-2549 - Meeds-io/MIPs#1112

### DIFF
--- a/extension/war/src/main/resources/locale/notification/template/Notification_en.properties
+++ b/extension/war/src/main/resources/locale/notification/template/Notification_en.properties
@@ -125,6 +125,7 @@ UINotification.title.EditActivityPlugin=Someone edits a post
 Notification.subject.ActivityCommentPlugin=$USER has commented one of your activities
 Notification.subject.EditCommentPlugin=$USER edited a comment
 Notification.subject.EditActivityPlugin=$USER 's post was edited
+Notification.subject.ActivityCommentWatchPlugin=$USER has commented on a watched activity
 # For template
 Notification.title.ActivityCommentPlugin=New comment on your activity
 Notification.title.EditCommentPlugin=New edit on your activity stream


### PR DESCRIPTION
Prior to this change, the mail notification on a watched activity has as subject 'Notification.subject.ActivityCommentWatchPlugin'. This change will define this label to make it available on Crowdin.