### PR TITLE
fix: Link Node Type : redirection and target ko on left navigation menu drawer space details - EXO-70359 - Meeds-io/meeds#1790

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -64,6 +64,8 @@ import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.deprecation.DeprecatedAPI;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.PageType;
 import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.portal.mop.user.UserNode;
 import org.exoplatform.services.log.ExoLogger;
@@ -939,6 +941,12 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       app.setProperty("label", node.getResolvedLabel());
       app.setProperty("icon", node.getIcon());
       app.setProperty("uri", node.getURI());
+      if (node.getPageRef() != null) {
+        Page navigationNodePage = SpaceUtils.getLayoutService().getPage(node.getPageRef());
+        if (PageType.LINK.equals(PageType.valueOf(navigationNodePage.getType()))) {
+          app.setProperty("link", navigationNodePage.getLink());
+        }
+      }
       return app.getDataEntity();
     }).collect(Collectors.toList());
     return Response.ok(spaceNavigations, MediaType.APPLICATION_JSON).build();

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -941,6 +941,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       app.setProperty("label", node.getResolvedLabel());
       app.setProperty("icon", node.getIcon());
       app.setProperty("uri", node.getURI());
+      app.setProperty("target", node.getTarget());
       if (node.getPageRef() != null) {
         Page navigationNodePage = SpaceUtils.getLayoutService().getPage(node.getPageRef());
         if (PageType.LINK.equals(PageType.valueOf(navigationNodePage.getType()))) {

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
@@ -19,7 +19,7 @@
 
 -->
 <template>
-  <v-list-item :href="navigationUri" dense>
+  <v-list-item :href="navigationUri" :target="target" dense>
     <v-list-item-icon class="my-auto d-flex">
       <v-icon class="icon-default-color icon-default-size ma-auto">
         {{ navigationIcon }}
@@ -61,6 +61,9 @@ export default {
     },
     navigationUri() {
       return this.navigation?.link && this.urlVerify(this.navigation?.link) || this.navigation?.uri;
+    },
+    target() {
+      return this.navigation?.target === 'SAME_TAB' && '_self' || '_blank';
     },
     badgeApplicationName() {
       // TODO to know what application id to associate to each page uri

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigationItem.vue
@@ -60,7 +60,7 @@ export default {
       return this.navigation?.label;
     },
     navigationUri() {
-      return this.navigation?.uri || '';
+      return this.navigation?.link && this.urlVerify(this.navigation?.link) || this.navigation?.uri;
     },
     badgeApplicationName() {
       // TODO to know what application id to associate to each page uri
@@ -82,5 +82,25 @@ export default {
       return this.unreadBadge > 0 ? { 'max-width': '140px' } : { 'max-width': '200px'};
     }
   },
+  methods: {
+    urlVerify(url) {
+      if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/) && this.isValidUrl(url) ) {
+        url = `//${url}`;
+      }
+      return url ;
+    },
+    isValidUrl(str) {
+      const pattern = new RegExp(
+        '^([a-zA-Z]+:\\/\\/)?' +
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' +
+        '((\\d{1,3}\\.){3}\\d{1,3}))' +
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' +
+        '(\\?[;&a-z\\d%_.~+=-]*)?' +
+        '(\\#[-a-z\\d_]*)?$',
+        'i'
+      );
+      return pattern.test(str);
+    }
+  }
 };
 </script>


### PR DESCRIPTION
Before this change, in the left navigation drawer space node details, when a node is of link type and has a new page as a target, on click blank page is opened in the same tab.
This change applies the link and target options to the space nodes drawer since it was not treated