### PR TITLE
feat: Refresh Space Cache even when user is already member of space - MEED-2602 - Meeds-io/meeds#1142

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -999,6 +999,10 @@ public class SpaceUtils {
       GroupHandler groupHandler = organizationService.getGroupHandler();
       Group existingGroup = groupHandler.findGroupById(groupId);
       membershipHandler.linkMembership(user, existingGroup, membershipType, true);
+    } catch (Exception e) {
+      throw new IllegalStateException("Unable to add user: " + remoteId + " to group: " + groupId + " with membership: " + membership,
+                                      e);
+    } finally {
       clearIdentityCaching(OrganizationIdentityProvider.NAME, remoteId);
       if (groupId.startsWith(SpaceUtils.SPACE_GROUP)) {
         Space space = getSpaceService().getSpaceByGroupId(groupId);
@@ -1007,9 +1011,6 @@ public class SpaceUtils {
           clearSpaceCache(space.getId());
         }
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to add user: " + remoteId + " to group: " + groupId + " with membership: " + membership,
-                                 e);
     }
   }
 


### PR DESCRIPTION
Prior to this change, when the user is added to a space via `OrganizationService.MembershipHandler`, the caches aren't updated as when doing it via `SpaceService.addMember`. This change ensures to clar the cache even after adding the user via `OrganizationService.MembershipHandler.linkMembership`