### PR TITLE
fix: Fix Saving Branding form the second time - MEED-3151 - Meeds-io/meeds#1522 (#3389)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
@@ -262,7 +262,10 @@ export default {
     },
     companyName() {
       this.$root.$emit('refresh-company-name', this.companyName);
-    }
+    },
+    branding() {
+      this.init();
+    },
   },
   mounted() {
     this.init();

--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBrandingWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/branding/SiteBrandingWindow.vue
@@ -25,7 +25,10 @@
       lg="6"
       class="pa-0 mb-12 pb-5">
       <portal-general-settings-branding-site 
-        :branding="branding" />
+        :branding="branding"
+        @changed="$emit('changed')"
+        @saved="$emit('saved')"
+        @close="$emit('close')" />
     </v-col>
     <v-col
       cols="12"


### PR DESCRIPTION
Prior to this change, when saving the branding form the first time, it's not reset including Uploaded Files Ids which makes the second save operation fails. This change will fix the propagation of saving information to the parent in order to make the re-initialize the form.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
