### PR TITLE
fix: In space settings, if the wallet application is not active for the current space, the extension about wallet configuration is emty, but display a margin - EXO-69808 - meeds-io/meeds#1710

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
@@ -8,7 +8,8 @@
     <space-setting-applications :space-id="spaceId" class="mb-5" />
     <template>
       <extension-registry-components
-        :params="spaceSettingParam"
+        :key="spaceApplications"
+        :params="extensionParams"
         name="SpaceSettings"
         type="space-settings-components"
         parent-element="div"
@@ -23,7 +24,21 @@
 export default {
   data: () => ({
     spaceId: eXo.env.portal.spaceId,
+    spaceApplications: null,
     displayed: true,
-  })
+  }),
+  created() {
+    this.$spaceService.getSpaceApplications(this.spaceId).then(applications => {
+      this.spaceApplications=applications;
+    });
+  },
+  computed: {
+    extensionParams() {
+      return {
+        spaceId: this.spaceId,
+        spaceApplications: this.spaceApplications
+      };
+    },
+  },
 };
 </script>


### PR DESCRIPTION
Before this fix, even if a space have not wallet application, the wallet settings extension display a margin in space settings. So, when there is another extension under this one, there is a double margin displayed

This commit add the function isEnabled one the walletSettings extension, and pass spaceApplications list to this function. If the list contains the application SpaceWallet, then the extension is active, and displayed. If not, then the extension is not active, and not displayed, the unwanted margin is not displayed

Resolve meeds-io/meeds#1710

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
