### PR TITLE
feat: Margins cleanup - Remove extra-margins - MEED-2895-Meeds-io/MIPs#103

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/portlet/ActivityStream/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/ActivityStream/Style.less
@@ -238,15 +238,6 @@
           padding-left: 10px ~'; /** orientation=lt */ ';
           padding-right: 10px ~'; /** orientation=rt */ ';
 
-          .v-application {
-            &:not(.hiddenable-widget) {
-              margin-bottom: 20px;
-            }
-            &.hiddenable-widget > .v-application--wrap > div {
-              margin-bottom: 20px;
-            }
-          }
-
           /* Added for sticky container */
           .UIContainer, .NormalContainerBlock, .VIEW-CONTAINER, .UIIntermediateContainer, .UIRowContainer {
             display: inline;

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotifications.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotifications.vue
@@ -6,7 +6,7 @@
       @back="closeDetail" />
     <v-card
       v-else
-      class="my-3 card-border-radius"
+      class="card-border-radius"
       flat>
       <v-list @click="openNotificationSettingDetail">
         <v-list-item>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-header/components/SpaceHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-header/components/SpaceHeader.vue
@@ -2,7 +2,7 @@
   <v-app :class="hasNavigations && 'hasNavigations' | ''">
     <v-card
       color="transparent"
-      class="mb-6 card-border-radius overflow-hidden"
+      class="card-border-radius overflow-hidden"
       flat>
       <v-hover>
         <v-img

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app v-if="displayed">
-    <v-card class="mb-3 card-border-radius overflow-hidden" flat>
+    <v-card class="card-border-radius overflow-hidden" flat>
       <v-list two-line>
         <v-list-item>
           <v-list-item-content>

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
@@ -6,7 +6,7 @@
         @back="closeSecurityDetail" />
       <v-card
         v-else
-        class="my-3 card-border-radius"
+        class="card-border-radius"
         flat>
         <v-list>
           <v-list-item>


### PR DESCRIPTION
All Vue applications parents no longer have margins due to these changes. 
The margin will be added as a CSS variable inside the less variables, so we can change this variable using the branding UI.