### PR TITLE
fix: Hide the reset filter button when using mobile - MEED-2543 - Meeds-io/MIP#54 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilterDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamFilterDrawer.vue
@@ -39,7 +39,7 @@
     <template slot="footer">
       <div class="VuetifyApp flex d-flex">
         <v-btn
-          class="dark-grey-color px-1"
+          class="dark-grey-color px-1 hidden-xs-only"
           text
           @click="resetFilter">
           <template>


### PR DESCRIPTION
This change will hide the reset filter button when using mobile.