### PR TITLE
fix: Fix Rendering Old Grouped Comments - MEED-2533 - Meeds-io/meeds#1101

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotifications.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotifications.vue
@@ -110,6 +110,10 @@ export default {
     document.addEventListener('cometdNotifEvent', this.notificationUpdated);
     this.loadNotifications();
   },
+  beforeDestroy() {
+    document.removeEventListener('refresh-notifications', this.refreshNotifications);
+    document.removeEventListener('cometdNotifEvent', this.notificationUpdated);
+  },
   methods: {
     reset() {
       this.loading = false;
@@ -149,7 +153,7 @@ export default {
         .finally(() => this.loading = false);
     },
     notificationUpdated(event) {
-      if (event && event.detail) {
+      if (!this.loading && event && event.detail) {
         this.loadNotifications();
       }
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/ActivityCommentPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/ActivityCommentPlugin.vue
@@ -2,17 +2,18 @@
   <user-notification-activity-base
     :loading="loading"
     :notification="notification"
+    :message-text="message"
+    :from-identity="fromIdentity"
     :reply="!isWatchedNotification"
-    message-key="Notification.intranet.message.one.ActivityCommentPlugin"
     icon="fa-comment">
     <template v-if="isWatchedNotification" #reply>
       <v-btn
         v-if="!watchCanceled"
         :loading="unwatching"
-        class="btn primary px-2"
+        class="btn primary px-2 position-relative z-index-two"
         outlined
         small
-        @click="unwatch">
+        @click.stop.prevent="unwatch">
         <v-hover v-slot="{hover}">
           <div>
             <v-icon size="14" class="mt-n1 pt-2px">{{ hover && 'fa-eye-slash' || 'fa-eye' }}</v-icon>
@@ -37,26 +38,73 @@ export default {
     loading: true,
     unwatching: false,
     watchCanceled: false,
+    posterIdentities: [],
   }),
   computed: {
+    fromIdentity() {
+      return this.notification?.from
+        || (this.posterIdentities?.length && this.posterIdentities[0]);
+    },
+    posterUsernames() {
+      return this.notification?.parameters?.poster
+        && this.notification.parameters.poster.split(',')
+        || [this.notification.parameters.poster];
+    },
     isWatchedNotification() {
       return this.notification?.parameters?.watched === 'true';
     },
     activityId() {
       return this.notification?.parameters?.activityId;
     },
+    message() {
+      if (!this.posterIdentities?.length) {
+        return 'Notification.intranet.message.one.ActivityCommentPlugin';
+      } else if (this.posterUsernames.length < 2) {
+        return this.$t('Notification.intranet.message.one.ActivityCommentPlugin', {
+          0: `<a class="user-name font-weight-bold">${this.posterIdentities[0].fullname}</a>`,
+        });
+      } else if (this.posterUsernames.length < 3) {
+        return this.$t('Notification.intranet.message.two.ActivityCommentPlugin', {
+          0: `<a class="user-name font-weight-bold">${this.posterIdentities[0].fullname}</a>`,
+          1: `<a class="user-name font-weight-bold">${this.posterIdentities[1].fullname}</a>`,
+        });
+      } else {
+        return this.$t('Notification.intranet.message.more.ActivityCommentPlugin', {
+          0: `<a class="user-name font-weight-bold">${this.posterIdentities[0].fullname}</a>`,
+          1: `<a class="user-name font-weight-bold">${this.posterIdentities[1].fullname}</a>`,
+          2: `<strong>${this.posterUsernames.length - 2}</strong>`,
+        });
+      }
+    },
   },
   created() {
     if (this.isWatchedNotification) {
-      this.$observerService.isObserved('activity', this.activityId)
-        .then(watched => this.watchCanceled = !watched)
-        .finally(() => this.loading = false);
+      Promise.all([
+        this.loadIdentities(),
+        this.checkObserved()
+      ]).finally(() => this.loading = false);
       this.$root.$on('activity-notification-unwatch', this.markAsUnwatched);
     } else {
-      this.loading = false;
+      this.loadIdentities().finally(() => this.loading = false);
     }
   },
+  beforeDestroy() {
+    this.$root.$off('activity-notification-unwatch', this.markAsUnwatched);
+  },
   methods: {
+    loadIdentities() {
+      if (this.posterUsernames?.length && this.posterUsernames?.length > 1) {
+        return Promise.all(this.posterUsernames.slice(0, 2).map(u => this.$identityService.getIdentityByProviderIdAndRemoteId('organization', u)))
+          .then(identities => this.posterIdentities = identities.map(i => i?.profile).filter(p => !!p));
+      } else {
+        this.posterIdentities = this.notification.from && [this.notification.from] || [];
+        return Promise.resolve();
+      }
+    },
+    checkObserved() {
+      return this.$observerService.isObserved('activity', this.activityId)
+        .then(watched => this.watchCanceled = !watched);
+    },
     unwatch() {
       this.unwatching = true;
       this.$observerService.deleteObserver('activity', this.activityId)

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/ActivityReplyToCommentPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/ActivityReplyToCommentPlugin.vue
@@ -1,7 +1,9 @@
 <template>
   <user-notification-activity-base
+    :loading="loading"
     :notification="notification"
-    message-key="Notification.intranet.message.one.ActivityReplyToCommentPlugin"
+    :message-text="message"
+    :from-identity="fromIdentity"
     icon="fa-comment"
     reply />
 </template>
@@ -11,6 +13,55 @@ export default {
     notification: {
       type: Object,
       default: null,
+    },
+  },
+  data: () => ({
+    loading: true,
+    posterIdentities: [],
+  }),
+  computed: {
+    fromIdentity() {
+      return this.notification?.from
+        || (this.posterIdentities?.length && this.posterIdentities[0]);
+    },
+    posterUsernames() {
+      return this.notification?.parameters?.poster
+        && this.notification.parameters.poster.split(',')
+        || [this.notification.parameters.poster];
+    },
+    message() {
+      if (!this.posterIdentities?.length) {
+        return 'Notification.intranet.message.one.ActivityReplyToCommentPlugin';
+      } else if (this.posterUsernames.length < 2) {
+        return this.$t('Notification.intranet.message.one.ActivityReplyToCommentPlugin', {
+          0: `<a class="user-name font-weight-bold">${this.posterIdentities[0].fullname}</a>`,
+        });
+      } else if (this.posterUsernames.length < 3) {
+        return this.$t('Notification.intranet.message.two.ActivityReplyToCommentPlugin', {
+          0: `<a class="user-name font-weight-bold">${this.posterIdentities[0].fullname}</a>`,
+          1: `<a class="user-name font-weight-bold">${this.posterIdentities[1].fullname}</a>`,
+        });
+      } else {
+        return this.$t('Notification.intranet.message.more.ActivityReplyToCommentPlugin', {
+          0: `<a class="user-name font-weight-bold">${this.posterIdentities[0].fullname}</a>`,
+          1: `<a class="user-name font-weight-bold">${this.posterIdentities[1].fullname}</a>`,
+          2: `<strong>${this.posterUsernames.length - 2}</strong>`,
+        });
+      }
+    },
+  },
+  created() {
+    this.loadIdentities().finally(() => this.loading = false);
+  },
+  methods: {
+    loadIdentities() {
+      if (this.posterUsernames?.length && this.posterUsernames?.length > 1) {
+        return Promise.all(this.posterUsernames.slice(0, 2).map(u => this.$identityService.getIdentityByProviderIdAndRemoteId('organization', u)))
+          .then(identities => this.posterIdentities = identities.map(i => i?.profile).filter(p => !!p));
+      } else {
+        this.posterIdentities = this.notification.from && [this.notification.from] || [];
+        return Promise.resolve();
+      }
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/LikeCommentPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/LikeCommentPlugin.vue
@@ -3,6 +3,7 @@
     :loading="loading"
     :notification="notification"
     :message-text="message"
+    :from-identity="fromIdentity"
     message-key="Notification.intranet.message.one.LikeCommentPlugin"
     icon="fa-thumbs-up" />
 </template>
@@ -19,6 +20,10 @@ export default {
     loading: true,
   }),
   computed: {
+    fromIdentity() {
+      return this.notification?.from
+        || (this.likerIdentities?.length && this.likerIdentities[0]);
+    },
     likerUsernames() {
       return this.notification?.parameters?.likers
         && this.notification.parameters.likers.split(',')
@@ -26,7 +31,7 @@ export default {
     },
     message() {
       if (!this.likerIdentities?.length) {
-        return null;
+        return 'Notification.intranet.message.one.LikeCommentPlugin';
       } else if (this.likerUsernames.length < 2) {
         return this.$t('Notification.intranet.message.one.LikeCommentPlugin', {
           0: `<a class="user-name font-weight-bold">${this.likerIdentities[0].fullname}</a>`,
@@ -51,7 +56,7 @@ export default {
         .then(identities => this.likerIdentities = identities.map(i => i?.profile).filter(p => !!p))
         .finally(() => this.loading = false);
     } else {
-      this.likerIdentities = this.notification.parameters.from && [this.notification.parameters.from] || [];
+      this.likerIdentities = this.notification.from && [this.notification.from] || [];
       this.loading = false;
     }
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/LikePlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/LikePlugin.vue
@@ -2,6 +2,7 @@
   <user-notification-activity-base
     :notification="notification"
     :message-text="message"
+    :from-identity="fromIdentity"
     message-key="Notification.intranet.message.one.LikePlugin"
     icon="fa-thumbs-up" />
 </template>
@@ -18,6 +19,10 @@ export default {
     loading: true,
   }),
   computed: {
+    fromIdentity() {
+      return this.notification?.from
+        || (this.likerIdentities?.length && this.likerIdentities[0]);
+    },
     likerUsernames() {
       return this.notification?.parameters?.likers
         && this.notification.parameters.likers.split(',')
@@ -25,7 +30,7 @@ export default {
     },
     message() {
       if (!this.likerIdentities?.length) {
-        return null;
+        return 'Notification.intranet.message.one.LikePlugin';
       } else if (this.likerUsernames.length < 2) {
         return this.$t('Notification.intranet.message.one.LikePlugin', {
           0: `<a class="user-name font-weight-bold">${this.likerIdentities[0].fullname}</a>`,
@@ -50,7 +55,7 @@ export default {
         .then(identities => this.likerIdentities = identities.map(i => i?.profile).filter(p => !!p))
         .finally(() => this.loading = false);
     } else {
-      this.likerIdentities = this.notification.parameters.from && [this.notification.parameters.from] || [];
+      this.likerIdentities = this.notification.from && [this.notification.from] || [];
       this.loading = false;
     }
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/abstract/ActivityBasedPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/abstract/ActivityBasedPlugin.vue
@@ -77,6 +77,10 @@ export default {
       type: String,
       default: () => 'Notification.label.Reply',
     },
+    fromIdentity: {
+      type: Object,
+      default: null,
+    },
   },
   data: () => ({
     loading: true,
@@ -91,7 +95,7 @@ export default {
   }),
   computed: {
     profile() {
-      return this.notification?.from;
+      return this.notification?.from || this.fromIdentity;
     },
     username() {
       return this.profile?.username;

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
@@ -63,6 +63,10 @@ export default {
     this.$root.$on('notification-badge-updated', this.updateBadge);
     this.badge = this.$root.badge;
   },
+  beforeDestroy() {
+    document.removeEventListener('cometdNotifEvent', this.updateBadgeByEvent);
+    this.$root.$off('notification-badge-updated', this.updateBadge);
+  },
   mounted() {
     this.$root.$applicationLoaded();
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -184,6 +184,10 @@ export default {
     this.$root.$on('notification-loading-start', this.incrementLoading);
     this.$root.$on('notification-loading-end', this.decrementLoading);
   },
+  beforeDestroy() {
+    this.$root.$off('notification-loading-start', this.incrementLoading);
+    this.$root.$off('notification-loading-end', this.decrementLoading);
+  },
   methods: {
     open() {
       this.$refs.drawer.open();


### PR DESCRIPTION
Prior to this change, the old grouped comments wasn't displayed names of commenters. This change will consider grouping of old comments by retrieving poster identities.