### PR TITLE
fix: Fix Sanitized HTML Processing - MEED-2644 - Meeds-io/meeds#1155

### DIFF
--- a/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
@@ -21,7 +21,7 @@
   };
   ExtendedDomPurify.prototype.purify = function(content) {
     content = content.replace(/<div> <\/div>/g, '<div><br><\/div>');
-    content = content.replace(/  /g, '&nbsp;&nbsp;');
+    content = content.trim().replace(/>[ \n]+</g, '><').replace(/  /g, '&nbsp;&nbsp;');
     const pureHtml = DOMPurify.sanitize(Autolinker.link(content, {
       email: false,
       replaceFn : function (match) {


### PR DESCRIPTION
Prior to this change, the HTML was displayed with `&nbsp;` characters instead of simple spaces. This change will ensure to remove the spaces characters at the beginning of the Html to render and to delete useless spaces between html elements to avoid replacing it by `&nbsp;`.