### PR TITLE
fix: In topbar menu the link Node Type redirection ko if '/#/' is included - EXO-70678 - Meeds-io/meeds#1815 (#3687)

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -40,6 +40,7 @@
         :aria-label="$t('topBar.navigation.menu.openMenu')"
         role="tab"
         @click.stop="checkLink(navigation, $event)"
+        @click="openUrl(navigationNodeUri, navigationNodeTarget)"
         @change="updateNavigationState(navigation.uri)">
         <span
           class="text-truncate-3">
@@ -108,7 +109,7 @@ export default {
       return !!this.navigation?.pageKey;
     },
     navigationNodeUri() {
-      return this.navigation?.pageLink && this.urlVerify(this.navigation?.pageLink) || `${this.baseSiteUri}${this.navigation.uri}`;
+      return this.navigation?.pageLink || `${this.baseSiteUri}${this.navigation.uri}`;
     },
     navigationNodeTarget() {
       return this.navigation?.target === 'SAME_TAB' && '_self' || '_blank';
@@ -165,11 +166,13 @@ export default {
       });
       return childrenHasPage;
     },
-    urlVerify(url) {
+    openUrl(url, target) {
       if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/)) {
         url = `//${url}`;
+      } else if (url.match(/^(\/portal\/)/)) {
+        url = `${window.location.origin}${url}`;
       }
-      return url ;
+      window.open(url, target);
     },
   }
 };


### PR DESCRIPTION
Before this change, When the href attribute contains a "#" followed by a fragment identifier, the browser treats it as an anchor link and tries to navigate to that fragment within the current page, instead of navigating to a different URL
After this change, the redirection will be done by a OnClick event, without removing the href attribute.
