### PR TITLE
fix: fix invite users suggester generated Exception - EXO-69652 - Meeds-io/meeds#1639

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/identity/ProfileFilterListAccess.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/ProfileFilterListAccess.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.social.core.identity;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -179,6 +180,7 @@ public class ProfileFilterListAccess implements ListAccess<Identity> {
       // Remove last element if the used limit to request data from DB
       // is incremented by 1
       if (identities.size() > limit) {
+        identities =  new ArrayList<>(identities);
         identities.remove(identities.size() -1);
       }
     }


### PR DESCRIPTION
before this change, the identities had ImmutableCollections as a type which did not support the remove function generating an exception while suggesting people After this change, before removing an element the identities collection is converted to ArrayList which supports the remove function to avoid generating exceptions