### PR TITLE
fix: Link Node Type : redirection target ko on left navigation menu drawer space details - EXO-70359 - Meeds-io/meeds#1790

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -941,6 +941,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       app.setProperty("label", node.getResolvedLabel());
       app.setProperty("icon", node.getIcon());
       app.setProperty("uri", node.getURI());
+      app.setProperty("target", node.getTarget());
       if (node.getPageRef() != null) {
         Page navigationNodePage = SpaceUtils.getLayoutService().getPage(node.getPageRef());
         if (PageType.LINK.equals(PageType.valueOf(navigationNodePage.getType()))) {

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
@@ -19,7 +19,7 @@
 
 -->
 <template>
-  <v-list-item :href="navigationUri" dense>
+  <v-list-item :href="navigationUri" :target="target" dense>
     <v-list-item-icon class="my-auto d-flex">
       <v-icon class="icon-default-color icon-default-size ma-auto">
         {{ navigationIcon }}
@@ -61,6 +61,9 @@ export default {
     },
     navigationUri() {
       return this.navigation?.link && this.urlVerify(this.navigation?.link) || this.navigation?.uri;
+    },
+    target() {
+      return this.navigation?.target === 'SAME_TAB' && '_self' || '_blank';
     },
     badgeApplicationName() {
       // TODO to know what application id to associate to each page uri


### PR DESCRIPTION
Before this change, in the left navigation drawer space node details, when a node is of link type and have a new page as target, on click blank page is opened in the same tab.
This change applies the target option to the space nodes drawer since it was not treated