### PR TITLE
fix: Unexpected attributes displayed - EXO-71322 - Meeds-io/meeds#1915 (#3717)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -434,7 +434,7 @@ public class EntityBuilder {
 
     Map<Long, ProfilePropertySettingEntity> properties = new HashMap<>();
     ProfilePropertyService profilePropertyService = CommonsUtils.getService(ProfilePropertyService.class);
-    List<ProfilePropertySetting> settings = profilePropertyService.getPropertySettings();
+    List<ProfilePropertySetting> settings = profilePropertyService.getPropertySettings().stream().filter(prop -> prop.isVisible() || prop.isEditable()).toList();
     List<ProfilePropertySetting> subProperties = new ArrayList<>();
     List<Long> parents = new ArrayList<>();
     boolean internal = false;

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/ProfileSettingsRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/ProfileSettingsRest.java
@@ -31,6 +31,7 @@ import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.rest.entity.ProfilePropertySettingEntity;
@@ -52,6 +53,8 @@ import java.util.Map;
 public class ProfileSettingsRest implements ResourceContainer {
 
   private static final Log LOG = ExoLogger.getLogger(ProfileSettingsRest.class);
+
+  private static final String GROUP_ADMINISTRATORS = "/platform/administrators";
 
   private final ProfilePropertyService profilePropertyService;
 
@@ -80,6 +83,9 @@ public class ProfileSettingsRest implements ResourceContainer {
     }
     try {
       List<ProfilePropertySetting> properties = profilePropertyService.getPropertySettings();
+      if (!ConversationState.getCurrent().getIdentity().isMemberOf(GROUP_ADMINISTRATORS)) {
+        properties = properties.stream().filter(prop -> prop.isVisible() || prop.isEditable()).toList();
+      }
       List<String> unHiddenbaleProperties = profilePropertyService.getUnhiddenableProfileProperties();
       List<String> excludedQuickSearchProperties = profilePropertyService.getExcludedQuickSearchProperties();
       List<ProfilePropertySettingEntity> propertySettingEntities =

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -16,55 +16,22 @@
  */
 package org.exoplatform.social.rest.impl.user;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import static org.exoplatform.social.rest.api.RestUtils.*;
+
+import java.io.*;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
-import jakarta.servlet.http.HttpServletRequest;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.CacheControl;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.EntityTag;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Request;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.picocontainer.Startable;
@@ -81,14 +48,7 @@ import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.rest.UserFieldValidator;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.Group;
-import org.exoplatform.services.organization.Membership;
-import org.exoplatform.services.organization.MembershipType;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.Query;
-import org.exoplatform.services.organization.User;
-import org.exoplatform.services.organization.UserHandler;
-import org.exoplatform.services.organization.UserStatus;
+import org.exoplatform.services.organization.*;
 import org.exoplatform.services.organization.idm.UserImpl;
 import org.exoplatform.services.organization.search.UserSearchService;
 import org.exoplatform.services.resources.LocaleConfigService;
@@ -107,6 +67,7 @@ import org.exoplatform.social.core.model.AvatarAttachment;
 import org.exoplatform.social.core.model.BannerAttachment;
 import org.exoplatform.social.core.profile.ProfileFilter;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.relationship.model.Relationship;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.SpaceUtils;
@@ -114,22 +75,8 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.IdentityStorageException;
 import org.exoplatform.social.metadata.thumbnail.ImageThumbnailService;
-import org.exoplatform.social.rest.api.EntityBuilder;
-import org.exoplatform.social.rest.api.ErrorResource;
-import org.exoplatform.social.rest.api.RestUtils;
-import org.exoplatform.social.rest.api.UserImportResultEntity;
-import org.exoplatform.social.rest.api.UserRestResources;
-import org.exoplatform.social.rest.entity.ActivityEntity;
-import org.exoplatform.social.rest.entity.CollectionEntity;
-import org.exoplatform.social.rest.entity.DataEntity;
-import org.exoplatform.social.rest.entity.ExperienceEntity;
-import org.exoplatform.social.rest.entity.IMEntity;
-import org.exoplatform.social.rest.entity.PhoneEntity;
-import org.exoplatform.social.rest.entity.ProfileEntity;
-import org.exoplatform.social.rest.entity.ProfilePropertySettingEntity;
-import org.exoplatform.social.rest.entity.SpaceEntity;
-import org.exoplatform.social.rest.entity.URLEntity;
-import org.exoplatform.social.rest.entity.UserEntity;
+import org.exoplatform.social.rest.api.*;
+import org.exoplatform.social.rest.entity.*;
 import org.exoplatform.social.rest.impl.activity.ActivityRestResourcesV1;
 import org.exoplatform.social.service.rest.Util;
 import org.exoplatform.social.service.rest.api.VersionResources;
@@ -144,8 +91,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import static org.exoplatform.social.rest.api.RestUtils.*;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * 
@@ -593,7 +539,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     String expandedSettings = expand;
     if (expand != null && expand.contains("settings")) {
       expandedSettings =
-                       String.valueOf(Objects.hash(EntityBuilder.buildEntityProfilePropertySettingList(profilePropertyService.getPropertySettings(),
+              String.valueOf(Objects.hash(EntityBuilder.buildEntityProfilePropertySettingList(profilePropertyService.getPropertySettings().stream().filter(prop -> prop.isVisible() || prop.isEditable()).toList(),
                                                                                                        profilePropertyService,
                                                                                                        ProfilePropertyService.LABELS_OBJECT_TYPE,
                                                                                                        Long.parseLong(identity.getId()))));

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -1,6 +1,6 @@
 package org.exoplatform.social.rest.impl.users;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,17 +18,11 @@ import javax.imageio.ImageIO;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.ObjectAlreadyExistsException;
-import org.exoplatform.social.core.jpa.search.ProfileSearchConnector;
-import org.exoplatform.social.core.jpa.storage.RDBMSIdentityStorageImpl;
-import org.exoplatform.social.core.model.ProfileLabel;
-import org.exoplatform.social.core.profilelabel.ProfileLabelService;
-import org.exoplatform.social.core.storage.api.IdentityStorage;
-import org.exoplatform.social.rest.entity.ProfilePropertySettingEntity;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mortbay.cometd.continuation.EXoContinuationBayeux;
 
+import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.utils.IOUtil;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.portal.config.UserACL;
@@ -43,10 +37,14 @@ import org.exoplatform.services.user.UserStateService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.jpa.search.ProfileSearchConnector;
+import org.exoplatform.social.core.jpa.storage.RDBMSIdentityStorageImpl;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.manager.RelationshipManager;
 import org.exoplatform.social.core.mock.MockUploadService;
+import org.exoplatform.social.core.model.ProfileLabel;
+import org.exoplatform.social.core.profilelabel.ProfileLabelService;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.service.LinkProvider;
@@ -59,6 +57,7 @@ import org.exoplatform.social.rest.api.UserImportResultEntity;
 import org.exoplatform.social.rest.entity.CollectionEntity;
 import org.exoplatform.social.rest.entity.DataEntity;
 import org.exoplatform.social.rest.entity.ProfileEntity;
+import org.exoplatform.social.rest.entity.ProfilePropertySettingEntity;
 import org.exoplatform.social.rest.impl.activity.ActivityRestResourcesV1;
 import org.exoplatform.social.rest.impl.user.UserRestResourcesV1;
 import org.exoplatform.social.service.test.AbstractResourceTest;
@@ -161,18 +160,24 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     ProfilePropertySetting urlsPropertySetting = new ProfilePropertySetting();
     urlsPropertySetting.setPropertyName("urls");
     urlsPropertySetting.setMultiValued(true);
+    urlsPropertySetting.setVisible(true);
+    urlsPropertySetting.setEditable(true);
     urlsPropertySetting = profilePropertyService.createPropertySetting(urlsPropertySetting);
     tearDownProfilePropertyList.add(urlsPropertySetting);
 
     // Create profile properties
     ProfilePropertySetting phonesPropertySetting = new ProfilePropertySetting();
     phonesPropertySetting.setPropertyName("phones");
+    phonesPropertySetting.setVisible(true);
+    phonesPropertySetting.setEditable(true);
     phonesPropertySetting = profilePropertyService.createPropertySetting(phonesPropertySetting);
     tearDownProfilePropertyList.add(phonesPropertySetting);
 
     ProfilePropertySetting workPhonePropertySetting = new ProfilePropertySetting();
     workPhonePropertySetting.setPropertyName("phones.work");
     workPhonePropertySetting.setMultiValued(false);
+    workPhonePropertySetting.setVisible(true);
+    workPhonePropertySetting.setEditable(true);
     workPhonePropertySetting.setParentId(phonesPropertySetting.getId());
     workPhonePropertySetting = profilePropertyService.createPropertySetting(workPhonePropertySetting);
     tearDownProfilePropertyList.add(workPhonePropertySetting);
@@ -180,6 +185,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     ProfilePropertySetting homePhonePropertySetting = new ProfilePropertySetting();
     homePhonePropertySetting.setPropertyName("phones.home");
     homePhonePropertySetting.setMultiValued(false);
+    homePhonePropertySetting.setVisible(true);
+    homePhonePropertySetting.setEditable(true);
     homePhonePropertySetting.setParentId(phonesPropertySetting.getId());
     homePhonePropertySetting = profilePropertyService.createPropertySetting(homePhonePropertySetting);
     tearDownProfilePropertyList.add(homePhonePropertySetting);
@@ -188,12 +195,16 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     ProfilePropertySetting imsPropertySetting = new ProfilePropertySetting();
     imsPropertySetting.setPropertyName("ims");
     imsPropertySetting.setMultiValued(false);
+    imsPropertySetting.setVisible(true);
+    imsPropertySetting.setEditable(true);
     imsPropertySetting = profilePropertyService.createPropertySetting(imsPropertySetting);
     tearDownProfilePropertyList.add(imsPropertySetting);
 
     ProfilePropertySetting facebookPropertySetting = new ProfilePropertySetting();
     facebookPropertySetting.setPropertyName("ims.facebook");
     facebookPropertySetting.setMultiValued(false);
+    facebookPropertySetting.setVisible(true);
+    facebookPropertySetting.setEditable(true);
     facebookPropertySetting.setParentId(imsPropertySetting.getId());
     facebookPropertySetting = profilePropertyService.createPropertySetting(facebookPropertySetting);
     tearDownProfilePropertyList.add(facebookPropertySetting);
@@ -203,6 +214,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
           ProfilePropertySetting basicProfilePropertySetting = new ProfilePropertySetting();
           basicProfilePropertySetting.setPropertyName(profileProperty);
           basicProfilePropertySetting.setMultiValued(false);
+      basicProfilePropertySetting.setVisible(true);
           try {
             basicProfilePropertySetting = profilePropertyService.createPropertySetting(basicProfilePropertySetting);
             tearDownProfilePropertyList.add(basicProfilePropertySetting);
@@ -490,6 +502,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
     ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting();
     profilePropertySetting.setPropertyName(Profile.LOCATION);
+    profilePropertySetting.setEditable(true);
     profilePropertyService.createPropertySetting(profilePropertySetting);
     ContainerResponse response1 = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
     String etag1 = response1.getHttpHeaders().get("etag").toString();
@@ -500,7 +513,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     label.setLabel("labelTest");
     label.setLanguage("en");
     label.setObjectType("profileProperty");
-    label.setObjectId(profilePropertyService.getProfileSettingByName(Profile.FIRST_NAME).getId().toString());
+    label.setObjectId(profilePropertyService.getProfileSettingByName(Profile.LOCATION).getId().toString());
     profileLabelService.createLabel(label);
     ContainerResponse response2 = service("GET", getURLResource("users/john?expand=settings"), "", null, null);
     String etag2 = response2.getHttpHeaders().get("etag").toString();


### PR DESCRIPTION
Prior to this change, all attributes are displayed on the edit mode of profile of all users, this may display some technical/private data to all users, so only editable or visible attributes should be visible in the edit drawer of profiles. This fix filter the list of attributes to be retrieved to simple users.

(cherry picked from commit c29f0652c2fbc083575726168dbc3d04bf3fde2d)