### PR TITLE
fix: Image in AS post is blur after editing it - EXO-69849 - Meeds-io/meeds#1715

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInput.vue
@@ -61,7 +61,8 @@ export default {
     attachedFiles() {
       if (this.attachments.length && this.attachmentUpdated) {
         this.attachments.forEach(attachment => {
-          attachment.src = `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/attachments/${this.objectType}/${this.attachmentObjectId}/${attachment.id}?lastModified=${attachment.updated}&size=120x120`;
+          const baseAttchementSrc = `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/attachments/${this.objectType}/${this.attachmentObjectId}/${attachment.id}?lastModified=${attachment.updated}`;
+          attachment.src = ( this.objectType === 'activity' ) ? baseAttchementSrc : `${baseAttchementSrc}&size=120x120`;
         });
       }
       return [...this.attachments, ...this.images];


### PR DESCRIPTION
Before this change, when edit a post contains an image and edit the image then save and update the post, the image is displayed blurry in the post. After this change, the image quality remained the same.

(cherry picked from commit 96a652416fc31fadc1ded4000f95750c8be596e7)