### PR TITLE
fix: Fix link type node opening from top bar navigation menu portlet - EXO-68401 - Meeds-io/meeds#1488

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/NavigationService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/NavigationService.js
@@ -15,7 +15,7 @@
     Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-export function getNavigations(siteName, siteType, scope, visibility, exclude, nodeId, expandBreadcrumb) {
+export function getNavigations(siteName, siteType, scope, visibility, exclude, nodeId, expandBreadcrumb, expand) {
   const formData = new FormData();
   if (siteName) {
     formData.append('siteName', siteName);
@@ -36,6 +36,9 @@ export function getNavigations(siteName, siteType, scope, visibility, exclude, n
   }
   if (expandBreadcrumb) {
     formData.append('expandBreadcrumb', expandBreadcrumb);
+  }
+  if (expand) {
+    formData.append('expand', expand);
   }
 
   const params = new URLSearchParams(formData).toString();

--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/TopBarNavigationMenu.vue
@@ -138,11 +138,11 @@ export default {
     },
     getNavigations() {
       const siteName = eXo.env.portal.portalName;
-      return this.$navigationService.getNavigations(siteName, this.siteType, this.globalScope, this.visibility, this.exclude)
+      return this.$navigationService.getNavigations(siteName, this.siteType, this.globalScope, this.visibility, this.exclude, null, null, true)
         .then(navs => {
           if (navs.length) {
             const homeNavigation = navs[0];
-            return this.$navigationService.getNavigations(siteName, this.siteType, this.scope, this.visibility, null, homeNavigation.id)
+            return this.$navigationService.getNavigations(siteName, this.siteType, this.scope, this.visibility, null, homeNavigation.id, null, true)
               .then(navigations => {
                 this.navigations = navigations || [];
                 this.constructNavigations();


### PR DESCRIPTION
Prior to this change, when adding a link type node as a subnode for the root node of any site, it is opened from the top bar navigation menu portlet as a simple page node instead of a link node. This is due to the to the "expand" param passed as false (default value) which not allows to bring the pageLink value of the node. After this change, we ensure to pass this param with "true" value in order to get the needed pageLink value and open the node as a link.