### PR TITLE
fix: button favorite and 3 dots menu in activity detail have no accessible name - EXO-62416 - Meeds-io/meeds#1376

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -268,6 +268,7 @@ activity.composer.post.error=An error occurred when posting the message
 activity.composer.old=Use the old composer
 activity.composer.invalidUsers.message=Previously mentioned users will be removed as they are not member of your audience
 activity.composer.invalidUser.message=This user isn't member of the new audience
+activity.head.menu.title.open=Open activity menu
 
 #####################################################################################
 #                                    Activity Stream                                #

--- a/webapp/portlet/src/main/webapp/skin/less/common/Notification/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/common/Notification/Style.less
@@ -100,6 +100,7 @@ li {
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
+    width: 100%;
 
     .contentSmall {
       .status {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
@@ -13,6 +13,7 @@
           :loading="loading"
           icon
           small
+          :aria-label="$t('activity.head.menu.title.open')"
           class="me-2"
           v-bind="attrs"
           v-on="on">

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
@@ -8,6 +8,7 @@
           :style="buttonStyle"
           :loading="loading"
           :disabled="loading"
+          :aria-label="favoriteTooltip"
           class="pa-0 mt-0"
           icon
           :small="small"
@@ -28,6 +29,7 @@
         <v-list-item 
           v-bind="attrs" 
           v-on="on" 
+          :aria-label="favoriteTooltip"
           @click="changeFavorite">
           <v-icon 
             class="mr-3"


### PR DESCRIPTION
Before this change, after creating an activity in a space when you open DevTools of your browser and in the flagship tab, run the accessibility check, the favorite button and the 3 dots menu button have no accessible name. To resolve this problem, added props arial-label in favorite button with the keys used by favoriteTooltip and added in the Portlets_eu.properties file the key activity.head.menu.title.open which rounds a text Open activity menu and in the ActivityHeadMenu file added an arial-label props with this key for the 3 dots menu. After this change, these faulty elements are no longer displayed in the flagship tab, launch accessibility.
(cherry-picked from [PR](https://github.com/Meeds-io/social/pull/3254))