### PR TITLE
fix: Fix used meta site name reference - MEED-3024 - Meeds-io/meeds#1351

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/processor/MentionsProcessor.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/processor/MentionsProcessor.java
@@ -52,7 +52,7 @@ public class MentionsProcessor extends BaseActivityProcessorPlugin {
 
   public void processActivity(ExoSocialActivity activity) {
     if (activity != null) {
-      String portalOwner = userPortalConfigService.getDefaultPortal();
+      String portalOwner = userPortalConfigService.getMetaPortal();
       activity.setTitle(MentionUtils.substituteUsernames(identityManager, portalOwner, activity.getTitle()));
       activity.setBody(MentionUtils.substituteUsernames(identityManager, portalOwner, activity.getBody()));
       Map<String, String> templateParams = activity.getTemplateParams();

--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -233,27 +233,6 @@ public class LinkProvider {
   }
 
   /**
-   * Gets URI to connections of a user and all people.
-   * 
-   * @param remoteId Name of the user (remoteId), for example root.
-   * @return The URI.
-   * @LevelAPI Platform
-   */
-  public static String getUserConnectionsUri(final String remoteId) {
-    return getBaseUri(null, null) + "/connections/all-people" + ROUTE_DELIMITER + remoteId;
-  }
-  
-  /**
-   * Gets URI to connections of a user.
-   * 
-   * @param remoteId The name of user (remoteId), for example root.
-   * @return The link to network of provided user who has connection with the current user. 
-   */
-  public static String getUserConnectionsYoursUri(final String remoteId) {
-    return getBaseUri(null, null) + "/connections/network" + ROUTE_DELIMITER + remoteId;
-  }
-  
-  /**
    * Gets URI to a user profile.
    *
    * @param remoteId The name of user (remoteId), for example root.

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -1294,7 +1294,7 @@ public class SpaceUtils {
     } else {
       remoteId = conversationState.getIdentity().getUserId();
     }
-    return userPortalConfigSer.getUserPortalConfig(userPortalConfigSer.getDefaultPortal(),
+    return userPortalConfigSer.getUserPortalConfig(userPortalConfigSer.getMetaPortal(),
                                                    remoteId,
                                                    NULL_CONTEXT);
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceAccessHandler.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceAccessHandler.java
@@ -200,7 +200,7 @@ public class SpaceAccessHandler extends WebRequestHandler {
   private String getURI(ControllerContext controllerContext, String uri) {
     String portalName = (String) controllerContext.getRequest().getSession().getAttribute(LAST_PORTAL_NAME);
     if (StringUtils.isBlank(portalName)) {
-      portalName = userPortalConfigService.getDefaultPortal();
+      portalName = userPortalConfigService.getMetaPortal();
     }
 
     SiteKey siteKey = SiteKey.portal(portalName);

--- a/component/core/src/test/java/org/exoplatform/social/core/processor/MentionsProcessorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/MentionsProcessorTest.java
@@ -69,8 +69,8 @@ public class MentionsProcessorTest extends AbstractCoreTest {
 
     String root = "root", john = "john";
 
-    String rootLink = LinkProvider.getProfileLink(root, userPortalConfigService.getDefaultPortal());
-    String johnLink = LinkProvider.getProfileLink(john, userPortalConfigService.getDefaultPortal());
+    String rootLink = LinkProvider.getProfileLink(root, userPortalConfigService.getMetaPortal());
+    String johnLink = LinkProvider.getProfileLink(john, userPortalConfigService.getMetaPortal());
 
     activity.setTitle("single @root substitution");
     processor.processActivity(activity);
@@ -108,10 +108,10 @@ public class MentionsProcessorTest extends AbstractCoreTest {
     processor.processActivity(activity);
     
     templateParams = activity.getTemplateParams();
-    assertEquals(LinkProvider.getProfileLink("root", userPortalConfigService.getDefaultPortal()) + " and " +
-                 LinkProvider.getProfileLink("john", userPortalConfigService.getDefaultPortal()),
+    assertEquals(LinkProvider.getProfileLink("root", userPortalConfigService.getMetaPortal()) + " and " +
+                 LinkProvider.getProfileLink("john", userPortalConfigService.getMetaPortal()),
                  templateParams.get("a"));
-    assertEquals(LinkProvider.getProfileLink("john", userPortalConfigService.getDefaultPortal()),
+    assertEquals(LinkProvider.getProfileLink("john", userPortalConfigService.getMetaPortal()),
                  templateParams.get("b"));    
     assertEquals("@mary", templateParams.get("d"));  
   }

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -1007,7 +1007,7 @@
       <description>this listener init the portal configuration for social test</description>
       <init-params>
         <value-param>
-          <name>default.portal</name>
+          <name>meta.portal</name>
           <description>The default portal for checking db is empty or not</description>
           <value>classic</value>
         </value-param>

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -1833,7 +1833,7 @@ public class EntityBuilder {
     try {
       HttpUserPortalContext userPortalContext = new HttpUserPortalContext(request);
       UserPortalConfig userPortalConfig =
-                                        getUserPortalConfigService().getUserPortalConfig(siteType != SiteType.PORTAL ? getUserPortalConfigService().getDefaultPortal()
+                                        getUserPortalConfigService().getUserPortalConfig(siteType != SiteType.PORTAL ? getUserPortalConfigService().getMetaPortal()
                                                                                                                      : site.getName(),
                                                                                          currentUser,
                                                                                          userPortalContext);
@@ -1964,7 +1964,7 @@ public class EntityBuilder {
   }
 
   private static boolean isMetaSite(String siteName) {
-    return getUserPortalConfigService().getDefaultPortal().equals(siteName);
+    return getUserPortalConfigService().getMetaPortal().equals(siteName);
   }
   public static String getTranslatedLabel(String fieldName, long siteId, Locale locale) {
     return getTranslationService().getTranslationLabel(SITE_OBJECT_TYPE,

--- a/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
@@ -155,8 +155,8 @@ public class NotificationsRestService implements ResourceContainer {
                                             @PathParam("receiverId") String receiverId) throws Exception {
     checkAuthenticatedUserPermission(receiverId);
 
-    Identity sender = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, senderId, true);
-    Identity receiver = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, receiverId, true);
+    Identity sender = getIdentityManager().getOrCreateUserIdentity(senderId);
+    Identity receiver = getIdentityManager().getOrCreateUserIdentity(receiverId);
     if (sender == null || receiver == null) {
       throw new WebApplicationException(Response.Status.BAD_REQUEST);
     }
@@ -165,7 +165,7 @@ public class NotificationsRestService implements ResourceContainer {
     }
 
     //redirect to the requesters list and display a feedback message
-    String targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("connexions/receivedInvitations/" + receiver.getRemoteId() + "?feedbackMessage=ConnectionRequestRefuse&userName=" + sender.getRemoteId());
+    String targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("people/" + receiver.getRemoteId() + "?feedbackMessage=ConnectionRequestRefuse&userName=" + sender.getRemoteId());
 
     // redirect to target page
     return Response.seeOther(URI.create(targetURL)).build();
@@ -228,11 +228,11 @@ public class NotificationsRestService implements ResourceContainer {
     String targetURL = Util.getBaseUrl();
     if (Arrays.asList(space.getInvitedUsers()).contains(userId)) {
       if (getSpaceService().isMember(space, userId)) {
-        targetURL = targetURL + LinkProvider.getRedirectUri("all-spaces?feedbackMessage=SpaceInvitationAlreadyMember&spaceId=" + spaceId);
+        targetURL = targetURL + LinkProvider.getRedirectUri("spaces?feedbackMessage=SpaceInvitationAlreadyMember&spaceId=" + spaceId);
       } else {
         getSpaceService().removeInvitedUser(space, userId);
         //redirect to all spaces and display a feedback message
-        targetURL = targetURL + LinkProvider.getRedirectUri("all-spaces?feedbackMessage=SpaceInvitationRefuse&spaceId=" + spaceId);
+        targetURL = targetURL + LinkProvider.getRedirectUri("spaces?feedbackMessage=SpaceInvitationRefuse&spaceId=" + spaceId);
       }
     }
     
@@ -425,20 +425,20 @@ public class NotificationsRestService implements ResourceContainer {
           break;
         }
         case all_space: {
-          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("all-spaces");
+          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("spaces");
           break;
         }
         case connections: {
-          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("connexions");
+          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("people");
           break;
         }
         case connections_request: {
           userIdentity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, objectId, true);
-          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("connexions/receivedInvitations/" + userIdentity.getRemoteId());
+          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("profile/" + userIdentity.getRemoteId());
           break;
         }
         case space_invitation: {
-          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("invitationSpace");
+          targetURL = Util.getBaseUrl() + LinkProvider.getRedirectUri("spaces");
           break;
         }
         case notification_settings: {

--- a/component/service/src/main/java/org/exoplatform/social/service/rest/SpacesRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/SpacesRestService.java
@@ -116,7 +116,7 @@ public class SpacesRestService implements ResourceContainer {
    */
   private static final QualifiedName REQUEST_SITE_NAME = QualifiedName.create("gtn", "sitename");
   
-  private static final String ALL_SPACES = "all-spaces";
+  private static final String ALL_SPACES = "spaces";
   
   private static final String JSON = "json";
 

--- a/component/service/src/main/java/org/exoplatform/social/service/rest/Util.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/Util.java
@@ -239,7 +239,7 @@ public final class Util {
    */
   @Deprecated
   public static final IdentityManager getIdentityManager() {
-    return (IdentityManager) getDefaultPortalContainer().getComponentInstanceOfType(IdentityManager.class);
+    return (IdentityManager) getPortalContainer().getComponentInstanceOfType(IdentityManager.class);
   }
 
   /**
@@ -265,7 +265,7 @@ public final class Util {
    */
   @Deprecated
   public static final SpaceService getSpaceService() {
-    return (SpaceService) getDefaultPortalContainer().getComponentInstanceOfType(SpaceService.class);
+    return (SpaceService) getPortalContainer().getComponentInstanceOfType(SpaceService.class);
   }
 
   /**
@@ -290,7 +290,7 @@ public final class Util {
    */
   @Deprecated
   public static final ActivityManager getActivityManager() {
-    return (ActivityManager) getDefaultPortalContainer().getComponentInstanceOfType(ActivityManager.class);
+    return (ActivityManager) getPortalContainer().getComponentInstanceOfType(ActivityManager.class);
   }
 
   /**
@@ -315,7 +315,7 @@ public final class Util {
    */
   @Deprecated
   public static final RelationshipManager getRelationshipManager() {
-    return (RelationshipManager) getDefaultPortalContainer().getComponentInstanceOfType(RelationshipManager.class);
+    return (RelationshipManager) getPortalContainer().getComponentInstanceOfType(RelationshipManager.class);
   }
 
 
@@ -449,7 +449,7 @@ public final class Util {
    *
    * @return the portal container
    */
-  private static PortalContainer getDefaultPortalContainer() {
+  private static PortalContainer getPortalContainer() {
     return PortalContainer.getInstance();
   }
   

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/common-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/common-configuration.xml
@@ -70,14 +70,6 @@
                     <value><string>/profile/{streamOwnerId}</string></value>
                   </entry>
                   <entry>
-                    <key><string>connections.network.extended.show</string></key>
-                    <value><string><![CDATA[/connections/{relationshipStatus}/{streamOwnerId}/{<.*>path}]]></string></value>
-                  </entry>
-                  <entry>
-                    <key><string>connections.network.show</string></key>
-                    <value><string>/connections/{relationshipStatus}/{streamOwnerId}</string></value>
-                  </entry>
-                  <entry>
                     <key><string>space.access</string></key>
                     <value><string>{spacePrettyName}</string></value>
                   </entry>

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/login/oauth_invitation.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/login/oauth_invitation.jsp
@@ -40,7 +40,7 @@
 
     UserPortalConfigService userPortalConfigService = portalContainer.getComponentInstanceOfType(UserPortalConfigService.class);
     SkinService skinService = portalContainer.getComponentInstanceOfType(SkinService.class);
-    String skinName = userPortalConfigService.getDefaultPortalSkinName();
+    String skinName = userPortalConfigService.getMetaPortalSkinName();
     Collection<SkinConfig> skins = skinService.getPortalSkins(skinName);
     String loginCssPath = skinService.getSkin("portal/login", skinName).getCSSPath();
 

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/login/oauth_register.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/login/oauth_register.jsp
@@ -45,7 +45,7 @@
 
     UserPortalConfigService userPortalConfigService = portalContainer.getComponentInstanceOfType(UserPortalConfigService.class);
     SkinService skinService = portalContainer.getComponentInstanceOfType(SkinService.class);
-    String skinName = userPortalConfigService.getDefaultPortalSkinName();
+    String skinName = userPortalConfigService.getMetaPortalSkinName();
     Collection<SkinConfig> skins = skinService.getPortalSkins(skinName);
     String loginCssPath = skinService.getSkin("portal/login", skinName).getCSSPath();
 

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/welcome-screens/accountSetup.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/welcome-screens/accountSetup.jsp
@@ -52,7 +52,7 @@
   ResourceBundle rb = service.getResourceBundle(service.getSharedResourceBundleNames(), request.getLocale());
 
   UserPortalConfigService userPortalConfigService = portalContainer.getComponentInstanceOfType(UserPortalConfigService.class);
-  String skinName = userPortalConfigService.getDefaultPortalSkinName();
+  String skinName = userPortalConfigService.getMetaPortalSkinName();
   SkinService skinService = portalContainer.getComponentInstanceOfType(SkinService.class);
   SkinConfig skin = skinService.getSkin("portal/AccountSetup", skinName);
   String cssPath = "";

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsListItems.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsListItems.vue
@@ -69,7 +69,7 @@ export default {
       return this.user && !this.user.relationshipStatus && !this.sameUser;
     },
     profileUrl() {
-      return this.user && `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.user.username}`;
+      return this.user && `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.user.username}`;
     },
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityNotFound.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityNotFound.vue
@@ -30,8 +30,8 @@
 export default {
   data: () =>({
     activityStreamUrl: eXo.env.portal.isExternal === 'true' ?
-      `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/external-stream`
-      : `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/stream`,
+      `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/external-stream`
+      : `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/stream`,
   }),
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageUser.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageUser.vue
@@ -73,10 +73,10 @@ export default {
       return this.$currentUserIdentity && this.$currentUserIdentity.profile && this.$currentUserIdentity.profile.fullname;
     },
     profileUri() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile`;
     },
     spacesUri() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/spaces`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/spaces`;
     },
     profilelink() {
       return `<a href="${this.profileUri}"><strong class="text-color">${this.profileName}</strong></a>`;

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -1,4 +1,4 @@
-const activityBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity`;
+const activityBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity`;
 
 extensionRegistry.registerComponent('ActivityStream', 'activity-stream-drawers', {
   id: 'share-drawer',

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
@@ -24,7 +24,7 @@ if (!Vue.prototype.$activityUtils) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-const activityBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity`;
+const activityBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity`;
 
 // get overrided components if exists
 if (extensionRegistry) {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -294,7 +294,7 @@ export default {
     },
     profileUrl() {
       if (this.url && !this.clickable && this.username) {
-        return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.username}`;
+        return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.username}`;
       } else {
         return null;
       }

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/spacesConstants.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/spacesConstants.js
@@ -1,7 +1,7 @@
 export const spacesConstants = {
   ENV: eXo.env.portal || '',
   PORTAL: eXo.env.portal.context || '',
-  PORTAL_NAME: eXo.env.portal.defaultPortal || '',
+  PORTAL_NAME: eXo.env.portal.metaPortalName || '',
   PORTAL_CONTEXT: eXo.env.portal.context,
   PORTAL_REST: eXo.env.portal.rest,
   PROFILE_SPACE_LINK: '/g/:spaces:',

--- a/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ActivityFavoriteItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/ActivityFavoriteItem.vue
@@ -75,7 +75,7 @@ export default {
     }
   },
   created() {
-    this.activityUrl = `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity?id=${this.id}`;
+    this.activityUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity?id=${this.id}`;
     this.$activityService.getActivityById(this.id)
       .then(fullActivity => {
         this.activity = fullActivity;

--- a/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/SpaceFavoriteItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/favorites-list-top-bar/components/SpaceFavoriteItem.vue
@@ -59,7 +59,7 @@ export default {
     isFavorite: true
   }),
   created() {
-    this.spaceUrl = `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity?id=${this.id}`;
+    this.spaceUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity?id=${this.id}`;
     this.$spaceService.getSpaceById(this.id)
       .then((spaceData)=> {
         this.space = spaceData;

--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/preview/SiteBrandingPreview.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/preview/SiteBrandingPreview.vue
@@ -42,7 +42,7 @@
 <script>
 export default {
   data: ()=> ({
-    pageHomeLink: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/stream?sticky=false`,
+    pageHomeLink: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/stream?sticky=false`,
   }),
   mounted() {
     this.$root.$on('refresh-style-property', this.setStyleProperty);

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/profile/ProfileHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/profile/ProfileHamburgerNavigation.vue
@@ -56,7 +56,7 @@ export default {
   },
   data() {
     return {
-      PROFILE_URI: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile`,
+      PROFILE_URI: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile`,
       IDENTITY_REST_API_URI: `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/identities/${eXo.env.portal.userIdentityId}`,
       profile: null,
     };

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesHamburgerNavigation.vue
@@ -125,7 +125,7 @@ export default {
       spacesLimit: 7,
       showItemActions: false,
       arrowIcon: 'fa-arrow-right',
-      allSpacesLink: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/spaces?createSpace=true`,
+      allSpacesLink: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/spaces?createSpace=true`,
       canAddSpaces: false,
       space: null,
       spacePanel: false,

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesNavigationEmpty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacesNavigationEmpty.vue
@@ -52,7 +52,7 @@ export default {
     },
   },
   data: () => ({
-    spacesLink: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/spaces`,
+    spacesLink: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/spaces`,
   }),
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/user/UserHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/user/UserHamburgerNavigation.vue
@@ -42,7 +42,7 @@
 <script>
 export default {
   data: () => ({
-    settingsUrl: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/settings`,
+    settingsUrl: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/settings`,
     logoutUrl: `${eXo.env.portal.context}/${eXo.env.portal.portalName}/?portal:action=Logout&portal:componentId=UIPortal`,
   }),
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/NewUser.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/NewUser.vue
@@ -18,7 +18,7 @@ export default {
       return this.notification?.from;
     },
     profileUrl() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.username}`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.username}`;
     },
     username() {
       return this.profile?.username;

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/RelationshipReceivedRequestPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/RelationshipReceivedRequestPlugin.vue
@@ -49,7 +49,7 @@ export default {
       return this.notification?.from;
     },
     profileUrl() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.username}`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.username}`;
     },
     username() {
       return this.profile?.username;

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/RequestJoinSpacePlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/RequestJoinSpacePlugin.vue
@@ -55,7 +55,7 @@ export default {
       return this.profile?.username;
     },
     profileUrl() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.username}`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.username}`;
     },
     space() {
       return this.notification?.space;

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/abstract/ActivityBasedPlugin.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/plugins/abstract/ActivityBasedPlugin.vue
@@ -124,12 +124,12 @@ export default {
       return this.activity?.type;
     },
     activityUrl() {
-      return (this.commentId && this.activityId && `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity?id=${this.activityId}#comment-${this.commentId}`)
-        || (this.activityId && `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity?id=${this.activityId}`)
+      return (this.commentId && this.activityId && `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity?id=${this.activityId}#comment-${this.commentId}`)
+        || (this.activityId && `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity?id=${this.activityId}`)
         || '#';
     },
     replyUrl() {
-      return this.activity && `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity?id=${this.activityId}#comment-reply${(this.parentCommentId || this.commentId) && '-' || ''}${this.parentCommentId || this.commentId || ''}`
+      return this.activity && `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity?id=${this.activityId}#comment-reply${(this.parentCommentId || this.commentId) && '-' || ''}${this.parentCommentId || this.commentId || ''}`
         || '#';
     },
     space() {

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -156,8 +156,7 @@ export default {
     badgeByPlugin: null,
     separatorWidth: 0,
     markingAllAsRead: false,
-    settingsLink: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/settings#notifications`,
-    allNotificationsLink: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/allNotifications`,
+    settingsLink: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/settings#notifications`,
   }),
   computed: {
     markingAsReadDisabled() {

--- a/webapp/portlet/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
@@ -49,7 +49,7 @@
 export default {
   computed: {
     defaultLink() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}`;
     },
   },
   mounted() {

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -381,7 +381,7 @@ export default {
     },
     url() {
       if (this.user && this.user.username) {
-        return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.user.username}`;
+        return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.user.username}`;
       } else {
         return '#';
       }

--- a/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverviewPeopleListItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverviewPeopleListItem.vue
@@ -115,7 +115,7 @@ export default {
       return this.user && this.user.avatar || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.user.username}/avatar`;
     },
     url() {
-      return this.user && this.user.profile || `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.user.username}/`;
+      return this.user && this.user.profile || `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.user.username}/`;
     },
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/search-activity/components/SearchActivityCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/search-activity/components/SearchActivityCard.vue
@@ -143,9 +143,9 @@ export default {
     },
     link() {
       if (this.isComment) {
-        return `/${eXo.env.portal.containerName}/${eXo.env.portal.defaultPortal}/activity?id=${this.result.id}#comment-comment${this.result.comment.id}`;
+        return `/${eXo.env.portal.containerName}/${eXo.env.portal.metaPortalName}/activity?id=${this.result.id}#comment-comment${this.result.comment.id}`;
       } else {
-        return `/${eXo.env.portal.containerName}/${eXo.env.portal.defaultPortal}/activity?id=${this.activity.id}`;
+        return `/${eXo.env.portal.containerName}/${eXo.env.portal.metaPortalName}/activity?id=${this.activity.id}`;
       }
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/space-access/components/SpaceAccess.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-access/components/SpaceAccess.vue
@@ -102,7 +102,7 @@ export default {
   }),
   computed: {
     spacesLink() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/spaces`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/spaces`;
     },
     spaceLink() {
       return this.parameters?.originalUri;

--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -59,7 +59,7 @@ export default {
       description: '',
       managers: [],
       redactors: [],
-      profileUrl: `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/`
+      profileUrl: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/`
     };
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleListItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleListItem.vue
@@ -65,7 +65,7 @@ export default {
       if (!this.people || !this.people.suggestionId) {
         return '#';
       }
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/profile/${this.people.username}`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.people.username}`;
     },
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserLanguageDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserLanguageDrawer.vue
@@ -53,7 +53,7 @@ export default {
     },
     saveLanguage() {
       const lang = this.value.replace('_', '-');
-      window.location.replace(`${eXo.env.portal.context}/${lang}/${eXo.env.portal.defaultPortal}/settings`);
+      window.location.replace(`${eXo.env.portal.context}/${lang}/${eXo.env.portal.metaPortalName}/settings`);
     },
     cancel() {
       this.$refs.userLanguageDrawer.close();


### PR DESCRIPTION
Prior to this change, the Meta site name was referenced as 'defaultPortal'. The notion of 'default' portal doesn't exist anymore and was replaced by 'meta' site with 'aggregated' sites. This change will replace to use the Meta site name where the list of referenced applications are added.