### PR TITLE
fix: Unify space between activities- MEED-2987-Meeds-io/meeds#1310

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
@@ -2,7 +2,7 @@
   <div
     v-if="activityLoading"
     :key="activity.id"
-    class="white border-radius activity-detail flex d-flex flex-column mb-6 contentBox">
+    class="white border-radius activity-detail flex d-flex flex-column mb-5 contentBox">
     <v-progress-circular
       color="primary"
       size="32"
@@ -29,7 +29,7 @@
       :comment-types="commentTypes"
       :comment-actions="commentActions"
       :is-activity-detail="isActivityDetail"
-      class="mb-6 contentBox"
+      class="mb-5 contentBox"
       @loaded="$emit('loaded')" />
   </transition>
 </template>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -21,12 +21,12 @@
         :comment-actions="commentActions"
         :is-activity-detail="activityId"
         :pin-activity-enabled="pinActivityEnabled"
-        class="mb-6 contentBox"
+        class="mb-5 contentBox"
         @loaded="activityLoaded(activity.id)" />
     </template>
     <div
       v-else-if="loading"
-      class="white border-radius activity-detail flex d-flex flex-column mb-6 contentBox">
+      class="white border-radius activity-detail flex d-flex flex-column mb-5 contentBox">
       <v-progress-circular
         color="primary"
         size="32"


### PR DESCRIPTION
Prior to this change space between activities is 24 px. This change allows to put the margin between the activities 20px instead of 24px to harmonize with all the other spaces on the platform.