### PR TITLE
fix: Filter Drag & Drop effect to be display on files drag only - MEED-3287 - Meeds-io/meeds#1594 (#3489)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
@@ -210,7 +210,7 @@ Vue.directive('draggable', {
       });
       ['dragenter', 'dragstart'].forEach((event) => {
         el.addEventListener(event, (e) => {
-          if (e?.dataTransfer) {
+          if (e?.dataTransfer && e?.dataTransfer?.types?.find?.(f => f === 'Files' || f.includes('image/'))) {
             counter++;
             document.dispatchEvent(new CustomEvent('attachments-show-drop-zone'));
           }


### PR DESCRIPTION
Prior to this change, the drag zone is displayed when drag & drop text on drawers. This change will filter and ensures that dragged objects are of type file before displaying drag zone.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
