### PR TITLE
fix : Disallow attachment of non-image types in task description-EXO-70180-Meeds-io/meeds#1767

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputMultiUpload.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/attach-image/components/form/ImageInputMultiUpload.vue
@@ -77,7 +77,7 @@ export default {
         return;
       } else {
         filesArray.forEach((file) => {
-          if (!file?.type?.includes('image/')) {
+          if (!file?.type?.includes?.('image/')) {
             return;
           }
           if (file.size > this.maxFileSize) {


### PR DESCRIPTION
This PR is to update as instructed in previous
[PR](https://github.com/Meeds-io/social/pull/3614#discussion_r1522790166)

(cherry picked from commit 056be1cfb007db4d2a42362f2bf8d0464a70ce58)