### PR TITLE
fix: Fix single attributes when it is considered as parent  - EXO-67825 - Meeds-io/meeds#1383

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
@@ -104,4 +104,11 @@ public interface ProfilePropertyService {
    * @return Boolean : true if the current property has child properties
    */
   boolean hasChildProperties(ProfilePropertySetting propertySetting);
+
+  /**
+   * Checks if the current property is a default propertie
+   * @param propertySetting
+   * @return Boolean : true if the current property is a default propertie
+   */
+  boolean isDefaultProperties(ProfilePropertySetting propertySetting);
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
@@ -108,6 +108,11 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     if (!isGroupSynchronizedEnabledProperty(profilePropertySetting)) {
       profilePropertySetting.setGroupSynchronized(false);
     }
+    if (isDefaultProperties(profilePropertySetting)) {
+      ProfilePropertySetting createdProfilePropertySetting =
+                                                           profileSettingStorage.getProfileSettingById(profilePropertySetting.getId());
+      profilePropertySetting.setMultiValued(createdProfilePropertySetting.isMultiValued());
+    }
     profileSettingStorage.saveProfilePropertySetting(profilePropertySetting, false);
   }
 
@@ -164,5 +169,19 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   @Override
   public boolean hasChildProperties(ProfilePropertySetting propertySetting) {
     return profileSettingStorage.hasChildProperties(propertySetting.getId());
+  }
+
+  @Override
+  public boolean isDefaultProperties(ProfilePropertySetting propertySetting) {
+    for (ProfilePropertyDatabaseInitializer plugin : profielPropertyPlugins) {
+      if (plugin.getConfig().getProfileProperties() != null && !plugin.getConfig().getProfileProperties().isEmpty()
+          && plugin.getConfig()
+                   .getProfileProperties()
+                   .stream()
+                   .anyMatch(profileProperty -> profileProperty.getPropertyName().equals(propertySetting.getPropertyName()))) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/profile/ProfilePropertyServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/profile/ProfilePropertyServiceTest.java
@@ -94,6 +94,20 @@ public class ProfilePropertyServiceTest extends AbstractCoreTest {
     profilePropertyService.updatePropertySetting(profilePropertySetting);
     profilePropertySetting = profilePropertyService.getProfileSettingByName(profilePropertySetting.getPropertyName());
     assertFalse(profilePropertySetting.isActive());
+    profilePropertySetting = profilePropertyService.createPropertySetting(createProfileSettingInstance("fullName"));
+    assertFalse(profilePropertySetting.isMultiValued());
+    profilePropertySetting.setMultiValued(true);
+    profilePropertyService.updatePropertySetting(profilePropertySetting);
+    profilePropertySetting = profilePropertyService.getProfileSettingByName(profilePropertySetting.getPropertyName());
+    assertFalse(profilePropertySetting.isMultiValued());
+    profilePropertySetting = createProfileSettingInstance("urls");
+    profilePropertySetting.setMultiValued(true);
+    profilePropertySetting = profilePropertyService.createPropertySetting(profilePropertySetting);
+    assertTrue(profilePropertySetting.isMultiValued());
+    profilePropertySetting.setMultiValued(false);
+    profilePropertyService.updatePropertySetting(profilePropertySetting);
+    profilePropertySetting = profilePropertyService.getProfileSettingByName(profilePropertySetting.getPropertyName());
+    assertTrue(profilePropertySetting.isMultiValued());
   }
 
   public void testGetProfilePropertySettings() throws Exception {

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -1652,6 +1652,7 @@ public class EntityBuilder {
     profilePropertySettingEntity.setGroupSynchronizationEnabled(profilePropertyService.isGroupSynchronizedEnabledProperty(profilePropertySetting));
     profilePropertySettingEntity.setLabels(profileLabelService.findLabelByObjectTypeAndObjectId(objectType,
                                                                                                 String.valueOf(profilePropertySetting.getId())));
+    profilePropertySettingEntity.setDefault(profilePropertyService.isDefaultProperties(profilePropertySetting));
     return profilePropertySettingEntity;
   }
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
@@ -64,6 +64,8 @@ public class ProfilePropertySettingEntity {
 
   private List<ProfilePropertySettingEntity> children;
 
+  private boolean                            isDefault;
+
   public List<ProfilePropertySettingEntity> getChildren() {
     if (children!=null){
       return children;

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -733,6 +733,7 @@ profileSettings.property.name.team=Team
 profileSettings.property.name.profession=Profession
 profileSettings.property.name.country=Country
 profileSettings.property.name.city=City
+profileSettings.label.canNotEdit=This option can't be updated for this attribute
 
 #####################################################################################
 #                              Translation Drawer                                   #

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -139,11 +139,14 @@
                 {{ $t('profileSettings.label.multiValued') }}
               </div>
             </v-list-item-title>
+            <v-list-item-subtitle v-if="setting.default" class="mt-n3">
+              <span class="caption"> {{ $t('profileSettings.label.attribute.canNotEdit') }} </span>
+            </v-list-item-subtitle>
           </v-list-item-content>
           <v-list-item-action>
             <v-switch
               v-model="setting.multiValued"
-              :disabled="saving"
+              :disabled="saving || setting.default"
               :ripple="false"
               color="primary"
               class="requiredSwitcher my-auto" />
@@ -305,7 +308,7 @@ export default {
       this.setting = {visible: true, editable: true, groupSynchronized: false, active: true, groupSynchronizationEnabled: true};
       this.labels = [{language: 'en', label: '', objectType: this.labelsObjectType}];
       this.parents = Object.assign([], this.settings);
-      this.parents = this.parents.filter(setting => setting.id !== this.setting.id && !setting.parentId);
+      this.parents = this.parents.filter(setting => (setting.id !== this.setting.id && !setting.parentId) && (setting.children?.length || setting.multiValued));
       this.parents.forEach(setting => setting.resolvedLabel = this.getResolvedName(setting));
       this.newSetting = true;
       this.changes= false;
@@ -316,7 +319,7 @@ export default {
       this.initialLabels = JSON.parse(JSON.stringify(setting.labels));
       this.setting = { ...setting};
       this.parents = Object.assign([], this.settings);
-      this.parents = !(Array.isArray(this.setting?.children) && this.setting?.children.length) && this.parents.filter(setting => setting.id !== this.setting.id && !setting.parentId) || [];
+      this.parents = !(Array.isArray(this.setting?.children) && this.setting?.children.length) && this.parents.filter(setting => (setting.id !== this.setting.id && !setting.parentId) &&  (setting.children?.length || setting.multiValued)) || [];
       this.parents.forEach(setting => setting.resolvedLabel = this.getResolvedName(setting));
       this.parents.unshift({resolvedLabel: ''});
       this.newSetting = false;


### PR DESCRIPTION
before this change, while retrieving profile attributes are acting like a single String value, after considering it as a parent when retrieving children a cast exception is thrown due to the non-match of types (String and ArrayList) After this change, only multivalued attributes are suggested as a parent, and for all the default attributes their multivalued values are the default value (could not be updated)

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
