### PR TITLE
fix: Connot deselect a text in Ckeditor when the whole text is selected - MEED-3265 - Meeds-io/meeds#1574 

### DIFF
--- a/webapp/portlet/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
+++ b/webapp/portlet/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
@@ -78,25 +78,28 @@
   });
 
   function setupMouseObserver(editor) {
-    balloonToolbar.destroy();
-    initBalloonToolbar(editor);
     const selection = editor.getSelection(),
-      link = getSelectedLink(editor);
-    if (!balloonToolbar.getItem('unlink')) {
-      if (link) {
-        addUnlinkItem(editor);
-      } 
-    } else {
-      if (!link) {
-        balloonToolbar.deleteItem('unlink');
-      } 
-    }
+        link = getSelectedLink(editor);
     if ( selection && selection.getSelectedText().trim().length > 0) {
-      const selectedElement = editor.getSelection().getRanges()[0].startContainer.$;
-      if (!(selectedElement.parentElement.classList.contains("metadata-tag") || (selectedElement.classList && selectedElement.classList.contains("metadata-tag")))
-          && !(selectedElement.parentElement.classList.contains("atwho-query") || (selectedElement.classList && selectedElement.classList.contains("atwho-query")))) {
-        balloonToolbar.attach( selection );
+      const balloonElement = document.querySelector(".cke_balloontoolbar .cke_balloon_content");
+      const isVisible = balloonElement != null && balloonElement.innerHTML.trim() !== '';
+      balloonToolbar.destroy();
+      initBalloonToolbar(editor);
+
+      if (!balloonToolbar.getItem('unlink')) {
+        if (link) {
+          addUnlinkItem(editor);
+        }
+      } else {
+        if (!link) {
+          balloonToolbar.deleteItem('unlink');
+        }
       }
+        const selectedElement = editor.getSelection().getRanges()[0].startContainer.$;
+        if (!(selectedElement.parentElement.classList.contains("metadata-tag") || (selectedElement.classList && selectedElement.classList.contains("metadata-tag")))
+            && !(selectedElement.parentElement.classList.contains("atwho-query") || (selectedElement.classList && selectedElement.classList.contains("atwho-query"))) && !isVisible) {
+          balloonToolbar.attach( selection );
+        }
     } else {
       balloonToolbar.hide();
     }


### PR DESCRIPTION
Before this fix, when the whole text is selected in the rich editor, we cannot deselect it due to the mouse up event fired by the balloon toolbar to display the link toolbar on the selected text. This PR tests if the balloon link is attached, so we can deselect the selected text once we click in the text area.