### PR TITLE
feat: Mark a notification as read when click - MEED-2551 - Meeds-io/meeds#1111

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
@@ -34,7 +34,7 @@
               end: moveEnd,
               move: moveSwipe,
             }"
-            @click="markAsRead">
+            @mousedown="markAsRead">
             <v-list-item-avatar
               v-if="$slots.avatar || avatarUrl"
               :rounded="spaceAvatar"


### PR DESCRIPTION
This change will mark the web notification as read once the user right, left or center clicks on the web notification to open it in a new tab.