### PR TITLE
feat: Fix UI display of space popover for the external visio list - EXO-69422

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
@@ -137,7 +137,7 @@ export default {
       }
       if (this.menu) {
         // workaround for menu v-select absolute content that must be displayed inside the menu
-        $('.profile-popover-menu').css('height', '160px');
+        $('.profile-popover-menu').css('height', '100%');
       }
     });
     // Force to close user popover when scrolling

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -10,6 +10,7 @@
       :nudge-width="200"
       max-width="350"
       min-width="300"
+      content-class="no-box-shadow full-height pa-1 mt-6 "
       offset-y>
       <template #activator="{ on, attrs }">
         <div


### PR DESCRIPTION
Prior to this change, the external visio list was not fully displayed, requiring a scrollbar. After this fix, the entire list is now visible without the need for scrolling.