### PR TITLE
fix: fix PLF language change makes link gadget labels to disappear - EXO-70358 - Meeds-io/meeds#1610

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/main.js
@@ -60,12 +60,13 @@ export function init(appId, name, canEdit) {
         },
         methods: {
           init() {
-            return this.retrieveSettings().then(() => this.computeDefaultTranslations()) ;
+            return this.retrieveSettings();
           },
           retrieveSettings() {
             return this.$linkService.getSettings(this.name, this.language)
               .then(settings => {
                 this.settings = settings;
+                this.computeDefaultTranslations();
               });
           },
           computeDefaultTranslations() {


### PR DESCRIPTION
Before this change, After adding links without translations and then changing the PLF language the Link labels disappear because the current language do not have labels After this change, If no translation is added to names (or descriptions), then consider the link name (or description) as the default language
If translation is added, then it should be displayed if the language changed to a related one