### PR TITLE
fix: Default activity - no radius applied- MEED-2932-Meeds-io/meeds#1287

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageFilter.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="d-flex flex-column white border-radius">
+  <div class="d-flex flex-column white card-border-radius">
     <v-flex class="d-flex my-auto border-box-sizing">
       <div class="d-flex flex-column ma-auto py-10 text-center text-sub-title">
         <v-icon

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageUser.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageUser.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="d-flex flex-column white border-radius">
+  <div class="d-flex flex-column white card-border-radius">
     <div class="mx-4 my-4">
       <p v-sanitized-html="welcomeTitle"></p>
       <v-card


### PR DESCRIPTION
Add the brand-able border radius to default activity and for empty message filter