### PR TITLE
fix: Extra margin to remove when no about me in profile you visit- MEED-2989-Meeds-io/meeds#1315

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
@@ -77,6 +77,15 @@ export default {
       return this.owner || !this.initialized || this.aboutMe?.trim().length;
     },
   },
+  watch: {
+    displayApp() {
+      if (this.displayApp) {
+        this.$el.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
+      } else {
+        this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
+      }
+    }
+  },
   created() {
     this.$userService.getUser(eXo.env.portal.profileOwner)
       .then(user => this.refresh(user && user.aboutMe || ''))


### PR DESCRIPTION
Prior to this PR when you visit a user profile (not your profile) than don't have an about me section, an extra margin is displayed.
This change allows to remove extra margin when about-me portlet is not shown.