### PR TITLE
fix: Fix Test Random Fail - MEED-3395 - Meeds-io/meeds#1679

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/manager/IdentityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/IdentityManagerTest.java
@@ -387,7 +387,7 @@ public class IdentityManagerTest extends AbstractCoreTest {
     profile.setProperty(Profile.POSITION, "Changed POSITION");
     profile.setProperty(Profile.ABOUT_ME, "Changed ABOUT_ME");
     identityManager.updateProfile(profile, true);
-    assertEquals(2, changes.size());
+    assertTrue(changes.size() >= 2);
     assertTrue(changes.contains(5));
 
     List<Map<String, String>> experiences = new ArrayList<>();
@@ -396,7 +396,7 @@ public class IdentityManagerTest extends AbstractCoreTest {
     company.put(Profile.EXPERIENCES_COMPANY, "oldValue");
     profile.setProperty(Profile.EXPERIENCES, experiences);
     identityManager.updateProfile(profile, true);
-    assertEquals(3, changes.size());
+    assertTrue(changes.size() >= 3);
     assertTrue(changes.contains(1));
   }
   public void testUpdateProfileAndDetectChangeBanner() throws Exception {


### PR DESCRIPTION
Prior to this change, the list of profile updates may differ switch previously executed tests on `root identity`. This change will ensure to make this change independent from previously executed tests by changing the assertion.