### PR TITLE
fix: bug - Some actions on people ui glitches the filter - EXO-71049 - Meeds-io/meeds#1956

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -105,6 +105,7 @@ export default {
     limitToFetch: 0,
     originalLimitToFetch: 0,
     abortController: null,
+    advancedFilter: null,
   }),
   computed: {
     profileActionExtensions() {
@@ -152,7 +153,7 @@ export default {
 
     // To broadcast event about current page supporting profile extensions
     document.dispatchEvent(new CustomEvent('profile-extension-init'));
-    this.$root.$on('reset-advanced-filter', this.searchPeople);
+    this.$root.$on('reset-advanced-filter', this.resetAdvancedFilter);
 
     this.$root.$on('advanced-filter', profileSettings => this.getUsersByadvancedfilter(profileSettings));
 
@@ -181,6 +182,8 @@ export default {
           || this.filter === 'redactor'
           || this.filter === 'publisher') {
         searchUsersFunction = this.$spaceService.getSpaceMembers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.filter, this.spaceId, this.abortController.signal);
+      } else if (this.advancedFilter) {
+        searchUsersFunction = this.$userService.getUsersByAdvancedFilter(this.advancedFilter, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve,this.filter, this.abortController.signal);
       } else {
         searchUsersFunction = this.$userService.getUsers(this.keyword, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve, this.abortController.signal, true);
       }
@@ -211,11 +214,15 @@ export default {
         this.limitToFetch = this.originalLimitToFetch;
       }
     },
+    resetAdvancedFilter() {
+      this.advancedFilter = null;
+      this.searchPeople();
+    },
     loadNextPage() {
       this.originalLimitToFetch = this.limitToFetch += this.pageSize;
     },
     getUsersByadvancedfilter(profileSettings) {
-
+      this.advancedFilter=profileSettings;
       this.loadingPeople = true;
       // Using 'limitToFetch + 1' to retrieve current user and then delete it from result
       // to finally let only 'limitToFetch' users


### PR DESCRIPTION
Prior to this change, when user search for people using the advanced filter then click on a any action of the peaple card, the list of users is refreshed and the filter in igonred, the fix take into account the advaced filter when refreshing the list of users
