### PR TITLE
fix: avoid reusing recycled HTTP requests - Meeds-io/meeds#1565 - EXO-69030

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceAccessHandler.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceAccessHandler.java
@@ -53,8 +53,6 @@ public class SpaceAccessHandler extends WebRequestHandler {
 
   private static final String     SPACES_GROUP_PREFIX = SpaceUtils.SPACE_GROUP + "/";
 
-  private static final String     LAST_PORTAL_NAME    = "prc.lastPortalName";
-
   public static final String      PAGE_URI       = "space-access";
 
   private IdentityManager         identityManager;
@@ -198,10 +196,7 @@ public class SpaceAccessHandler extends WebRequestHandler {
   }
 
   private String getURI(ControllerContext controllerContext, String uri) {
-    String portalName = (String) controllerContext.getRequest().getSession().getAttribute(LAST_PORTAL_NAME);
-    if (StringUtils.isBlank(portalName)) {
-      portalName = userPortalConfigService.getMetaPortal();
-    }
+    String portalName = userPortalConfigService.getMetaPortal();
 
     SiteKey siteKey = SiteKey.portal(portalName);
     NavigationResource resource = new NavigationResource(siteKey.getType(), siteKey.getName(), uri);


### PR DESCRIPTION
Accessing the request session is forbidden after the request expires and gets recycled.
The current fix will avoid using the session to store the current portal name which is no more necessary after the introduction of the Meta sites

