### PR TITLE
feat: Improve Administration Menu UX - MEED-3047 - Meeds-io/meeds#1388

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/common/AdministrationSite/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/common/AdministrationSite/Style.less
@@ -20,10 +20,10 @@
 
 @media (min-width: 1280px) {
   .administrationSiteVerticalMenuContainerClass {
-    width: 350px !important;
+    width: 310px !important;
   }
   .administrationSitePageBodyContainerClass {
-    width: ~"calc(100% - 350px)" !important;
+    width: ~"calc(100% - 310px)" !important;
   }
 }
 

--- a/webapp/portlet/src/main/webapp/skin/less/portlet/VerticalMenu/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/VerticalMenu/Style.less
@@ -28,8 +28,8 @@
   height: 100%;
   min-height: var(--100vh, 100vh);
   max-height: var(--100vh, 100vh);
-  max-width:350px !important;
-  min-width:350px !important;
+  max-width:310px !important;
+  min-width:310px !important;
   left: 0 !important;
   top: 0 !important;
   position: fixed !important;

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/profile/ProfileHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/profile/ProfileHamburgerNavigation.vue
@@ -24,7 +24,11 @@
       :href="PROFILE_URI"
       class="accountTitleItem top-bar-height">
       <v-list-item-avatar size="44" class="me-3 mt-0 mb-0 elevation-1">
-        <v-img :src="avatar" eager />
+        <img
+          :src="avatar"
+          :alt="fullName"
+          width="44"
+          height="44">
       </v-list-item-avatar>
       <v-list-item-content class="py-0 accountTitleLabel">
         <v-list-item-title class="font-weight-bold body-2 mb-0">{{ fullName }} <span v-if="external" class="externalFlagClass">{{ $t('menu.profile.external') }}</span></v-list-item-title>

--- a/webapp/portlet/src/main/webapp/vue-apps/site-details/components/SiteDetails.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/site-details/components/SiteDetails.vue
@@ -35,9 +35,13 @@
           </v-icon>
         </v-btn>
       </row>
-      <v-img
+      <img
         :src="site?.bannerUrl"
-        class="mx-1 pt-1" />
+        :alt="site?.displayName"
+        width="100%"
+        height="auto"
+        class="mx-1 pt-1"
+        eager />
       <v-card-title :title="site?.displayName" class="text-capitalize font-weight-bold text-subtitle-1">
         {{ site?.displayName }}
       </v-card-title>

--- a/webapp/portlet/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuDrawer.vue
@@ -19,7 +19,7 @@
     id="verticalMenuDrawer"
     ref="verticalMenuDrawer"
     :right="$vuetify.rtl"
-    drawer-width="350"
+    drawer-width="310"
     eager
     allow-expand
     @closed="close">


### PR DESCRIPTION
Prior to this change, the administration menu wasn't following the same UX as Hamburger Menu. This change will allow to reduce the flickering effect when changing from a page to another in administration site. In addition, the width of Administration menu has been adapted to reuse the same width as the Hamburger Menu of Meta site.