### PR TITLE
feat: Read Activity with new comment or replay -MEED-4541 - Meeds-io/MIPs#124

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -236,10 +236,7 @@ export default {
       if (this.initialized && !this.isActivityShared) {
         this.unreadMetadata = this.activity?.metadatas?.unread?.length && this.activity?.metadatas?.unread[0];
         const isLikeAction = this.activity?.metadatas?.unread[0]?.properties?.actionType === 'Like'
-            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'LikeComment'
-            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityComment'
-            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityReplyToComment'
-            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'EditComment';
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'LikeComment';
         const isNewCommentAction = this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityComment'
             || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityReplyToComment'
             || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'EditComment';

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -41,6 +41,7 @@
           :activity="activity"
           :comment-types="commentTypes"
           :comment-actions="commentActions"
+          :display-comments="activityCommented"
           class="px-4" />
       </template>
     </template>
@@ -77,6 +78,7 @@
           :activity="activity"
           :comment-types="commentTypes"
           :comment-actions="commentActions"
+          :display-comments="activityCommented"
           class="px-4" />
       </template>
     </template>
@@ -128,7 +130,8 @@ export default {
     initialized: false,
     noExtension: false,
     unreadMetadata: null,
-    isRead: false
+    isRead: false,
+    hasNewComment: false,
   }),
   computed: {
     id() {
@@ -203,6 +206,9 @@ export default {
     spaceId() {
       return this.activity?.activityStream?.space?.id || '';
     },
+    activityCommented() {
+      return this.hasNewComment;
+    }
   },
   watch: {
     activityLoading() {
@@ -229,8 +235,16 @@ export default {
     initialized() {
       if (this.initialized && !this.isActivityShared) {
         this.unreadMetadata = this.activity?.metadatas?.unread?.length && this.activity?.metadatas?.unread[0];
-        const isLikeAction = this.activity?.metadatas?.unread[0]?.properties?.actionType === 'Like' || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'LikeComment';
-        this.isRead = this.unreadMetadata && !isLikeAction;
+        const isLikeAction = this.activity?.metadatas?.unread[0]?.properties?.actionType === 'Like'
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'LikeComment'
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityComment'
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityReplyToComment'
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'EditComment';
+        const isNewCommentAction = this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityComment'
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityReplyToComment'
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'EditComment';
+        this.isRead = this.unreadMetadata && !isLikeAction && !isNewCommentAction;
+        this.hasNewComment = this.unreadMetadata && isNewCommentAction;
       }
     },
   },
@@ -280,6 +294,7 @@ export default {
           }
         }
         this.isRead = true;
+        this.hasNewComment = true;
         this.loading = false;
         this.initialized = true;
       });

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -242,6 +242,7 @@ export default {
       }
     });
     this.$root.$on('activity-stream-activity-updateActivity', this.updateActivityDisplayById);
+    this.$root.$on('activity-stream-activity-createComment', this.updateActivityDisplayById);
     this.$root.$on('activities-refresh', this.refreshActivities);
     this.$root.$on('activity-read', this.markActivityAsRead);
     this.$root.$on('activity-loaded', this.refreshUnreadCount);
@@ -259,6 +260,7 @@ export default {
   },
   beforeDestroy() {
     this.$root.$off('activity-stream-activity-updateActivity', this.updateActivityDisplayById);
+    this.$root.$off('activity-stream-activity-createComment', this.updateActivityDisplayById);
   },
   methods: {
     init() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
@@ -6,6 +6,7 @@
       height="2"
       indeterminate />
     <activity-comments
+      v-if="displayComments"
       :activity="activity"
       :comments="comments"
       :comment-types="commentTypes"
@@ -15,7 +16,7 @@
       @comment-deleted="retrieveLastComment"
       @comment-updated="retrieveLastComment" />
     <v-btn
-      v-if="commentsSize > 2"
+      v-if="commentsSize > 0"
       :disabled="loading"
       class="primary--text font-weight-bold mb-1 subtitle-2 px-0"
       small
@@ -42,6 +43,10 @@ export default {
       type: Object,
       default: null,
     },
+    displayComments: {
+      type: Boolean,
+      default: false,
+    }
   },
   data: () => ({
     comments: [],
@@ -53,6 +58,13 @@ export default {
     parentCommentClass() {
       return this.commentsSize && 'pb-0 pt-5' || 'pa-0';
     },
+  },
+  watch: {
+    displayComments() {
+      if (this.displayComments) {
+        this.retrieveLastComment();
+      }
+    }
   },
   created() {
     if (this.activity && this.activity.comments && typeof this.activity.comments === 'object') {


### PR DESCRIPTION
This PR enables the display of the two latest comments on the activity only if they are newly added. If no new comments are added, we simply display the 'See all comments' label to open the full comments drawer.