### PR TITLE
fix: Setting the 'isMember' Property During Notification Sending to Ensure Accurate Workspace Membership Verification - EXO-69364 - Meeds-io/meeds#1651

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -731,6 +731,9 @@ public class EntityBuilder {
       spaceEntity.setIsManager(isManager);
       spaceEntity.setIsRedactor(spaceService.isRedactor(space, userId));
       spaceEntity.setIsPublisher(spaceService.isPublisher(space, userId));
+    } else if (space != null && StringUtils.isNotBlank(space.getId())) {
+      Identity currentUserIdentity = RestUtils.getCurrentUserIdentity();
+      spaceEntity.setIsMember(spaceService.isMember(space, currentUserIdentity.getRemoteId()));
     }
 
     PortalConfig portalConfig = getLayoutService().getPortalConfig(new SiteKey(GROUP, space.getGroupId()));


### PR DESCRIPTION
Before this change, users who were not members of a specific workspace would receive notifications with the 'isMember' property set to null. After this change, the 'isMember' property now returns the correct value when users interact with notifications.

(cherry picked from commit c51b9ade01c5c7dd703afa60c07359b56703e3e6)