### PR TITLE
fix: Left/right arrow buttons in activity have not accessible name - EXO-62419 - Meeds-io/meeds#1304

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -826,3 +826,10 @@ publicAccess.siteIsVisibleTooltip=Site is accessible to anyone. Click to make it
 siteAccess.pageNotFoundTitle=Page not found
 siteAccess.pageNotFoundSubTitle=Try again later or contact your administrator
 siteAccess.pageNotFoundButton=Back home
+
+#####################################################################################
+#                              Card Carousel                                        #
+#####################################################################################
+
+cardCarousel.leftArrowButtonTitle=Previous visual
+cardCarousel.rightArrowButtonTitle=Next visual

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/CardCarousel.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/CardCarousel.vue
@@ -3,6 +3,7 @@
     <v-fab-transition>
       <v-btn
         v-show="displayLeftArrow"
+        :aria-label="$t('cardCarousel.leftArrowButtonTitle')"
         color="while"
         width="23px"
         height="23px"
@@ -29,6 +30,7 @@
     <v-fab-transition>
       <v-btn
         v-show="displayRightArrow"
+        :aria-label="$t('cardCarousel.rightArrowButtonTitle')"
         color="while"
         width="23px"
         height="23px"


### PR DESCRIPTION
Before this change, create a space then open activity composer drawer and create an activity with 3 or more attachments then launch a lighthouse report related to accessibility, left/right arrow buttons in published activity are reported as not accessible. To resolve this problem, added the aria-label for this left arrow button by the key cardCarousel.leftArrowButtonTitle which returns a text Previous visual and this right arrow button by the key cardCarousel.rightArrowButtonTitle which returns a text Next visual. After this change, this failing element is no longer displayed in the launch accessiblity of the Lighthouse tab.

(cherry picked from commit 32939f72cda732c98df4dc20e0e15192558d6629)