### PR TITLE
fix: Unable to manage documents and notes app in space settings - EXO-65679

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingApplicationCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingApplicationCard.vue
@@ -111,7 +111,7 @@ export default {
       return this.application && this.application.id && this.application.removable && String(this.application.removable) === 'true';
     },
     applicationId() {
-      return this.application && this.application.id;
+      return this.application && `${this.application.id}App`;
     },
     applicationName() {
       return this.application && this.$t(`SpaceSettings.application.${/\s/.test(this.application.displayName) ? this.application.displayName.replace(/ /g,'.').toLowerCase() : this.application.displayName.toLowerCase()}.title`);


### PR DESCRIPTION
Prior to this change, the 3-dot menu did not display for the Documents and Notes application due to ID duplication in the DOM, preventing proper attachment to the component. After this change, we concatenate the string 'App' to the card ID, ensuring the avoidance of DOM ID duplication.