### PR TITLE
fix: Radius not to be applied to language settings drawer- MEED-2952-Meeds-io/meeds#1298

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app v-if="displayed">
-    <v-card class="mb-3 card-border-radius overflow-hidden" flat>
+    <div class="card-border-radius overflow-hidden">
       <v-list two-line>
         <v-list-item>
           <v-list-item-content>
@@ -25,7 +25,7 @@
         ref="languagesDrawer"
         v-model="language"
         :languages="languages" />
-    </v-card>
+    </div>
   </v-app>
 </template>
 


### PR DESCRIPTION
This PR remove the border radius applied to the language settings drawer.