### PR TITLE
Revert "fix: In topbar  menu the link Node Type redirection ko if '/#/' is included - EXO-70678 - Meeds-io/meeds#1815"

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -34,11 +34,12 @@
         :class="`mx-auto text-caption text-break ${extraClass} ${notClickable}`"
         v-on="on"
         v-bind="attrs"
+        :href="navigationNodeUri"
+        :target="navigationNodeTarget"
         :link="hasPage"
         :aria-label="$t('topBar.navigation.menu.openMenu')"
         role="tab"
         @click.stop="checkLink(navigation, $event)"
-        @click="openUrl(navigationNodeUri, navigationNodeTarget)"
         @change="updateNavigationState(navigation.uri)">
         <span
           class="text-truncate-3">
@@ -107,7 +108,7 @@ export default {
       return !!this.navigation?.pageKey;
     },
     navigationNodeUri() {
-      return this.navigation?.pageLink || `${this.baseSiteUri}${this.navigation.uri}`;
+      return this.navigation?.pageLink && this.urlVerify(this.navigation?.pageLink) || `${this.baseSiteUri}${this.navigation.uri}`;
     },
     navigationNodeTarget() {
       return this.navigation?.target === 'SAME_TAB' && '_self' || '_blank';
@@ -164,13 +165,11 @@ export default {
       });
       return childrenHasPage;
     },
-    openUrl(url, target) {
+    urlVerify(url) {
       if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/)) {
         url = `//${url}`;
-      } else if (url.match(/^(\/portal\/)/)) {
-        url = `${window.location.origin}${url}`;
       }
-      window.open(url, target);
+      return url ;
     },
   }
 };


### PR DESCRIPTION
This reverts commit 5c75a9b6ff8e1158a5475437f7400e7c2a733085. Since it causes CICD failure, we need to rework this fix and use hrefs instead onclick event. 
