### PR TITLE
feat: Extra margin to remove when CMS portlets are not displayed - MEED-2953-Meeds-io/MIPs#103

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/LinksApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/LinksApp.vue
@@ -68,6 +68,15 @@ export default {
       return !this.previewMode && this.$root.canEdit;
     },
   },
+  watch: {
+    canView() {
+      if (this.canView) {
+        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
+      } else {
+        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.add('hidden');
+      }
+    }
+  },
   created() {
     document.addEventListener('cms-preview-mode', this.switchToPreview);
     document.addEventListener('cms-edit-mode', this.switchToEdit);


### PR DESCRIPTION
Prior to this change, When we toggle between show/hide of the preview mode in the public page, an extra margin in displayed when the app is hidden. This change  allows to remove extra margin when app is hidden.