### PR TITLE
feat: Allow metadata filter to fetch depends on multiple properties within same item - EXO-70705 - Meeds-io/MIPs#130

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataFilter.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataFilter.java
@@ -31,6 +31,8 @@ import java.util.Map;
 @NoArgsConstructor
 public class MetadataFilter {
 
+  private Long                creatorId;
+
   private String              metadataName;
 
   private String              metadataTypeName;
@@ -39,7 +41,13 @@ public class MetadataFilter {
 
   private List<Long>          metadataSpaceIds;
 
-  private Long                creatorId;
-
   private Map<String, String> metadataProperties;
+
+  /**
+   * To be used when we need to combine list of properties using or condition:
+   * ((in spacesIds and metadataProperties equal condition)
+   * or (combinedMetadataProperties equal condition))
+   */
+  private Map<String, String> combinedMetadataProperties;
+
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -15,20 +15,15 @@
  */
 package org.exoplatform.social.core.jpa.storage.dao.jpa;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
-import org.exoplatform.social.core.jpa.storage.entity.MetadataEntity;
 import org.exoplatform.social.core.jpa.storage.entity.MetadataItemEntity;
 import org.exoplatform.social.metadata.MetadataFilter;
 
@@ -36,13 +31,6 @@ import jakarta.persistence.NoResultException;
 import jakarta.persistence.Query;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.JoinType;
-import jakarta.persistence.criteria.MapJoin;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 
 public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long> {
 
@@ -396,37 +384,107 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
   }
 
   private Query buildMetadataFilterQuery(MetadataFilter filter, long metadataType) {
-    CriteriaBuilder criteriaBuilder = getEntityManager().getCriteriaBuilder();
-    CriteriaQuery<MetadataItemEntity> criteriaQuery = criteriaBuilder.createQuery(MetadataItemEntity.class);
-    Root<MetadataItemEntity> root = criteriaQuery.from(MetadataItemEntity.class);
 
-    List<Predicate> predicates = new ArrayList<>();
-    predicates.add(criteriaBuilder.equal(root.get(METADATA).get(TYPE), metadataType));
-    predicates.add(criteriaBuilder.and(criteriaBuilder.equal(root.get(METADATA).get(NAME), filter.getMetadataName())));
-
-    if (!CollectionUtils.isEmpty(filter.getMetadataObjectTypes())) {
-      predicates.add(criteriaBuilder.and(root.get(OBJECT_TYPE_PARAM).in(filter.getMetadataObjectTypes())));
-    }
-    if (!CollectionUtils.isEmpty(filter.getMetadataSpaceIds())) {
-      predicates.add(criteriaBuilder.and(root.get(SPACE_ID).in(filter.getMetadataSpaceIds())));
+    StringBuilder query = new StringBuilder();
+    query.append("""
+        SELECT metadataItems.* FROM SOC_METADATA_ITEMS metadataItems
+        INNER JOIN SOC_METADATAS  ON metadataItems.METADATA_ID = SOC_METADATAS.METADATA_ID\s
+        AND SOC_METADATAS.TYPE=""");
+    query.append(metadataType);
+    query.append(" AND SOC_METADATAS.NAME ='");
+    query.append(filter.getMetadataName());
+    query.append("' ");
+    if (!MapUtils.isEmpty(filter.getMetadataProperties())) {
+      query.append("""
+           INNER JOIN SOC_METADATA_ITEMS_PROPERTIES\s
+          ON metadataItems.METADATA_ITEM_ID = SOC_METADATA_ITEMS_PROPERTIES.METADATA_ITEM_ID\s
+          """);
     }
     if (filter.getCreatorId() != null) {
-      predicates.add(criteriaBuilder.and(criteriaBuilder.equal(root.get(CREATOR_ID), filter.getCreatorId())));
+      query.append(" AND metadataItems.CREATOR_ID =");
+      query.append(filter.getCreatorId());
     }
-
+    if (!CollectionUtils.isEmpty(filter.getMetadataObjectTypes())) {
+      String objectTypes = filter.getMetadataObjectTypes().stream()
+                                 .map(s -> "'" + s + "'")
+                                 .collect(Collectors.joining(","));
+      query.append(" AND metadataItems.OBJECT_TYPE in (");
+      query.append(objectTypes);
+      query.append(")");
+    }
+    StringBuilder spaceIdsQuery = new StringBuilder();
+    if (!CollectionUtils.isEmpty(filter.getMetadataSpaceIds())) {
+      String spaceIds = filter.getMetadataSpaceIds().stream()
+                              .map(String::valueOf)
+                              .collect(Collectors.joining(","));
+      spaceIdsQuery.append(" metadataItems.SPACE_ID in (");
+      spaceIdsQuery.append(spaceIds);
+      spaceIdsQuery.append(")");
+    }
+    StringBuilder propertiesQuery = new StringBuilder();
     if (!MapUtils.isEmpty(filter.getMetadataProperties())) {
-      Join<MetadataItemEntity, MetadataEntity> metadata = root.join(METADATA, JoinType.INNER);
-      MapJoin<MetadataItemEntity, String, String> metadataItemProp = root.joinMap(PROPERTIES, JoinType.INNER);
-      predicates.add(criteriaBuilder.and(criteriaBuilder.equal(metadata.get(TYPE), metadataType)));
-      predicates.add(criteriaBuilder.and(criteriaBuilder.equal(metadata.get(NAME), filter.getMetadataName())));
-      filter.getMetadataProperties().forEach((key, value) -> {
-        predicates.add(criteriaBuilder.and(criteriaBuilder.equal(metadataItemProp.key(), key)));
-        predicates.add(criteriaBuilder.and(criteriaBuilder.equal(metadataItemProp.value(), value)));
-      });
+      if (StringUtils.isNotBlank(spaceIdsQuery)) {
+        propertiesQuery.append(" AND ");
+        buildPropertiesQuery(propertiesQuery, filter.getMetadataProperties());
+      }
+      StringBuilder combinedPropertiesQuery = new StringBuilder();
+      if (!MapUtils.isEmpty(filter.getCombinedMetadataProperties())) {
+        if (StringUtils.isNotBlank(spaceIdsQuery)) {
+          combinedPropertiesQuery.append(") OR ");
+        }
+        buildPropertiesQuery(combinedPropertiesQuery, filter.getCombinedMetadataProperties());
+      }
+      query.append(" AND (");
+      query.append(spaceIdsQuery);
+      query.append(propertiesQuery);
+      query.append(combinedPropertiesQuery);
+      query.append(") )");
+    } else if (StringUtils.isNotBlank(spaceIdsQuery)) {
+      query.append(" AND ");
+      query.append(spaceIdsQuery);
     }
+    query.append(" GROUP BY metadataItems.METADATA_ITEM_ID");
+    query.append(" ORDER BY metadataItems.CREATED_DATE DESC, metadataItems.METADATA_ID DESC");
+    return getEntityManager().createNativeQuery(query.toString(), MetadataItemEntity.class);
+  }
 
-    criteriaQuery.select(root).where(predicates.toArray(new Predicate[0]));
-    criteriaQuery.orderBy(criteriaBuilder.desc(root.get(CREATED_DATE)), criteriaBuilder.desc(root.get(ID)));
-    return getEntityManager().createQuery(criteriaQuery);
+  private void buildPropertiesQuery(StringBuilder query, Map<String, String> properties) {
+    Iterator<Map.Entry<String, String>> iterator = properties.entrySet().iterator();
+    Map.Entry<String, String> lastEntry = iterator.next();
+    String lastKey = lastEntry.getKey();
+    String lastValue = lastEntry.getValue();
+    if (properties.size() == 1) {
+      query.append(" ( SOC_METADATA_ITEMS_PROPERTIES.NAME='");
+      query.append(lastKey);
+      query.append("' AND SOC_METADATA_ITEMS_PROPERTIES.VALUE='");
+      query.append(lastValue);
+      query.append("' ");
+      return;
+    }
+    StringBuilder whereClaus = new StringBuilder();
+    query.append(""" 
+        ( metadataItems.METADATA_ITEM_ID IN (
+        SELECT %s.METADATA_ITEM_ID FROM
+        """.formatted(lastKey + lastValue));
+    query.append(" SOC_METADATA_ITEMS_PROPERTIES %s ".formatted(lastKey + lastValue));
+    whereClaus.append("WHERE %s.NAME = '%s' AND %s.VALUE = '%s' ".formatted(lastKey + lastValue,
+                                                                            lastKey,
+                                                                            lastKey + lastValue,
+                                                                            lastValue));
+    while (iterator.hasNext()) {
+      Map.Entry<String, String> entry = iterator.next();
+      String key = entry.getKey();
+      String value = entry.getValue();
+      query.append("JOIN SOC_METADATA_ITEMS_PROPERTIES %s ".formatted(key + value));
+      query.append("ON %s.METADATA_ITEM_ID ".formatted(lastKey + lastValue));
+      query.append("= %s.METADATA_ITEM_ID ".formatted(key + value));
+
+      whereClaus.append(" AND %s.NAME = '%s' AND %s.VALUE = '%s' ".formatted(key + value, key, key + value, value));
+      lastEntry = entry;
+      lastValue = lastEntry.getValue();
+      lastKey = lastEntry.getKey();
+    }
+    query.append(whereClaus);
+    query.append(")");
   }
 }

--- a/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
@@ -448,16 +448,86 @@ public class MetadataServiceTest extends AbstractCoreTest {
     assertEquals(storedMetadataItem3.getId(), metadataItems.get(0).getId());
     assertEquals(storedMetadataItem.getId(), metadataItems.get(1).getId());
 
+    objectId = "objectId10598";
+    metadataItemObject = newMetadataObjectInstance(objectType, objectId, parentObjectId);
+
+    Map<String, String> properties0 = new LinkedHashMap<>();
+    properties0.put("onlyOneKey", "value");
+    name = "testMetadataPropFilter";
+    metadataItemObject.setSpaceId(spaceId);
+    metadataService.createMetadataItem(metadataItemObject, new MetadataKey(type, name, audienceId), properties0, creatorId);
+
+    metadataFilter = new MetadataFilter();
+    metadataFilter.setMetadataName(name);
+    metadataFilter.setMetadataTypeName(type);
+    metadataFilter.setMetadataObjectTypes(List.of(objectType));
+    metadataFilter.setMetadataSpaceIds(List.of(spaceId, space3Id));
+    metadataFilter.setMetadataProperties(properties0);
+    metadataFilter.setCreatorId(creatorId);
+
+    metadataItems = metadataService.getMetadataItemsByFilter(metadataFilter, 0, 10);
+    assertNotNull(metadataItems);
+    assertEquals(1, metadataItems.size());
+
+    objectId = "objectId1058";
+    metadataItemObject = newMetadataObjectInstance(objectType, objectId, parentObjectId);
+
     Map<String, String> properties1 = new LinkedHashMap<>();
     properties1.put("staged", String.valueOf(true));
+    properties1.put("audience", "all");
+    properties1.put("posted", "true");
+    properties1.put("otherKey", "value");
     name = "testMetadataPropFilter";
+    metadataItemObject.setSpaceId(spaceId);
     metadataService.createMetadataItem(metadataItemObject, new MetadataKey(type, name, audienceId), properties1, creatorId);
+
+    objectId = "objectId1059";
+    metadataItemObject = newMetadataObjectInstance(objectType, objectId, parentObjectId);
+
+    Map<String, String> properties2 = new LinkedHashMap<>();
+    properties2.put("staged", String.valueOf(true));
+    properties2.put("audience", "spaces");
+    properties2.put("posted", "false");
+    properties2.put("otherKey", "otherValue");
+    name = "testMetadataPropFilter";
+    metadataService.createMetadataItem(metadataItemObject, new MetadataKey(type, name, audienceId), properties2, creatorId);
     metadataFilter = new MetadataFilter();
     metadataFilter.setMetadataName(name);
     metadataFilter.setMetadataTypeName(type);
     metadataFilter.setMetadataObjectTypes(List.of(objectType));
     metadataFilter.setMetadataSpaceIds(List.of(spaceId, space3Id));
     metadataFilter.setMetadataProperties(properties1);
+    metadataFilter.setCombinedMetadataProperties(properties2);
+    metadataFilter.setCreatorId(creatorId);
+
+    metadataItems = metadataService.getMetadataItemsByFilter(metadataFilter, 0, 10);
+    assertNotNull(metadataItems);
+    assertEquals(2, metadataItems.size());
+
+    objectId = "objectId10585";
+    metadataItemObject = newMetadataObjectInstance(objectType, objectId, parentObjectId);
+
+    Map<String, String> properties3 = new LinkedHashMap<>();
+    properties3.put("otherOnlyOneKey", "value");
+    name = "testMetadataPropFilter";
+    metadataItemObject.setSpaceId(spaceId);
+    metadataService.createMetadataItem(metadataItemObject, new MetadataKey(type, name, audienceId), properties3, creatorId);
+
+    objectId = "objectId10586";
+    metadataItemObject = newMetadataObjectInstance(objectType, objectId, parentObjectId);
+
+    Map<String, String> properties4 = new LinkedHashMap<>();
+    properties4.put("otherOnlyOneKey", "otherValue");
+    name = "testMetadataPropFilter";
+    metadataItemObject.setSpaceId(spaceId);
+    metadataService.createMetadataItem(metadataItemObject, new MetadataKey(type, name, audienceId), properties4, creatorId);
+
+    metadataFilter = new MetadataFilter();
+    metadataFilter.setMetadataName(name);
+    metadataFilter.setMetadataTypeName(type);
+    metadataFilter.setMetadataObjectTypes(List.of(objectType));
+    metadataFilter.setMetadataProperties(properties3);
+    metadataFilter.setCombinedMetadataProperties(properties4);
     metadataFilter.setCreatorId(creatorId);
 
     metadataItems = metadataService.getMetadataItemsByFilter(metadataFilter, 0, 10);


### PR DESCRIPTION
Allow metadata filter to fetch depends on multiple properties within same item
Allow metadata filter to combine properties with or condition
fix include properties in the metadata filter query when spaceIds list
is empty