### PR TITLE
fix: letters should be maintained in the search field when searching for long names - EXO-66349 - Meeds-io/meeds#1128

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleList.vue
@@ -3,7 +3,6 @@
     class="transparent peopleList"
     flat>
     <people-toolbar
-      :keyword="keyword"
       :filter="filter"
       :people-count="peopleCount"
       @keyword-changed="keyword = $event"

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
@@ -57,10 +57,6 @@
 
 export default {
   props: {
-    keyword: {
-      type: String,
-      default: null,
-    },
     filter: {
       type: String,
       default: null,
@@ -73,12 +69,14 @@ export default {
   data: () => ({
     filterToChange: null,
     bottomMenu: false,
-    startSearchAfterInMilliseconds: 300,
+    startSearchAfterInMilliseconds: 600,
     endTypingKeywordTimeout: 50,
     startTypingKeywordTimeout: 0,
     typing: false,
     advancedFilterCount: 0,
     mobileFilter: false,
+    iconWidth: '24px',
+    keyword: null,
   }),
   created() {
     this.$root.$on('advanced-filter-count', (filterCount) => this.advancedFilterCount = filterCount);


### PR DESCRIPTION
Prior to this change, when PLF has many users some with long first+ last name, then with low connection (tested with slow 3g) search for long named users in people page and check the typed text or results, While typing the username letters, the page loads to retrieve the corresponding profile cards, yet once the page stops loading, some last typed letters disappear from the search field which leads to wrong results. To fix this problem, changed the props keyword to property in peopelToolbar. After this change, all the typed letters are maintained in the search field and correct profile results corresponding to the typed user names are retrieved.

(cherry picked from commit 6a115eca7d567e2ce1e7e2717aab6263675be57d)