### PR TITLE
fix: bug - BUG - Users management / search isn't working - EXO-71616 - Meeds-io/meeds#1964 (#3779)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -164,7 +164,7 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
   public String getMapping() {
     StringBuilder profileSettingsFieldsMapping = new StringBuilder();
     for(ProfilePropertySetting propertySetting : profilePropertyService.getPropertySettings()) {
-      if(!propertySetting.isMultiValued() && propertySetting.getParentId() == null && !profilePropertyService.hasChildProperties(propertySetting) && !"email".equals(propertySetting.getPropertyName())) {
+      if(propertySetting.isVisible() && propertySetting.isEditable() && !propertySetting.isMultiValued() && propertySetting.getParentId() == null && !profilePropertyService.hasChildProperties(propertySetting) && !"email".equals(propertySetting.getPropertyName())) {
         profileSettingsFieldsMapping.append("    \"").append(propertySetting.getPropertyName().equals("fullName")? "name" : propertySetting.getPropertyName()).append("\" : {")
                 .append("      \"type\" : \"text\",")
                 .append("      \"index_options\": \"offsets\",")
@@ -249,22 +249,23 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     }
     Date createdDate = new Date(profile.getCreatedTime());
 
-    for (String profilePropertySettingName : profilePropertyService.getPropertySettingNames()) {
-      if (!fields.containsKey(profilePropertySettingName)) {
-        if (profile.getProperty(profilePropertySettingName) != null && profile.getProperty(profilePropertySettingName) instanceof String value) {
+    for (ProfilePropertySetting profilePropertySetting : profilePropertyService.getPropertySettings()) {
+      if (profilePropertySetting.isVisible() && profilePropertySetting.isEditable() && !fields.containsKey(profilePropertySetting.getPropertyName())) {
+        // Avoid indexing invisible and not editable properties
+        if (profile.getProperty(profilePropertySetting.getPropertyName()) != null && profile.getProperty(profilePropertySetting.getPropertyName()) instanceof String value) {
           if (StringUtils.isNotEmpty(value)) {
             // Avoid having dots in field names in ES, otherwise properties with String values may be converted in Objects in some cases
-            addPropertyToDocumentFields(fields, profilePropertySettingName, value, Long.parseLong(id));
+            addPropertyToDocumentFields(fields, profilePropertySetting.getPropertyName(), value, Long.parseLong(id));
           }
         } else {
-          List<Map<String, String>> multiValues = (List<Map<String, String>>) profile.getProperty(profilePropertySettingName);
+          List<Map<String, String>> multiValues = (List<Map<String, String>>) profile.getProperty(profilePropertySetting.getPropertyName());
           if (CollectionUtils.isNotEmpty(multiValues)) {
             String value = multiValues.stream()
                 .filter(property -> property.get("value") != null)
                 .map(property -> property.get("value"))
                 .collect(Collectors.joining(",", "", ""));
             if (StringUtils.isNotEmpty(value)) {
-              addPropertyToDocumentFields(fields, profilePropertySettingName, removeAccents(value), Long.parseLong(id));
+              addPropertyToDocumentFields(fields, profilePropertySetting.getPropertyName(), removeAccents(value), Long.parseLong(id));
             }
           }
         }


### PR DESCRIPTION
Prior to this change, Any property added to a profile is indexed and since some properties comes from third-party systems integration that may need specific mapping and can make indxation failure, this fix avoid to index this kind of properties and any property that is not visible and not editable bu users.

(cherry picked from commit 26e7e58294b4d0a366d15f876d3ca72d1f5221f5)