### PR TITLE
fix: Handle 'Everyone' permission when computing site permissions - EXO-68132 - Meeds-io/meeds#1474

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -1916,6 +1916,10 @@ public class EntityBuilder {
         String[] permissionParts = permission.split(":");
         String sitePermissionGroupId;
         if (permissionParts.length == 1) {
+          if (permission.equals("Everyone")){
+            sitePermission.put("membershipType", permission);
+            return sitePermission;
+          }
           sitePermissionGroupId = permission;
         } else if (permissionParts.length == 2) {
           sitePermission.put("membershipType", permissionParts[0]);


### PR DESCRIPTION
Prior to this change, after setting the site access permission to 'Everyone' and saving, the displayed access permission on the manage site permissions drawer was incorrect. This was due to mishandling of the 'Everyone' permission when computing site permissions. This change addresses the issue by appropriately handling the 'Everyone' permission case during the computation of site permissions.