### PR TITLE
fix: For space avatar, aria-label on link does not contains the text - EXO-69059 - Meeds-io/meeds#1564

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
@@ -35,7 +35,7 @@
       v-on="on"
       :id="id"
       :href="url"
-      :arial-label="$t('space.avatar.href.title',{0:prettyName})"
+      :aria-label="$t('space.avatar.href.title',{0:displayName})"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
@@ -79,7 +79,7 @@
       v-on="on"
       :id="id"
       :href="url"
-      :aria-label="$t('space.avatar.href.title',{0:prettyName})"
+      :aria-label="$t('space.avatar.href.title',{0:displayName})"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"


### PR DESCRIPTION
Before this fix, the space avatar link has an incorrect aria-label. This label must contains the text of the link, and as it display 'Open the {prettyName}' instead of 'Open the {displayName}', this is shown as error in lighthouse This commit correctly use displayName instead of prettyname

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
