### PR TITLE
fix: Display the audience choice when only create an activity - MEED-2572 - Meeds-io/MIP#54 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -28,7 +28,7 @@
     </template>
     <template #content>
       <v-card flat>
-        <div v-if="!audienceTypesDisplay" class="mt-1 px-4 pt-4">
+        <div v-if="audienceTypesDisplay" class="mt-1 px-4 pt-4">
           <span class="subtitle-1 text-color"> {{ $t('activity.composer.content.title') }} </span>
           <v-radio-group
             v-if="postToNetwork"
@@ -199,7 +199,7 @@ export default {
       };
     },
     audienceTypesDisplay() {
-      return eXo.env.portal.spaceId;
+      return !eXo.env.portal.spaceId && !this.activityId;
     },
     postInYourSpacesChoice() {
       return this.audienceChoice === 'oneOfYourSpaces';


### PR DESCRIPTION
This change will display the audience choice when only create an activity.