### PR TITLE
fix: Fix Propagating keydown event when using CKEDitor - MEED-3075 - Meeds-io/MIPs#107

### DIFF
--- a/webapp/portlet/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
+++ b/webapp/portlet/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
@@ -57,13 +57,13 @@
         }); 
       });
 
-      editor.setKeystroke( CKEDITOR.CTRL + 75 /*K*/, 'addLink' );   
-      document.onkeydown = function(evt) {
+      editor.setKeystroke( CKEDITOR.CTRL + 75 /*K*/, 'addLink' );
+      document.addEventListener('keydown', (evt) => {
         evt = evt || window.event;
-        if ( evt.key === 'Escape' && isInputTextToolbar) { 
+        if (evt.key === 'Escape' && isInputTextToolbar) {
           hideInputTextPanel(editor);
-        } 
-      };
+        }
+      });
     },
   });
 


### PR DESCRIPTION
Prior to this change, when clicking escape on page, the event keypress isn't propagated. This change will allow to propagate the event to close the drawer.