### PR TITLE
fix: Delete zoom on Links Column preview - MEED-2716 - Meeds-io/meeds#1187

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkDisplayPreview.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkDisplayPreview.vue
@@ -20,9 +20,6 @@
 -->
 <template>
   <v-card
-    :style="{
-      zoom: isColumn && '40%' || '100%'
-    }"
     class="d-flex align-center justify-center grey-background"
     flat>
     <v-card


### PR DESCRIPTION
Prior to this change, a zoom was applied on Links Settings Preview in Column to reduce preview size. This change will delete the zoom effect to display the real size of Portlet in preview mode.