### PR TITLE
fix: fix add links issue with overlay effect - EXO-69307

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
@@ -204,11 +204,13 @@ export default {
           }
         }, 200);
       }
-      this.$el.closest('#stickyBlockDesktop').style.position = 'static';
     }
   },
   created() {
     this.$root.$on('links-form-drawer', this.open);
+  },
+  mounted() {
+    document.querySelector('#vuetify-apps').appendChild(this.$el);
   },
   beforeDestroy() {
     this.$root.$off('links-form-drawer', this.open);

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
@@ -386,13 +386,6 @@ export default {
       } else {
         this.stepper = 1;
       }
-    },
-    drawer(){
-      if (this.drawer) {
-        this.$el.closest('#stickyBlockDesktop').style.position = 'static';
-      } else {
-        this.$el.closest('#stickyBlockDesktop').style.position = 'sticky';
-      }
     }
   },
   created() {
@@ -400,6 +393,9 @@ export default {
   },
   beforeDestroy() {
     this.$root.$off('links-settings-drawer', this.open);
+  },
+  mounted() {
+    document.querySelector('#vuetify-apps').appendChild(this.$el);
   },
   methods: {
     open(openForm) {


### PR DESCRIPTION
Before this change, When the drawer parent was inside a container with a position: sticky, it was always displayed under the overlay and we could not interact with it.
after this change, The fix will mount the element to the vuetify-apps and will not be affected by the sticky container