### PR TITLE
feat: fix wallet identity fileItem error - MEED-3267 -Meeds-io/MIPs#83

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
@@ -482,7 +482,9 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
       profile.setId(String.valueOf(entity.getId()));
       if (entity.getAvatarFileId() != null && entity.getAvatarFileId() > 0) {
         FileItem fileItem = fileService.getFile(entity.getAvatarFileId());
-        profile.setDefaultAvatar(EntityConverterUtils.DEFAULT_AVATAR.equals(fileItem.getFileInfo().getName()));
+        if (fileItem != null) {
+          profile.setDefaultAvatar(EntityConverterUtils.DEFAULT_AVATAR.equals(fileItem.getFileInfo().getName()));
+        }
       }
       EntityConverterUtils.mapToProfile(entity, profile);
       profile.clearHasChanged();

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
@@ -922,10 +922,11 @@ public class IdentityStorageTest extends AbstractCoreTest {
     assertNotNull(avatarFile.getFileInfo().getId());
     assertEquals(EntityConverterUtils.DEFAULT_AVATAR, avatarFile.getFileInfo().getName());
     assertTrue(profile.isDefaultAvatar());
+  }
 
+  public void testGroupIdentityDefaultAvatar() throws Exception {
     // We check that any identities other than user or space identity shouldn't have
     // a generated default avatar
-
     Identity groupIdentity = new Identity("group", "testGroup");
     identityStorage.saveIdentity(groupIdentity);
     Profile groupProfile = new Profile(groupIdentity);

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
@@ -922,6 +922,21 @@ public class IdentityStorageTest extends AbstractCoreTest {
     assertNotNull(avatarFile.getFileInfo().getId());
     assertEquals(EntityConverterUtils.DEFAULT_AVATAR, avatarFile.getFileInfo().getName());
     assertTrue(profile.isDefaultAvatar());
+
+    // We check that any identities other than user or space identity shouldn't have
+    // a generated default avatar
+
+    Identity groupIdentity = new Identity("group", "testGroup");
+    identityStorage.saveIdentity(groupIdentity);
+    Profile groupProfile = new Profile(groupIdentity);
+    identityStorage.saveProfile(groupProfile);
+    groupIdentity.setProfile(groupProfile);
+    tearDownIdentityList.add(groupIdentity);
+    String groupIdentityId = groupIdentity.getId();
+    assertNotNull(groupIdentityId);
+
+    FileItem groupAvatarFile = identityStorage.getAvatarFile(groupIdentity);
+    assertNull(groupAvatarFile);
   }
 
   public void testIdentityDefaultAvatarWhenRenameUserFirstName() throws Exception {


### PR DESCRIPTION
Prior to this change, on prod and pre-prod environments  we have a NPE when getting the identity avatar in wallet and reward configurations, This change allows to fix the NPE exception by testing if the object is null before the edit.