### PR TITLE
fix: Make GroupSynchronizationSocialProfileListener Asynchronous - EXO-69333

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/common/lifecycle/LifeCycleCompletionService.java
+++ b/component/api/src/main/java/org/exoplatform/social/common/lifecycle/LifeCycleCompletionService.java
@@ -75,16 +75,8 @@ public class LifeCycleCompletionService implements Startable {
       this.configAsyncExecution = DEFAULT_ASYNC_EXECUTION;
     }
 
+    this.executor = Executors.newFixedThreadPool(this.configThreadNumber);
 
-    //
-    if (configAsyncExecution) {
-      this.executor = Executors.newFixedThreadPool(this.configThreadNumber);
-    }
-    else {
-      this.executor = new DirectExecutor();
-    }
-
-    //
     this.ecs = new ExecutorCompletionService(executor);
 
   }
@@ -115,13 +107,4 @@ public class LifeCycleCompletionService implements Startable {
       ((ExecutorService) executor).shutdown();
     }
   };
-
-  private class DirectExecutor implements Executor {
-
-    public void execute(final Runnable runnable) {
-      if (Thread.interrupted()) throw new RuntimeException();
-
-      runnable.run();
-    }
-  }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.*;
@@ -46,6 +47,7 @@ import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
  * group related to this property (if the group not exist) - Add the profile
  * owner to the group
  */
+@Asynchronous
 public class GroupSynchronizationSocialProfileListener extends ProfileListenerPlugin {
 
   private static final Log             LOG                = ExoLogger.getLogger(GroupSynchronizationSocialProfileListener.class);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1096,10 +1096,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
       }
       try {
         if (!(profileProperty.isMultiValued() || !profileProperty.getChildren().isEmpty())) {
-          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), true);
-          if (profileProperty.getPropertyName().equals(Profile.FIRST_NAME) || profileProperty.getPropertyName().equals(Profile.LAST_NAME) ) {
-            profile = getUserIdentity(username).getProfile();
-          }
+          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), false);
         } else {
           List<Map<String, String>> maps = new ArrayList<>();
           profileProperty.getChildren().forEach(profilePropertySettingEntity -> {
@@ -1112,7 +1109,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
               maps.add(childrenMap);
             }
           });
-          updateProfileField(profile, profileProperty.getPropertyName(), maps, true);
+          updateProfileField(profile, profileProperty.getPropertyName(), maps, false);
         }
       } catch (IllegalAccessException e) {
         LOG.error("User {} is not allowed to update attributes", currentUser);
@@ -1121,8 +1118,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
         LOG.error("Error updating user {} attributes", currentUser, e);
         return Response.serverError().build();
       }
-
     }
+    identityManager.updateProfile(profile, getCurrentUser(), true);
     return Response.ok().build();
   }
 


### PR DESCRIPTION
Prior to this change, the group synchronization listener was executed in a synchronous way, so it may block the user profile update when we need to synchronize many profile fields since adding and removing users to groups may take a long time.
This commit will change the way the listener is executed so it will be in a separate thread.
The commit also avoids saving the profile for each property, so the listener will be executed once for all properties updated in the rest call