### PR TITLE
fix: In topbar  menu the link Node Type redirection ko if '/#/' is included - EXO-70678 - Meeds-io/meeds#1815

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -34,12 +34,11 @@
         :class="`mx-auto text-caption text-break ${extraClass} ${notClickable}`"
         v-on="on"
         v-bind="attrs"
-        :href="navigationNodeUri"
-        :target="navigationNodeTarget"
         :link="hasPage"
         :aria-label="$t('topBar.navigation.menu.openMenu')"
         role="tab"
         @click.stop="checkLink(navigation, $event)"
+        @click="openUrl(navigationNodeUri, navigationNodeTarget)"
         @change="updateNavigationState(navigation.uri)">
         <span
           class="text-truncate-3">
@@ -108,7 +107,7 @@ export default {
       return !!this.navigation?.pageKey;
     },
     navigationNodeUri() {
-      return this.navigation?.pageLink && this.urlVerify(this.navigation?.pageLink) || `${this.baseSiteUri}${this.navigation.uri}`;
+      return this.navigation?.pageLink || `${this.baseSiteUri}${this.navigation.uri}`;
     },
     navigationNodeTarget() {
       return this.navigation?.target === 'SAME_TAB' && '_self' || '_blank';
@@ -165,11 +164,13 @@ export default {
       });
       return childrenHasPage;
     },
-    urlVerify(url) {
+    openUrl(url, target) {
       if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/)) {
         url = `//${url}`;
+      } else if (url.match(/^(\/portal\/)/)) {
+        url = `${window.location.origin}${url}`;
       }
-      return url ;
+      window.open(url, target);
     },
   }
 };


### PR DESCRIPTION
Before this change, When the href attribute contains a "#" followed by a fragment identifier, the browser treats it as an anchor link and tries to navigate to that fragment within the current page, instead of navigating to a different UR
After this change, Handling the click and manually perform the redirection