### PR TITLE
fix: Update people card profile action extension point to be able to load a vue component as extension - EXO-71271 - Meeds-io/MIPs#127

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -151,19 +151,25 @@
         </div>
         <div
           v-if="!isSameUser"
-          class="ms-auto">
-          <v-btn
-            v-for="extension in filteredProfileActionExtensions"
-            :key="extension.id"
-            :aria-label="extension.title"
-            icon
-            @click.prevent="extension.click(user)">
-            <v-icon
-              :title="extension.title"
-              size="22">
-              {{ extension.class }}
-            </v-icon>
-          </v-btn>
+          class="ms-auto d-flex">
+          <span v-for="extension in filteredProfileActionExtensions"
+            :key="extension.id">
+            <v-btn
+              v-if="!extension.init"
+              :aria-label="extension.title"
+              icon
+              @click.prevent="extension.click(user)">
+              <v-icon
+                :title="extension.title"
+                size="22">
+                {{ extension.class }}
+              </v-icon>
+            </v-btn>
+            <span v-else
+              :class="`${extension.appClass} ${extension.typeClass}`"
+              :ref="extension.id">
+            </span>
+          </span>
         </div>
       </v-card-actions>
     </v-card>
@@ -275,6 +281,9 @@ export default {
   created() {
     document.addEventListener('mousedown',  this.closeMenu);
   },
+  mounted() {
+    this.initExtensions();
+  },
   methods: {
     closeMenu() {
       if (this.menu) {
@@ -282,6 +291,17 @@ export default {
           this.menu = false;
         }, 200);
       }
+    },
+    initExtensions() {
+      this.filteredProfileActionExtensions.forEach((extension) => {
+        if (extension.init) {
+          let container = this.$refs[extension.id];
+          if (container && container.length > 0) {
+            container = container[0];
+            extension.init(container, this.user.username);
+          }
+        }
+      });
     }
   }
 };


### PR DESCRIPTION
Before this fix, the extension point in user card for profile action, is only able to display and icon, with a onclick action. In some cases, we need to load a complete vue component. This fix update the extension point to able to load such component

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
