### PR TITLE
fix: Hide Activity Composer when not space redactor - MEED-2698 - Meeds-io/meeds#1174

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -99,7 +99,7 @@
             </v-tooltip>
           </div>
         </div>
-        <div v-if="spaceId" class="hidden-xs-only">
+        <div v-if="spaceId && userCanPost" class="hidden-xs-only">
           <v-divider />
           <extension-registry-components
             :params="extensionParams"


### PR DESCRIPTION
Prior to this change, the composer extra actions was displayed even for non redactor. This change adds a condition to test is user can redact on space or not.