### PR TITLE
feat: Disable ckeditor version check by default - MEED-3087 - Meeds-io/MIPs#107

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
@@ -90,6 +90,9 @@ CKEDITOR.editorConfig = function(config) {
   // remove the white mask on dialog
   config.dialog_backgroundCoverColor = 'transparent';
   config.dialog_backgroundCoverOpacity = 1;
+  
+  // Disable the version check by default
+  config.versionCheck = false;
 
   // Here is configure for suggester
   var peopleSearchCached = {};


### PR DESCRIPTION
Prior to this change, the version check in the Ckeditor is enabled by default. The version check feature  inform users by a notification system if the editor version is secure.
This change allows to disable this feature by default for the rich editor `config.versionCheck = false;`