### PR TITLE
fix: Fix Direct Access to Search application - MEED-3125 - Meeds-io/meeds#1486 (#3341)

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/search.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/search.jsp
@@ -61,7 +61,7 @@
       </button>
       <textarea id="searchConnectorsDefaultValue" class="d-none"><%= jsonSearchConnectors%></textarea>
       <textarea id="searchSkinUrlsDefaultValue" class="d-none"><%= skinUrlsString%></textarea>
-      <% if (rcontext.getRequestURI().endsWith("/search")) { %>
+      <% if (rcontext.getRequestURI().endsWith("/search") || rcontext.getRequestURI().equals("search")) { %>
       <script type="text/javascript">
         require(['PORTLET/social-portlet/Search'], app => app.init());
       </script>


### PR DESCRIPTION

Prior to this change, after having changed the Response of **RequestContext#getRequestURI** API in commit

https://github.com/Meeds-io/gatein-portal/commit/3aa055c808ebd6cbfe994356aa81ecf6ce2b21fe#diff-a01aa9a80ddf559954cba5e07d35dd1c78c4e747284ce8e5759e98893d5f9861, the request URI format isn't the same anymore. This change adds a workaround until a revert is done to make the direct access to Search Application possible.

(cherry picked from commit acacaa2a97f23cf92947763461f7700354a7d03c)
