### PR TITLE
fix: fix issue when adding or removing managers -  EXO-69206 - Meeds-io/MIPs#112

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -234,6 +234,8 @@ export default {
       if (event) {
         this.properties = JSON.parse(JSON.stringify(event));
       }
+      this.propertiesToSave = [];
+      this.disabled = true;
       this.$refs.profileContactInformationDrawer.open();
     },
     propertyUpdated(item){

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactUserTypeProperty.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactUserTypeProperty.vue
@@ -44,8 +44,8 @@
       </div>
     </div>
     <profile-user-type-property-values
-      :user-type-properties="property?.children || property"
-      :disabled="!property.editable"
+      :user-type-properties="propertyObject?.children || propertyObject"
+      :disabled="!propertyObject.editable"
       @remove-value="removeUser" />
   </div>
 </template>
@@ -71,12 +71,17 @@ export default {
     }
   },
   watch: {
-
+    'property.children': function() {
+      this.clonePropertyObject();
+    }
   },
   created() {
-    this.propertyObject = this.property;
+    this.clonePropertyObject();
   },
   methods: {
+    clonePropertyObject() {
+      this.propertyObject = structuredClone(this.property);
+    },
     removeUser(value) {
       if (this.propertyObject.multiValued) {
         const index = this.propertyObject?.children?.findIndex(property => property.value === value);
@@ -102,10 +107,10 @@ export default {
         this.propertyObject.value = user.remoteId;
       }
       this.ignoredItems.push(user.id);
-      this.$emit('property-updated', this.propertyObject);
       this.$nextTick(() => {
         this.users = null;
       });
+      this.$emit('property-updated', this.propertyObject);
     },
     getResolvedName(property){
       const lang = eXo?.env.portal.language || 'en';


### PR DESCRIPTION
Prior to this change, when open the profile contact information edit drawer and remove or add managers then close it without save and open it again will cause an issue related to the update of the managers property.
This PR will make sure reinitialize the properties to saved list each open of the drawer to avoid such issue.

