### PR TITLE
fix: Fix WhoIsOnline App display using New Layout Manager - MEED-5942 - Meeds-io/MIPs#120

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
@@ -45,7 +45,7 @@ export default {
     this.$root.$applicationLoaded();
   },
   created() {
-    if (document.readyState === 'complete' && !this.loaded) {
+    if (document.readyState === 'complete') {
       this.init();
     } else {
       document.onreadystatechange = () => {
@@ -53,15 +53,21 @@ export default {
           this.init();
         }
       };
+      window.setTimeout(() => {
+        if (!this.loaded) {
+          this.init();
+        }
+      }, 2000);
     }
+    if (window.whosOnlineInterval) {
+      window.clearInterval(window.whosOnlineInterval);
+    }
+    window.whosOnlineInterval = window.setInterval(() => this.retrieveOnlineUsers(), this.delay);
   },
   methods: {
     init() {
-      this.loaded=true;
+      this.loaded = true;
       this.initOnlineUsers(this.$root.onlineUsers && this.$root.onlineUsers.users || []);
-      setInterval(function () {
-        this.retrieveOnlineUsers();
-      }.bind(this), this.delay);
     },
     retrieveOnlineUsers() {
       return whoIsOnlineServices.getOnlineUsers(eXo.env.portal.spaceId)


### PR DESCRIPTION
Prior to this change, the WhoIsOnline application isn't displayed when added in a new page using layout manager. This is due to missing initialisation phase execution once the portlet is added into the page after the 'complete' phase is done. This change ensures to init the app once loaded using new layout manager mechanism.