### PR TITLE
fix: Delete spacing in Links Portlet - MEED-2674 - Meeds-io/meeds#1167

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksIcon.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksIcon.vue
@@ -22,15 +22,15 @@
   <component
     :is="list && 'v-list-item-avatar' || 'v-avatar'"
     :height="iconSize"
-    :min-width="width"
-    :width="width"
+    :min-width="iconSize"
+    :width="iconSize"
     tile>
     <v-img
       v-if="iconUrl"
       :src="iconUrl"
       :max-height="iconSize"
       :height="iconSize"
-      :max-width="width"
+      :max-width="iconSize"
       contain
       eager />
     <v-icon
@@ -55,14 +55,6 @@ export default {
     list: {
       type: Boolean,
       default: false,
-    },
-  },
-  data: () => ({
-    iconWidthRatio: 1.3,
-  }),
-  computed: {
-    width() {
-      return this.iconSize * this.iconWidthRatio;
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksList.vue
@@ -22,6 +22,7 @@
   <component
     v-if="links?.length"
     :is="isColumn && 'v-list' || 'card-carousel'"
+    :class="isColumn && 'pa-0'"
     v-bind="isColumn && {
       dense: !largeIcon
     }">


### PR DESCRIPTION
This change will reduce Spacing used for Link app items display especially in Column setting type.