### PR TITLE
feat: engance ESC usage in richeditor when balloon toolbar is opened-MEED-3079 - Meeds-io/MIPs#107

### DIFF
--- a/webapp/portlet/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
+++ b/webapp/portlet/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
@@ -65,8 +65,9 @@
 
       editor.setKeystroke( CKEDITOR.CTRL + 75 /*K*/, 'addLink' );
       document.addEventListener('keydown', (evt) => {
+        const selection = editor.getSelection();
         evt = evt || window.event;
-        if (evt.key === 'Escape' && isInputTextToolbar) {
+        if (evt.key === 'Escape' && isInputTextToolbar && selection && selection.getSelectedText().trim().length >= 0) {
           hideInputTextPanel(editor);
         }
       });

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -260,7 +260,8 @@ export default {
     },
     closeDisplayedDrawer() {
       const isLastOpenedDrawer = eXo.openedDrawers.indexOf(this) === eXo.openedDrawers.length - 1;
-      if (this.drawer && isLastOpenedDrawer) {
+      const inputTextDisplayed = !!document.getElementById('inputURL');
+      if (this.drawer && isLastOpenedDrawer && !inputTextDisplayed) {
         this.close();
       }
     },


### PR DESCRIPTION
Prior to this change, when we fire ESC keybord event to hide the balloon panel, the drawer is closed also.
This change allows to prevent the drawer close when the balloon toolbar is opened.