### PR TITLE
fix: Make users and space popovers controllable from the keyboard - EXO-68900

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
@@ -23,6 +23,7 @@
     v-if="menu"
     v-model="menu"
     rounded="rounded"
+    role="tooltip"
     :close-on-content-click="false"
     :position-x="offsetX"
     :position-y="offsetY"
@@ -119,6 +120,12 @@ export default {
     document.addEventListener('drawerClosed', () => this.closePopover(true));
     document.addEventListener('modalOpened', () => this.closePopover(true));
     document.addEventListener('modalClosed', () => this.closePopover(true));
+    document.addEventListener('popover-identity-hide', () => this.closePopover(true));
+    window.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        this.closePopover(true);
+      }
+    });
     this.$root.$on('popover-hovered', this.setPopoverHovered);
     this.$root.$on('popover-not-hovered', this.setPopoverNotHovered);
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -25,10 +25,8 @@ Vue.directive('identity-popover', (el, binding) => {
   el.addEventListener('mouseover', () => {
     showPopover(el, identity, isUser);
   });
-  el.addEventListener('keyup', (event) => {
-    if (event.key === 'Tab') {
-      showPopover(el, identity, isUser);
-    }
+  el.addEventListener('focusin', () => {
+    showPopover(el, identity, isUser);
   });
   el.addEventListener('focusout', () => {
     document.dispatchEvent(new CustomEvent('popover-identity-hide'));

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/main.js
@@ -23,18 +23,30 @@ Vue.directive('identity-popover', (el, binding) => {
   }
 
   el.addEventListener('mouseover', () => {
-    const rect = el.getBoundingClientRect();
-    document.dispatchEvent(new CustomEvent('popover-identity-display', {
-      detail: Object.assign({
-        offsetX: rect.left + window.scrollX,
-        offsetY: rect.top > 150 + rect.height ? rect.top : rect.bottom + window.scrollY,
-        top: rect.top > 150 + rect.height ? true : false, 
-        identityType: isUser ? 'User' : 'Space',
-        element: el,
-      }, identity || {})
-    }));
+    showPopover(el, identity, isUser);
+  });
+  el.addEventListener('keyup', (event) => {
+    if (event.key === 'Tab') {
+      showPopover(el, identity, isUser);
+    }
+  });
+  el.addEventListener('focusout', () => {
+    document.dispatchEvent(new CustomEvent('popover-identity-hide'));
   });
 });
+
+export function showPopover(el, identity, isUser) {
+  const rect = el.getBoundingClientRect();
+  document.dispatchEvent(new CustomEvent('popover-identity-display', {
+    detail: Object.assign({
+      offsetX: rect.left + window.scrollX,
+      offsetY: rect.top > 150 + rect.height ? rect.top : rect.bottom + window.scrollY,
+      top: rect.top > 150 + rect.height ? true : false,
+      identityType: isUser ? 'User' : 'Space',
+      element: el,
+    }, identity || {})
+  }));
+}
 
 const appId = 'Popovers';
 


### PR DESCRIPTION
Before this change, users and spaces popovers were not displayed when navigating by the keyboard (TAB action) and did not close when tapping ESC.
after this change, the space and user popovers are displayed with the TAB when the TAB action is on the popover element and  it closes when the ESC key is taped