### PR TITLE
fix: Delete Breadcrumb Margins - MEED-3023 - Meeds-io/meeds#1349

### DIFF
--- a/webapp/portlet/src/main/webapp/js/BodyScrollListener.js
+++ b/webapp/portlet/src/main/webapp/js/BodyScrollListener.js
@@ -21,6 +21,7 @@ function() {
     siteBody.classList.add('site-scroll-parent');
     if (!siteBody.getAttribute('scroll-control')) {
       siteBody.classList.add('overflow-y-auto');
+      siteBody.classList.add('overflow-x-hidden');
       siteBody.style.maxHeight = bodyMaxHeight;
       siteBody.setAttribute('scroll-control', 'true');
       const middleBar = document.querySelector('.MiddleToolBarTDContainer .MiddleToolBar');

--- a/webapp/portlet/src/main/webapp/vue-apps/breadcrumb/components/Breadcrumb.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/breadcrumb/components/Breadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <div v-if="breadcrumbToDisplay.length" class="white mx-5 px-2 py-2 card-border-radius d-flex">
+    <div v-if="breadcrumbToDisplay.length" class="white px-2 py-2 card-border-radius d-flex">
       <div
         v-for="(breadcrumb, index) in breadcrumbToDisplay"
         :key="index"

--- a/webapp/portlet/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuButton.vue
@@ -20,11 +20,9 @@
     size="22"
     outlined
     icon
-    class="mx-2">
-    <v-icon
-      class="mb-2"
-      size="22"
-      @click="$root.$emit('open-vertical-menu-drawer')">
+    class="ma-2"
+    @click="$root.$emit('open-vertical-menu-drawer')">
+    <v-icon size="22">
       fas fa-bars
     </v-icon>
   </v-btn>


### PR DESCRIPTION
This change will allow to rely on Page management styling to define x margins for breadcrumb.
At the same time, this will move `@click` event on button instead of icon inside a button.