### PR TITLE
feat: display of portlets titles when using firefox - MEED-2818 - Meeds-io/MIPs#81

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/Widget.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/Widget.vue
@@ -27,7 +27,7 @@
         :class="headerPadding" 
         class="d-flex align-center">
         <slot v-if="$slots.title" name="title"></slot>
-        <div v-else-if="title" class="widget-text-header text-capitalize-first-letter text-truncate">{{ title }}</div> 
+        <div v-else-if="title" class="widget-text-header text-truncate">{{ title }}</div> 
         <v-spacer />
         <slot v-if="$slots.action" name="action"></slot>
         <v-btn 


### PR DESCRIPTION
This PR allows to remove padding left in all widget titles when using Firefox.