### PR TITLE
fix: Suggest isn't displaying users - EXO-68574 - Meeds-io/meeds#1503 .

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoIdentitySuggester.vue
@@ -67,8 +67,8 @@
           </v-avatar>
           <span class="text-truncate">
             {{ item.profile.external
-              ? (itemText ? item[itemText] : item.profile.fullName).concat(' (').concat($t('userAvatar.external.label')).concat(')')
-              : (itemText) ? item[itemText] : item.profile.fullName
+              ? (itemText !== 'profile.fullName' ? item[itemText] : item.profile.fullName).concat(' (').concat($t('userAvatar.external.label')).concat(')')
+              : itemText !== 'profile.fullName' ? item[itemText] : item.profile.fullName
             }}          
           </span>
         </v-chip>


### PR DESCRIPTION
Before this change, when create user1 & user2, add user & user2 in spaceX, on spaceX, user1 Sends kudos and on suggestor types user2 name, suggestor isn't displaying any results. To resolve this problem, added the default profile.fullName value to the itemText props. After this change, suggestor should display results related to typed string.