### PR TITLE
fix: Increase font size in the default avatar initial letters - MEED-3462 -Meeds-io/meeds#1702

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/image/ImageUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/image/ImageUtils.java
@@ -179,7 +179,7 @@ public class ImageUtils {
     graphics.fillRect(0, 0, DEFAULT_AVATAR_WIDTH, DEFAULT_AVATAR_HEIGHT);
     graphics.setColor(Color.WHITE);
 
-    graphics.setFont(new Font("Arial", Font.BOLD, 100));
+    graphics.setFont(new Font("Arial", Font.BOLD, 150));
     FontMetrics fm = graphics.getFontMetrics();
 
     int x = (DEFAULT_AVATAR_WIDTH - fm.stringWidth(fullNameAbbreviation)) / 2;


### PR DESCRIPTION
This change allows to increase the letter size in the default avatar initial letters to make them more readable.