### PR TITLE
fix: Add Branding Stylesheet in CKEditor iframe - MEED-3188 - Meeds-io/meeds#1547

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
@@ -68,7 +68,9 @@ CKEDITOR.editorConfig = function(config) {
 
   // style inside the editor
   config.contentsCss = [];
-  document.querySelectorAll('[skin-type=portal-skin]').forEach(link => config.contentsCss.push(link.href))
+  document.querySelectorAll('[skin-type=portal-skin]')
+    .forEach(link => config.contentsCss.push(link.href));
+  config.contentsCss.push(document.querySelector('#brandingSkin').href);
   config.contentsCss.push('/commons-extension/ckeditorCustom/contents.css'); // load last
 
   config.toolbar = [


### PR DESCRIPTION
Prior to this change, the branding style wasn't loaded in the Iframe of CKEditor. This change will add it in generic configuration loaded in all CKEditors.