### PR TITLE
fix: fix PLF language change makes link gadget labels to disappear - EXO-70358 - Meeds-io/meeds#1610

### DIFF
--- a/component/core/src/main/java/io/meeds/social/link/service/LinkServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/link/service/LinkServiceImpl.java
@@ -391,7 +391,10 @@ public class LinkServiceImpl implements LinkService {
       if (StringUtils.isBlank(label)) {
         String defaultLanguage = localeConfigService.getDefaultLocaleConfig().getLocale().toLanguageTag();
         if (StringUtils.equals(defaultLanguage, language)) {
-          return Collections.singletonMap(defaultLanguage, "");
+          if (!Locale.ENGLISH.toLanguageTag().equals(language)) {
+            label = translationService.getTranslationLabel(objectType, objectId, fieldName, Locale.ENGLISH);
+          }
+          return Collections.singletonMap(Locale.ENGLISH.toLanguageTag(), !StringUtils.isBlank(label) ? label : "");
         } else {
           return Collections.singletonMap(language,
                                           getTranslations(objectType, objectId, fieldName, defaultLanguage).get(defaultLanguage));

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
@@ -221,12 +221,10 @@ export default {
         link = {};
       }
       if (!link.name?.[this.$root.defaultLanguage]) {
-        link.name = {};
-        link.name[this.$root.defaultLanguage] = '';
+        link.name[this.$root.defaultLanguage] = link.name['en'] || '';
       }
       if (!link.description?.[this.$root.defaultLanguage]) {
-        link.description = {};
-        link.description[this.$root.defaultLanguage] = '';
+        link.description[this.$root.defaultLanguage] = link.description['en'] || '';
       }
       if (!link.iconSrc) {
         link.iconSrc = null;

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkFormDrawer.vue
@@ -219,6 +219,10 @@ export default {
     open(link, edit, index) {
       if (!link) {
         link = {};
+        link.name = {};
+        link.name[this.$root.defaultLanguage] = '';
+        link.description = {};
+        link.description[this.$root.defaultLanguage] = '';
       }
       if (!link.name?.[this.$root.defaultLanguage]) {
         link.name[this.$root.defaultLanguage] = link.name['en'] || '';

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
@@ -406,6 +406,14 @@ export default {
         .then(settings => {
           this.settings = settings;
           this.links = settings?.links || [];
+          this.links.forEach(link => {
+            if (!link.name?.[this.$root.defaultLanguage]) {
+              link.name[this.$root.defaultLanguage] = link.name['en'] || '';
+            }
+            if (!link.description?.[this.$root.defaultLanguage]) {
+              link.description[this.$root.defaultLanguage] = link.description['en'] || '';
+            }
+          });
           this.showHeader = !!this.settings?.header?.[this.$root.defaultLanguage]?.length;
           this.seeMore = !!this.settings?.seeMore?.length;
           if (!this.showHeader) {

--- a/webapp/portlet/src/main/webapp/vue-apps/links/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/main.js
@@ -64,7 +64,17 @@ export function init(appId, name, canEdit) {
           },
           retrieveSettings() {
             return this.$linkService.getSettings(this.name, this.language)
-              .then(settings => this.settings = settings);
+              .then(settings => {
+                settings.links.forEach(link => {
+                  if (!link.name?.[this.defaultLanguage]) {
+                    link.name[this.defaultLanguage] = link.name['en'] || '';
+                  }
+                  if (!link.description?.[this.defaultLanguage]) {
+                    link.description[this.defaultLanguage] = link.description['en'] || '';
+                  }
+                });
+                this.settings = settings;
+              });
           },
         },
         template: `<links-app id="${appId}"></links-app>`,

--- a/webapp/portlet/src/main/webapp/vue-apps/links/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/main.js
@@ -60,22 +60,24 @@ export function init(appId, name, canEdit) {
         },
         methods: {
           init() {
-            return this.retrieveSettings();
+            return this.retrieveSettings().then(() => this.computeDefaultTranslations()) ;
           },
           retrieveSettings() {
             return this.$linkService.getSettings(this.name, this.language)
               .then(settings => {
-                settings.links.forEach(link => {
-                  if (!link.name?.[this.defaultLanguage]) {
-                    link.name[this.defaultLanguage] = link.name['en'] || '';
-                  }
-                  if (!link.description?.[this.defaultLanguage]) {
-                    link.description[this.defaultLanguage] = link.description['en'] || '';
-                  }
-                });
                 this.settings = settings;
               });
           },
+          computeDefaultTranslations() {
+            return this.settings.links.forEach(link => {
+              if (!link.name?.[this.defaultLanguage]) {
+                link.name[this.defaultLanguage] = link.name['en'] || '';
+              }
+              if (!link.description?.[this.defaultLanguage]) {
+                link.description[this.defaultLanguage] = link.description['en'] || '';
+              }
+            });
+          }
         },
         template: `<links-app id="${appId}"></links-app>`,
         vuetify: Vue.prototype.vuetifyOptions,


### PR DESCRIPTION
Before this change, After  adding links without translations and then changing the PLF language the Link labels disappear
because the current language do not have labels
After this change, If no translation is added to names (or descriptions), then consider the link name (or description) as the default language
If translation is added, then it should be displayed if the language changed to a related one