### PR TITLE
fix: Display unread notifications correctly after clicking - EXO-66167 - Meeds-io/meeds#1103

### DIFF
--- a/webapp/portlet/src/main/webapp/groovy/social/portlet/UIIntranetNotificationsPortlet.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/portlet/UIIntranetNotificationsPortlet.gtmpl
@@ -41,3 +41,25 @@ jsManager.require("SHARED/jquery", "jq")
 	</div>
   <div class="bottomContainer"></div>
 </div>
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    var contentElements = document.querySelectorAll(".unread");
+    if (contentElements.length) {
+      contentElements.forEach(function(element) {
+        var elmt = element.querySelectorAll(".contentSmall");
+        var notificationId = element.getAttribute("data-id");
+        elmt[0].addEventListener("click", function(event) {
+          var restPath = "/portal/rest/notifications/webNotifications/"+notificationId;
+          fetch(restPath, {
+            headers: {
+              "Content-Type": "text/plain",
+              credentials: "include",
+            },
+            method: "PATCH",
+            body: "markAsRead"
+          });
+        });
+      });
+    }
+});
+</script>


### PR DESCRIPTION
Prior to this change, when open notif drawer, click on see all button, click on any notif unread and check notif in drawer or on full page, notif colored in blue as if it was unread. To fix this problem, added a script to trigger the rest of the change to read after clicking on this notif. After this change, this notif is colored white and marked as read.