### PR TITLE
feat: Keep last selected suggestions of complementary filter displayed  when there is only one user - EXO-70301 - Meeds-io/MIPs#110

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/complementary-filter/components/ComplementaryFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/complementary-filter/components/ComplementaryFilter.vue
@@ -166,7 +166,7 @@ export default {
       return this.getSelectionIndex(suggestion) !== -1;
     },
     updateFilterSuggestions() {
-      if (!this.listObjectIds?.length) {
+      if (this.listObjectIds?.length <= 1) {
         this.suggestions = [...this.selections].sort((a, b) => b.count - a.count);
       } else {
         this.getComplementaryFilterSuggestions();


### PR DESCRIPTION


Keep last selected suggestions of complementary filter displayed when there is only one user
