### PR TITLE
fix: Refresh Space Favorite Button in Popups when change elsewhere - MEED-2673 - Meeds-io/meeds#1166

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -11,17 +11,13 @@ const urls = [
 Vue.directive('identity-popover', (el, binding) => {
   const identity = binding?.value;
   const isUser = identity?.username;
-  if (!isUser) {
-    document.addEventListener('space-favorite-added', event => {
-      const spaceId = event?.detail;
-      if (spaceId === identity.id) {
-        identity.isFavorite = 'true';
-      }
-    });
-    document.addEventListener('space-favorite-removed', event => {
-      const spaceId = event?.detail;
-      if (spaceId === identity.id) {
-        identity.isFavorite = 'false';
+  if (identity && !isUser) {
+    document.addEventListener('metadata.favorite.updated', event => {
+      const metadata = event?.detail;
+      if (metadata?.objectType === 'space'
+        && metadata.objectId === identity.id
+        && metadata.favorite !== (identity.isFavorite === 'true')) {
+        identity.isFavorite = `${metadata.favorite}`;
       }
     });
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -196,10 +196,6 @@ export default {
       type: String,
       default: ''
     },
-    isFavorite: {
-      type: Boolean,
-      default: false
-    },
     muted: {
       type: Boolean,
       default: false
@@ -216,12 +212,21 @@ export default {
     mangersToDisplay() {
       return this.managers;
     },
+    isFavorite() {
+      return this.$root.isFavorite;
+    },
     params() {
       return {
         identityType: 'space',
         identityId: eXo.env.portal.spaceId
       };
     },
+  },
+  created() {
+    document.addEventListener('metadata.favorite.updated', this.favoriteUpdated);
+  },
+  destroyed() {
+    document.removeEventListener('metadata.favorite.updated', this.favoriteUpdated);
   },
   methods: {
     popoverActionEvent(clickedItem) {
@@ -230,7 +235,15 @@ export default {
     openDetails() {
       this.$root.$emit('displaySpaceHosts', this.mangersToDisplay);
       this.popoverActionEvent('displaySpaceHosts');
-    }
+    },
+    favoriteUpdated(event) {
+      const metadata = event && event.detail;
+      if (metadata && metadata.objectType === 'space'
+          && metadata.objectId === this.spaceId
+          && metadata.favorite !== this.isFavorite) {
+        this.$root.isFavorite = `${metadata.favorite}`;
+      }
+    },
   }
 };
 </script>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/main.js
@@ -38,7 +38,6 @@ export function init(params) {
       template: `<exo-space-logo-banner
                     id="SpaceTopBannerLogo"
                     :space-id="spaceId"
-                    :is-favorite="isFavorite"
                     :muted="muted"
                     :is-member="isMember"
                     :logo-path="logoPath" 


### PR DESCRIPTION
Prior to this change, when changing the space as favorite from Favorites list, from popover or from banner menu, the other buttons aren't updated and still remain with the old status. This change allows to update the favorite button status in all UIs when changing it from one location.