### PR TITLE
fix: quicksearch result is not correct - EXO-70143 - Meeds-io/MIPs#110

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -175,9 +175,7 @@ public class ProfileSearchConnector {
 
         esSubQuery.append("    \"filter\": [\n");
         esSubQuery.append("      {");
-        esSubQuery.append("          \"query_string\": {\n");
-        esSubQuery.append("            \"query\": \"" + expEsForAdvancedFilter + "\"\n");
-        esSubQuery.append("          }\n");
+        esSubQuery.append(expEsForAdvancedFilter);
         esSubQuery.append("      }\n");
         esSubQuery.append("    ],\n");
 
@@ -489,28 +487,26 @@ public class ProfileSearchConnector {
   }
 
   private String buildAdvancedFilterExpression(ProfileFilter filter) {
-    StringBuilder esExp = new StringBuilder();
+    StringBuilder query = new StringBuilder();
     Map<String, String> settings = filter.getProfileSettings();
-    esExp.append("( ");
-    int settingsCount = 0 ;
-    for (Map.Entry<String, String> entry : settings.entrySet()){
-      String inputKey = entry.getKey().replace(" ", "\\\\ ");
-      String inputValue = entry.getValue().replace(StorageUtils.ASTERISK_STR, StorageUtils.EMPTY_STR);
-      if (inputValue.startsWith("\"") && inputValue.endsWith("\"")) {
-        inputValue = inputValue.replace("\"", "");
-      }
-      esExp.append("( ")
-           .append(inputKey)
-           .append(":")
-           .append(StorageUtils.ASTERISK_STR)
-           .append(removeAccents(inputValue))
-           .append(StorageUtils.ASTERISK_STR);
-      esExp.append(")");
-      if ( settingsCount != settings.size()- 1 ) esExp.append(" AND ") ;
-      settingsCount += 1 ;
-    }
-    esExp.append(" )");
-    return esExp.toString();
+    query.append("""
+            "bool": {
+              "must": [""");
+    settings.forEach((key, value) -> query.append("""
+                    {
+                    "term": {
+                       "%s.raw": "%s"
+                     }
+                   },
+                """.formatted(key, value)));
+    int lastComma = query.lastIndexOf(",");
+    query.replace(lastComma, lastComma + 1, "");
+    query.append("""
+               ]
+            }
+            """);
+
+    return query.toString();
   }
 
   private static String removeAccents(String string) {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -14,6 +14,8 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.*;
 
 import static org.mockito.Mockito.mockStatic;
@@ -63,7 +65,7 @@ public class ProfileSearchConnectorTest {
     }
 
     @Test
-    public void testSearchWithEmail() {
+    public void testSearchWithEmail() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         ElasticSearchingClient elasticSearchClient = Mockito.mock(ElasticSearchingClient.class);
         IdentityManagerImpl identityManager = Mockito.mock(IdentityManagerImpl.class);
         Identity identity1 = new Identity("test","test");
@@ -97,9 +99,8 @@ public class ProfileSearchConnectorTest {
                 "        \"filter\" : {\n" +
                 "          \"bool\" :{\n" +
                 "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( ( test:*test*) )\"\n" +
-                "          }\n" +
+                "      {"+
+                buildAdvancedFilterQuery(filter) +
                 "      }\n" +
                 "    ],\n" +
                 "    \"should\": [\n" +
@@ -186,7 +187,7 @@ public class ProfileSearchConnectorTest {
     }
 
     @Test
-    public void testSearchWithNameOrUsername() {
+    public void testSearchWithNameOrUsername() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         ElasticSearchingClient elasticSearchClient = Mockito.mock(ElasticSearchingClient.class);
         profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient);
         IdentityManagerImpl identityManager = Mockito.mock(IdentityManagerImpl.class);
@@ -220,9 +221,8 @@ public class ProfileSearchConnectorTest {
                 "        \"filter\" : {\n" +
                 "          \"bool\" :{\n" +
                 "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( ( test:*test*) )\"\n" +
-                "          }\n" +
+                "      {"+
+                buildAdvancedFilterQuery(filter) +
                 "      }\n" +
                 "    ],\n" +
                 "    \"should\": [\n" +
@@ -303,7 +303,7 @@ public class ProfileSearchConnectorTest {
     }
 
     @Test
-    public void testCount() {
+    public void testCount() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         ElasticSearchingClient elasticSearchClient = Mockito.mock(ElasticSearchingClient.class);
         profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient);
         ProfileFilter filter = new ProfileFilter();
@@ -336,9 +336,8 @@ public class ProfileSearchConnectorTest {
                 "        \"filter\" : {\n" +
                 "          \"bool\" :{\n" +
                 "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( ( test:*test*) )\"\n" +
-                "          }\n" +
+                "      {"+
+                buildAdvancedFilterQuery(filter) +
                 "      }\n" +
                 "    ],\n" +
                 "    \"should\": [\n" +
@@ -416,6 +415,14 @@ public class ProfileSearchConnectorTest {
         Assert.assertEquals(1, result);
     }
 
+    private String buildAdvancedFilterQuery(ProfileFilter filter) throws NoSuchMethodException,
+                                                                  InvocationTargetException,
+                                                                  IllegalAccessException {
+      Method method = profileSearchConnector.getClass().getDeclaredMethod("buildAdvancedFilterExpression", ProfileFilter.class);
+      method.setAccessible(true);
+      return (String) method.invoke(profileSearchConnector, filter);
+    }
+    
     private InitParams getInitParams() {
         InitParams params = new InitParams();
         PropertiesParam constructorParams = new PropertiesParam();


### PR DESCRIPTION
prior to this change when using the advanced filter api in quicksearch the returned result are not exact because of how the api was designed. 
This PR adjusts the filter part that based on profile settings to fit only the exact request setting keyword

