### PR TITLE
fix: Correctly display the space after space selection in composer - EXO-67423 - meeds-io/meeds#1273

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -291,6 +291,8 @@ export default {
     document.addEventListener('activity-composer-drawer-open', this.open);
     document.addEventListener('activity-composer-edited', this.isActivityBodyEdited);
     document.addEventListener('activity-composer-closed', this.close);
+
+    this.resetAudienceChoice();
   },
   methods: {
     isActivityBodyEdited(event) {
@@ -438,7 +440,11 @@ export default {
       }
     },
     resetAudienceChoice() {
-      this.audienceChoice = 'yourNetwork';
+      if (this.postToNetwork) {
+        this.audienceChoice = 'yourNetwork';
+      } else {
+        this.audienceChoice = 'oneOfYourSpaces';
+      }
       this.audience = '';
     },
     removeAudience() {


### PR DESCRIPTION
Before this fix, when the feature PostToNetwork is disabled, the suggester do not correctly disappear to display the choosen space, as when feature is activated This is due to the audience, which is not correctly set to oneOfYourSpaces when the PostToNetwork is disabled. To fix it, we update the function "resetAudience" to take care of this settings to set the audienceChoice value, and we call this function when component is created to correctly set it at startup

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
