### PR TITLE
fix: Update the global stream cache after joining or leaving space - EXO-66567 - Meeds-io/meeds#1145 (#3085)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
@@ -34,6 +34,7 @@ import org.exoplatform.social.core.space.SpaceUtils;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
 
 /**
  * SocialMembershipListenerImpl is registered to OrganizationService to handle membership operation associated
@@ -100,6 +101,7 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
           spaceService.removePublisher(space, m.getUserName());
         }
         SpaceUtils.refreshNavigation();
+        clearOwnerGlobalStreamCache(m.getUserName());
       }
     }
     else if (m.getGroupId().startsWith(SpaceUtils.PLATFORM_USERS_GROUP)) {
@@ -125,6 +127,7 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
           space.setEditor(state.getIdentity().getUserId());
         }
         String userName = m.getUserName();
+        clearOwnerGlobalStreamCache(userName);
         if (acl.getAdminMSType().equalsIgnoreCase(m.getMembershipType()) ||
             MembershipTypeHandler.ANY_MEMBERSHIP_TYPE.equalsIgnoreCase(m.getMembershipType())) {
           if (spaceService.isManager(space, userName)) {
@@ -182,5 +185,9 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
     
     //clear caching for identity
     storage.updateIdentityMembership(null);
+  }
+  protected void clearOwnerGlobalStreamCache(String owner) {
+    CachedActivityStorage cachedActivityStorage = CommonsUtils.getService(CachedActivityStorage.class);
+    cachedActivityStorage.clearOwnerStreamCache(owner);
   }
 }


### PR DESCRIPTION

Before this change, when joining or leaving a space, the global stream wasn't updated. This change will update the owner stream cache to display or hide space activities on the global stream.
