### PR TITLE
fix: Fix replacing algorithm for Rich Editor Cotnent - MEED-2704 - Meeds-io/meeds#1178

### DIFF
--- a/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
@@ -21,7 +21,7 @@
   };
   ExtendedDomPurify.prototype.purify = function(content) {
     content = content.replace(/<div> <\/div>/g, '<div><br><\/div>');
-    content = content.trim().replace(/>[ \n]+</g, '><').replace(/  /g, '&nbsp;&nbsp;');
+    content = content.trim().replace(/>[ \n]+</g, '> <').replace(/  /g, '&nbsp;&nbsp;');
     const pureHtml = DOMPurify.sanitize(Autolinker.link(content, {
       email: false,
       replaceFn : function (match) {


### PR DESCRIPTION
Prior to this change, when adding a space between two html elements in rich editor, all spaces are deleted instead of deleting extra spaces only. This change will replace the extra spaces and breaklines by a single space instead of an empty string.