### PR TITLE
fix: Problem when option post to network is set to false for edit activity case - EXO-67423 - Meeds-io/meeds#1273

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -440,7 +440,7 @@ export default {
     },
     resetAudienceChoice() {
       this.audienceChoice = eXo.env.portal.postToNetworkEnabled && 'yourNetwork' || 'oneOfYourSpaces';
-      this.audience = '';
+      this.audience = eXo.env.portal.spaceId;
     },
     removeAudience() {
       this.audience = '';


### PR DESCRIPTION
before this change, after saving an activity we reset Audience Choice and the audience become null causing  a disabled update button
After this change, we reset the audience choice to the current spaceId in space case and to ' ' in the other case