### PR TITLE
fix: Fix WhoIsOnline App display in New Layout Manager - MEED-5942 - Meeds-io/MIPs#120

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
@@ -49,17 +49,24 @@ export default {
     this.$root.$applicationLoaded();
   },
   created() {
-    document.onreadystatechange = () => {
-      if (document.readyState === 'complete' && !this.loaded) {
-        this.initOnlineUsers(this.$root.onlineUsers && this.$root.onlineUsers.users || []);
-        setInterval(function () {
-          this.retrieveOnlineUsers();
-        }.bind(this), this.delay);
-        this.loaded=true;
-      }
-    };
+    if (document.readyState === 'complete' && !this.loaded) {
+      this.init();
+    } else {
+      document.onreadystatechange = () => {
+        if (document.readyState === 'complete' && !this.loaded) {
+          this.init();
+        }
+      };
+    }
   },
   methods: {
+    init() {
+      this.loaded=true;
+      this.initOnlineUsers(this.$root.onlineUsers && this.$root.onlineUsers.users || []);
+      setInterval(function () {
+        this.retrieveOnlineUsers();
+      }.bind(this), this.delay);
+    },
     retrieveOnlineUsers() {
       return whoIsOnlineServices.getOnlineUsers(eXo.env.portal.spaceId)
         .then(data => {


### PR DESCRIPTION
Prior to this change, the Who is Online application isn't rendered when its display is made after the page is completely loaded. This change will initialize the application if the application is created after the whole page loading phase is completed.