### PR TITLE
feat: Read activity with new comment or reply - MEED-4541 - Meeds-io/MIPs#124

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -248,6 +248,7 @@ export default {
   created() {
     this.$root.$on('activity-extension-abort', this.abortSpecificExtension);
     this.$root.$on('activity-refresh-ui', this.retrieveActivityProperties);
+    this.$root.$on('activity-stream-activity-createComment', this.refreshActivityLastComments);
     this.retrieveActivityProperties();
   },
   mounted() {
@@ -271,6 +272,7 @@ export default {
   beforeDestroy() {
     this.$root.$off('activity-refresh-ui', this.retrieveActivityProperties);
     this.$root.$off('activity-extension-abort', this.abortSpecificExtension);
+    this.$root.$off('activity-stream-activity-createComment', this.refreshActivityLastComments);
   },
   methods: {
     retrieveActivityProperties(activityId) {
@@ -291,7 +293,6 @@ export default {
           }
         }
         this.isRead = true;
-        this.hasNewComment = true;
         this.loading = false;
         this.initialized = true;
       });
@@ -325,6 +326,11 @@ export default {
     abortSpecificExtension(activityId) {
       if (activityId === this.activityId) {
         this.noExtension = true;
+      }
+    },
+    refreshActivityLastComments(activityId) {
+      if (activityId === this.activityId) {
+        this.hasNewComment = true;
       }
     },
     markAsRead() {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -242,7 +242,6 @@ export default {
       }
     });
     this.$root.$on('activity-stream-activity-updateActivity', this.updateActivityDisplayById);
-    this.$root.$on('activity-stream-activity-createComment', this.updateActivityDisplayById);
     this.$root.$on('activities-refresh', this.refreshActivities);
     this.$root.$on('activity-read', this.markActivityAsRead);
     this.$root.$on('activity-loaded', this.refreshUnreadCount);
@@ -260,7 +259,6 @@ export default {
   },
   beforeDestroy() {
     this.$root.$off('activity-stream-activity-updateActivity', this.updateActivityDisplayById);
-    this.$root.$off('activity-stream-activity-createComment', this.updateActivityDisplayById);
   },
   methods: {
     init() {


### PR DESCRIPTION
Before this change, when we added a new comment to an existing activity, it displayed the full content. This change allows the activity content to remain collapsed when we add a new comment or reply to a comment.