### PR TITLE
feat: rename the org chart extension to load it on popver - Meeds-io/meeds#112 - EXO-71405

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1905,9 +1905,6 @@
         <module>vuetify</module>
       </depends>
       <depends>
-        <module>organizationalChartExtension</module>
-      </depends>
-      <depends>
         <module>translationField</module>
       </depends>
       <depends>
@@ -2032,9 +2029,6 @@
       <module>vuetify</module>
     </depends>
     <depends>
-      <module>organizationalChartExtension</module>
-    </depends>
-    <depends>
       <module>eXoVueI18n</module>
     </depends>
     <depends>
@@ -2098,9 +2092,6 @@
       <minify>false</minify>
       <path>/js/peopleListComponents.bundle.js</path>
     </script>
-    <depends>
-      <module>organizationalChartExtension</module>
-    </depends>
     <depends>
       <module>commonVueComponents</module>
     </depends>
@@ -2831,7 +2822,8 @@
   </module>
 
   <module>
-    <name>organizationalChartExtension</name>
+    <name>organizationalChartPopoverExtension</name>
+    <load-group>popoverGRP</load-group>
     <script>
       <minify>false</minify>
       <path>/js/organizationalChartExtension.bundle.js</path>

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/main.js
@@ -3,8 +3,9 @@ import {registerExtension} from './extensions.js';
 const lang = eXo?.env?.portal?.language || 'en';
 
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Portlets-${lang}.json`;
-
-exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-  registerExtension(i18n.t('organizationalChart.header.label'));
-});
+export function init() {
+  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+    registerExtension(i18n.t('organizationalChart.header.label'));
+  });
+}
 


### PR DESCRIPTION
in this fix we renamed the AMD module of the organization chart extensions to make it load automatically with the User Popover 