### PR TITLE
fix: fix space menu navigation display of selected application - EXO-70787 - Meeds-io/meeds#1841

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
@@ -30,6 +30,7 @@
         v-for="nav in navigations"
         :key="nav.id"
         :value="nav.id"
+        :href="nav.uri"
         @click="openUrl(nav.uri, nav?.target)"
         class="spaceNavigationTab">
         {{ nav.label }}


### PR DESCRIPTION
Before this change, when opening a space application member/tasks ... the application is well displayed but the selected application is the stream because the URI param is not added to check the active tab
After this change, the active tab is well computed after adding the URI 