### PR TITLE
fix: Breadcrumb portlet not displayed in spaces - EXO-70408 - Meeds-io/meeds#1789

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/breadcrumb/components/Breadcrumb.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/breadcrumb/components/Breadcrumb.vue
@@ -66,6 +66,7 @@ export default {
     scope: 'SINGLE',
     visibility: ['displayed', 'temporal'],
     siteType: 'PORTAL',
+    spaceType: 'GROUP',
     ellipsis: '...',
   }),
   computed: {
@@ -103,7 +104,7 @@ export default {
   },
   methods: {
     getCurrentNavigations() {
-      this.$navigationService.getNavigations(eXo.env.portal.portalName, this.siteType, this.scope, this.visibility, null,  eXo.env.portal.selectedNodeId, true)
+      this.$navigationService.getNavigations((!!eXo.env.portal.spaceId && `/spaces/${eXo.env.portal.spaceGroup}`) || eXo.env.portal.portalName, (!!eXo.env.portal.spaceId && this.spaceType) || this.siteType, this.scope, this.visibility, null,  eXo.env.portal.selectedNodeId, true)
         .then(navigations => {
           this.navigation = navigations &&  navigations[0] || {};
           this.userNodeBreadcrumbItemList = navigations &&  navigations[0].userNodeBreadcrumbItemList || [];


### PR DESCRIPTION
before this change, when the breadcrumb is added into a space layout, it is not displayed since the wrong parameters are set for the space case After this change, the site name and the site type are set correctly and the breadcrumb portlet is well-displayed