### PR TITLE
fix: Fix displaying non initialized CMS Portlet anonymously - MEED-3128 - Meeds-io/meeds#1491

### DIFF
--- a/component/web/src/main/java/io/meeds/social/portlet/CMSPortlet.java
+++ b/component/web/src/main/java/io/meeds/social/portlet/CMSPortlet.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.config.model.ApplicationState;
 import org.exoplatform.portal.config.model.ApplicationType;
@@ -46,6 +47,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.rest.api.RestUtils;
 import org.exoplatform.social.webui.Utils;
 
 import io.meeds.social.cms.service.CMSService;
@@ -93,6 +95,9 @@ public class CMSPortlet extends GenericDispatchedViewPortlet {
   protected void saveSettingName(String name, String pageReference, long spaceId) {
     String identityId = Utils.getViewerIdentityId();
     try {
+      if (identityId == null) {
+        identityId = getSuperUserIdentityId();
+      }
       getCmsService().saveSettingName(contentType,
                                       name,
                                       pageReference,
@@ -183,6 +188,12 @@ public class CMSPortlet extends GenericDispatchedViewPortlet {
       cmsService = ExoContainerContext.getService(CMSService.class);
     }
     return cmsService;
+  }
+
+  private String getSuperUserIdentityId() {
+    UserACL userAcl = ExoContainerContext.getService(UserACL.class);
+    String superUser = userAcl.getSuperUser();
+    return RestUtils.getUserIdentity(superUser).getId();
   }
 
   private Identity getCurrentAclIdentity() {


### PR DESCRIPTION
Prior to this change, when adding a new portlet without adding content into it and then anonymously displayed by a user, the portlet setting isn't saved due to missing current user identity id. This change will use super user identity id in that special case.