### PR TITLE
feat: Change the  display of see more of collapsed activity -  MEED-5901 - Meeds-io/MIPs#124

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <div
+    :class="collapsed && !fullContent && readMore && 'mb-3'"
+    class="position-relative">
     <dynamic-html-element
       v-if="isBodyNotEmpty"
       :child="bodyElement"
@@ -9,7 +11,7 @@
       dir="auto" />
     <v-btn
       v-if="collapsed && !fullContent && readMore"
-      class="d-flex ml-auto mb-3"
+      class="d-flex ml-auto pb-1 mb-0 pl-2 pr-0 height-auto position-absolute r-0 b-0 application-background hover-underline"
       color="blue"
       text
       plain

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -89,7 +89,7 @@
           {{ defaultIconClass }}
         </v-icon>
       </v-avatar>
-      <div class="my-4">
+      <div class="my-4 position-relative">
         <dynamic-html-element
           v-if="title"
           :child="titleElement"
@@ -105,7 +105,7 @@
           dir="auto" />
         <v-btn
           v-if="showReadMore"
-          class="d-flex ml-auto mb-3"
+          class="d-flex ml-auto  pb-1 mb-0 pl-2 pr-0 height-auto position-absolute r-0 b-0 application-background hover-underline"
           color="blue"
           text
           plain


### PR DESCRIPTION
This change allows to edit the display of the see more label at the end of the collapsed content with an underline decoration when user hover it.
