### PR TITLE
fix: Refresh Space cache when activity marked as read - MEED-2986 - Meeds-io/meeds#1309

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/AbstractMetadataItemListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/AbstractMetadataItemListener.java
@@ -90,10 +90,20 @@ public abstract class AbstractMetadataItemListener<S, D> extends Listener<S, D> 
             // systematically Trigger clearing cache when it's about a space
             // metadata
             cachedActivityStorage.clearOwnerStreamCache(space.getPrettyName());
+            clearSpaceCache(space.getId());
           }
         }
       }
       handleMetadataModification(objectType, metadataItem.getObjectId());
+    }
+  }
+
+  protected void handleMetadataDeletion(MetadataItem metadataItem) {
+    String objectType = metadataItem.getObjectType();
+    String objectId = metadataItem.getObjectId();
+    handleMetadataModification(objectType, objectId);
+    if (metadataItem.getSpaceId() > 0) {
+      clearSpaceCache(String.valueOf(metadataItem.getSpaceId()));
     }
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/MetadataItemDeleted.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/MetadataItemDeleted.java
@@ -35,9 +35,7 @@ public class MetadataItemDeleted extends AbstractMetadataItemListener<Long, Meta
   public void onEvent(Event<Long, MetadataItem> event) throws Exception {
     // If the modified metadata concerns an 'activity'
     MetadataItem metadataItem = event.getData();
-    String objectType = event.getData().getObjectType();
-    String objectId = metadataItem.getObjectId();
-    handleMetadataModification(objectType, objectId);
+    handleMetadataDeletion(metadataItem);
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
@@ -67,8 +67,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public void clearCache() {
 
     try {
-      exoActivitiesCache.select(new CacheSelector<ListActivitiesKey, ListActivitiesData>());
-      exoActivitiesCountCache.select(new CacheSelector<ActivityCountKey, IntegerData>());
+      exoActivitiesCache.clearCache();
+      exoActivitiesCountCache.clearCache();
     } catch (Exception e) {
       LOG.error(e);
     }

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedRelationshipStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedRelationshipStorage.java
@@ -104,8 +104,8 @@ public class CachedRelationshipStorage implements RelationshipStorage {
       exoRelationshipsCache.select(new RelationshipCacheSelector(identities.toArray(new String[] {})));
       exoRelationshipCountCache.select(new RelationshipCacheSelector(identities.toArray(new String[] {})));
       exoSuggestionCache.select(new SuggestionCacheSelector(identities.toArray(new String[] {})));
-      exoActivitiesCache.select(new CacheSelector<ListActivitiesKey, ListActivitiesData>());
-      exoActivitiesCountCache.select(new CacheSelector<ActivityCountKey, IntegerData>());
+      exoActivitiesCache.clearCache();
+      exoActivitiesCountCache.clearCache();
     } catch (Exception e) {
       LOG.error(e);
     }

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
@@ -240,8 +240,8 @@ public class CachedSpaceStorage extends RDBMSSpaceStorageImpl {
   void clearSpaceCache() {
 
     try {
-      exoSpacesCache.select(new CacheSelector<ListSpacesKey, ListSpacesData>());
-      exoSpacesCountCache.select(new CacheSelector<SpaceFilterKey, IntegerData>());
+      exoSpacesCache.clearCache();
+      exoSpacesCountCache.clearCache();
     }
     catch (Exception e) {
       LOG.error("Error deleting space caches", e);

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/selector/CacheSelector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/selector/CacheSelector.java
@@ -26,14 +26,14 @@ import org.exoplatform.social.core.storage.cache.model.key.CacheKey;
  * @author <a href="mailto:alain.defrance@exoplatform.com">Alain Defrance</a>
  * @version $Revision$
  */
-public class CacheSelector<T extends CacheKey, U> implements CachedObjectSelector<T, U> {
+public abstract class CacheSelector<T extends CacheKey, U> implements CachedObjectSelector<T, U> {
 
   private T key;
 
-  public CacheSelector() {
+  CacheSelector() {
   }
 
-  public CacheSelector(T key) {
+  CacheSelector(T key) {
     this.key = key;
   }
 


### PR DESCRIPTION
Prior to this change, the space cache time wasn't updated when a related metadata item is deleted. This change will update Space cache each time a related metadata item is deleted or modified.