### PR TITLE
feat: Define a centralized API to hide empty widgets - MEED-6202 - Meeds-io/MIPs#120

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
@@ -102,6 +102,22 @@ Vue.prototype.$applicationLoaded = function() {
   }}));
 };
 
+Vue.prototype.$updateApplicationVisibility = function(visible, element) {
+  if (!element) {
+    element = this?.$root?.$el;
+  }
+  if (!element?.className?.includes?.('PORTLET-FRAGMENT')) {
+    element = element?.parentElement;
+  }
+  if (element?.parentElement) {
+    if (visible) {
+      element.closest?.('.PORTLET-FRAGMENT')?.parentElement?.classList?.remove?.('hidden');
+    } else {
+      element.closest?.('.PORTLET-FRAGMENT')?.parentElement?.classList?.add?.('hidden');
+    }
+  }
+};
+
 Vue.createApp = function(params, el, appName) {
   const element = typeof el === 'string' ? document.querySelector(el) : el;
   if (element) {

--- a/webapp/portlet/src/main/webapp/vue-apps/getting-started/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/getting-started/main.js
@@ -16,14 +16,14 @@ if (parentAppElement) {
     parentAppElementBtn.onclick = () => {
       hideGettingStarted().then(() => {
         const parentElementToHide = parentAppElement.closest('.PORTLET-FRAGMENT');
-        hideGettingStarted().then(() => parentElementToHide.classList.add('hidden'));
+        hideGettingStarted().then(() => Vue.prototype.$updateApplicationVisibility(false, parentElementToHide));
       });
     };
   }
 } else {
-  document.querySelector('#GettingStartedContainerChildren .PORTLET-FRAGMENT').classList.add('hidden');
+  Vue.prototype.$updateApplicationVisibility(false, document.querySelector('#GettingStartedContainerChildren .PORTLET-FRAGMENT'));
 }
 
 if (parentAppElement && parentAppElement.dataset.canClose === 'true') {
-  parentAppElement.closest('.PORTLET-FRAGMENT').classList.add('hidden');
+  Vue.prototype.$updateApplicationVisibility(false, parentAppElement);
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/LinksApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/LinksApp.vue
@@ -70,11 +70,7 @@ export default {
   },
   watch: {
     canView() {
-      if (this.canView) {
-        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
-      } else {
-        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.add('hidden');
-      }
+      this.$root.$updateApplicationVisibility(this.canView);
     }
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
@@ -93,11 +93,7 @@ export default {
   },
   watch: {
     displayApp() {
-      if (this.displayApp) {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
-      } else {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
-      }
+      this.$root.$updateApplicationVisibility(this.displayApp);
     }
   },
   created() {

--- a/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleAndSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleAndSpace.vue
@@ -69,11 +69,7 @@ export default {
       }
     },
     isVisible() {
-      if (this.isVisible) {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
-      } else {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
-      }
+      this.$root.$updateApplicationVisibility(this.isVisible);
     }
   },
   created() {
@@ -90,7 +86,7 @@ export default {
   },
   mounted() {
     if (!this.isVisible) {
-      this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
+      this.$root.$updateApplicationVisibility(false);
     }
   },
   methods: {

--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
@@ -38,11 +38,7 @@ export default {
   },
   watch: {
     display() {
-      if (this.display) {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
-      } else {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
-      }
+      this.$root.$updateApplicationVisibility(this.display);
     }
   },
   mounted() {

--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/main.js
@@ -29,7 +29,7 @@ export function init() {
     .then(() => {
       const onlineUsers = JSON.parse(document.getElementById('whoIsOnlineDefaultValue').value);
       if (!onlineUsers.length) {
-        document.querySelector('#OnlinePortlet').closest('.PORTLET-FRAGMENT').classList.add('hidden');
+        Vue.prototype.$updateApplicationVisibility(false, document.querySelector('#OnlinePortlet'));
       }
       if (onlineUsers && onlineUsers.length) {
         const avatars = JSON.parse(document.getElementById('whoIsOnlineAvatarsDefaultValue').value);


### PR DESCRIPTION
Prior to this change, each widget had to invoke the same instructions to hide/display hiddenable widgets. This change will ensure to centralize the behavior to improve evolutivity and maintainability. In addition, this will change the behavior to apply the `hidden` class on the parent element of the portlet instead of a child in order to allow disable Grid gap in new layout management addon.