### PR TITLE
fix: Disallow attachment of non-image types in task description - EXO-70180 - Meeds-io/meeds#1767

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputMultiUpload.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputMultiUpload.vue
@@ -77,6 +77,9 @@ export default {
         return;
       } else {
         filesArray.forEach((file) => {
+          if (!file?.type?.includes('image/')) {
+            return;
+          }
           if (file.size > this.maxFileSize) {
             this.$root.$emit('alert-message', this.$t('attachment.tooBigFile.label', {
               0: Number.parseFloat(file.size / 1024 / 1024).toFixed(2).replace('.00', ''),


### PR DESCRIPTION
Prior to this change , attaching a non-image type to a task description by the task description rich editor image attachment button was possible , this change is going to prevent the non-image type attachment from being attached to a task description .