### PR TITLE
fix: Wrong alignment of the attribute in profile - EXO-69220 - Meeds-io/MIPs#111

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileMultiValuedProperty.vue
@@ -61,6 +61,7 @@
               v-if="searchable"
               v-autolinker="childProperty.value"
               class="primary--text font-weight-regular text-subtitle-2 pa-0 ma-auto"
+              min-width="auto"
               text
               @click="quickSearch(childProperty)" />
             <span

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileSingleValuedProperty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileSingleValuedProperty.vue
@@ -35,6 +35,7 @@
         v-if="searchable"
         v-autolinker="property.value"
         class="primary--text text-subtitle-2 pa-0 font-weight-regular"
+        min-width="auto"
         text
         @click="quickSearch">
         {{ property.value }}


### PR DESCRIPTION
Prior to this change , Wrong alignment of the attribute in profile due to the auto-width css attribute in the default `v-btn` tag.
This PR sets the `auto-width` of the v-btn to `auto` to fix this issue