### PR TITLE
feat: Avoid Auto Stream filter Reset - MEED-2647 - Meeds-io/meeds#1156

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -6,7 +6,7 @@
     <activity-stream-updater
       ref="activityUpdater"
       :space-id="spaceId"
-      :activities="activities"
+      :activity-ids="activityIds"
       :standalone="!!activityId"
       :stream-filter="streamFilter"
       @loadActivities="loadActivities" />
@@ -109,6 +109,9 @@ export default {
     },
     allActivitiesRead() {
       return this.hadUnread && !this.loading && !this.hasMore && this.streamFilter === 'unread_spaces_stream' && !this.unreadCount;
+    },
+    activityIds() {
+      return this.activities?.map?.(a => a.id)?.filter?.(id => !!id) || [];
     },
   },
   watch: {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/common/ActivityStreamUpdater.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/common/ActivityStreamUpdater.vue
@@ -15,7 +15,6 @@
     </div>
   </div>
 </template>
-
 <script>
 export default {
   props: {
@@ -23,7 +22,7 @@ export default {
       type: String,
       default: null,
     },
-    activities: {
+    activityIds: {
       type: Array,
       default: null,
     },
@@ -61,7 +60,9 @@ export default {
       this.$root.$emit(`activity-stream-activity-${updateParams.eventName}`, updateParams.activityId, updateParams.spaceId, updateParams.commentId, updateParams.parentCommentId);
     },
     increaseActivitiesLimitToRetrieve(activityId, spaceId) {
-      if (!eXo.env.portal.spaceId || eXo.env.portal.spaceId === spaceId) {
+      if ((!eXo.env.portal.spaceId || eXo.env.portal.spaceId === spaceId)
+          && !this.updatedActivities.has(activityId)
+          && !this.activityIds.includes(activityId)) {
         this.updatedActivities.add(activityId);
         this.newerActivitiesCount = this.updatedActivities.size;
       }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -242,7 +242,6 @@ export default {
     notifyAsRead(allowReset) {
       if (allowReset) {
         window.setTimeout(() => {
-          this.$root.$emit('activity-stream-reset-filter', true);
           document.dispatchEvent(new CustomEvent('alert-message-html-confeti', {detail: {
             alertMessage: this.$t('activity.filter.empty_unread_spaces_stream.switchMessage'),
             alertType: 'success',

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/Notifications.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/Notifications.vue
@@ -44,7 +44,7 @@
       <div class="d-flex flex-nowrap align-center full-width">
         <span
           v-if="useHtml"
-          class="text--lighten-1 flex-grow-1 pe-4"
+          class="text--lighten-1 flex-grow-1 text-start pe-4"
           v-sanitized-html="alertMessage"
           @click="handleAlertClicked">
         </span>
@@ -62,7 +62,7 @@
           rel="nofollow noreferrer noopener"
           link
           @click="linkCallback">
-          <div v-if="alertLinkText" class="text-none mt-1">{{ alertLinkText }}</div>
+          <div v-if="alertLinkText" class="text-none">{{ alertLinkText }}</div>
           <v-icon v-else-if="alertLinkIcon">{{ alertLinkIcon }}</v-icon>
         </v-btn>
       </div>


### PR DESCRIPTION
Prior to this change, the selected stream filter is reset automatically when no activities are found using the selected filter. This change avoids this knowing that w have already CTAs in UI to let user choose the next action to do, either reset or keep it as is.