### PR TITLE
fix: UX issue of the button update when editing a post when having imges : EXO-68203

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -224,7 +224,13 @@ export default {
       return this.drawer && this.$refs.activityContent || null;
     },
     postDisabled() {
-      return (!this.messageLength && !this.activityBodyEdited && !this.activityAttachmentsEdited) || this.messageLength > this.MESSAGE_MAX_LENGTH || this.loading || (!!this.activityId && !this.activityBodyEdited && !this.attachments?.length) || (!this.attachments?.length && !this.messageLength && !this.activityBodyEdited) || (this.postInYourSpacesChoice && !this.spaceId) || (!this.postToNetwork && !eXo.env.portal.spaceId && !this.spaceId && !this.messageEdited);
+      return (!this.messageLength && !this.activityBodyEdited && !this.activityAttachmentsEdited)
+          || this.messageLength > this.MESSAGE_MAX_LENGTH
+          || this.loading
+          || (!!this.activityId && !this.activityBodyEdited && !this.activityAttachmentsEdited)
+          || (!this.activityAttachmentsEdited && !this.messageLength && !this.activityBodyEdited)
+          || (this.postInYourSpacesChoice && !this.spaceId)
+          || (!this.postToNetwork && !eXo.env.portal.spaceId && !this.spaceId && !this.messageEdited);
     },
     metadataObjectId() {
       return this.templateParams?.metadataObjectId || this.activityId;
@@ -297,9 +303,9 @@ export default {
     isActivityBodyEdited(event) {
       this.activityBodyEdited = (this.messageEdited && this.messageLength) || event.detail !== 0 || (event.detail === 0 && this.messageLength);
     },
-    attachmentsEdit(attachments) {
+    attachmentsEdit(attachments, changed) {
       this.attachments = attachments;
-      this.activityAttachmentsEdited = true;
+      this.activityAttachmentsEdited = changed;
     },
     open(params) {
       params = params && params.detail;

--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
@@ -54,7 +54,8 @@ export default {
     images: [],
     attachments: [],
     attachmentUpdated: true,
-    metadatasObjectId: null
+    metadatasObjectId: null,
+    haveChanges: false,
   }),
   computed: {
     attachedFiles() {
@@ -71,7 +72,10 @@ export default {
   },
   watch: {
     attachedFiles() {
-      this.$emit('changed', this.attachedFiles);
+      this.$emit('changed', this.attachedFiles, this.haveChanges);
+      if (!this.haveChanges) {
+        this.haveChanges = true;
+      }
     },
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -34,7 +34,7 @@
       :object-type="objectType"
       :object-id="objectId"
       :disable-paste="disableImageAttachmentPaste"
-      @changed="$emit('attachments-edited', $event)" />
+      @changed="emitChanges" />
   </div>
 </template>
 
@@ -794,6 +794,9 @@ export default {
         }
       }
       return document.body;
+    },
+    emitChanges(attachements, changed){
+      this.$emit('attachments-edited', attachements, changed);
     }
   }
 };


### PR DESCRIPTION
Before this change, when trying to edit a post having images, and delete them the button was disabled because the check of the length of the attachments and the activityAttachmentsEdited returns that we have changes without attachments
After this change, When retrieving the activity images and emitting the attachments it is emitted with changed false so the checks work correctly