### PR TITLE
fix: Delete useless Class in Image Preview - MEED-2713 - Meeds-io/meeds#1185

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/preview/ImagePreviewDialog.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/preview/ImagePreviewDialog.vue
@@ -22,7 +22,7 @@
     :persistent="false"
     width="80vw"
     overlay-opacity="0.9"
-    content-class="uiPopup overflow-y-initial "
+    content-class="overflow-y-initial"
     max-width="80vw">
     <template v-if="dialog">
       <div class="ignore-vuetify-classes ClearFix preview-attachment-action d-flex justify-end">


### PR DESCRIPTION
Prior to this change, a class was added for Images preview which is overridden in Member DAO codebase while this class is useless, which may cause errors in future maintenance changes as well. This change will simply delete the declared class in Image Preview dialog.