### PR TITLE
fix: Notification snack-bar not closed - EXO-68048 - Meeds-io/meeds#1425 (#3317)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/Notifications.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/Notifications.vue
@@ -28,8 +28,7 @@
     class="z-index-snackbar"
     color="transparent ma-0"
     elevation="0"
-    app
-    @input="dispatchDismissed">
+    app>
     <confeti-animation
       v-if="confeti"
       class="overflow-hidden" />
@@ -93,7 +92,7 @@
       <template v-if="!isMobile" #close="{toggle}">
         <v-btn
           icon
-          @click="dispatchDismissed(!toggle)">
+          @click="toggle">
           <v-icon size="16" class="icon-default-color">fa-times</v-icon>
         </v-btn>
       </template>
@@ -123,6 +122,7 @@ export default {
     left: 0,
     startEvent: null,
     moving: false,
+    isHandleAlertClicked: false,
   }),
   computed: {
     isMobile() {
@@ -153,6 +153,10 @@ export default {
           this.interval = 0;
         }
       }
+      if (!this.snackbar && !this.isHandleAlertClicked){
+        this.dispatchDismissed();
+      }
+      this.isHandleAlertClicked = false;
     },
   },
   created() {
@@ -224,10 +228,8 @@ export default {
     });
   },
   methods: {
-    dispatchDismissed(opened) {
-      if (!opened) {
-        document.dispatchEvent(new CustomEvent('alert-message-dismissed'));
-      }
+    dispatchDismissed() {
+      document.dispatchEvent(new CustomEvent('alert-message-dismissed'));
     },
     openAlert(params) {
       this.reset();
@@ -259,6 +261,7 @@ export default {
       this.snackbar = false;
     },
     linkCallback() {
+      this.isHandleAlertClicked = true;
       if (this.alertLinkCallback) {
         this.alertLinkCallback();
       }


### PR DESCRIPTION
Before this change, when snack-bar alert is diplayed & clicking on X, it doesn't close the alert snack-bar.
To resolve this problem, closing click event was replaced by toggle event on closing & launch event alert-message-dismissed only when snack-bar alert is displayed & handle alert is clicked.
Thus, snack-bar alert closing works as expected.
(cherry picked from commit https://github.com/Meeds-io/social/commit/a664de20e3106284dcdba2d0d4e7f9e8a8b2a72c)