### PR TITLE
fix: top bar application - ESC not working when on filter by name - EXO-67784 - Meeds-io/meeds#1369

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
@@ -459,16 +459,33 @@ export default {
   created() {
     if (this.showTextFilter) {
       document.addEventListener('keydown', this.clearSearch);
+    } else {
+      document.addEventListener('keydown', this.closeFilter);
     }
   },
   beforeDestroy() {
     document.removeEventListener('keydown', this.clearSearch);
+    document.removeEventListener('keydown', this.closeFilter);
   },
   methods: {
     clearSearch(event) {
       if (event?.key === 'Escape' && this.$refs?.applicationToolbarFilterInput?.isFocused) {
         this.term = null;
       }
+    },
+    closeFilter(event) {
+      if (this.expandFilter && event.key === 'Escape' && this.isOverlayVisible()) {
+        this.expandFilter = false;
+      }
+    },
+    isOverlayVisible() {
+      const elementsOverlays = document.querySelectorAll('.v-overlay--active');
+      for (const elementOverlay of elementsOverlays) {
+        if (getComputedStyle(elementOverlay).display !== 'none') {
+          return false;
+        }
+      }
+      return true;
     },
     setTerm(value) {
       this.term = value;


### PR DESCRIPTION
Before this change, when you have 3 filter options in the component, open the filter option, write a name on the filter by name and press ESC key, Nothing happens. After this change, The filter option is closed but the filters stay active. It is the same behavior as if we click on the back arrow.

(cherry picked from commit dd8cfb80376d2211c85e7bece85815027da2417e)