### PR TITLE
feat: fix default space avatar when newly created - MEED-3288 -Meeds-io/MIPs#83

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
@@ -717,9 +717,6 @@ public class RDBMSSpaceStorageImpl implements SpaceStorage {
       return null;
     }
     Space space = new Space();
-    if (entity.getAvatarLastUpdated() == null) {
-      entity.setAvatarLastUpdated(new Date(System.currentTimeMillis()));
-    }
     fillSpaceSimpleFromEntity(entity, space);
 
     space.setPendingUsers(getSpaceMembers(entity.getId(), Status.PENDING));
@@ -873,6 +870,12 @@ public class RDBMSSpaceStorageImpl implements SpaceStorage {
     Date lastUpdated = entity.getAvatarLastUpdated();
     if (lastUpdated != null) {
       space.setAvatarLastUpdated(entity.getAvatarLastUpdated().getTime());
+    } else {
+      space.setAvatarLastUpdated(System.currentTimeMillis());
+      Identity spaceIdentity = identityStorage.findIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());
+      if (spaceIdentity == null) {
+        lastUpdated = new Date(System.currentTimeMillis());
+      }
     }
     space.setAvatarUrl(LinkProvider.buildAvatarURL(SpaceIdentityProvider.NAME, space.getId(), true, lastUpdated == null ? null : lastUpdated.getTime()));
     lastUpdated = entity.getBannerLastUpdated();

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
@@ -872,10 +872,7 @@ public class RDBMSSpaceStorageImpl implements SpaceStorage {
       space.setAvatarLastUpdated(entity.getAvatarLastUpdated().getTime());
     } else {
       space.setAvatarLastUpdated(System.currentTimeMillis());
-      Identity spaceIdentity = identityStorage.findIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());
-      if (spaceIdentity == null) {
-        lastUpdated = new Date(System.currentTimeMillis());
-      }
+      lastUpdated = new Date(System.currentTimeMillis());
     }
     space.setAvatarUrl(LinkProvider.buildAvatarURL(SpaceIdentityProvider.NAME, space.getId(), true, lastUpdated == null ? null : lastUpdated.getTime()));
     lastUpdated = entity.getBannerLastUpdated();

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
@@ -717,6 +717,9 @@ public class RDBMSSpaceStorageImpl implements SpaceStorage {
       return null;
     }
     Space space = new Space();
+    if (entity.getAvatarLastUpdated() == null) {
+      entity.setAvatarLastUpdated(new Date(System.currentTimeMillis()));
+    }
     fillSpaceSimpleFromEntity(entity, space);
 
     space.setPendingUsers(getSpaceMembers(entity.getId(), Status.PENDING));


### PR DESCRIPTION
Prior to this change, when create a new space the old default space avatar is displayed instead of the new default avatar 
 because the avatar last modified date is null.
This change allows to set the last modified date to System.currentTimeMillis() when creating a new space.