### PR TITLE
fix: Fix Display of People Menu item icon - MEED-6656 - Meeds-io/meeds#1931

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardFront.vue
@@ -110,8 +110,11 @@
               :key="i"
               @click="extension.click(user)">
               <v-list-item-title class="align-center d-flex">
-                <v-icon
-                  size="18">
+                <i
+                  v-if="extension.icon"
+                  :class="extension.icon"
+                  class="uiIcon"></i>
+                <v-icon v-else size="18">
                   {{ extension.class }}
                 </v-icon>
                 <span class="mx-2">


### PR DESCRIPTION
Prior to this change, the Space Members Three dots menu items doesn't display its icons. This change will allow to display it knowing that not all extensions has changed its icons to use FA or MDI.

(Resolves https://github.com/Meeds-io/meeds/issues/1931)