### PR TITLE
fix: Fix I18N Activity processing when having emoji - MEED-2990 - Meeds-io/meeds#1117

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/processor/I18NActivityUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/processor/I18NActivityUtils.java
@@ -33,7 +33,9 @@ public class I18NActivityUtils {
   
   /** */
   private final static String RESOURCE_BUNDLE_VALUES_CHARACTER = "#";
-  
+
+  private final static String RESOURCE_BUNDLE_VALUES_REGEX = "(?<!&)#";
+
   /** */
   private final static String RESOURCE_BUNDLE_ESCAPE_CHARACTER = "${_}";
   
@@ -62,7 +64,7 @@ public class I18NActivityUtils {
     if (valueParam == null) {
       return null;
     }
-    String[] got = valueParam.split(RESOURCE_BUNDLE_VALUES_CHARACTER);
+    String[] got = valueParam.split(RESOURCE_BUNDLE_VALUES_REGEX);
     for(int i = 0; i<got.length; i++) {
       got[i] = postProcess(got[i].trim());
     }

--- a/component/core/src/test/java/org/exoplatform/social/core/processor/I18NActivityUtilsTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/I18NActivityUtilsTest.java
@@ -37,7 +37,7 @@ public class I18NActivityUtilsTest extends TestCase {
   }
   
   public void testGetParamValues() throws Exception {
-    String input = "v1#v2#v3";
+    String input = "v1&#v2#v2#v3";
     
     String[] got = I18NActivityUtils.getParamValues(input);
     


### PR DESCRIPTION
Prior to this change, when having emoji in a I18N Activity, the title was wrongly processed since it contains the separator `#` that exists in emojis **Unicode Hex Character Code**. This change will fix the split regex to ensure to not split emoji character encoding.