### PR TITLE
fix: Fix Notification Overflow Display when expanded - MEED-3134 - Meeds-io/meeds#1492

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -89,7 +89,7 @@
           </v-expand-x-transition>
           <v-card
             :max-height="expanded && '100%' || 'auto'"
-            class="d-flex flex-column flex-grow-1 flex-shrink-1 transparent no-border-radius"
+            class="d-flex flex-column flex-grow-1 flex-shrink-1 transparent no-border-radius overflow-hidden"
             flat>
             <v-card
               :max-height="expanded && '100%' || 'auto'"


### PR DESCRIPTION
Prior to this change, the Notification center displays items without considering max width of parent element. This change will ensure to apply the max-width added in parent with the class `singlePageApplication` by using the 'overflow-hidden' class.

(Resolves Meeds-io/meeds#1492)