### PR TITLE
fix: Fix Hamburger Menu Hiding on key down - MEED-6349 - Meeds-io/meeds#1835

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/portlet/HamburgerMenu/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/HamburgerMenu/Style.less
@@ -72,7 +72,7 @@
     display: none;
   }
   
-  .UserPageLink:hover .homePage {
+  .UserPageLink:hover .homePage, .UserPageLink:focus .homePage, .UserPageLink button:focus .homePage {
     display: flex;
   }
 

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/HamburgerMenuParentSticky.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/HamburgerMenuParentSticky.vue
@@ -20,7 +20,7 @@
 -->
 <template>
   <v-menu
-    :value="true"
+    v-model="menu"
     :absolute="false"
     :close-on-click="false"
     :close-on-content-click="false"
@@ -29,6 +29,8 @@
     :role="null"
     max-width="none"
     attach="#ParentSiteStickyMenu"
+    disable-keys
+    disabled
     eager
     tile>
     <slot></slot>
@@ -52,6 +54,7 @@ export default {
   },
   data: () => ({
     open: false,
+    menu: true,
     componentId: `sticky-menu-${parseInt(Math.random() * 65536)}`,
     extraClass: '',
   }),
@@ -63,6 +66,11 @@ export default {
         window.setTimeout(() => {
           this.extraClass = '';
         }, 300);
+      }
+    },
+    menu() {
+      if (!this.menu) {
+        this.$nextTick().then(() => this.menu = true);
       }
     },
     open() {


### PR DESCRIPTION
Prior to this change, when hitting Tab key twice after the page display, the Left Menu disappears. This change ensures to not hide the Hamburger Menu using Vuetify inner events by forcing to reopen the menu just after changing it.