### PR TITLE
feat: Fix default avatar in mention user popover- MEED-3111 - Meeds-io/MIPs#83

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/image/ImageUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/image/ImageUtils.java
@@ -179,7 +179,7 @@ public class ImageUtils {
     graphics.fillRect(0, 0, DEFAULT_AVATAR_WIDTH, DEFAULT_AVATAR_HEIGHT);
     graphics.setColor(Color.WHITE);
 
-    graphics.setFont(new Font("Arial", Font.BOLD, 85));
+    graphics.setFont(new Font("Arial", Font.BOLD, 100));
     FontMetrics fm = graphics.getFontMetrics();
 
     int x = (DEFAULT_AVATAR_WIDTH - fm.stringWidth(fullNameAbbreviation)) / 2;

--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -200,7 +200,7 @@ public class LinkProvider {
                .append(identity.getProfile().getProperty(Profile.EXTERNAL) != null && StringUtils.equals("true", String.valueOf(identity.getProfile().getProperty(Profile.EXTERNAL))))
                .append("',")
                .append("enabled: '")
-               .append(identity.isEnable() && !identity.isDeleted() && StringUtils.equals("true", String.valueOf(identity.isEnable())))
+               .append(identity.isEnable() && !identity.isDeleted())
                .append("',")
                .append("}\"")
                .append(">")

--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -199,6 +199,9 @@ public class LinkProvider {
                .append("external: '")
                .append(identity.getProfile().getProperty(Profile.EXTERNAL) != null && StringUtils.equals("true", String.valueOf(identity.getProfile().getProperty(Profile.EXTERNAL))))
                .append("',")
+               .append("enabled: '")
+               .append(identity.isEnable() && !identity.isDeleted() && StringUtils.equals("true", String.valueOf(identity.isEnable())))
+               .append("',")
                .append("}\"")
                .append(">")
                .append(StringEscapeUtils.escapeHtml4(identity.getProfile().getFullName()));

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
@@ -180,11 +180,13 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
         + "v-identity-popover=\"{id: '" + rootIdentity.getId() + "',username: '" + rootIdentity.getRemoteId() + "',fullName: '"
         + rootIdentity.getProfile().getFullName() + "',avatar: '" + rootIdentity.getProfile().getAvatarUrl() + "',position: '"
         + StringUtils.trimToEmpty(rootIdentity.getProfile().getPosition()) + "',external: '" + (rootExternal == null ? "false" : rootExternal)
+        + "',enabled: '" + (rootIdentity.isEnable() && !rootIdentity.isDeleted())
         + "',}\" rel=\"nofollow\" target=\"_self\">Root Root</a> " +
         "<a class=\"user-suggester\" href=\"" + currentDomain + "/portal/classic/profile/john\" "
         + "v-identity-popover=\"{id: '" + johnIdentity.getId() + "',username: '" + johnIdentity.getRemoteId() + "',fullName: '"
         + johnIdentity.getProfile().getFullName() + "',avatar: '" + johnIdentity.getProfile().getAvatarUrl() + "',position: '"
         + StringUtils.trimToEmpty(johnIdentity.getProfile().getPosition()) + "',external: '" + (johnExternal == null ? "false" : johnExternal)
+        + "',enabled: '" + (johnIdentity.isEnable() && !johnIdentity.isDeleted())
         + "',}\" rel=\"nofollow\" target=\"_self\">John Anthony</a>";
     activity.setTitle("test @root @john");
     activityStorage.updateActivity(activity);

--- a/component/core/src/test/java/org/exoplatform/social/core/service/LinkProviderTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/service/LinkProviderTest.java
@@ -46,6 +46,7 @@ public class LinkProviderTest extends AbstractCoreTest { // NOSONAR
         + rootIdentity.getProfile().getFullName() + "',avatar: '" + rootIdentity.getProfile().getAvatarUrl() + "',position: '"
         + StringUtils.trimToEmpty(rootIdentity.getProfile().getPosition()) + "',external: '"
         + (external == null ? "false" : external)
+        + "',enabled: '" + (rootIdentity.isEnable() && !rootIdentity.isDeleted())
         + "',}\">" + rootFullName + "</a>";
     assertEquals(expected, actualLink);
   }


### PR DESCRIPTION
This change allows to add a new property (enabled) to the identity-popover values to display the new default user avatar in the user popover when hovering on a mention user if the user is enabled.