### PR TITLE
fix: Fix Attaching images in Activity Composer - MEED-3137 - Meeds-io/meeds#1506

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
@@ -121,7 +121,7 @@ export default {
     },
     save() {
       const uploadedFiles = this.images
-        .filter((file) => file.progress === 100)
+        .filter((file) => file.progress >= 100)
         .map((file) => ({
           uploadId: file.uploadId,
           altText: file?.altText || ''

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -27,7 +27,8 @@
     </div>
     <div v-if="containInvalidUsers" class="mt-4 text-sub-title">{{ $t('activity.composer.invalidUsers.message') }}</div>
     <attachments-image-input
-      v-if="displayAttachmentEditor"
+      v-if="attachmentEnabled"
+      v-show="displayAttachmentEditor"
       ref="attachmentsInput"
       :max-file-size="maxFileSize"
       :object-type="objectType"


### PR DESCRIPTION
Prior to this change, the Attachments component wasn't saving image attachments when creating items. This change will make the instance of Attachments remains until the 'save' process is completely finished.

(Resolves https://github.com/Meeds-io/meeds/issues/1506)