### PR TITLE
feat: Increase Links Icon size when small - MEED-2726 - Meeds-io/meeds#1188

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkIconInput.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkIconInput.vue
@@ -63,7 +63,7 @@ export default {
     },
   },
   data: () => ({
-    iconSize: 30,
+    iconSize: 34,
     maxFileSize: 102400,
     sending: false,
     resetInput: false,

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkInput.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkInput.vue
@@ -80,7 +80,7 @@ export default {
     },
   },
   data: () => ({
-    iconSize: 30,
+    iconSize: 34,
   }),
   computed: {
     name() {

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksCard.vue
@@ -98,7 +98,7 @@ export default {
       }
     },
     iconSize() {
-      return this.largeIcon && 48 || 30;
+      return this.largeIcon && 48 || 34;
     },
     itemSize() {
       return this.largeIcon && 150 || 135;

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksColumn.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksColumn.vue
@@ -87,7 +87,7 @@ export default {
       }
     },
     iconSize() {
-      return this.largeIcon && 48 || 30;
+      return this.largeIcon && 48 || 34;
     },
   },
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksIcon.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/view/LinksIcon.vue
@@ -46,7 +46,7 @@ export default {
   props: {
     iconSize: {
       type: Number,
-      default: () => 30,
+      default: () => 34,
     },
     iconUrl: {
       type: String,


### PR DESCRIPTION
Prior to this change, the small icon size is `30px` in Links app. This change will increase it to be `34px` instead.