### PR TITLE
fix: Long Space node names not displaying properly in recent spaces drawer - EXO-68186 - Meeds-io/meeds#1746 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
@@ -27,7 +27,7 @@
     </v-list-item-icon>
     <v-list-item-content class="d-flex">
       <div class="d-flex align-center justify-space-between my-auto">
-        <span>{{ navigationLabel }}</span>
+        <span class="text-truncate" :style="navigationLabelStyle">{{ navigationLabel }}</span>
         <v-chip
           v-if="unreadBadge"
           color="error-color-background"
@@ -78,6 +78,9 @@ export default {
         && (this.badgeApplicationName === 'activity' && Object.values(this.spaceUnreadItems).reduce((sum, v) => sum += v, 0) || 0)
       || 0;
     },
+    navigationLabelStyle() {
+      return this.unreadBadge > 0 ? { 'max-width': '140px' } : { 'max-width': '200px'};
+    }
   },
 };
 </script>


### PR DESCRIPTION

Prior to this change, when editing a space node name by setting a long name, the space navigation item would be displayed on multiple lines. This change will adjust the styling for the space navigation node names.
