### PR TITLE
fix: fix add users suggester generates an Exception on log server  - EXO-69655 - Meeds-io/meeds#1645 

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/identity/UserFilterListAccess.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/UserFilterListAccess.java
@@ -73,6 +73,9 @@ public class UserFilterListAccess implements ListAccess<User> {
       List<User> users = new ArrayList<User>();
       int i = 0;
       for (Identity identity : identities) {
+        if (identity == null) {
+          continue;
+        }
         String userId = identity.getRemoteId();
         User user = organizationService.getUserHandler().findUserByName(userId);
         if (user == null) {


### PR DESCRIPTION
This change fixes the generated null exception by continuing to the next iteration when the identity is null