### PR TITLE
fix: Problem when option post to network is set to false - EXO-67423 - Meeds-io/meeds#1273

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -438,7 +438,7 @@ export default {
       }
     },
     resetAudienceChoice() {
-      this.audienceChoice =  eXo.env.portal.postToNetworkEnabled && 'yourNetwork' ||  'oneOfYourSpaces';
+      this.audienceChoice = eXo.env.portal.postToNetworkEnabled && 'yourNetwork' || 'oneOfYourSpaces';
       this.audience = '';
     },
     removeAudience() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -191,8 +191,8 @@ export default {
       attachments: null,
       activityToolbarAction: false,
       postToNetwork: eXo.env.portal.postToNetworkEnabled,
-      audienceChoice: 'yourNetwork',
-      audience: '',
+      audienceChoice: eXo.env.portal.postToNetworkEnabled && 'yourNetwork' ||  'oneOfYourSpaces',
+      audience: eXo.env.portal.spaceId,
       username: eXo.env.portal.userName
     };
   },
@@ -438,7 +438,7 @@ export default {
       }
     },
     resetAudienceChoice() {
-      this.audienceChoice = 'yourNetwork';
+      this.audienceChoice =  eXo.env.portal.postToNetworkEnabled && 'yourNetwork' ||  'oneOfYourSpaces';
       this.audience = '';
     },
     removeAudience() {


### PR DESCRIPTION
Before this fix, when the feature PostToNetwork is disabled, the suggester does not correctly disappear to display the chosen space, as when the feature is activated. This is due to the audience, which is not correctly set to oneOfYourSpaces when the PostToNetwork is disabled. To fix it, we set the value of audienceChoice in the function of the feature PostToNetwork status.