### PR TITLE
fix: Space Activity Stream Load more issue - EXO-66818 - Meeds-io/meeds#1199 (#3072)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
@@ -1019,8 +1019,11 @@ public class ActivityRestResourcesV1 implements ResourceContainer {
 
   private void addPreloadActivityIds(List<String> activityIds, int preloadLimit, String expand, ResponseBuilder responseBuilder) {
     int offset = preloadLimit > MAX_TO_PRELOAD ? preloadLimit - MAX_TO_PRELOAD : 0;
-    List<String> preloadActivityIds =
-                                    activityIds.size() >= preloadLimit ? activityIds.subList(offset, preloadLimit) : activityIds;
+    if (activityIds.size() < preloadLimit) {
+          preloadLimit = activityIds.size();
+          offset = offset > MAX_TO_PRELOAD ? offset : 0;
+    }
+    List<String> preloadActivityIds = activityIds.subList(offset, preloadLimit);
     for (String activityId : preloadActivityIds) {
       String activityLoadingURL = "/portal/rest/v1/social/activities/" + activityId + "?expand=" + expand;
       responseBuilder.header("Link", "<" + activityLoadingURL + ">; rel=preload; as=fetch; crossorigin=use-credentials");


### PR DESCRIPTION

Before this change, when attempting to load more than 50 space-posted activities, an HeadersTooLargeException exception would be raised. This issue was caused by the addPreloadActivityIds method, which added the entire list of Activity IDs to the response headers when the preload limit value exceeded the length of the activity IDs list. This change resolves this issue by recalculating the limit and offset in the specific case where the limit is greater than the length of the activity IDs list
