### PR TITLE
fix: fix add links issue with overlay effect - EXO-69307 (#3499)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
@@ -204,7 +204,8 @@ export default {
           }
         }, 200);
       }
-    },
+      this.$el.closest('#stickyBlockDesktop').style.position = 'static';
+    }
   },
   created() {
     this.$root.$on('links-form-drawer', this.open);

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
@@ -387,6 +387,13 @@ export default {
         this.stepper = 1;
       }
     },
+    drawer(){
+      if (this.drawer) {
+        this.$el.closest('#stickyBlockDesktop').style.position = 'static';
+      } else {
+        this.$el.closest('#stickyBlockDesktop').style.position = 'sticky';
+      }
+    }
   },
   created() {
     this.$root.$on('links-settings-drawer', this.open);


### PR DESCRIPTION
Before this change, When the drawer parent was inside a container with a position: sticky, it was always displayed under the overlay and we could not interact with it. after this change, The fix changes the CSS property position when the drawer is opened and restores it to the initial value once closed.