### PR TITLE
fix: Fix Saving Branding form the second time - MEED-3151 - Meeds-io/meeds#1522

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
@@ -262,7 +262,10 @@ export default {
     },
     companyName() {
       this.$root.$emit('refresh-company-name', this.companyName);
-    }
+    },
+    branding() {
+      this.init();
+    },
   },
   mounted() {
     this.init();

--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBrandingWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBrandingWindow.vue
@@ -25,7 +25,10 @@
       lg="6"
       class="pa-0 mb-12 pb-5">
       <portal-general-settings-branding-site 
-        :branding="branding" />
+        :branding="branding"
+        @changed="$emit('changed')"
+        @saved="$emit('saved')"
+        @close="$emit('close')" />
     </v-col>
     <v-col
       cols="12"


### PR DESCRIPTION
Prior to this change, when saving the branding form the first time, it's not reset including Uploaded Files Ids which makes the second save operation fails. This change will fix the propagation of saving information to the parent in order to make the re-initialize the form.