### PR TITLE
fix: fix enabled/disabled button in about me section in user's profile according to chars number

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
@@ -76,7 +76,7 @@ export default {
   }),
   computed: {
     valid() {
-      return !this.modifyingAboutMe || this.modifyingAboutMe.length <= this.maxLength;
+      return !this.modifyingAboutMe || this.$utils.htmlToText(this.modifyingAboutMe).length <= this.maxLength;
     },
     title() {
       return this.owner && this.$t('profileAboutYouself.title') || this.$t('profileAboutMe.title');


### PR DESCRIPTION
prior to this change, in about me section, when a user add a text containing format options through ckeditor, the save button gets disabled before reaching the maximum number of chars which is set to 1300 because the count takes into account the length html tags too.
to fix this I proceeded to call the existing "htmlToText" method from utils file, so the save button gets disabled only if the number of chars exceeds 1300.