### PR TITLE
fix: Space application titles not well displayed on mobile view - EXO-68043 - Meeds-io/meeds#1424

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenuItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenuItem.vue
@@ -39,7 +39,7 @@ export default {
       return this.navigation?.label;
     },
     icon() {
-      return `${this.navigation.icon || 'fas fa-folder'} icon-default-color icon-default-size`;
+      return `${this.navigation.icon || 'fas fa-folder'} icon-default-color icon-default-size pb-8`;
     }
   }
 };


### PR DESCRIPTION
Prior to this change, space application titles not well displayed on mobile view.After this change, space application titles are correctly displayed under the associated icons.