### PR TITLE
feat: Read activity if like or comment's likes is collapsed - MEED-4543 - Meeds-io/MIPs#124

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/notification/model/SpaceWebNotificationItem.java
+++ b/component/api/src/main/java/org/exoplatform/social/notification/model/SpaceWebNotificationItem.java
@@ -44,6 +44,8 @@ public class SpaceWebNotificationItem {
 
   private String      activityId;
 
+  private String      activityActionType;
+
   public SpaceWebNotificationItem(String applicationName, String applicationItemId, long userId, long spaceId) {
     this.applicationName = applicationName;
     this.applicationItemId = applicationItemId;

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
@@ -59,18 +59,19 @@ import org.exoplatform.social.core.manager.IdentityManager;
 @SuppressWarnings("removal")
 public class SpaceWebNotificationServiceImpl implements SpaceWebNotificationService, Startable {
 
-  private static final String              SPACE_NOT_FOUND               = "Space with id %s doesn't exist";
+  private static final String              SPACE_NOT_FOUND                        = "Space with id %s doesn't exist";
 
-  private static final String              USER_NOT_MEMBER_OF_SPACE      = "User %s isn't member of space %s";
+  private static final String              USER_NOT_MEMBER_OF_SPACE               = "User %s isn't member of space %s";
 
-  public static final String               APPLICATION_SUB_ITEM_IDS      = "applicationSubItemIds";
+  public static final String               APPLICATION_SUB_ITEM_IDS               = "applicationSubItemIds";
 
-  public static final String               METADATA_TYPE_NAME            = "unread";
+  public static final String               METADATA_TYPE_NAME                     = "unread";
 
-  public static final String               METADATA_ACTIVITY_ID_PROPERTY = "activityId";
+  public static final String               METADATA_ACTIVITY_ID_PROPERTY          = "activityId";
 
-  private static final Log                 LOG                           =
-                                               ExoLogger.getLogger(SpaceWebNotificationServiceImpl.class);
+  public static final String               METADATA_ACTIVITY_ACTION_TYPE_PROPERTY = "actionType";
+
+  private static final Log                 LOG                                    = ExoLogger.getLogger(SpaceWebNotificationServiceImpl.class);
 
   private PortalContainer                  container;
 
@@ -330,6 +331,7 @@ public class SpaceWebNotificationServiceImpl implements SpaceWebNotificationServ
     Map<String, String> props = new HashMap<>();
     props.put(APPLICATION_SUB_ITEM_IDS, StringUtils.join(notificationItem.getApplicationSubItemIds(), ","));
     props.put(METADATA_ACTIVITY_ID_PROPERTY, notificationItem.getActivityId());
+    props.put(METADATA_ACTIVITY_ACTION_TYPE_PROPERTY, notificationItem.getActivityActionType());
     return props;
   }
 

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivitySpaceWebNotificationPlugin.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.notification.plugin;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
@@ -28,7 +29,9 @@ import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
 
 public class ActivitySpaceWebNotificationPlugin extends SpaceWebNotificationPlugin {
 
-  public static final String ID = "ActivitySpaceWebNotificationPlugin";
+  public static final String ID                     = "ActivitySpaceWebNotificationPlugin";
+
+  public static final String ACTIVITY_ACTION_SUFFIX = "Plugin";
 
   private ActivityManager    activityManager;
 
@@ -57,11 +60,20 @@ public class ActivitySpaceWebNotificationPlugin extends SpaceWebNotificationPlug
                                                                                        metadataObject.getId(),
                                                                                        0,
                                                                                        metadataObject.getSpaceId());
+
       if (activity.isComment()) {
         spaceWebNotificationItem.setActivityId(activity.getParentId());
         spaceWebNotificationItem.addApplicationSubItem(activity.getId());
       } else {
         spaceWebNotificationItem.setActivityId(activity.getId());
+      }
+      String activityActionType = notification.getKey().getId();
+      if (StringUtils.isNotBlank(activityActionType)) {
+        if (activityActionType.endsWith(ACTIVITY_ACTION_SUFFIX)) {
+          activityActionType =
+              activityActionType.substring(0, activityActionType.length() - ACTIVITY_ACTION_SUFFIX.length()).trim();
+        }
+        spaceWebNotificationItem.setActivityActionType(activityActionType);
       }
       return spaceWebNotificationItem;
     } else {

--- a/component/notification/src/test/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceTest.java
@@ -184,6 +184,7 @@ public class SpaceWebNotificationServiceTest extends AbstractCoreTest {
     String itemId1 = "subItem1";
     spaceWebNotificationItem.setActivityId(activityId);
     spaceWebNotificationItem.addApplicationSubItem(itemId1);
+    spaceWebNotificationItem.setActivityActionType("Like");
 
     MetadataKey metadataKey = new MetadataKey(METADATA_TYPE_NAME, String.valueOf(userIdentityId), userIdentityId);
     MetadataObject metadataObject = new MetadataObject(METADATA_OBJECT_TYPE,
@@ -196,7 +197,7 @@ public class SpaceWebNotificationServiceTest extends AbstractCoreTest {
                                                          eq(metadataKey),
                                                          argThat(
                                                            props -> 
-                                                             props != null && props.size() == 2
+                                                             props != null && props.size() == 3
                                                                  && itemId1.equals(props.get("applicationSubItemIds"))
                                                                  && spaceWebNotificationItem.getActivityId().equals(props.get(ACTIVITY_ID_PROP))
                                                          ),
@@ -229,13 +230,14 @@ public class SpaceWebNotificationServiceTest extends AbstractCoreTest {
     String itemId2 = "subItem2";
     spaceWebNotificationItem.addApplicationSubItem(itemId2);
     spaceWebNotificationItem.setActivityId(activityId);
+    spaceWebNotificationItem.setActivityActionType("Like");
     spaceWebNotificationService.markAsUnread(spaceWebNotificationItem);
 
     verify(metadataService, times(1)).createMetadataItem(eq(metadataObject),
                                                          eq(metadataKey),
                                                          argThat(
                                                            props -> 
-                                                             props != null && props.size() == 2
+                                                             props != null && props.size() == 3
                                                                  && (itemId1 + "," + itemId2).equals(props.get("applicationSubItemIds"))
                                                                  && spaceWebNotificationItem.getActivityId().equals(props.get(ACTIVITY_ID_PROP))
                                                          ),

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -229,7 +229,8 @@ export default {
     initialized() {
       if (this.initialized && !this.isActivityShared) {
         this.unreadMetadata = this.activity?.metadatas?.unread?.length && this.activity?.metadatas?.unread[0];
-        this.isRead = this.unreadMetadata;
+        const isLikeAction = this.activity?.metadatas?.unread[0]?.properties?.actionType === 'Like' || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'LikeComment';
+        this.isRead = this.unreadMetadata && !isLikeAction;
       }
     },
   },


### PR DESCRIPTION
This change allows the activity content to remain **collapsed** if there is a like activity or like comment action.