### PR TITLE
fix: Update people card profile action extension point to be able to load a vue component as extension - EXO-71271 - Meeds-io/MIPs#127

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/common/ProfileCard/Style-mobile.less
+++ b/webapp/portlet/src/main/webapp/skin/less/common/ProfileCard/Style-mobile.less
@@ -86,7 +86,7 @@
 
 #peopleCompactCardBottomDrawer {
   .itemIconSize {
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
   }
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleCompactCardOptionsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleCompactCardOptionsDrawer.vue
@@ -26,21 +26,28 @@
     <template slot="content">
       <v-list dense>
         <v-list-item-group>
-          <v-list-item
-            v-for="(extension, i) in profileActionExtensions"
-            :key="i"
-            @click="triggerExtension(extension)">
-            <v-list-item-title class="align-center d-flex">
-              <v-icon
-                class="ms-4 me-2 itemIconSize"
-                size="18">
-                {{ extension.class }}
-              </v-icon>
-              <span class="mx-2">
-                {{ extension.title || $t(extension.titleKey) }}
-              </span>
-            </v-list-item-title>
-          </v-list-item>
+          <span v-for="(extension, i) in profileActionExtensions"
+            :key="i">
+            <v-list-item
+              v-if="!extension.init"
+              @click="triggerExtension(extension)">
+                <v-list-item-title class="align-center d-flex">
+                <v-icon
+                  class="ms-4 me-2 itemIconSize"
+                  size="20">
+                  {{ extension.class }}
+                </v-icon>
+                <span class="mx-2">
+                  {{ extension.title || $t(extension.titleKey) }}
+                </span>
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item
+              v-else
+              :class="`${extension.appClass} ${extension.typeClass}`"
+              :ref="extension.id">
+            </v-list-item>
+          </span>
         </v-list-item-group>
         <v-divider
           v-if="spaceMembersExtensions.length"
@@ -53,7 +60,7 @@
             <v-list-item-title class="align-center d-flex">
               <v-icon
                 class="ms-4 me-2 itemIconSize"
-                size="18">
+                size="20">
                 {{ extension.class }}
               </v-icon>
               <span class="mx-2">
@@ -90,6 +97,21 @@ export default {
       this.profileActionExtensions = profileActions;
       this.spaceMembersExtensions = spaceMembersActions;
       this.$refs.userOptionsDrawer.open();
+      this.$nextTick().then(() => {
+        this.initExtensions();
+      });
+    },
+    initExtensions() {
+      this.profileActionExtensions.forEach((extension) => {
+        if (extension.init) {
+          let container = this.$refs[extension.id];
+          if (container && container.length > 0) {
+            container = container[0].$el;
+            container.innerHTML='';
+            extension.init(container, this.user.username);
+          }
+        }
+      });
     }
   }
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -144,7 +144,7 @@
             @click.prevent="extension.click(user)">
             <v-icon
               :title="extension.title"
-              size="22">
+              size="20">
               {{ extension.class }}
             </v-icon>
           </v-btn>
@@ -161,7 +161,7 @@
               @click.prevent="extension.click(user)">
               <v-icon
                 :title="extension.title"
-                size="22">
+                size="20">
                 {{ extension.class }}
               </v-icon>
             </v-btn>

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
@@ -6,16 +6,18 @@
     flat
     tile>
     <div class="d-flex justify-end flex-wrap my-auto">
-      <v-btn
-        v-for="(extension, i) in enabledProfileActionExtensions"
-        :key="i"
-        class="btn ma-2 mb-0"
-        @click="extension.click(user)">
-        <i :class="extension.icon ? extension.icon : 'hidden'" class="uiIcon"></i>
-        <span class="buttonText">
-          {{ extension.title }}
-        </span>
-      </v-btn>
+      <span v-for="(extension, i) in enabledProfileActionExtensions"
+        :key="i">
+        <v-btn
+          class="btn ma-2 mb-0"
+          @click="extension.click(user)"
+          v-if="!extension.init">
+          <i :class="extension.icon ? extension.icon : 'hidden'" class="uiIcon"></i>
+          <span class="buttonText">
+            {{ extension.title }}
+          </span>
+        </v-btn>
+      </span>
       <div v-if="invited" class="invitationButtons d-inline">
         <v-dialog
           v-model="mobileAcceptRefuseConnectionDialog"


### PR DESCRIPTION
Before this fix, the extension point in user card for profile action, is only able to display and icon, with a onclick action. In some cases, we need to load a complete vue component. This commit manage mobile case, in addition to Profile case (which use the same extension point)

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
