### PR TITLE
 fix: restore user avatar position - EXO-70235 - Meeds-io/MIPs#112 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -1,7 +1,6 @@
 <template>
-  <div v-if="show">
     <div
-      v-if="popover"
+      v-if="popover && show"
       v-identity-popover="popoverIdentity"
       class="profile-popover user-wrapper text-truncate"
       :class="parentClass">
@@ -105,7 +104,7 @@
       </component>
     </div>
     <div
-      v-else
+      v-else-if="show"
       class="profile-popover user-wrapper text-truncate"
       :class="parentClass">
       <component
@@ -207,7 +206,6 @@
         </template>
       </component>
     </div>
-  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Latest changes caused that the user avatar appears in the middle vertically when displayed in user comments on social activities. The fix removes the extra div and adds the boolean **show** inside both cases, this simplifies the DOM structure and avoids the regression
