### PR TITLE
fix: Space Activity Stream Load more issue - EXO-66818 - Meeds-io/meeds#1199

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
@@ -1075,8 +1075,11 @@ public class ActivityRestResourcesV1 implements ResourceContainer {
 
   private void addPreloadActivityIds(List<String> activityIds, int preloadLimit, String expand, ResponseBuilder responseBuilder) {
     int offset = preloadLimit > MAX_TO_PRELOAD ? preloadLimit - MAX_TO_PRELOAD : 0;
-    List<String> preloadActivityIds =
-                                    activityIds.size() >= preloadLimit ? activityIds.subList(offset, preloadLimit) : activityIds;
+    if (activityIds.size() < preloadLimit) {
+          preloadLimit = activityIds.size();
+          offset = offset > MAX_TO_PRELOAD ? offset : 0;
+    }
+    List<String> preloadActivityIds = activityIds.subList(offset, preloadLimit);
     for (String activityId : preloadActivityIds) {
       String activityLoadingURL = "/portal/rest/v1/social/activities/" + activityId + "?expand=" + expand;
       responseBuilder.header("Link", "<" + activityLoadingURL + ">; rel=preload; as=fetch; crossorigin=use-credentials");

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.rest.impl.OutputHeadersMap;
 import org.exoplatform.services.rest.tools.DummyContainerResponseWriter;
 import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.activity.model.*;
@@ -1464,6 +1465,69 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     space = this.spaceService.createSpace(space, creator);
     restartTransaction();
     return space;
+  }
+
+  public void testPreloadActivitiesId() throws Exception {
+    startSessionAs("john");
+    Space space = getSpaceInstance(1, "john");
+    Identity spaceIdentity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());
+    for (int i = 0; i < 4; i++) {
+      ExoSocialActivity activity = new ExoSocialActivityImpl();
+      activity.setTitle("activity"+i);
+      activity.setUserId(johnIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+    }
+    restartTransaction();
+    ContainerResponse response = service("GET",
+            getURLResource("activities?streamType=ALL_STREAM&spaceId=" + space.getId() + "&limit=20&offset=0&expand=ids"),
+            "",
+            null,
+            null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    CollectionEntity collections = (CollectionEntity) response.getEntity();
+    assertEquals(5, collections.getEntities().size());
+    OutputHeadersMap outputHeadersMap = (OutputHeadersMap) response.getHttpHeaders();
+    assertEquals(5, outputHeadersMap.get("Link").size());
+    //
+    for (int i = 5; i < 52; i++) {
+      ExoSocialActivity activity = new ExoSocialActivityImpl();
+      activity.setTitle("activity"+i);
+      activity.setUserId(johnIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+    }
+    restartTransaction();
+    response = service("GET",
+            getURLResource("activities?streamType=ALL_STREAM&spaceId=" + space.getId() + "&limit=40&offset=0&expand=ids"),
+            "",
+            null,
+            null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    collections = (CollectionEntity) response.getEntity();
+    assertEquals(40, collections.getEntities().size());
+    outputHeadersMap = (OutputHeadersMap) response.getHttpHeaders();
+     //Max to preload is 10
+    assertEquals(10, outputHeadersMap.get("Link").size());
+    //
+    restartTransaction();
+    response = service("GET",
+            getURLResource("activities?streamType=ALL_STREAM&spaceId=" + space.getId() + "&limit=120&offset=0&expand=ids"),
+            "",
+            null,
+            null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    collections = (CollectionEntity) response.getEntity();
+    assertEquals(52, collections.getEntities().size());
+    outputHeadersMap = (OutputHeadersMap) response.getHttpHeaders();
+    assertEquals(4, outputHeadersMap.size());
+    /* Activity ids list length is 52
+     Max to preload is 10
+     Preload limit is limit / 2 = 60
+     Offset is Preload limit - max to preload = 50
+     Expected: 2 links  */
+    assertEquals(2, outputHeadersMap.get("Link").size());
   }
 
 }


### PR DESCRIPTION

Before this change, when attempting to load more than 50 space-posted activities, an HeadersTooLargeException exception would be raised. This issue was caused by the addPreloadActivityIds method, which added the entire list of Activity IDs to the response headers when the preload limit value exceeded the length of the activity IDs list. This change resolves this issue by recalculating the limit and offset in the specific case where the limit is greater than the length of the activity IDs list

