### PR TITLE
fix: Use "about an hour" instead of "about 60 minutes" - MEED-2828 - Meeds-io/meeds#162

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
@@ -97,7 +97,7 @@ export function getRelativeTimeLabelKey(dateObj, short) {
     return short && 'TimeConvert.type.JUSTNOW' || 'TimeConvert.label.Less_Than_A_Minute';
   } else if (periodInSeconds < 120) {
     return short && 'TimeConvert.type.MINUTE' ||'TimeConvert.label.About_A_Minute';
-  } else if (periodInSeconds < 3600) {
+  } else if (periodInSeconds < 3540) {
     return short && 'TimeConvert.type.MINUTES' ||'TimeConvert.label.About_?_Minutes';
   } else if (periodInSeconds < 7200) {
     return short && 'TimeConvert.type.HOUR' ||'TimeConvert.label.About_An_Hour';


### PR DESCRIPTION
Before this change when we post an activity about exactly one hour , it puts in the time section "about 60 minutes".
This change fixes the time label to 'About an hour' when an activity has been posted exactly for 60 minutes.