### PR TITLE
feat: update field name after upgrade of profile index - Meeds-io/MIPs#110 - EXO-69902

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ComplementaryFilterSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ComplementaryFilterSearchConnector.java
@@ -83,7 +83,7 @@ public class ComplementaryFilterSearchConnector {
                 query.append(""" 
                     "common_%s": {
                        "terms": {
-                         "field": "%s.keyword",
+                         "field": "%s.raw",
                          "exclude": ["hidden"],
                          "min_doc_count":%s,
                          "size": 50,


### PR DESCRIPTION
The server is returning empty an response when loading complementary filters in the quick search drawer.
After the upgrade of indexes, the field name used for the complementary filters changed from **attribute.keyword** to **attribute.raw**
