### PR TITLE
fix: User and space avatar are not accessible - EXO-62527 - Meeds-io/meeds#1356

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -615,6 +615,12 @@ TimeConvert.label.Short.Edited={0} (edited)
 space.logo.banner.popover.members=Members
 space.logo.banner.popover.managers=Hosts
 space.logo.banner.popover.home=Return to home
+space.avatar.href.title=Open space {0}
+space.avatar.img.alt=Space {0} avatar
+
+popover.userAvatar.title=Open {0} profile
+popover.userAvatar.alt={0}'s avatar
+
 
 Favorite.tooltip.bookmark=Bookmark it
 Favorite.tooltip.unBookmark=Unbookmark it
@@ -629,6 +635,7 @@ Tag.tooltip.startSearch=Start a search based on this tag
 Tag.search.button=Tags
 Tag.search.placeholder=Start typing to search a Tag
 Tag.last.added=Last tags added
+
 #####################################################################################
 #                              UITopBarFavoritesPortlet                       #
 #####################################################################################

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
@@ -18,7 +18,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy"
           role="presentation"
-          alt="">
+          :alt="$t('space.avatar.img.alt',{0:spacePrettyName})">
       </v-avatar>
       <div
         v-if="fullname || !isMobile"
@@ -36,6 +36,7 @@
       v-on="on"
       :id="id"
       :href="url"
+      :arial-label="$t('space.avatar.href.title',{0:prettyName})"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
@@ -48,7 +49,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy"
           role="presentation"
-          alt="">
+          :alt="$t('space.avatar.img.alt',{0:prettyName})">
       </v-avatar>
     </a>
     <a
@@ -80,6 +81,7 @@
       v-on="on"
       :id="id"
       :href="url"
+      :aria-label="$t('space.avatar.href.title',{0:prettyName})"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
@@ -92,7 +94,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy"
           role="presentation"
-          alt="">
+          :alt="$t('space.avatar.img.alt',{0:prettyName})">
       </v-avatar>
       <div
         v-if="displayName || $slots.subTitle"
@@ -171,6 +173,7 @@ export default {
       type: String,
       default: () => '',
     },
+      
   },
   data() {
     return {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -11,6 +11,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
+      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -23,7 +24,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy"
           role="presentation"
-          alt="">
+          :alt="$t('popover.userAvatar.alt',{0:userFullname})">
       </v-avatar>
     </component>
     <component
@@ -54,6 +55,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
+      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="d-flex flex-nowrap flex-grow-1 text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -66,7 +68,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy"
           role="presentation"
-          alt="">
+          :alt="$t('popover.userAvatar.alt',{0:userFullname})">
       </v-avatar>
       <div v-if="userFullname || $slots.subTitle" class="ms-2 overflow-hidden">
         <p
@@ -96,6 +98,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
+      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -107,8 +110,7 @@
           :src="userAvatarUrl"
           class="object-fit-cover ma-auto"
           loading="lazy"
-          role="presentation"
-          alt="">
+          :alt="$t('popover.userAvatar.alt',{0:userFullname})">
       </v-avatar>
     </component>
     <component 
@@ -139,6 +141,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
+      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="d-flex flex-nowrap flex-grow-1 text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -151,7 +154,7 @@
           class="object-fit-cover ma-auto"
           loading="lazy"
           role="presentation"
-          alt="">
+          :alt="$t('popover.userAvatar.alt',{0:userFullname})">
       </v-avatar>
       <div v-if="userFullname || $slots.subTitle" class="ms-2 overflow-hidden">
         <p

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpaceNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpaceNavigationItem.vue
@@ -30,7 +30,7 @@
       tile>
       <img
         :src="spaceAvatar"
-        :alt="spaceDisplayName"
+        :alt="$t('space.avatar.img.alt',{0:space.prettyName})"
         width="28"
         height="28">
     </v-list-item-avatar>
@@ -55,6 +55,7 @@
     :href="spaceLink"
     :class="homeIcon && (homeLink === spaceLink && 'UserPageLinkHome' || 'UserPageLink')"
     link
+    :arial-label="$t('space.avatar.href.title',{0:space.prettyName})"
     class="px-2 spaceItem"
     @mouseover="showItemActions = true"
     @mouseleave="showItemActions = false">
@@ -64,7 +65,7 @@
       tile>
       <img
         :src="spaceAvatar"
-        :alt="spaceDisplayName"
+        :alt="$t('space.avatar.img.alt',{0:space.prettyName})"
         class="rounded"
         width="28"
         height="28">

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -16,14 +16,14 @@
           v-on="on"
           v-bind="attrs"
           class="d-inline-flex">
-          <a :href="portalPath">
+          <a :href="portalPath" :aria-label="$t('space.avatar.href.title',{0:logoTitle})">
             <v-list-item-avatar 
               v-if="logoPath"
               id="UserHomePortalLink"
               size="30"
               class="tile my-0 spaceAvatar ms-0 me-3"
               tile>
-              <v-img :src="logoPath" :alt="logoTitle" />
+              <v-img :src="logoPath" :alt="$t('space.avatar.img.alt',{0:logoTitle})" />
             </v-list-item-avatar>
           </a>
           <a
@@ -43,6 +43,7 @@
               width="60"
               height="60">
               <v-img
+                :alt="$t('space.avatar.img.alt',{0:logoTitle})"
                 class="object-fit-cover"
                 :src="`${logoPath}&size=60x60`" />
             </v-list-item-avatar>


### PR DESCRIPTION
Before this change, when create an activity and refresh stream, the a tag of avatar have not a discernible name, the img tag for avatar have a role=presentation which is not the correct one and space and user avatar are concerned. To fix this, added:
  -the arial-label for this a tag of user avatar by the key popover.userAvatar.title which returns a text Open {userFullname} profile.
  -the alt for this image tag by the key popover.userAvatar.title which returns a text{userFullname}'s avatar.
  -the arial-label for this a tag of space avatar by the key space.logo.banner.title which returns a text Open {userFullname} profile.
  -the alt for this image tag by the keyspace.logo.banner.alt which returns a text{userFullname}'s avatar.
After this change, user and space avatar are accessible.

(cherry picked from commit 5fd04b538d8aac571eb759f37762899e827da37a)