### PR TITLE
fix: Filter Drag & Drop effect to be display on files drag only - MEED-3287 - Meeds-io/meeds#1594

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
@@ -210,7 +210,7 @@ Vue.directive('draggable', {
       });
       ['dragenter', 'dragstart'].forEach((event) => {
         el.addEventListener(event, (e) => {
-          if (e?.dataTransfer) {
+          if (e?.dataTransfer && e?.dataTransfer?.types?.find?.(f => f === 'Files' || f.includes('image/'))) {
             counter++;
             document.dispatchEvent(new CustomEvent('attachments-show-drop-zone'));
           }


### PR DESCRIPTION
Prior to this change, the drag zone is displayed when drag & drop text on drawers. This change will filter and ensures that dragged objects are of type file before displaying drag zone.

(Resolves Meeds-io/meeds#1594)