### PR TITLE
fix: display of call button in mobile device - EXO-67690 - Meeds-io/meeds#1586

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
@@ -101,7 +101,7 @@
         <div
           v-for="action in enabledProfileHeaderActionComponents"
           :key="action.key"
-          :class="`${action.appClass} ${action.typeClass}`"
+          :class="actionClass(action)"
           :ref="action.key">
           <div v-if="action.component">
             <component
@@ -273,7 +273,10 @@ export default {
           }
         });
       }
-    }
+    },
+    actionClass(action) {
+      return (this.isMobile && action.key === 'userProfileCallButton') ? `${action.appClass} ${action.typeClass} call-button-mini` : `${action.appClass} ${action.typeClass}`;
+    },
   },
 };
 </script>


### PR DESCRIPTION
Before this change, when using mobile device, open the profile of a user, The call button is displayed as a button with call text. After this change, The call button is displayed only the icon, without the border and without the text.

(cherry picked from commit b8dc2a820fdd4b96fefec2b3ebf026e8ab8159bf)