### PR TITLE
fix: Add the space administration portlet to the ManageSpaceGRP load group - EXO-68206 - Meeds-io/meeds#1467

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -735,6 +735,9 @@ public class EntityBuilder {
       spaceEntity.setIsPublisher(spaceService.isPublisher(space, userId));
     }
 
+    PortalConfig portalConfig = getLayoutService().getPortalConfig(new SiteKey(GROUP, space.getGroupId()));
+    spaceEntity.setSiteId((portalConfig.getStorageId().split("_"))[1]);
+
     spaceEntity.setDisplayName(space.getDisplayName());
     spaceEntity.setLastUpdatedTime(space.getLastUpdatedTime());
     spaceEntity.setCreatedTime(String.valueOf(space.getCreatedTime()));

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/SpaceEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/SpaceEntity.java
@@ -224,6 +224,15 @@ public class SpaceEntity extends BaseEntity {
     return (Boolean) getProperty("canEditNavigations");
   }
 
+  public SpaceEntity setSiteId(String siteId) {
+    setProperty("siteId", siteId);
+    return this;
+  }
+
+  public String getSiteId() {
+    return (String) getProperty("siteId");
+  }
+
   public SpaceEntity setManagers(LinkEntity managers) {
     setProperty("managers", managers.getData());
     return this;

--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1512,6 +1512,9 @@
       <depends>
         <module>extensionRegistry</module>
       </depends>
+      <depends>
+        <module>ManageSpacesExtension</module>
+      </depends>
     </module>
   </portlet>
 

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
@@ -88,8 +88,8 @@
             type="manage-space-actions"
             :params="{ disabled: !space.canEditNavigations,
                        iconColor: 'primary',
-                       canManageSiteNavigation: true,
                        siteName: space.groupId,
+                       siteId: space.siteId,
                        siteType: 'GROUP'}" />
         </td>
       </tr>
@@ -190,6 +190,9 @@
         <div class="btn" @click="closeRemoveBindingModal">{{ $t('social.spaces.administration.manageSpaces.spaceBindingForm.cancel') }}</div>
       </div>
     </exo-spaces-administration-modal>
+    <extension-registry-components
+      name="manageSpaceDrawers"
+      type="manage-space-drawers" />
   </div>
 </template>
 <script>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
@@ -88,6 +88,7 @@
             type="manage-space-actions"
             :params="{ disabled: !space.canEditNavigations,
                        iconColor: 'primary',
+                       canManageSiteNavigation: true,
                        siteName: space.groupId,
                        siteType: 'GROUP'}" />
         </td>

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
@@ -35,5 +35,5 @@ export function init(applicationsByCategory) {
       i18n,
       vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Spaces Administration');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('ManageSpaceActions'));
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/main.js
@@ -35,5 +35,5 @@ export function init(applicationsByCategory) {
       i18n,
       vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'Spaces Administration');
-  }).finally(() => Vue.prototype.$utils.includeExtensions('ManageSpaceActions'));
+  });
 }


### PR DESCRIPTION
Prior to this change, the site navigation icon is not displayed on the space administration page due to the hide of sharedLayout for the aggregated site containing the site navigation portlet.This commit creates a load-group for site navigation, which will then be loaded with the Spaces Administration Portlet.