### PR TITLE
fix: Problem when option post to network is set to false for edit activity case - EXO-67423 - Meeds-io/meeds#1273

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -313,6 +313,7 @@ export default {
         this.activityType = params.activityType;
         this.attachments = this.templateParams?.metadatas?.attachments;
         this.activityToolbarAction = params.activityToolbarAction;
+        this.audience = params.spaceId;
       } else {
         this.activityId = null;
         this.spaceId = null;


### PR DESCRIPTION
before this change, in the activity stream not in space when opening the drawer to edit an activity the update btn is disabled since the audience is null
After this change, the audience is set when opening the drawer and the update btn is active