### PR TITLE
fix: chart preview issue when select user from suggester - EXO-70949 - Meeds-io/MIPs#112

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/OrganizationalChartApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/OrganizationalChartApp.vue
@@ -206,12 +206,18 @@ export default {
         }).finally(() => this.isPrintingPdf = false);
     },
     updateUrl(identityId) {
+      if (this.preview) {
+        return;
+      }
       const searchParams = new URLSearchParams(window.location.search);
       searchParams.set(this.centerUserIdUrlParam, identityId);
       const url = `${window.location.pathname}?${searchParams.toString()}`;
       window.history.pushState('OrganizationalChartUrl', '', url);
     },
     getRequestedCenterUserId() {
+      if (this.preview) {
+        return null;
+      }
       const urlParams = new URLSearchParams(window.location.search);
       return urlParams?.get(this.centerUserIdUrlParam);
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/settings/OrganizationalChartSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/settings/OrganizationalChartSettingsDrawer.vue
@@ -290,7 +290,7 @@ export default {
       this.listIgnoredItems = [user?.id];
     },
     bindDefaultHeaderTitle() {
-      if (!this.hasHeaderTitle) {
+      if (!this.hasHeaderTitle && this.hasSettings) {
         return;
       }
       this.headerTitle = this.headerTitle || {};
@@ -303,7 +303,7 @@ export default {
       this.headerTitle = !this.selectedUser && this.defaultHeaderTitle
                                             || this.savedHeaderTranslations;
       this.bindDefaultHeaderTitle();
-      this.showHeaderInput = this.hasSettings && !!this.headerTitle;
+      this.showHeaderInput = !!this.headerTitle;
       this.chartCenterUser = (!this.selectedUser || this.isConnectedUserSelected)
                                                 && this.connectedUserOption
                                                 || this.specificUserOption;


### PR DESCRIPTION
prior to this change, when select a user from chart settings drawer, the chart preview always show the preview chart of connected user, due to an unhandled issue when extracting the user id from url in case of preview which should be prevented.
This PR make sure to prevent the extract or the update of the user from the url in case of preview

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
