### PR TITLE
fix: display of call button in mobile device - EXO-67690 - Meeds-io/m…eeds#1586 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
@@ -275,7 +275,7 @@ export default {
       }
     },
     actionClass(action) {
-      return (this.isMobile && action.key === 'userProfileCallButton') ? `${action.appClass} ${action.typeClass} call-button-mini` : `${action.appClass} ${action.typeClass}`;
+      return this.isMobile && action.mobileClass ? `${action.appClass} ${action.typeClass} ${action.mobileClass}` : `${action.appClass} ${action.typeClass}`;
     },
   },
 };


### PR DESCRIPTION
Before this change, when using mobile device, open the profile of a user, The call button is displayed as a button with call text. After this change, The call button is displayed only the icon, without the border and without the text.

(cherry picked from commit 78305404b18c6832db454d7411bbc01afe9d84ef)