### PR TITLE
fix: bug - redirection ko following space binding - EXO-71024 - Meeds-io/meeds#1919

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationManageSpaces.vue
@@ -369,7 +369,7 @@ export default {
     goToBindingReports() {
       this.showGroupBindingForm = false;
       this.$emit('bindingReports');
-      this.navigateTo('g/:platform:users/spacesAdministration#bindingReports');
+      this.navigateTo('administration/home/organisation/spaces');
       this.forceRerender();
     },
     navigateTo(pagelink) {


### PR DESCRIPTION
Prior to this change, when user try to bind a space with a group the redirection is KO since the space administarton page was moved to the new settings page. This fix chage the redirection url to the new page.