### PR TITLE
fix: Fix Drawer Display when Sticky parent containers - MEED-5304 - Meeds-io/MIPs#131

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -261,7 +261,12 @@ export default {
   },
   methods: {
     open() {
-      this.drawer = true;
+      if (this.$el?.closest?.('.layout-sticky-application')) {
+        document.querySelector('#vuetify-apps').appendChild(this.$el);
+        this.$nextTick().then(() => this.drawer = true);
+      } else {
+        this.drawer = true;
+      }
     },
     setModalOpened() {
       this.modalOpened = this.drawer;


### PR DESCRIPTION
Prior to this change, when the sticky behavior is applied on parent container, the drawers inside applications aren't correctly displayed. This change ensure to display the drawers correctly by mounting them in a parent element outside of the application to not have the bad display which due to sticky position style.