### PR TITLE
fix : Non visible profile attribute is visible in the advanced filter drawer - EXO-65618 - Meeds-io/meeds#1100 (#2880)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleAdvancedFilterDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleAdvancedFilterDrawer.vue
@@ -112,7 +112,7 @@ export default {
     getSettings() {
       return this.$profileSettingsService.getSettings()
         .then(settings => {
-          this.settings =  settings.filter((e) => e.active && e.parentId === null ).map(obj => ({ ...obj, valueToSearch: '' })) || [];
+          this.settings =  settings.filter((e) => e.active && e.visible && e.parentId === null ).map(obj => ({ ...obj, valueToSearch: '' })) || [];
         });
     },
     confirm() {


### PR DESCRIPTION
Prior to this change a non visible profile attribute was displayed in the advanced filter drawer.
This change is going to prevent to filtering people by the non visible profile attribute attribute.