### PR TITLE
fix: no subordinates on  organizational chart - EXO-69839,EXO-70024,EXO-69789 - Meeds-io/MIPs#112

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -6,13 +6,17 @@ import org.exoplatform.container.xml.PropertiesParam;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManagerImpl;
 import org.exoplatform.social.core.profile.ProfileFilter;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.relationship.model.Relationship;
 import org.exoplatform.social.core.search.Sorting;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -20,15 +24,20 @@ import java.util.*;
 
 import static org.mockito.Mockito.mockStatic;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ProfileSearchConnectorTest {
     private ProfileSearchConnector profileSearchConnector;
+
+    @Mock
+    private ProfilePropertyService profilePropertyService;
+
     private static final MockedStatic<CommonsUtils> COMMONS_UTILS = mockStatic(CommonsUtils.class);
 
     @Test
     public void testSearch() {
         ElasticSearchingClient elasticSearchClient = Mockito.mock(ElasticSearchingClient.class);
         IdentityManagerImpl identityManager = Mockito.mock(IdentityManagerImpl.class);
-        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient);
+        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient, profilePropertyService);
         ProfileFilter filter = new ProfileFilter();
         Identity identity1 = new Identity("test","usernameee");
         String index = "profile_alias";
@@ -56,7 +65,6 @@ public class ProfileSearchConnectorTest {
         long offset = 0;
         long limit = 10;
         Mockito.when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
-        Mockito.when(identityManager.getIdentity(Mockito.anyString())).thenReturn(identity1);
         COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);
         Identity identity = new Identity("username","test");
         Relationship.Type type = Relationship.Type.CONFIRMED;
@@ -70,7 +78,7 @@ public class ProfileSearchConnectorTest {
         IdentityManagerImpl identityManager = Mockito.mock(IdentityManagerImpl.class);
         Identity identity1 = new Identity("test","test");
         Identity identity2 = new Identity("test2","test2");
-        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient);
+        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient, profilePropertyService);
         ProfileFilter filter = new ProfileFilter();
         Sorting sorting = new Sorting(Sorting.SortBy.FIRSTNAME, Sorting.OrderBy.DESC);
         Map <String,String> profileSettings = new HashMap<>();
@@ -176,7 +184,6 @@ public class ProfileSearchConnectorTest {
         long offset = 0;
         long limit = 10;
         Mockito.when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
-        Mockito.when(identityManager.getIdentity(Mockito.anyString())).thenReturn(identity1);
         COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);
 
         List<String> result = profileSearchConnector.search(null, filter, null, offset, limit);
@@ -186,7 +193,7 @@ public class ProfileSearchConnectorTest {
     @Test
     public void testSearchWithNameOrUsername() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         ElasticSearchingClient elasticSearchClient = Mockito.mock(ElasticSearchingClient.class);
-        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient);
+        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient, profilePropertyService);
         IdentityManagerImpl identityManager = Mockito.mock(IdentityManagerImpl.class);
         ProfileFilter filter = new ProfileFilter();
         Sorting sorting = new Sorting(Sorting.SortBy.DATE, Sorting.OrderBy.DESC);
@@ -288,7 +295,6 @@ public class ProfileSearchConnectorTest {
                 ",\"fields\": [\"_id\"]\n" +
                 "}\n";
         Mockito.when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
-        Mockito.when(identityManager.getIdentity(Mockito.anyString())).thenReturn(identity1);
         COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);
         long offset = 0;
         long limit = 10;
@@ -299,7 +305,7 @@ public class ProfileSearchConnectorTest {
     @Test
     public void testCount() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         ElasticSearchingClient elasticSearchClient = Mockito.mock(ElasticSearchingClient.class);
-        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient);
+        profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient, profilePropertyService);
         ProfileFilter filter = new ProfileFilter();
         Sorting sorting = new Sorting(Sorting.SortBy.DATE, Sorting.OrderBy.DESC);
         Map <String,String> profileSettings = new HashMap<>();

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -435,6 +435,7 @@ public class EntityBuilder {
       Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, property.get(VALUE));
       if (identity != null) {
         ProfileEntity manager = buildEntityProfile(identity.getProfile(), restPath, SETTINGS);
+        buildManagedUsersCount(manager);
         managers.add(manager.getDataEntity());
       }
     });

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/settings/OrganizationalChartSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/settings/OrganizationalChartSettingsDrawer.vue
@@ -110,12 +110,13 @@
             <v-text-field
               v-if="showHeaderInput"
               v-model="headerTitle"
-              append-icon="fas fa-language"
               :aria-label="headerTitle"
+              append-icon="fas fa-language"
               class="pt-3"
               maxlength="500"
               outlined
-              dense />
+              dense
+              @click:append="setI18nHeaderTitle" />
           </div>
         </v-sheet>
       </div>
@@ -223,6 +224,9 @@ export default {
     }
   },
   methods: {
+    setI18nHeaderTitle() {
+      this.headerTitle = this.$t('organizationalChart.header.label');
+    },
     removeSelectedUser() {
       this.user = this.selectedUserData = null;
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChart.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChart.vue
@@ -155,7 +155,7 @@ export default {
     },
     scrollUserToViewCenter() {
       setTimeout(() => {
-        document.getElementById('user').scrollIntoView(this.scrollToViewProps);
+        document.getElementById('chartCenterUser').scrollIntoView(this.scrollToViewProps);
       }, 500);
     }
   }

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChartHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChartHeader.vue
@@ -45,7 +45,7 @@
       v-if="isAdmin"
       class="ms-auto d-flex">
       <v-btn
-        class="ms-auto my-0 pt-1 icon-default-color"
+        class="ms-auto my-0 icon-default-color"
         small
         icon
         @click="openChartSettingsDrawer">


### PR DESCRIPTION
this PR fixes:
1- no subordinate list caused unhandled case in search query with multivalued properties 
2 - set i18n header title option
3 - hover effect on cog icon in chart settings is not circeled 
4 - fix display of manageduserscount in managers cards
