### PR TITLE
fix : Adjust the space's navigation stream icon after the migration context - EXO-69389 - Meeds-io/meeds#1677

### DIFF
--- a/component/core/src/main/java/io/meeds/social/core/upgrade/SpaceNavigationIconUpgradePlugin.java
+++ b/component/core/src/main/java/io/meeds/social/core/upgrade/SpaceNavigationIconUpgradePlugin.java
@@ -41,7 +41,7 @@ public class SpaceNavigationIconUpgradePlugin extends UpgradeProductPlugin {
                                                            UPDATE PORTAL_NAVIGATION_NODES
                                                            SET ICON =
                                                              CASE
-                                                               WHEN (SELECT pn.NAME FROM (SELECT * FROM PORTAL_NAVIGATION_NODES) pn WHERE pn.NODE_ID = PARENT_ID) = 'default' THEN TRIM('fas fa-stream')
+                                                               WHEN PARENT_ID IN (SELECT NODE_ID FROM (SELECT * FROM PORTAL_NAVIGATION_NODES WHERE NAME LIKE 'default') AS PARENT_NAVIGATION) THEN TRIM('fas fa-stream')
                                                                %s
                                                              END
                                                            WHERE ICON IS NULL
@@ -59,6 +59,8 @@ public class SpaceNavigationIconUpgradePlugin extends UpgradeProductPlugin {
   private final EntityManagerService entityManagerService;
 
   private final Map<String, String>  spaceNodes           = new HashMap<>();
+
+  private int migratedSpaceNodeIcons;
 
   public SpaceNavigationIconUpgradePlugin(EntityManagerService entityManagerService, InitParams initParams) {
     super(initParams);
@@ -84,7 +86,7 @@ public class SpaceNavigationIconUpgradePlugin extends UpgradeProductPlugin {
 
     LOG.info("Start:: Upgrade of space node icons");
     Set<Map.Entry<String, String>> spaceNodesEntrySet = spaceNodes.entrySet();
-    int migratedSpaceNodeIcons = upgradeSpaceNodeIcons(spaceNodesEntrySet);
+    this.migratedSpaceNodeIcons = upgradeSpaceNodeIcons(spaceNodesEntrySet);
     LOG.info("End:: Upgrade of '{}' space node icons. It tooks {} ms",
              migratedSpaceNodeIcons,
              (System.currentTimeMillis() - startupTime));
@@ -103,5 +105,9 @@ public class SpaceNavigationIconUpgradePlugin extends UpgradeProductPlugin {
 
     Query query = entityManager.createNativeQuery(sqlStatement);
     return query.executeUpdate();
+  }
+
+  public int getMigratedSpaceNodeIcons() {
+    return migratedSpaceNodeIcons;
   }
 }

--- a/component/core/src/test/java/io/meeds/social/core/upgrade/SpaceNavigationIconUpgradePluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/core/upgrade/SpaceNavigationIconUpgradePluginTest.java
@@ -1,68 +1,32 @@
 package io.meeds.social.core.upgrade;
-
-import java.util.HashSet;
-import java.util.List;
-
-import io.meeds.social.core.upgrade.SpaceNavigationIconUpgradePlugin;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.persistence.impl.EntityManagerService;
-import org.exoplatform.component.test.AbstractKernelTest;
-import org.exoplatform.component.test.ConfigurationUnit;
-import org.exoplatform.component.test.ConfiguredBy;
-import org.exoplatform.component.test.ContainerScope;
-import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
-import org.exoplatform.portal.mop.SiteKey;
-import org.exoplatform.portal.mop.dao.NodeDAO;
-import org.exoplatform.portal.mop.service.NavigationService;
-import org.exoplatform.portal.mop.user.UserNode;
-import org.exoplatform.services.security.ConversationState;
-import org.exoplatform.services.security.Identity;
-import org.exoplatform.services.security.IdentityRegistry;
-import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.social.core.space.SpaceUtils;
-import org.exoplatform.social.core.space.model.Space;
-import org.exoplatform.social.core.space.spi.SpaceService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 
-@ConfiguredBy({ @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
-    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
-    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.portal.component.portal-configuration-local.xml"),
-    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "org/exoplatform/portal/config/conf/configuration.xml"), })
-public class SpaceNavigationIconUpgradePluginTest extends AbstractKernelTest {
-
-  protected PortalContainer      container;
-
-  protected SpaceService         spaceService;
-
-  protected NavigationService    navigationService;
-
-  protected IdentityRegistry     identityRegistry;
-
-  protected EntityManagerService entityManagerService;
-
-  protected SettingService       settingService;
-
+@RunWith(MockitoJUnitRunner.class)
+public class SpaceNavigationIconUpgradePluginTest {
   private SpaceNavigationIconUpgradePlugin spaceNavigationIconUpgradePlugin;
+  @Mock
+  private EntityManagerService entityManagerService;
 
-  private NodeDAO                nodeDao;
+  InitParams initParams = new InitParams();
 
   @Before
   public void setUp() {
-    container = PortalContainer.getInstance();
-    entityManagerService = container.getComponentInstanceOfType(EntityManagerService.class);
-    spaceService = container.getComponentInstanceOfType(SpaceService.class);
-    navigationService = container.getComponentInstanceOfType(NavigationService.class);
-    nodeDao = container.getComponentInstanceOfType(NodeDAO.class);
-    identityRegistry = container.getComponentInstanceOfType(IdentityRegistry.class);
-    begin();
-    InitParams initParams = new InitParams();
     ValueParam productGroupIdValueParam = new ValueParam();
     productGroupIdValueParam.setName("product.group.id");
     productGroupIdValueParam.setValue("org.exoplatform.platform");
@@ -75,64 +39,45 @@ public class SpaceNavigationIconUpgradePluginTest extends AbstractKernelTest {
     initParams.addParameter(productGroupIdValueParam);
     initParams.addParameter(spaceNodeNamesValueParam);
     initParams.addParameter(spaceNodeIconsValueParam);
-    spaceNavigationIconUpgradePlugin = new SpaceNavigationIconUpgradePlugin(entityManagerService, initParams);
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    RequestLifeCycle.end();
-  }
-
-  protected void begin() {
-    ExoContainerContext.setCurrentContainer(container);
-    RequestLifeCycle.begin(container);
+    this.spaceNavigationIconUpgradePlugin = new SpaceNavigationIconUpgradePlugin(entityManagerService, initParams);
   }
 
   @Test
   public void testProcessUpgrade() throws Exception {
-    HashSet<MembershipEntry> memberships = new HashSet<MembershipEntry>();
-    memberships.add(new MembershipEntry("/platform/users", "*"));
-    memberships.add(new MembershipEntry("/platform/administrators", "*"));
-    Identity root = new Identity("root", memberships);
-    identityRegistry.register(root);
-    ConversationState conversationState = new ConversationState(root);
-    ConversationState.setCurrent(conversationState);
-    Space space = new Space();
-    space.setDisplayName("testspace");
-    space.setPrettyName(space.getDisplayName());
-    String shortName = SpaceUtils.cleanString(space.getDisplayName());
-    space.setGroupId("/spaces/" + shortName);
-    space.setUrl(shortName);
-    space.setEditor("root");
-    space.setTemplate("communication");
-    space.setVisibility("public");
-    space.setRegistration("validation");
-    space.setPriority("2");
-    String[] manager = new String[] { "root" };
-    String[] members = new String[] { "root", "john" };
-    space.setManagers(manager);
-    space.setMembers(members);
-    space = spaceService.createSpace(space, "root");
-    List<UserNode> spaceUserNodeChildren = SpaceUtils.getSpaceUserNodeChildren(space);
-    
-    long streamNodeId = Long.parseLong(navigationService.loadNode(SiteKey.group(space.getGroupId())).getNode(0).getId());
-    assertNotNull(nodeDao.find(streamNodeId));
-    assertNull(nodeDao.find(streamNodeId).getIcon());
-    long dashboardNodeId = Long.parseLong(spaceUserNodeChildren.get(0).getId());
-    assertNotNull(nodeDao.find(dashboardNodeId));
-    assertNull(nodeDao.find(dashboardNodeId).getIcon());
-    long settingsNodeId = Long.parseLong(spaceUserNodeChildren.get(1).getId());
-    assertNotNull(nodeDao.find(settingsNodeId));
-    assertNull(nodeDao.find(settingsNodeId).getIcon());
-    long membersNodeId = Long.parseLong(spaceUserNodeChildren.get(2).getId());
-    assertNotNull(nodeDao.find(membersNodeId));
-    assertNull(nodeDao.find(membersNodeId).getIcon());
+    EntityManager entityManager = mock(EntityManager.class);
+    when(entityManagerService.getEntityManager()).thenReturn(entityManager);
+    Query query = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(query);
+    when(query.executeUpdate()).thenReturn(2);
+    boolean proceedToUpgrade = spaceNavigationIconUpgradePlugin.shouldProceedToUpgrade(null, null);
+    //
+    assertTrue(proceedToUpgrade);
+    UpgradePluginExecutionContext upgradePluginExecutionContext = new UpgradePluginExecutionContext("6.4.0", 0);
+    proceedToUpgrade = spaceNavigationIconUpgradePlugin.shouldProceedToUpgrade("6.5.0", "6.4.0", upgradePluginExecutionContext);
+    //
+    assertTrue(proceedToUpgrade);
+    spaceNavigationIconUpgradePlugin.processUpgrade("oldVersion", "newVersion");
+    // Capture the argument passed to createNativeQuery
+    ArgumentCaptor<String> sqlStatementCaptor = ArgumentCaptor.forClass(String.class);
+    verify(entityManager).createNativeQuery(sqlStatementCaptor.capture());
+    // Get the captured SQL statement
+    String actualSQLStatement = sqlStatementCaptor.getValue();
 
-    spaceNavigationIconUpgradePlugin.processUpgrade(null, null);
-    restartTransaction();
-    assertEquals("fas fa-stream", nodeDao.find(streamNodeId).getIcon());
-    assertNull(nodeDao.find(dashboardNodeId).getIcon());
-    assertEquals("fas fa-cog", nodeDao.find(settingsNodeId).getIcon());
-    assertEquals("fas fa-users", nodeDao.find(membersNodeId).getIcon());
+    // Expected SQL statement
+    String expectedSql = "  UPDATE PORTAL_NAVIGATION_NODES\n" +
+            "  SET ICON =\n" +
+            "    CASE\n" +
+            "      WHEN PARENT_ID IN (SELECT NODE_ID FROM (SELECT * FROM PORTAL_NAVIGATION_NODES WHERE NAME LIKE 'default') AS PARENT_NAVIGATION) THEN TRIM('fas fa-stream')\n" +
+            "         WHEN NAME in ('settings') THEN TRIM('fas fa-cog')\n   WHEN NAME in ('members') THEN TRIM('fas fa-users')\n\n" +
+            "    END\n" +
+            "  WHERE ICON IS NULL\n" +
+            "  AND EXISTS (SELECT * FROM PORTAL_PAGES p INNER JOIN PORTAL_SITES s ON s.ID = p.SITE_ID WHERE PAGE_ID = p.ID AND s.TYPE = 1 AND s.NAME LIKE '/spaces/%')\n";
+    // Assert the captured SQL statement is equal to expected SQL statement
+    assertEquals(expectedSql.trim(),actualSQLStatement.trim());
+    verify(query).executeUpdate();
+    // Verify the result
+    assertEquals(2, spaceNavigationIconUpgradePlugin.getMigratedSpaceNodeIcons());
+    // Verify no more interactions
+    verifyNoMoreInteractions(entityManager, query);
   }
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.social.core.test;
 
+import io.meeds.social.core.upgrade.SpaceNavigationIconUpgradePluginTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -52,6 +53,7 @@ import io.meeds.social.image.plugin.ImageAttachmentPluginTest;
     UserProfileComparatorTest.class,
     ActivityIndexingServiceConnectorTest.class,
     ActivitySearchConnectorTest.class,
+    SpaceNavigationIconUpgradePluginTest.class,
 })
 public class NoContainerTestSuite {
 

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/upgrade-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/upgrade-plugins-configuration.xml
@@ -54,7 +54,7 @@
       </init-params>
     </component-plugin>
     <component-plugin>
-      <name>SpaceNavigationIconUpgradePlugin</name>
+      <name>SpaceNavigationIconMigration</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.core.upgrade.SpaceNavigationIconUpgradePlugin</type>
       <description>Configure space node icons</description>
@@ -66,8 +66,8 @@
         </value-param>
         <value-param>
           <name>plugin.upgrade.target.version</name>
-          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.5.0)</description>
-          <value>6.5.0</value>
+          <description>The plugin target version (will not be executed if previous version is equal or higher than 6.5.2)</description>
+          <value>6.5.2</value>
         </value-param>
         <value-param>
           <name>space.node.names</name>


### PR DESCRIPTION
Prior to this change, after updating the space navigation upgrade plugin type to resolve the PostgreSQL issue, the stream navigation icon was not updated following the migration context. This issue arose due to the query which did not retrieve the stream navigation correctly for updating it. This change will update the query to set the stream navigation icon and update the plugin configuration to be re-executed, resolving this issue