### PR TITLE
fix: Display People Card Menu item icon - MEED-5908

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -110,8 +110,8 @@
               :key="i"
               @click="extension.click(user)">
               <v-list-item-title class="align-center d-flex">
-                <v-icon
-                  size="18">
+                <i v-if="extension.icon" :class="extension.icon" class="uiIcon"></i>
+                <v-icon v-else size="18">
                   {{ extension.class }}
                 </v-icon>
                 <span class="mx-2">


### PR DESCRIPTION
This change will apply a workaround for Meeds-io/MIPs#110 Meeds-io/MIPs#111 in order to display people card menu icons.