### PR TITLE
feat: Display user contribution comment when unread - MEED-5944 - Meeds-io/MIPs#124

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -239,7 +239,8 @@ export default {
             || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'LikeComment';
         const isNewCommentAction = this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityComment'
             || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'ActivityReplyToComment'
-            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'EditComment';
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'EditComment'
+            || this.activity?.metadatas?.unread[0]?.properties?.actionType === 'GamificationActionAnnouncedNotification';
         this.isRead = this.unreadMetadata && !isLikeAction && !isNewCommentAction;
         this.hasNewComment = this.unreadMetadata && isNewCommentAction;
       }

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -11,6 +11,7 @@
       dir="auto" />
     <v-btn
       v-if="collapsed && !fullContent && readMore"
+      :aria-label="$t('UIActivity.label.seeMore')"
       class="d-flex ml-auto pb-1 mb-0 pl-2 pr-0 height-auto position-absolute r-0 b-0 application-background hover-underline"
       color="blue"
       text

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -105,6 +105,7 @@
           dir="auto" />
         <v-btn
           v-if="showReadMore"
+          :aria-label="$t('UIActivity.label.seeMore')"
           class="d-flex ml-auto  pb-1 mb-0 pl-2 pr-0 height-auto position-absolute r-0 b-0 application-background hover-underline"
           color="blue"
           text


### PR DESCRIPTION
Prior to this change, when contributor add a new contribution to an action, the comment is hidden even the activity is marked as unread.
This PR ensures that the comment remains displayed if the activity is unread.