### PR TITLE
feat: add connections field to the ES mapping - Meeds-io/MIPs#110 - EXO-69939

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -208,6 +208,7 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
             .append("    \"userName\" : {\"type\" : \"keyword\"},\n")
             .append(profileSettingsFieldsMapping)
             .append("    \"email\" : {\"type\" : \"keyword\"},\n")
+            .append("    \"connections\" : {\"type\" : \"long\"},\n")
             .append("    \"avatarUrl\" : {\"type\" : \"text\", \"index\": false},\n")
             .append("    \"skills\" : {\"type\" : \"text\", \"index_options\": \"offsets\"},\n")
             .append("    \"aboutMe\" : {\"type\" : \"text\", \"index_options\": \"offsets\"},\n")

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/indexing-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/indexing-configuration.xml
@@ -83,9 +83,9 @@
         <properties-param>
           <name>constructor.params</name>
           <property name="index_alias" value="profile_alias" />
-          <property name="index_current" value="profile_v3" />
-          <property name="index_previous" value="profile_v2" />
-          <property name="reindexOnUpgrade" value="true" />
+          <property name="index_current" value="${meeds.social.index.profile.current:profile_v3}" />
+          <property name="index_previous" value="${meeds.social.index.profile.previous:profile_v2}" />
+          <property name="reindexOnUpgrade" value="${meeds.social.index.profile.reindexOnUpgrade:true}" />
         </properties-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
This fix will :
 - variabilize the properties of Profile search index
 - add the connection field explicitely to the profile ES index