### PR TITLE
fix: Clean the profile property group synchronized name of special characters - EXO-66936 - Meeds-io/meeds#1228

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
@@ -150,14 +150,16 @@ public class GroupSynchronizationSocialProfileListener extends ProfileListenerPl
   }
 
   private Group getOrCreateGroup(String groupName, Group parentGroup) throws Exception {
+    String groupLabel = groupName;
+    groupName = Utils.cleanString(groupName);
     Group group = getGroup(buildGroupId(parentGroup, groupName));
     if (group != null) {
       return group;
     }
     GroupHandler groupHandler = organizationService.getGroupHandler();
     Group newGroup = groupHandler.createGroupInstance();
-    newGroup.setGroupName(Utils.cleanString(groupName.toLowerCase()));
-    newGroup.setLabel(StringUtils.capitalize(groupName));
+    newGroup.setGroupName(groupName.toLowerCase());
+    newGroup.setLabel(StringUtils.capitalize(groupLabel));
     newGroup.setDescription(groupName + " group");
     groupHandler.addChild(parentGroup, newGroup, true);
     return getGroup(buildGroupId(parentGroup, groupName));

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.*;
+import org.exoplatform.social.common.Utils;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
 import org.exoplatform.social.core.profile.ProfileListenerPlugin;
@@ -155,7 +156,7 @@ public class GroupSynchronizationSocialProfileListener extends ProfileListenerPl
     }
     GroupHandler groupHandler = organizationService.getGroupHandler();
     Group newGroup = groupHandler.createGroupInstance();
-    newGroup.setGroupName(groupName.toLowerCase());
+    newGroup.setGroupName(Utils.cleanString(groupName.toLowerCase()));
     newGroup.setLabel(StringUtils.capitalize(groupName));
     newGroup.setDescription(groupName + " group");
     groupHandler.addChild(parentGroup, newGroup, true);

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListenerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListenerTest.java
@@ -74,11 +74,28 @@ public class GroupSynchronizationSocialProfileListenerTest extends AbstractCoreT
     profile.setProperty("postalCode", "2100");
     identityManager.updateProfile(profile, true);
 
-    Group group = organizationService.getGroupHandler().findGroupById("/profile/postalCode/2100");
+    Group group = organizationService.getGroupHandler().findGroupById("/profile/postalcode/2100");
     assertNotNull(group);
-    Collection<Group> groups = organizationService.getGroupHandler().findGroupByMembership(paulRemoteId, "member");
+    Collection<Group> groups = organizationService.getGroupHandler().findGroupsOfUser(paulRemoteId);
     assertTrue(groups.contains(group));
     Group group1 = organizationService.getGroupHandler().findGroupById("/profile/street");
     assertNull(group1);
+    //
+    String propertyName = "propertytest";
+    profilePropertySetting.setPropertyName(propertyName);
+    profilePropertyService.createPropertySetting(profilePropertySetting);
+    String groupLabel = "Test'propertytest";
+    String expectedGroupName = "testpropertytest";
+    StringBuilder expectedGroupId = new StringBuilder();
+    expectedGroupId.append("/profile/");
+    expectedGroupId.append(propertyName);
+    expectedGroupId.append("/");
+    expectedGroupId.append(expectedGroupName);
+    profile.setProperty("propertytest", groupLabel);
+    identityManager.updateProfile(profile, true);
+    Group group2 = organizationService.getGroupHandler().findGroupById(expectedGroupId.toString());
+    assertNotNull(group2);
+    assertEquals(group2.getLabel(), groupLabel);
+    assertEquals(group2.getGroupName(), expectedGroupName);
   }
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListenerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListenerTest.java
@@ -97,5 +97,14 @@ public class GroupSynchronizationSocialProfileListenerTest extends AbstractCoreT
     assertNotNull(group2);
     assertEquals(group2.getLabel(), groupLabel);
     assertEquals(group2.getGroupName(), expectedGroupName);
+    groups = organizationService.getGroupHandler().findGroupsOfUser(paulRemoteId);
+    assertTrue(groups.contains(group2));
+    assertEquals(3, groups.size());
+    //
+    identityManager.updateProfile(profile);
+    groups = organizationService.getGroupHandler().findGroupsOfUser(paulRemoteId);
+    assertEquals(3, groups.size());
+
+
   }
 }


### PR DESCRIPTION
Prior to this change, after synchronizing a profile property value containing a special character, the group name caused an error when we attempted to retrieve a process. 
This change will clean the group name.