### PR TITLE
fix: Space popover Favorite icon status - MEED-2667 - Meeds-io/meeds#1161

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -123,7 +123,9 @@
               <exo-space-favorite-action
                 :is-favorite="isFavorite"
                 :space-id="spaceId"
-                entity-type="SPACE_TOP_BAR_TIPTIP" />
+                entity-type="SPACE_TOP_BAR_TIPTIP"
+                @added="$root.isFavorite = 'true'"
+                @removed="$root.isFavorite = 'false'" />
               <extension-registry-components
                 :params="params"
                 name="SpacePopover"


### PR DESCRIPTION
Prior to this change, the favorite button status isn't considered in space popover due to missing modification on original entity after user click. This change will make the effective modification on original entity to persist the new object status in UI after reopening it.