### PR TITLE
fix : extension point in space top bar popover does not display extensions the second time - EXO-70575

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/SpacePopoverActionComponents.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/SpacePopoverActionComponents.vue
@@ -21,7 +21,7 @@ export default {
   },
   methods: {
     initTitleActionComponent(action) {
-      if (action.init && !action.isStartedInit && action.enabled) {
+      if (action.init && action.enabled) {
         action.isStartedInit = true;
         let container = this.$refs[action.key];
         if (container && container.length > 0) {


### PR DESCRIPTION
Before this fix, when hovering the space name in top bar, the last extension point 'space-title-action-components' does not load correctly On first hover, it is displayed, on second it is not.

This commit force the reload of the extension to make is displayed each times

Resolves meeds-io/meeds#1839

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
