### PR TITLE
fix: Exclude hidden value from complementary filter attribute aggregations -EXO-69224 - Meeds-io/MIPs#110

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ComplementaryFilterSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ComplementaryFilterSearchConnector.java
@@ -84,6 +84,7 @@ public class ComplementaryFilterSearchConnector {
                     "common_%s": {
                        "terms": {
                          "field": "%s.keyword",
+                         "exclude": ["hidden"],
                          "min_doc_count":%s,
                          "size": 50,
                          "order": {


### PR DESCRIPTION
prior to this change, as the hidden attributes will take the hidden value in elastic search the complementary filter was showing the hidden value included in its items. This PR exclude the hidden value from attributes aggregation to fix this issue