### PR TITLE
fix: Adjust the padding left of the logout icon - MEED-3270 - Meeds-io/MIPs#117

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/user/UserHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/user/UserHamburgerNavigation.vue
@@ -46,7 +46,6 @@
               :href="settingsUrl"
               height="50px"
               min-width="40px"
-              class="px-0"
               v-bind="attrs"
               v-on="on"
               icon>
@@ -67,7 +66,6 @@
               :href="logoutUrl"
               height="50px"
               min-width="40px"
-              class="pe-1 ps-0"
               v-bind="attrs"
               v-on="on"
               icon>


### PR DESCRIPTION
This change will adjust the padding left of the logout icon.