### PR TITLE
feat: hide Org chart content and remove extensions when the field manager is inactive - Meeds-io/meeds#112 - EXO-71333

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/profileproperty/model/ProfilePropertySetting.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profileproperty/model/ProfilePropertySetting.java
@@ -53,4 +53,6 @@ public class ProfilePropertySetting {
   private boolean isMultiValued;
 
   private Long    id;
+
+  private Long    updated;
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
@@ -24,6 +24,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 
 import jakarta.persistence.*;
 import java.io.Serializable;
+import java.util.Date;
 
 @Entity(name = "SocProfileSettingEntity")
 @ExoEntity
@@ -76,6 +77,10 @@ public class ProfilePropertySettingEntity implements Serializable {
 
   @Column(name = "PROPERTY_TYPE")
   private String propertyType;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "UPDATED_DATE", nullable = false)
+  private Date updatedDate      = new Date();
 
   public Long getId() {
     return id;
@@ -171,6 +176,14 @@ public class ProfilePropertySettingEntity implements Serializable {
 
   public void setPropertyType(String propertyType) {
     this.propertyType = propertyType;
+  }
+
+  public Date getUpdatedDate() {
+    return updatedDate;
+  }
+
+  public void setUpdatedDate(Date updatedDate) {
+    this.updatedDate = updatedDate;
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
@@ -150,6 +150,7 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     if (!isGroupSynchronizedEnabledProperty(profilePropertySetting)) {
       profilePropertySetting.setGroupSynchronized(false);
     }
+    profilePropertySetting.setUpdated(System.currentTimeMillis());
     profilePropertySetting = profileSettingStorage.saveProfilePropertySetting(profilePropertySetting, true);
     if (profilePropertySetting.getOrder() == null) {
       profilePropertySetting.setOrder(profilePropertySetting.getId());
@@ -176,6 +177,7 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     if (createdProfilePropertySetting != null) {
       profilePropertySetting.setPropertyType(createdProfilePropertySetting.getPropertyType());
     }
+    profilePropertySetting.setUpdated(System.currentTimeMillis());
     profileSettingStorage.saveProfilePropertySetting(profilePropertySetting, false);
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
@@ -20,6 +20,7 @@
 
 package org.exoplatform.social.core.profileproperty.storage;
 
+import java.util.Date;
 import java.util.List;
 
 import org.exoplatform.social.core.jpa.storage.dao.jpa.ProfilePropertySettingDAO;
@@ -51,6 +52,7 @@ public class ProfileSettingStorage {
   }
 
   public ProfilePropertySetting saveProfilePropertySetting(ProfilePropertySetting profilePropertySetting, boolean isNew) {
+    profilePropertySetting.setUpdated(System.currentTimeMillis());
     if (isNew) {
       ProfilePropertySettingEntity newProfilePropertySettingEntity =
                                                                    profilePropertySettingDAO.create(convertToEntity(profilePropertySetting));
@@ -81,6 +83,7 @@ public class ProfileSettingStorage {
     profilePropertySettingEntity.setMultiValued(profilePropertySetting.isMultiValued());
     profilePropertySettingEntity.setHiddenable(profilePropertySetting.isHiddenbale());
     profilePropertySettingEntity.setPropertyType(profilePropertySetting.getPropertyType());
+    profilePropertySettingEntity.setUpdatedDate(new Date(profilePropertySetting.getUpdated()));
     return profilePropertySettingEntity;
   }
 
@@ -101,6 +104,7 @@ public class ProfileSettingStorage {
     profilePropertySetting.setMultiValued(profilePropertySettingEntity.isMultiValued());
     profilePropertySetting.setHiddenbale(profilePropertySettingEntity.isHiddenable());
     profilePropertySetting.setPropertyType(profilePropertySettingEntity.getPropertyType());
+    profilePropertySetting.setUpdated(profilePropertySettingEntity.getUpdatedDate().getTime());
     return profilePropertySetting;
   }
 

--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -933,4 +933,12 @@
         </sql>
     </changeSet>
 
+    <changeSet author="social" id="1.0.0-96">
+      <addColumn tableName="SOC_PROFILE_PROPERTY_SETTING">
+        <column name="UPDATED_DATE" type="TIMESTAMP" defaultValueDate="${now}">
+          <constraints nullable="false"/>
+        </column>
+      </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -1703,6 +1703,7 @@ public class EntityBuilder {
     profilePropertySettingEntity.setGroupSynchronized(profilePropertySetting.isGroupSynchronized());
     profilePropertySettingEntity.setRequired(profilePropertySetting.isRequired());
     profilePropertySettingEntity.setOrder(profilePropertySetting.getOrder());
+    profilePropertySettingEntity.setUpdated(profilePropertySetting.getUpdated());
     profilePropertySettingEntity.setMultiValued(profilePropertySetting.isMultiValued());
     profilePropertySettingEntity.setGroupSynchronizationEnabled(profilePropertyService.isGroupSynchronizedEnabledProperty(profilePropertySetting));
     profilePropertySettingEntity.setHiddenable(profilePropertyService.isPropertySettingHiddenable(profilePropertySetting));
@@ -1776,6 +1777,7 @@ public class EntityBuilder {
     profilePropertySetting.setMultiValued(profilePropertySettingEntity.isMultiValued());
     profilePropertySetting.setHiddenbale(profilePropertySettingEntity.isHiddenable());
     profilePropertySetting.setPropertyType(profilePropertySettingEntity.getPropertyType());
+    profilePropertySetting.setUpdated(profilePropertySettingEntity.getUpdated());
     return profilePropertySetting;
   }
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
@@ -60,6 +60,8 @@ public class ProfilePropertySettingEntity {
 
   private boolean                            isInternal;
 
+  private Long                               updated;
+
   private boolean                            isGroupSynchronizationEnabled;
 
   private boolean                            toHide;

--- a/webapp/portlet/package-lock.json
+++ b/webapp/portlet/package-lock.json
@@ -8668,9 +8668,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -905,3 +905,4 @@ organizationalChart.displayedUser.disabled.message=User from which the organizat
 organizationalChart.displayedUser.settings.disabled=This settings can't be changed
 organizationalChart.download.pdf.error=Error while downloading pdf
 organizationalChart.download.label=Download
+organizationalChart.property.manager.disabled=The organization chart is not available, the attribute manager should be activated by an administrator. 

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/organizationalChart.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/organizationalChart.jsp
@@ -7,6 +7,8 @@
 <%@ page import="org.exoplatform.social.core.space.model.Space" %>
 <%@ page import="org.exoplatform.social.core.space.spi.SpaceService" %>
 <%@ page import="org.exoplatform.social.core.space.SpaceUtils" %>
+<%@ page import="org.exoplatform.social.core.profileproperty.ProfilePropertyService" %>
+<%@ page import="org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting" %>
 <%@ page import="java.util.Objects" %>
 <%@ page import="org.exoplatform.social.webui.Utils" %>
 <%@ page import="javax.portlet.PortletPreferences" %>
@@ -20,6 +22,8 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 <portlet:defineObjects/>
 <%
+    ProfilePropertyService profilePropertyService = CommonsUtils.getService(ProfilePropertyService.class);
+    ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName("manager");
     String appObjectType = "organizationalChart";
     String id = UIPortlet.getCurrentUIPortlet().getStorageId();
     String applicationId =  appObjectType + id;
@@ -48,10 +52,10 @@
     if (centerUser == null) {
         centerUser = preferences.getValue("centerUser", null);
     }
+    ResourceBundleService resourceBundleService = CommonsUtils.getService(ResourceBundleService.class);
+    ResourceBundle resourceBundle = resourceBundleService.getResourceBundle("locale.portlet.Portlets", request.getLocale());
     if (headerTitle == null) {
         try {
-            ResourceBundleService resourceBundleService = CommonsUtils.getService(ResourceBundleService.class);
-            ResourceBundle resourceBundle = resourceBundleService.getResourceBundle("locale.portlet.Portlets", request.getLocale());
             headerTitle = resourceBundle.getString(preferences.getValue("headerTitle", null));
         } catch (Exception e) {
             headerTitle = "";
@@ -74,16 +78,29 @@
     <div data-app="true"
          id="organizationalChart"
          class="v-application transparent v-application--is-ltr theme--light">
-        <script type="text/javascript">
-            const settings = {
-                userId: "<%=centerUser%>" !== 'null' && "<%=centerUser%>" || null,
-                title: "<%=headerTitle%>" !== 'null' && "<%=headerTitle%>" || null,
-                headerTranslations: <%=headerTranslations%>,
-                canUpdateCenterUser: <%=canUpdateCenterUser%>,
-                hasHeaderTitle: <%=hasHeaderTitle%>,
-                isSpaceManager: <%=isManager%>
-            }
-            require(['PORTLET/social-portlet/OrganizationalChart'], app => app.init('<%=id%>', settings));
-        </script>
+        <% if (propertySetting.isActive()) { %>
+            <script type="text/javascript">
+                const settings = {
+                    userId: "<%=centerUser%>" !== 'null' && "<%=centerUser%>" || null,
+                    title: "<%=headerTitle%>" !== 'null' && "<%=headerTitle%>" || null,
+                    headerTranslations: <%=headerTranslations%>,
+                    canUpdateCenterUser: <%=canUpdateCenterUser%>,
+                    hasHeaderTitle: <%=hasHeaderTitle%>,
+                    isSpaceManager: <%=isManager%>
+                }
+                require(['PORTLET/social-portlet/OrganizationalChart'], app => app.init('<%=id%>', settings));
+            </script>
+        <% } else {%>
+			<div class="my-auto white border-radius pa-5 card-border-radius v-card v-sheet v-sheet--outlined theme--light" style="margin:0 auto;">
+			  <div class="d-flex mb-2 v-sheet theme--light" style="height: 28px;">
+			    <p class="my-auto widget-text-header text-truncate">
+			      <%=headerTitle%>
+			    </p>
+			  </div>
+              <p class="mt-2">
+                <%=resourceBundle.getString("organizationalChart.property.manager.disabled")%>
+              </p>
+            </div>
+        <% } %>
     </div>
 </div>

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/SettingService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/SettingService.js
@@ -22,7 +22,9 @@ export function getSettingValue(contextKey, contextValue, scopeKey, scopeValue, 
     credentials: 'include',
   }).then(resp => {
     if (!resp?.ok) {
-      throw new Error('Response code indicates a server error', resp);
+      if (resp.status !== 404) {
+        throw new Error('Response code indicates a server error', resp);
+      }
     } else {
       return resp.json();
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/main.js
@@ -4,8 +4,21 @@ const lang = eXo?.env?.portal?.language || 'en';
 
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Portlets-${lang}.json`;
 export function init() {
-  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    registerExtension(i18n.t('organizationalChart.header.label'));
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/profile/settings/manager`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error('Response code indicates a server error', resp);
+    } else {
+      return resp.json();
+    }
+  }).then(profileSetting => {
+    if (profileSetting.active) {
+      exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+        registerExtension(i18n.t('organizationalChart.header.label'));
+      });
+    }
   });
 }
 

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileAttributeSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileAttributeSettings.vue
@@ -66,6 +66,7 @@ export default {
     languagesData: null
   }),
   created() {
+    this.$root.$on('settings-set-filter', this.setFilter);
     this.languagesData = [...this.languages].sort((a, b) => a.value.localeCompare(b.value));
   },
   computed: {
@@ -82,6 +83,9 @@ export default {
     }
   },
   methods: {
+    setFilter(filter) {
+      this.filter = filter;
+    },
     close() {
       this.$emit('back-to-main-page');
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
@@ -106,7 +106,6 @@ export default {
     this.$root.$on('delete-labels', this.deleteLabels);
     this.$root.$on('move-up-setting', this.moveUpSetting);
     this.$root.$on('move-down-setting', this.moveDownSetting);
-    this.$root.$on('settings-set-filter', this.setFilter);
     this.$root.$on('cancel-edit-add', this.displayNoChangeWarning);
     window.addEventListener('popstate', this.updateSelected);
     setTimeout(() => {
@@ -202,9 +201,6 @@ export default {
     },
     deleteLabels(labels) {
       this.$profileLabelService.deleteLabels(labels);
-    },
-    setFilter(filter) {
-      this.filter = filter;
     },
     moveUpSetting(setting) {
       this.moveSetting(setting, 'up');


### PR DESCRIPTION
When the profile property **manager** is inactive, the Org chart button in the user card & user popover will be hidden.
besides, a message will be displayed in the Org chart application indicating that the property manager is inactive and the content of the application will be hidden.