### PR TITLE
fix: Fix App Toolbar ZIndex - MEED-6213 - EXO-70214 - Meeds-io/meeds#1903

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
@@ -18,7 +18,7 @@
 
 -->
 <template>
-  <v-toolbar flat>
+  <v-toolbar class="z-index-one" flat>
     <div id="applicationToolbar" class="d-flex flex-grow-1 align-center content-box-sizing position-relative">
       <!-- Left Content -->
       <div

--- a/webapp/portlet/src/main/webapp/vue-apps/complementary-filter/components/ComplementaryFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/complementary-filter/components/ComplementaryFilter.vue
@@ -62,7 +62,7 @@
       :suggestions="suggestions"
       :selections="selections"
       @select-suggestion="selectSuggestion"
-      @closed="filterDrawerClosed"/>
+      @closed="filterDrawerClosed" />
   </v-app>
 </template>
 

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -110,7 +110,10 @@
               :key="i"
               @click="extension.click(user)">
               <v-list-item-title class="align-center d-flex">
-                <i v-if="extension.icon" :class="extension.icon" class="uiIcon"></i>
+                <i
+                  v-if="extension.icon"
+                  :class="extension.icon"
+                  class="uiIcon"></i>
                 <v-icon v-else size="18">
                   {{ extension.class }}
                 </v-icon>

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
@@ -38,6 +38,7 @@
         :compact="true"
         :filter-message="filterMessage"
         filter-message-class="position-absolute filter-message subtitle-1 text-color ps-1"
+        class="transparent"
         @keyword-changed="keyword = $event" />
       <complementary-filter
         class="mt-n1 z-index-two position-relative"
@@ -49,7 +50,7 @@
         @build-suggestions-terminated="buildSuggestionsTerminated"
         @filter-changed="selectedSuggestionsUpdated"
         @filter-suggestion-unselected="unselectSuggestion"
-        @filter-drawer-closed="filterDrawerClosed"/>
+        @filter-drawer-closed="filterDrawerClosed" />
       <div
         v-if="!isSearching && !listUsers.length"
         class="mt-auto mb-auto pt-5 align-center">
@@ -159,7 +160,7 @@ export default {
           || this.properties;
     },
     filterMessage() {
-      return this.hasCombinations && this.$t('complementaryFilter.suggestions.message') || ' ';
+      return this.$t('complementaryFilter.suggestions.message') || ' ';
     }
   },
   watch: {


### PR DESCRIPTION
Prior to this change, the `ZIndex` of Toolbar was deleted to hide the `white` background color applied on toolbar. This change ensures to get back the `z-index` of toolbar, useful to make sure that toolbar elements are displayed on top of the other app content and it fixes the original issue by applying `transparent` background on toolbar.

Additionally, this will fix some Code format issues encountered using `eslint`.