### PR TITLE
fix: fix displaying activity by id in stream - EXO-68049 - Meeds-io/meeds#1460

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
@@ -24,7 +24,7 @@ if (!Vue.prototype.$activityUtils) {
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-const activityBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/activity`;
+const activityBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/activity`;
 
 // get overrided components if exists
 if (extensionRegistry) {


### PR DESCRIPTION
Before this change, for non meta sites when displaying an activity with its id, the activity stream [checks](https://github.com/Meeds-io/social/blob/develop/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue#L71) first of all if the current URL contains the activity base link which takes the meta site as the portal name instead of the current portal which leads to non coherent activity URL. 
After this change, the activity base URL should take the current site name instead of the meta site name.