### PR TITLE
fix: Fix Recent Spaces Loading - MEED-2951 - Meeds-io/meeds#1022

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/SpaceListAccess.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/SpaceListAccess.java
@@ -294,11 +294,11 @@ public class SpaceListAccess implements ListAccess<Space> {
           Space storedSpace = spaceStorage.getSpaceById(space.getId());
           storedSpace.setPendingUsers(space.getPendingUsers());
           return storedSpace;
-        }).collect(Collectors.toList());
+        }).toList();
       }
       break;
     }
-    return listSpaces.toArray(new Space[listSpaces.size()]);
+    return listSpaces == null ? new Space[0] : listSpaces.toArray(new Space[listSpaces.size()]);
   }
   
   /**

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -175,8 +175,8 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         + " INNER JOIN SOC_METADATAS sm"
         + " ON item.metadata_id = sm.metadata_id "
         + " AND sm.type = :metadataType "
-        + " AND sm.audience_id = :creatorId "
-        + " WHERE item.space_id = :spaceId "
+        + " WHERE item.creator_id = :creatorId"
+        + " AND item.space_id = :spaceId"
         + " GROUP BY item.object_type"
 )
 @NamedNativeQuery(

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceAccessHandler.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceAccessHandler.java
@@ -99,8 +99,13 @@ public class SpaceAccessHandler extends WebRequestHandler {
         && requestSiteName.startsWith(SPACES_GROUP_PREFIX)) {
       Space space = spaceService.getSpaceByGroupId(requestSiteName);
       if (space != null && canAccessSpace(remoteId, space)) {
-        spaceService.updateSpaceAccessed(remoteId, space);
+        HttpSession session = controllerContext.getRequest().getSession();
+        String lastAccessedSpaceId = (String) session.getAttribute(SpaceAccessType.ACCESSED_SPACE_ID_KEY);
+        if (!StringUtils.equals(lastAccessedSpaceId, space.getId())) {
+          spaceService.updateSpaceAccessed(remoteId, space);
+        }
         cleanupSession(controllerContext);
+        session.setAttribute(SpaceAccessType.ACCESSED_SPACE_ID_KEY, space.getId());
       } else {
         processSpaceAccess(controllerContext, remoteId, space);
         return true;

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
@@ -943,15 +943,14 @@ public class CachedSpaceStorage extends RDBMSSpaceStorageImpl {
     // we remove all cache entries for the given userId and for space type LATEST_ACCESSED
     LastAccessedSpacesCacheSelector selector = new LastAccessedSpacesCacheSelector(remoteId, space, cacheService);
     try {
+      // Update the storage only if the user has accessed a different space
+      if (selector.isUpdateStore()) {
+        super.updateSpaceAccessed(remoteId, space);
+      }
       exoSpacesCache.select(selector);
     } catch (Exception e) {
       LOG.error("Error while removing cache entries for remoteId=" + remoteId + ", space=" + space.getDisplayName() +
               " and type=" + SpaceType.LATEST_ACCESSED.name() + " or type=" + SpaceType.VISITED, e);
-    }
-
-    // Update the storage only if the user has accessed a different space
-    if (selector.isUpdateStore()) {
-      super.updateSpaceAccessed(remoteId, space);
     }
   }
 

--- a/extension/war/src/main/resources/locale/portal/HamburgerMenu_en.properties
+++ b/extension/war/src/main/resources/locale/portal/HamburgerMenu_en.properties
@@ -16,3 +16,7 @@ menu.expand=Keep the menu opened
 menu.collapse=Collapse the menu
 menu.createNewSpace=Create a space
 menu.seeMySpaces=See my spaces
+menu.spaces.joinOrCreateSpace=Join or create a space
+menu.spaces.joinSpace=Join a space
+menu.spaces.exploreSpaces=Explore Spaces
+menu.spaces.noSpacesFound=No spaces found

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/RecentSpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/RecentSpacesHamburgerNavigation.vue
@@ -20,7 +20,7 @@
 -->
 <template>
   <v-container class="recentDrawer" flat>
-    <v-flex class="filterSpaces d-flex align-center">
+    <v-flex v-if="initialized || hasSpaces" class="filterSpaces d-flex align-center">
       <v-list-item-icon
         v-if="!displaySequentially"
         class="backToMenu my-5 mx-2 icon-default-color justify-center"
@@ -44,6 +44,7 @@
           <v-text-field
             v-model="keyword"
             :placeholder="$t('menu.spaces.recentSpaces')"
+            :loading="loading"
             class="recentSpacesFilter border-bottom-color pt-0 mt-0"
             single-line
             hide-details
@@ -68,6 +69,16 @@
         </v-list-item-action>
       </v-list-item>
     </v-flex>
+    <div class="position-relative">
+      <v-progress-linear
+        v-if="(!initialized && !hasSpaces) && loading"
+        class="position-absolute ful-width"
+        indeterminate />
+      <spaces-navigation-empty
+        v-if="!hasSpaces && !loading"
+        :keyword="keyword"
+        class="py-5" />
+    </div>
     <spaces-navigation-content
       :limit="itemsToShow"
       :page-size="itemsToShow"
@@ -76,7 +87,9 @@
       show-more-button
       third-level
       class="recentSpacesWrapper mt-4"
-      @open-space-panel="$emit('open-space-panel',$event)" />
+      @open-space-panel="$emit('open-space-panel',$event)"
+      @loading="loading = $event"
+      @spaces-count="hasSpaces = $event" />
   </v-container>
 </template>
 <script>
@@ -91,12 +104,20 @@ export default {
       default: false,
     },
   },
-  data () {
-    return {
-      itemsToShow: 15,
-      showFilter: false,
-      keyword: '',
-    };
+  data: () => ({
+    itemsToShow: 15,
+    showFilter: false,
+    loading: false,
+    initialized: false,
+    hasSpaces: false,
+    keyword: '',
+  }),
+  watch: {
+    loading() {
+      if (!this.loading) {
+        this.initialized = true;
+      }
+    },
   },
   methods: {
     closeMenu() {

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpaceNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpaceNavigationItem.vue
@@ -28,7 +28,11 @@
       size="28"
       class="me-3 ms-3 tile my-0 spaceAvatar"
       tile>
-      <v-img :src="spaceAvatar" />
+      <img
+        :src="spaceAvatar"
+        :alt="spaceDisplayName"
+        width="28"
+        height="28">
     </v-list-item-avatar>
     <v-list-item-content>
       <v-list-item-title class="body-2" v-text="spaceDisplayName" />
@@ -58,7 +62,12 @@
       size="28"
       class="me-3 ms-2 tile my-0 spaceAvatar"
       tile>
-      <v-img :src="spaceAvatar" />
+      <img
+        :src="spaceAvatar"
+        :alt="spaceDisplayName"
+        class="rounded"
+        width="28"
+        height="28">
     </v-list-item-avatar>
     <v-list-item-content>
       <v-list-item-title class="body-2" v-text="spaceDisplayName" />

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesNavigationContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesNavigationContent.vue
@@ -38,8 +38,8 @@
     </v-list>
     <v-row v-if="canShowMore" class="mx-0 my-4 justify-center">
       <v-btn
+        class="btn"
         small
-        depressed
         @click="loadNextPage()">
         {{ $t('menu.spaces.showMore') }}
       </v-btn>
@@ -136,8 +136,14 @@ export default {
     limitToFetch() {
       this.searchSpaces();
     },
+    filteredSpaces() {
+      this.$emit('spaces-count', this.filteredSpaces?.length);
+    },
     spaces() {
       this.refreshSelectedSpace();
+    },
+    loadingSpaces() {
+      this.$emit('loading', this.loadingSpaces);
     },
   }, 
   created() {
@@ -165,6 +171,7 @@ export default {
       }
     },
     searchSpaces() {
+      this.loadingSpaces = true;
       return this.$spaceService.getSpaces('', this.offset, this.limitToFetch, 'lastVisited', 'member,managers,favorite,unread,muted')
         .then(data => {
           this.spaces = data && data.spaces || [];
@@ -205,4 +212,3 @@ export default {
   }
 };
 </script>
-

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesNavigationEmpty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesNavigationEmpty.vue
@@ -1,0 +1,58 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <div class="d-flex flex-column align-center justify-center">
+    <v-icon size="36">fa-people-arrows</v-icon>
+    <div class="my-6">
+      {{ $t('menu.spaces.noSpacesFound') }}
+    </div>
+    <template v-if="!keyword">
+      <div v-if="$root.canAddSpaces">
+        {{ $t('menu.spaces.joinOrCreateSpace') }}
+      </div>
+      <div v-else>
+        {{ $t('menu.spaces.joinSpace') }}
+      </div>
+    </template>
+    <v-btn
+      :href="spacesLink"
+      :title="$t('menu.spaces.exploreSpaces')"
+      :class="keyword && 'mb-6' || 'my-6'"
+      class="btn primary">
+      <span class="text-none">
+        {{ $t('menu.spaces.exploreSpaces') }}
+      </span>
+    </v-btn>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    keyword: {
+      type: String,
+      default: null,
+    },
+  },
+  data: () => ({
+    spacesLink: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/spaces`,
+  }),
+};
+</script>

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/initComponents.js
@@ -33,6 +33,7 @@ import SpacePanelHamburgerNavigation from './components/recent-spaces/SpacePanel
 import SpacePanelHamburgerNavigationItem from './components/recent-spaces/SpacePanelHamburgerNavigationItem.vue';
 import SpacesHamburgerNavigation from './components/recent-spaces/SpacesHamburgerNavigation.vue';
 import SpacesNavigationContent from './components/recent-spaces/SpacesNavigationContent.vue';
+import SpacesNavigationEmpty from './components/recent-spaces/SpacesNavigationEmpty.vue';
 import SiteHamburgerNavigation from './components/site/SiteHamburgerNavigation.vue';
 import UserHamburgerNavigation from './components/user/UserHamburgerNavigation.vue';
 import SitesHamburger from './components/site/SitesHamburger.vue';
@@ -59,6 +60,7 @@ const components = {
   'space-panel-hamburger-navigation': SpacePanelHamburgerNavigation,
   'space-panel-hamburger-navigation-item': SpacePanelHamburgerNavigationItem,
   'spaces-navigation-content': SpacesNavigationContent,
+  'spaces-navigation-empty': SpacesNavigationEmpty,
   'site-hamburger-navigation': SiteHamburgerNavigation,
   'user-hamburger-navigation': UserHamburgerNavigation,
   'sites-hamburger': SitesHamburger,


### PR DESCRIPTION
Prior to this change, the recent spaces menu performances offers a bad UX since it takes a lot of time and didn't display loading effect. This change will add a loading effect and a placeholder when empty spaces are retrieved even while searching. In addition, the backend services was taking  lot of time to compute unread activities per space. To fix the performances issue, the query has been modified to make sure that the unread activities retrieval is more performant. In addition, the eTag computing has been improved to rely on REST input queries, cache time of results and spaces list order. This will ensure to not having to compute unread flags each time the last visited spaces list are updated.