### PR TITLE
fix: fix posting activitities - EXO-5947 - Meeds-io/meeds#1708

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -381,6 +381,9 @@ export default {
           }
         } else {
           this.loading = true;
+          if (!this.spaceId && !!eXo.env.portal.spaceId) {
+            this.spaceId = eXo.env.portal.spaceId;
+          }
           this.$activityService.createActivity(message, activityType, this.files, this.spaceId, this.templateParams)
             .then(activity => {
               this.activityId = activity.id;


### PR DESCRIPTION
before this change, when opening a poll drawer and closing without adding a poll and then posting a message, the activity is saved without a space since the space ID is null
after this change, In the space stream when creating an activity and the space ID is null  the space id takes the current space ID
