### PR TITLE
feat: Allow to choose focus position in Rich Editor - MEED-2706 - Meeds-io/MIPs#93

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -79,6 +79,10 @@ export default {
       type: Boolean,
       default: false
     },
+    focusPosition: {
+      type: String,
+      default: () => 'end',
+    },
     useExtraPlugins: {
       type: Boolean,
       default: false
@@ -332,7 +336,7 @@ export default {
         typeOfRelation: this.suggestorTypeOfRelation,
         spaceURL: this.suggesterSpaceURL,
         activityId: this.activityId,
-        startupFocus: this.autofocus && 'end',
+        startupFocus: this.autofocus && this.focusPosition,
         pasteFilter: 'p; a[!href]; strong; i', 
         toolbarLocation: this.toolbarPosition,
       };


### PR DESCRIPTION
Prior to this change, the focus position was all time added into the end of rich editor. This change will allow to choose the focus position by props.