### PR TITLE
fix: fix log error for non activity handled MetadataModification - EXO-68532

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/AbstractMetadataItemListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/AbstractMetadataItemListener.java
@@ -108,7 +108,7 @@ public abstract class AbstractMetadataItemListener<S, D> extends Listener<S, D> 
   }
 
   protected void handleMetadataModification(String objectType, String objectId) {
-    if (clearActivityCache(objectType, objectId)) {
+    if (clearActivityCache(objectType, objectId) && isActivityEvent(objectType)) {
       // Ensure to re-execute MetadataActivityProcessor to compute & cache
       // metadatas of the activity again
       reindexActivity(objectId);


### PR DESCRIPTION
before this change, when handling metadata modification the activity is reindexed,  for non-activity metadata  it tries to reindex the activity  with the non-activity id causes a log error
After this change, if the metadata change is handled we check if it is an activity event to avoid reindexing 