### PR TITLE
feat: Update space default avatar when renaming space - MEED-3278 - Meeds-io/MIPs#83

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/identity/provider/SpaceIdentityProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/provider/SpaceIdentityProvider.java
@@ -82,5 +82,6 @@ public class SpaceIdentityProvider extends IdentityProvider<Space> {
   public void populateProfile(Profile profile, Space space) {
     profile.setAvatarUrl(space.getAvatarUrl());
     profile.setUrl(space.getUrl());
+    profile.setProperty(Profile.FULL_NAME, space.getDisplayName());
   }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -464,18 +464,22 @@ public class SpaceUtils {
   public static void updateDefaultSpaceAvatar(Space space) {
     IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
     Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
-    FileItem spaceAvatar = identityManager.getAvatarFile(spaceIdentity);
-    FileService fileService = CommonsUtils.getService(FileService.class);
-    if (spaceAvatar != null && spaceAvatar.getFileInfo().getId() != null
-        && EntityConverterUtils.DEFAULT_AVATAR.equals(spaceAvatar.getFileInfo().getName())) {
-      Profile profile = spaceIdentity.getProfile();
-      fileService.deleteFile(spaceAvatar.getFileInfo().getId());
-      profile.removeProperty(Profile.AVATAR);
-      profile.setAvatarUrl(null);
-      profile.setAvatarLastUpdated(null);
-      space.setAvatarAttachment(null);
-      identityManager.updateProfile(profile);
-      space.setAvatarLastUpdated(System.currentTimeMillis());
+    Profile profile = spaceIdentity.getProfile();
+    if (profile != null && profile.getProperty(Profile.FULL_NAME) != null && !profile.getProperty(Profile.FULL_NAME)
+                                                                                     .equals(space.getDisplayName())) {
+      FileItem spaceAvatar = identityManager.getAvatarFile(spaceIdentity);
+      if (spaceAvatar != null && spaceAvatar.getFileInfo().getId() != null
+          && EntityConverterUtils.DEFAULT_AVATAR.equals(spaceAvatar.getFileInfo().getName())) {
+        profile.setProperty(Profile.FULL_NAME, space.getDisplayName());
+        profile.removeProperty(Profile.AVATAR);
+        profile.setAvatarUrl(null);
+        profile.setAvatarLastUpdated(null);
+        space.setAvatarLastUpdated(System.currentTimeMillis());
+        identityManager.updateProfile(profile);
+
+        FileService fileService = CommonsUtils.getService(FileService.class);
+        fileService.deleteFile(spaceAvatar.getFileInfo().getId());
+      }
     }
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
@@ -6,70 +6,6 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
 
 public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
-
-  @Override
-  public void spaceAccessEdited(SpaceLifeCycleEvent event) {
-  }
-
-  @Override
-  public void spaceRegistrationEdited(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void spaceBannerEdited(SpaceLifeCycleEvent event) {
-  }
-
-  @Override
-  public void spaceCreated(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void spaceRemoved(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void applicationActivated(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void applicationAdded(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void applicationDeactivated(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void applicationRemoved(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void grantedLead(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void joined(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void left(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void revokedLead(SpaceLifeCycleEvent event) {
-
-  }
-
   @Override
   public void spaceRenamed(SpaceLifeCycleEvent event) {
     Space space = event.getSpace();
@@ -77,25 +13,4 @@ public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
     SpaceUtils.renameGroupLabel(space);
     SpaceUtils.updateDefaultSpaceAvatar(space);
   }
-
-  @Override
-  public void spaceDescriptionEdited(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void spaceAvatarEdited(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void addInvitedUser(SpaceLifeCycleEvent event) {
-
-  }
-
-  @Override
-  public void addPendingUser(SpaceLifeCycleEvent event) {
-
-  }
-
 }


### PR DESCRIPTION
This PR allows to map the space profile full name with the space#displayName in order to compare them and delete the default space avatar and generate a new one based on updated space name value.