### PR TITLE
fix: Fix include properties in the metadata filter query when spaceIds list is empty - EXO-70706 - Meeds-io/MIPs#130

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -425,11 +425,13 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     if (!MapUtils.isEmpty(filter.getMetadataProperties())) {
       if (StringUtils.isNotBlank(spaceIdsQuery)) {
         propertiesQuery.append(" AND ");
+        buildPropertiesQuery(propertiesQuery, filter.getMetadataProperties());
       }
-      buildPropertiesQuery(propertiesQuery, filter.getMetadataProperties());
       StringBuilder combinedPropertiesQuery = new StringBuilder();
       if (!MapUtils.isEmpty(filter.getCombinedMetadataProperties())) {
-        combinedPropertiesQuery.append(") OR ");
+        if (StringUtils.isNotBlank(spaceIdsQuery)) {
+          combinedPropertiesQuery.append(") OR ");
+        }
         buildPropertiesQuery(combinedPropertiesQuery, filter.getCombinedMetadataProperties());
       }
       query.append(" AND (");

--- a/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
@@ -532,7 +532,7 @@ public class MetadataServiceTest extends AbstractCoreTest {
 
     metadataItems = metadataService.getMetadataItemsByFilter(metadataFilter, 0, 10);
     assertNotNull(metadataItems);
-    assertEquals(2, metadataItems.size());
+    assertEquals(1, metadataItems.size());
   }
 
   public void testGetMetadataItemsByMetadataNameAndTypeAndObjectAndSpaceIds() throws ObjectAlreadyExistsException {


### PR DESCRIPTION
fix include properties in the metadata filter query when spaceIds list is empty
