### PR TITLE
fix: Suggest isn't displaying users - EXO-68574 - Meeds-io/meeds#1503 .

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -83,7 +83,7 @@
         <v-list-item-title
           :style="menuItemStyle"
           class="text-truncate identitySuggestionMenuItemText"
-          v-text="itemText ? data.item[itemText] : data.item.profile.fullName" />
+          v-text="itemText !== 'profile.fullName' ? data.item[itemText] : data.item.profile.fullName" />
       </template>
     </v-autocomplete>
   </v-flex>
@@ -109,7 +109,7 @@ export default {
     itemText: {
       type: String,
       default: function() {
-        return null;
+        return 'profile.fullName';
       },
     },
     labels: {


### PR DESCRIPTION
Before this change, when create user1 & user2, add user & user2 in spaceX, on spaceX, user1 Sends kudos and on suggestor types user2 name, suggestor isn't displaying any results. To resolve this problem, added the default profile.fullName value to the itemText props. After this change, suggestor should display results related to typed string.
