### PR TITLE
Add the space administration portlet to the ManageSpaceGRP load group - EXO-68206 -  Meeds-io/meeds#1467

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1486,7 +1486,6 @@
   <portlet>
     <name>SpacesAdministration</name>
     <module>
-      <load-group>ManageSpaceGRP</load-group>
       <script>
         <minify>false</minify>
         <path>/js/spacesAdministration.bundle.js</path>
@@ -1512,6 +1511,9 @@
       </depends>
       <depends>
         <module>extensionRegistry</module>
+      </depends>
+      <depends>
+        <module>ManageSpacesExtension</module>
       </depends>
     </module>
   </portlet>

--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1486,6 +1486,7 @@
   <portlet>
     <name>SpacesAdministration</name>
     <module>
+      <load-group>ManageSpaceGRP</load-group>
       <script>
         <minify>false</minify>
         <path>/js/spacesAdministration.bundle.js</path>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
@@ -88,6 +88,7 @@
             type="manage-space-actions"
             :params="{ disabled: !space.canEditNavigations,
                        iconColor: 'primary',
+                       canManageSiteNavigation: true,
                        siteName: space.groupId,
                        siteType: 'GROUP'}" />
         </td>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
@@ -35,5 +35,5 @@ export function init(applicationsByCategory) {
       i18n,
       vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Spaces Administration');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('ManageSpaceActions'));
 }


### PR DESCRIPTION
Prior to this change, the site navigation icon is not displayed on the space administration page due to the hide of sharedLayout for the aggregated site containing the site navigation portlet.This commit creates a load-group for site navigation, which will then be loaded with the Spaces Administration Portlet.