### PR TITLE
fix: For space avatar, aria-label on link does not contains the text - EXO-69059 - Meeds-io/meeds#1564

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
@@ -35,7 +35,7 @@
       v-on="on"
       :id="id"
       :href="url"
-      :arial-label="$t('space.avatar.href.title',{0:prettyName})"
+      :aria-label="$t('space.avatar.href.title',{0:displayName})"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
@@ -79,7 +79,7 @@
       v-on="on"
       :id="id"
       :href="url"
-      :aria-label="$t('space.avatar.href.title',{0:prettyName})"
+      :aria-label="$t('space.avatar.href.title',{0:displayName})"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"


### PR DESCRIPTION
Before this fix, the space avatar link has an incorrect aria-label. This label must contains the text of the link, and as it display 'Open the {prettyName}' instead of 'Open the {displayName}', this is shown as error in lighthouse This commit correctly use displayName instead of prettyname
