### PR TITLE
fix: PLF language set isn't considered on external invitation - EXO-70327 - Meeds-io/meeds#1609 

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -70,6 +70,7 @@ import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.portal.mop.user.UserNode;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.common.Utils;
 import org.exoplatform.social.core.identity.SpaceMemberFilterListAccess;
@@ -746,12 +747,11 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       StringBuilder url = new StringBuilder(uri);
 
       PasswordRecoveryService passwordRecoveryService = CommonsUtils.getService(PasswordRecoveryService.class);
-      LayoutService layoutService = CommonsUtils.getService(LayoutService.class);
-      String currentSiteName = CommonsUtils.getCurrentSite().getName();
+      LocaleConfigService localeConfigService = CommonsUtils.getService(LocaleConfigService.class);
       Locale locale = null;
       try {
-        String currentSiteLocale = layoutService.getPortalConfig(currentSiteName).getLocale();
-        locale = new Locale(currentSiteLocale);
+        String defaultLanguage = localeConfigService.getDefaultLocaleConfig().getLocale().toLanguageTag();
+        locale = new Locale(defaultLanguage);
       } catch (Exception e) {
         LOG.error("Failure to retrieve portal config", e);
       }


### PR DESCRIPTION
Before this change, when Setting the platform language to FR using fetch and sending an invitation to an external user to join a space, the email was sent in English since the locale is the current portal language After this change, the local is the default local config, and the email is well sent in French