### PR TITLE
feat: Add unit test for default space avatar - MEED-3282 - Meeds-io/MIPs#83

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/space/SpaceUtilsTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/SpaceUtilsTest.java
@@ -62,7 +62,6 @@ public class SpaceUtilsTest extends AbstractCoreTest {
   private org.exoplatform.services.security.Identity identity;
   private Identity rootIdentity;
   private IdentityManager identityManager;
-
   private IdentityStorage identityStorage;
   private PageService pageService;
 


### PR DESCRIPTION
This change add unit tests for 

-   Generate a new dafault space avatar, 
-   Update dafault space avatar when user rename the space display name
-   Upload a new space avatar by user