### PR TITLE
feat: Detach Drawers from App to a Root element when sticky behavior - MEED-6227 - Meeds-io/MIPs#120

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -107,6 +107,10 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    detached: {
+      type: Boolean,
+      default: () => false,
+    },
     eager: {
       type: Boolean,
       default: () => false,
@@ -239,6 +243,11 @@ export default {
     document.addEventListener('closeAllDrawers', this.close);
     document.addEventListener('closeDisplayedDrawer', this.closeDisplayedDrawer);
     document.addEventListener('close-editor-container', this.closeDisplayedDrawer);
+  },
+  mounted() {
+    if (this.detached || this.$el.closest('.layout-sticky-application')) {
+      document.querySelector('#vuetify-apps').appendChild(this.$el);
+    }
   },
   beforeDestroy() {
     document.removeEventListener('modalOpened', this.setModalOpened);

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoModal.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoModal.vue
@@ -84,11 +84,15 @@ export default {
     }
   },
   created() {
-    $(document).on('keydown', (event) => {
-      if (event.key === 'Escape') {
-        this.dialog = false;
-      }
-    });
+    document.addEventListener('keydown', this.closeOnEscape);
+  },
+  mounted() {
+    if (this.$el.closest('.layout-sticky-application')) {
+      document.querySelector('#vuetify-apps').appendChild(this.$el);
+    }
+  },
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.closeOnEscape);
   },
   methods: {
     open() {
@@ -96,6 +100,11 @@ export default {
     },
     close() {
       this.dialog = false;
+    },
+    closeOnEscape(event) {
+      if (event.key === 'Escape') {
+        this.close();
+      }
     },
   }
 };


### PR DESCRIPTION
Prior to this change, when the stream or any application is configured as sticky, all drawers inside this application are badly displayed. This change ensures to display the drawer and dialog outside of Sticky applications which makes the Z-index not applied as for static and relative parent DOM elements.