### PR TITLE
feat: Use Id in Avatar URLs instead of RemoteId - MEED-2909 - Meeds-io/MIPs#104

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/EntityConverterUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/EntityConverterUtils.java
@@ -85,34 +85,43 @@ public class EntityConverterUtils {
     Map<String, Object> props = p.getProperties();
     String providerId = entity.getProviderId();
     Identity identity = p.getIdentity();
-    if (!OrganizationIdentityProvider.NAME.equals(providerId) && !SpaceIdentityProvider.NAME.equals(providerId)) {
+    Long avatarLastUpdated = null;
+    if (entity.getAvatarFileId() != null && entity.getAvatarFileId() > 0) {
+      avatarLastUpdated = getFileLastUpdated(entity.getAvatarFileId());
+    }
+    Long bannerLastUpdated = null;
+    if (entity.getBannerFileId() != null && entity.getBannerFileId() > 0) {
+      bannerLastUpdated = getFileLastUpdated(entity.getBannerFileId());
+    }
+    if (!identity.isUser() && !identity.isSpace()) {
       p.setUrl(properties.get(Profile.URL));
-      p.setAvatarUrl(LinkProvider.buildAvatarURL(identity.getProviderId(), identity.getRemoteId()));
-      p.setBannerUrl(LinkProvider.buildBannerURL(identity.getProviderId(), identity.getRemoteId()));
+      p.setAvatarUrl(LinkProvider.buildAvatarURL(identity.getProviderId(),
+                                                 identity.getRemoteId(),
+                                                 avatarLastUpdated));
+      p.setBannerUrl(LinkProvider.buildBannerURL(identity.getProviderId(),
+                                                 identity.getRemoteId(),
+                                                 bannerLastUpdated));
     } else {
       String remoteId = entity.getRemoteId();
-      if (OrganizationIdentityProvider.NAME.equals(providerId)) {
+      if (identity.isUser()) {
         p.setUrl(LinkProvider.getUserProfileUri(remoteId));
-
-      } else if (SpaceIdentityProvider.NAME.equals(providerId)) {
-          p.setUrl(LinkProvider.getSpaceUri(remoteId));
+      } else if (identity.isSpace()) {
+        p.setUrl(LinkProvider.getSpaceUri(remoteId));
       }
-      Long lastUpdated = null;
-      if (entity.getAvatarFileId() != null && entity.getAvatarFileId() > 0) {
-        lastUpdated = getFileLastUpdated(entity.getAvatarFileId());
+      if (avatarLastUpdated != null) {
+        p.setAvatarLastUpdated(avatarLastUpdated);
       }
-      p.setAvatarUrl(LinkProvider.buildAvatarURL(identity.getProviderId(), identity.getRemoteId(), lastUpdated));
-      if (lastUpdated != null) {
-        p.setAvatarLastUpdated(lastUpdated);
+      if (bannerLastUpdated != null) {
+        p.setBannerLastUpdated(bannerLastUpdated);
       }
-      lastUpdated = null;
-      if (entity.getBannerFileId() != null && entity.getBannerFileId() > 0) {
-        lastUpdated = getFileLastUpdated(entity.getBannerFileId());
-      }
-      p.setBannerUrl(LinkProvider.buildBannerURL(identity.getProviderId(), identity.getRemoteId(), lastUpdated));
-      if (lastUpdated != null) {
-        p.setBannerLastUpdated(lastUpdated);
-      }
+      p.setAvatarUrl(LinkProvider.buildAvatarURL(identity.getProviderId(),
+                                                 identity.isUser() ? identity.getId() : identity.getRemoteId(),
+                                                 identity.isUser(),
+                                                 avatarLastUpdated));
+      p.setBannerUrl(LinkProvider.buildBannerURL(identity.getProviderId(),
+                                                 identity.isUser() ? identity.getId() : identity.getRemoteId(),
+                                                 identity.isUser(),
+                                                 bannerLastUpdated));
     }
     StringBuilder skills = new StringBuilder();
     StringBuilder positions = new StringBuilder();

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
@@ -869,14 +869,14 @@ public class RDBMSSpaceStorageImpl implements SpaceStorage {
     if (lastUpdated != null) {
       space.setAvatarLastUpdated(entity.getAvatarLastUpdated().getTime());
     }
-    space.setAvatarUrl(LinkProvider.buildAvatarURL(SpaceIdentityProvider.NAME, space.getPrettyName(), lastUpdated == null ? null : lastUpdated.getTime()));
+    space.setAvatarUrl(LinkProvider.buildAvatarURL(SpaceIdentityProvider.NAME, space.getId(), true, lastUpdated == null ? null : lastUpdated.getTime()));
     lastUpdated = entity.getBannerLastUpdated();
     if (lastUpdated == null && !StringUtils.isBlank(space.getTemplate())) {
       space.setBannerUrl(LinkProvider.buildBannerURL("spaceTemplates", space.getTemplate(), null));
     } else {
       Long bannerLastUpdated = lastUpdated == null ? null : lastUpdated.getTime();
       space.setBannerLastUpdated(bannerLastUpdated);
-      space.setBannerUrl(LinkProvider.buildBannerURL(SpaceIdentityProvider.NAME, space.getPrettyName(), bannerLastUpdated));
+      space.setBannerUrl(LinkProvider.buildBannerURL(SpaceIdentityProvider.NAME, space.getId(), true, bannerLastUpdated));
     }
     return space;
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -378,12 +378,12 @@ public class LinkProvider {
    * @param providerId
    * @param remoteId
    * @return
-   * @deprecated user {@link LinkProvider#buildAvatarURL(String, String, Long)}
+   * @deprecated user {@link LinkProvider#buildAvatarURL(String, String, boolean, Long)}
    *             to use browser cache
    */
   @Deprecated
   public static String buildAvatarURL(String providerId, String remoteId) {
-    return buildAttachmentUrl(providerId, remoteId, null, AvatarAttachment.TYPE);
+    return buildAttachmentUrl(providerId, remoteId, false, null, AvatarAttachment.TYPE);
   }
 
   /**
@@ -394,62 +394,74 @@ public class LinkProvider {
    * @return
    */
   public static String buildAvatarURL(String providerId, String remoteId, Long lastModifiedDate) {
-    return buildAttachmentUrl(providerId, remoteId, lastModifiedDate, AvatarAttachment.TYPE);
+    return buildAttachmentUrl(providerId, remoteId, false, lastModifiedDate, AvatarAttachment.TYPE);
+  }
+
+  public static String buildAvatarURL(String providerId, String id, boolean byId, Long lastModifiedDate) {
+    return buildAttachmentUrl(providerId, id, byId, lastModifiedDate, AvatarAttachment.TYPE);
   }
 
   /**
    * Builds the banner URL for a given profile
    * @param providerId
-   * @param remoteId
+   * @param id
    * @return
-   * @deprecated user {@link LinkProvider#buildBannerURL(String, String, Long)}
+   * @deprecated user {@link LinkProvider#buildBannerURL(String, String, boolean, Long)}
    *             to use browser cache
    */
   @Deprecated
-  public static String buildBannerURL(String providerId, String remoteId) {
-    return buildAttachmentUrl(providerId, remoteId, null, BannerAttachment.TYPE);
+  public static String buildBannerURL(String providerId, String id) {
+    return buildAttachmentUrl(providerId, id, false, null, BannerAttachment.TYPE);
   }
   
   /**
    * Builds the banner URL for a given profile
    * @param providerId
-   * @param remoteId
+   * @param id
    * @param lastModifiedDate last modified date of avatar
    * @return
    */
-  public static String buildBannerURL(String providerId, String remoteId, Long lastModifiedDate) {
-    return buildAttachmentUrl(providerId, remoteId, lastModifiedDate, BannerAttachment.TYPE);
+  public static String buildBannerURL(String providerId, String id, Long lastModifiedDate) {
+    return buildAttachmentUrl(providerId, id, false, lastModifiedDate, BannerAttachment.TYPE);
   }
 
-  private static String buildAttachmentUrl(String providerId, String remoteId, Long lastModifiedDate, String type) {
-    if (providerId == null || remoteId == null) {
+  public static String buildBannerURL(String providerId, String id, boolean byId, Long lastModifiedDate) {
+    return buildAttachmentUrl(providerId, id, byId, lastModifiedDate, BannerAttachment.TYPE);
+  }
+
+  private static String buildAttachmentUrl(String providerId,
+                                           String id,
+                                           boolean byId,
+                                           Long lastModifiedDate,
+                                           String type) {
+    if (providerId == null || id == null) {
       return null;
     } else if (providerId.equals("spaceTemplates")) {
       return new StringBuilder(getBaseURLSocialRest())
-          .append("/")
-          .append(providerId)
-          .append("/")
-          .append(remoteId)
-          .append("/")
-          .append(type)
-          .append("?lastModified=")
-          .append(DEFAULT_IMAGES_LAST_MODIFED)
-          .toString();
+                                                      .append("/")
+                                                      .append(providerId)
+                                                      .append("/")
+                                                      .append(id)
+                                                      .append("/")
+                                                      .append(type)
+                                                      .append("?lastModified=")
+                                                      .append(DEFAULT_IMAGES_LAST_MODIFED)
+                                                      .toString();
     }
 
     try {
-      remoteId = URLEncoder.encode(remoteId, "UTF-8");
+      id = URLEncoder.encode(id, "UTF-8");
     } catch (UnsupportedEncodingException ex) {
       LOG.warn("Failure to encode username for build URL", ex);
     }
 
     if (lastModifiedDate == null || lastModifiedDate <= 0 || lastModifiedDate == DEFAULT_IMAGES_LAST_MODIFED) {
-      remoteId = DEFAULT_IMAGE_REMOTE_ID;
+      id = DEFAULT_IMAGE_REMOTE_ID;
       lastModifiedDate = DEFAULT_IMAGES_LAST_MODIFED;
     }
 
     String lastModifiedString = String.valueOf(lastModifiedDate);
-    String token = generateAttachmentToken(providerId, remoteId, type, lastModifiedString);
+    String token = generateAttachmentToken(providerId, id, type, lastModifiedString);
     if (StringUtils.isNotBlank(token)) {
       try {
         token = URLEncoder.encode(token, "UTF8");
@@ -460,25 +472,33 @@ public class LinkProvider {
     }
 
     if (providerId.equals(OrganizationIdentityProvider.NAME)) {
-      return new StringBuilder(getBaseURLSocialUserRest()).append("/")
-                                                          .append(remoteId)
-                                                          .append("/")
-                                                          .append(type)
-                                                          .append("?lastModified=")
-                                                          .append(lastModifiedString)
-                                                          .append("&r=")
-                                                          .append(token)
-                                                          .toString();
+      StringBuilder urlBuilder = new StringBuilder(getBaseURLSocialUserRest());
+      urlBuilder.append("/")
+                .append(id)
+                .append("/")
+                .append(type)
+                .append("?lastModified=")
+                .append(lastModifiedString)
+                .append("&r=")
+                .append(token);
+      if (byId) {
+        urlBuilder.append("&byId=true");
+      }
+      return urlBuilder.toString();
     } else if (providerId.equals(SpaceIdentityProvider.NAME)) {
-      return new StringBuilder(getBaseURLSocialSpaceRest()).append("/")
-                                                           .append(remoteId)
-                                                           .append("/")
-                                                           .append(type)
-                                                           .append("?lastModified=")
-                                                           .append(lastModifiedString)
-                                                           .append("&r=")
-                                                           .append(token)
-                                                           .toString();
+      StringBuilder urlBuilder = new StringBuilder(getBaseURLSocialSpaceRest());
+      urlBuilder.append("/")
+                .append(id)
+                .append("/")
+                .append(type)
+                .append("?lastModified=")
+                .append(lastModifiedString)
+                .append("&r=")
+                .append(token);
+      if (byId) {
+        urlBuilder.append("&byId=true");
+      }
+      return urlBuilder.toString();
     } else {
       return null;
     }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
@@ -323,15 +323,15 @@ public class IdentityStorageTest extends AbstractCoreTest {
     identityStorage.saveIdentity(identity);
     identityStorage.saveProfile(profile);
 
-    identityStorage.loadProfile(profile);
+    profile = identityStorage.loadProfile(profile);
 
     String gotAvatarURL = profile.getAvatarUrl();
     assertNotNull(gotAvatarURL);
-    assertEquals(LinkProvider.buildAvatarURL(OrganizationIdentityProvider.NAME, userDotName, profile.getAvatarLastUpdated()), gotAvatarURL);
+    assertEquals(LinkProvider.buildAvatarURL(OrganizationIdentityProvider.NAME, profile.getId(), true, profile.getAvatarLastUpdated()), gotAvatarURL);
 
     String gotBannerURL = profile.getBannerUrl();
     assertNotNull(gotBannerURL);
-    assertEquals(LinkProvider.buildBannerURL(OrganizationIdentityProvider.NAME, userDotName, profile.getBannerLastUpdated()), gotBannerURL);
+    assertEquals(LinkProvider.buildBannerURL(OrganizationIdentityProvider.NAME, profile.getId(), true, profile.getBannerLastUpdated()), gotBannerURL);
 
     tearDownIdentityList.add(identityStorage.findIdentity(OrganizationIdentityProvider.NAME, userDotName));
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -116,7 +116,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-
 @Path(VersionResources.VERSION_ONE + "/social/spaces")
 @Tag(name = VersionResources.VERSION_ONE + "/social/spaces", description = "Operations on spaces with their activities and users")
 public class SpaceRestResourcesV1 implements SpaceRestResources {
@@ -507,7 +506,11 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
   public Response getSpaceAvatarById(@Context UriInfo uriInfo,
                                      @Context Request request,
                                      @Parameter(description = "The value of lastModified parameter will determine whether the query should be cached by browser or not. If not set, no 'expires HTTP Header will be sent'") @QueryParam("lastModified") String lastModified,
-                                     @Parameter(description = "Space pretty name", required = true) @PathParam("id") String id,
+                                     @Parameter(description = "Space pretty name or space id", required = true) @PathParam("id") String id,
+                                     @Parameter(description = "Whether to retrieve avatar by id or pretty name", required = false)
+                                     @DefaultValue("false")
+                                     @QueryParam("byId")
+                                     boolean byId,
                                      @Parameter(description = "Resized avatar size. Use 0x0 for original size.") @DefaultValue("45x45") @QueryParam("size") String size,
                                      @Parameter(
                                          description = "A mandatory valid token that is used to authorize anonymous request",
@@ -530,7 +533,8 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       }
 
       String authenticatedUser = RestUtils.getCurrentUser();
-      Space space = spaceService.getSpaceByPrettyName(id);
+      Space space = byId ? spaceService.getSpaceById(id)
+                         : spaceService.getSpaceByPrettyName(id);
       if (space == null
           || (Space.HIDDEN.equals(space.getVisibility()) && RestUtils.isAnonymous())
           || (Space.HIDDEN.equals(space.getVisibility()) && !RestUtils.isAnonymous()
@@ -604,6 +608,10 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
                                      @Context Request request,
                                      @Parameter(description = "The value of lastModified parameter will determine whether the query should be cached by browser or not. If not set, no 'expires HTTP Header will be sent'") @QueryParam("lastModified") String lastModified,
                                      @Parameter(description = "Space id", required = true) @PathParam("id") String id,
+                                     @Parameter(description = "Whether to retrieve banner by id or pretty name", required = false)
+                                     @DefaultValue("false")
+                                     @QueryParam("byId")
+                                     boolean byId,
                                      @Parameter(
                                        description = "A mandatory valid token that is used to authorize anonymous request",
                                        required = false
@@ -623,7 +631,8 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     }
 
     String authenticatedUser = RestUtils.getCurrentUser();
-    Space space = spaceService.getSpaceByPrettyName(id);
+    Space space = byId ? spaceService.getSpaceById(id)
+                       : spaceService.getSpaceByPrettyName(id);
     if (space == null
         || (Space.HIDDEN.equals(space.getVisibility()) && RestUtils.isAnonymous())
         || (Space.HIDDEN.equals(space.getVisibility()) && !RestUtils.isAnonymous()

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -645,6 +645,10 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
   public Response getUserAvatarById(@Context UriInfo uriInfo,
                                     @Context Request request,
                                     @Parameter(description = "User name", required = true) @PathParam("id") String id,
+                                    @Parameter(description = "Whether to retrieve avatar by identity id or username", required = true)
+                                    @DefaultValue("false")
+                                    @QueryParam("byId")
+                                    boolean byId,
                                     @Parameter(description = "The value of lastModified parameter will determine whether the query should be cached by browser or not. If not set, no 'expires HTTP Header will be sent'") @QueryParam("lastModified") String lastModified,
                                     @Parameter(description = "Resized avatar size. Use 0x0 for original size.") @DefaultValue("45x45") @QueryParam("size") String size,
                                     @Parameter(
@@ -659,8 +663,9 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     if (isDefault) {
       lastUpdated = DEFAULT_IMAGES_LAST_MODIFED.getTime();
     } else {
-      identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, id);
-      if (identity == null) {
+      identity = byId ? identityManager.getIdentity(id)
+                      : identityManager.getOrCreateUserIdentity(id);
+      if (identity == null || !identity.isUser()) {
         LOG.debug("Identity of user {} is not found, thus no avatar will be returned", id);
         return Response.status(Status.NOT_FOUND).build();
       } else {
@@ -746,7 +751,13 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
   public Response getUserBannerById(@Context UriInfo uriInfo,
                                     @Context Request request,
                                     @Parameter(description = "User name", required = true) @PathParam("id") String id,
-                                    @Parameter(description = "The value of lastModified parameter will determine whether the query should be cached by browser or not. If not set, no 'expires HTTP Header will be sent'") @QueryParam("lastModified") String lastModified,
+                                    @Parameter(description = "Whether to retrieve banner by identity id or username", required = true)
+                                    @DefaultValue("false")
+                                    @QueryParam("byId")
+                                    boolean byId,
+                                    @Parameter(description = "The value of lastModified parameter will determine whether the query should be cached by browser or not. If not set, no 'expires HTTP Header will be sent'")
+                                    @QueryParam("lastModified")
+                                    String lastModified,
                                     @Parameter(
                                         description = "A mandatory valid token that is used to authorize anonymous request"
                                     ) @QueryParam("r") String token) throws IOException {
@@ -759,8 +770,9 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     if (isDefault) {
       lastUpdated = DEFAULT_IMAGES_LAST_MODIFED.getTime();
     } else {
-      identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, id);
-      if (identity == null) {
+      identity = byId ? identityManager.getIdentity(id)
+                      : identityManager.getOrCreateUserIdentity(id);
+      if (identity == null || !identity.isUser()) {
         LOG.debug("Identity of user {} is not found, thus no banner will be returned", id);
         return Response.status(Status.NOT_FOUND).build();
       } else {


### PR DESCRIPTION
Prior to this change, the RemoteId was exclusively used to retrieve user and spaces avatars. This change will use Technical identifier instead in order to retrieve avatars to avoid using usernames in public Programs and Actions avatars.