### PR TITLE
fix: Fix User Sugester performances issue - MEED-2879 - Meeds-io/meeds#1258

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -274,6 +274,9 @@ public class PeopleRestService implements ResourceContainer{
           opt.setOrder(3);
           nameList.addOption(opt);
           exclusions.add(s);
+          if (nameList.getOptions().size() >= SUGGEST_LIMIT) {
+            break;
+          }
         }
       }
     } else if (SHARE_DOCUMENT.equals(typeOfRelation)) {
@@ -576,6 +579,9 @@ public class PeopleRestService implements ResourceContainer{
       Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, spaceMember, false);
       if (identity.isEnable() && !identity.isDeleted()) {
         userInfos = addUsernameToInfosList(spaceMember, identityFilter, userInfos, currentUser, true, locale);
+        if (userInfos.size() >= SUGGEST_LIMIT) {
+          break;
+        }
       }
     }
     return userInfos;
@@ -586,6 +592,9 @@ public class PeopleRestService implements ResourceContainer{
     for (String commentedUser : commentedUsers) {
       identityFilter.setExcludedIdentityList(excludedIdentityList);
       userInfos = addUsernameToInfosList(commentedUser, identityFilter, userInfos, currentUser, true, locale);
+      if (userInfos.size() >= SUGGEST_LIMIT) {
+        break;
+      }
     }
     return userInfos;
   }
@@ -595,6 +604,9 @@ public class PeopleRestService implements ResourceContainer{
     for (String mentionedUser : mentionedUsers) {
       identityFilter.setExcludedIdentityList(excludedIdentityList);
       userInfos = addUsernameToInfosList(mentionedUser, identityFilter, userInfos, currentUser, true, locale);
+      if (userInfos.size() >= SUGGEST_LIMIT) {
+        break;
+      }
     }
     return userInfos;
   }
@@ -604,6 +616,9 @@ public class PeopleRestService implements ResourceContainer{
     for (String likedUser : likedUsers) {
       identityFilter.setExcludedIdentityList(excludedIdentityList);
       userInfos = addUsernameToInfosList(likedUser, identityFilter, userInfos, currentUser, true, locale);
+      if (userInfos.size() >= SUGGEST_LIMIT) {
+        break;
+      }
     }
     return userInfos;
   }
@@ -634,6 +649,9 @@ public class PeopleRestService implements ResourceContainer{
       }
       opt.setOrder(order);
       options.addOption(opt);
+      if (options.getOptions().size() >= SUGGEST_LIMIT) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this change, the suggester algorithm retrieves all members of a space independently from the expected result list even if the expected result is 10 while the space members are thousands. This change will break the search loop when the limit of users to fetch has been reached to avoid useless computing.