### PR TITLE
fix: user card settings are not retrieved for simple users - Meeds-io/meeds#127 - EXO-71337

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1540,8 +1540,8 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @Operation(
-          summary = "Gets the filed settings of a user card",
-          description = "Gets the filed settings of a user card",
+          summary = "Gets the field settings of a user card",
+          description = "Gets the field settings of a user card",
           method = "GET")
   @ApiResponses(value = {
           @ApiResponse(responseCode = "200", description = "Request fulfilled"),

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -18,6 +18,7 @@ import javax.imageio.ImageIO;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.api.settings.SettingService;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mortbay.cometd.continuation.EXoContinuationBayeux;
@@ -97,6 +98,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
   private LocaleConfigService          localeConfigService;
 
+  private SettingService               settingService;
+
   private Identity                     rootIdentity;
 
   private Identity                     johnIdentity;
@@ -128,6 +131,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     imageThumbnailService = getContainer().getComponentInstanceOfType(ImageThumbnailService.class);
     passwordRecoveryService = getContainer().getComponentInstanceOfType(PasswordRecoveryService.class);
     localeConfigService = getContainer().getComponentInstanceOfType(LocaleConfigService.class);
+    settingService = getContainer().getComponentInstanceOfType(SettingService.class);
     rootIdentity = createIdentity("root");
     johnIdentity = createIdentity("john");
     maryIdentity = createIdentity("mary");
@@ -153,7 +157,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                       imageThumbnailService,
                                                                       profilePropertyService,
                                                                       passwordRecoveryService,
-                                                                      localeConfigService);
+                                                                      localeConfigService,
+                                                                      settingService);
     registry(userRestResourcesV1);
 
     // Create profile properties
@@ -307,7 +312,8 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                                     imageThumbnailService,
                                                                     profilePropertyService,
                                                                     passwordRecoveryService,
-                                                                    localeConfigService);
+                                                                    localeConfigService,
+                                                                    settingService);
     registry(userRestResources);
 
     //when

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -442,7 +442,7 @@ export function getUserCardSettings() {
     credentials: 'include',
   }).then((resp) => {
     if (!resp || !resp.ok) {
-      throw new Error('Error when updating users');
+      throw new Error('Error while getting user card settings');
     } else {
       return resp.json();
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/UserService.js
@@ -435,3 +435,16 @@ export function multiSelectAction(action, selectedUsers) {
     }
   });
 }
+
+export function getUserCardSettings() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/userCardSettings`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then((resp) => {
+    if (!resp || !resp.ok) {
+      throw new Error('Error when updating users');
+    } else {
+      return resp.json();
+    }
+  });
+}

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -113,11 +113,6 @@ export default {
     originalLimitToFetch: 0,
     abortController: null,
     loadingPeople: false,
-    userCardSettingsContextKey: 'GLOBAL',
-    userCardSettingScopeKey: 'GLOBAL',
-    userCardFirstFieldSettingKey: 'UserCardFirstFieldSetting',
-    userCardSecondFieldSettingKey: 'UserCardSecondFieldSetting',
-    userCardThirdFieldSettingKey: 'UserCardThirdFieldSetting',
     userCardSettings: null
   }),
   computed: {
@@ -177,22 +172,8 @@ export default {
     this.refreshUserExtensions();
   },
   methods: {
-    getCardSetting(settingKey) {
-      return this.$settingService.getSettingValue(this.userCardSettingsContextKey, '',
-        this.userCardSettingScopeKey, 'UserCardSettings', settingKey);
-    },
     getSavedUserCardSettings() {
-      return this.getCardSetting(this.userCardFirstFieldSettingKey).then((firstFieldSetting) => {
-        return this.getCardSetting(this.userCardSecondFieldSettingKey).then((secondFieldSetting) => {
-          return this.getCardSetting(this.userCardThirdFieldSettingKey).then((thirdFieldSetting) => {
-            this.userCardSettings = {
-              firstField: firstFieldSetting?.value,
-              secondField: secondFieldSetting?.value,
-              thirdField: thirdFieldSetting?.value
-            };
-          });
-        });
-      });
+      return this.$userService.getUserCardSettings().then(userCardSettings => this.userCardSettings = userCardSettings);
     },
     resetFilters() {
       this.$root.$emit('reset-filter');

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -98,11 +98,6 @@ export default {
     user: null,
     excludedSearchProps: [],
     settings: [],
-    userCardSettingsContextKey: 'GLOBAL',
-    userCardSettingScopeKey: 'GLOBAL',
-    userCardFirstFieldSettingKey: 'UserCardFirstFieldSetting',
-    userCardSecondFieldSettingKey: 'UserCardSecondFieldSetting',
-    userCardThirdFieldSettingKey: 'UserCardThirdFieldSetting',
     userCardSettings: null
   }),
   computed: {
@@ -151,22 +146,8 @@ export default {
           this.settings = settings?.settings || [];
         });
     },
-    getCardSetting(settingKey) {
-      return this.$settingService.getSettingValue(this.userCardSettingsContextKey, '',
-        this.userCardSettingScopeKey, 'UserCardSettings', settingKey);
-    },
     getSavedUserCardSettings() {
-      return this.getCardSetting(this.userCardFirstFieldSettingKey).then((firstFieldSetting) => {
-        return this.getCardSetting(this.userCardSecondFieldSettingKey).then((secondFieldSetting) => {
-          return this.getCardSetting(this.userCardThirdFieldSettingKey).then((thirdFieldSetting) => {
-            this.userCardSettings = {
-              firstField: firstFieldSetting?.value,
-              secondField: secondFieldSetting?.value,
-              thirdField: thirdFieldSetting?.value
-            };
-          });
-        });
-      });
+      return this.$userService.getUserCardSettings().then(userCardSettings => this.userCardSettings = userCardSettings);
     },
     canShowProperty(property) {
       return !this.isPropertyHidden(property) || this.isPropertyHidden(property) && (this.isAdmin || this.owner);

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
@@ -89,7 +89,7 @@
                   :user="user"
                   :user-navigation-extensions="userExtensions"
                   :profile-action-extensions="profileActionExtensions"
-                  :settings-preferences="userCardSettings" />
+                  :user-card-settings="userCardSettings" />
               </v-col>
             </v-row>
           </v-container>

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
@@ -250,22 +250,8 @@ export default {
       return this.$settingService.setSettingValue(this.userCardSettingsContextKey, '',
         this.userCardSettingScopeKey, 'UserCardSettings', settingKey, settingValue);
     },
-    getCardSetting(settingKey) {
-      return this.$settingService.getSettingValue(this.userCardSettingsContextKey, '',
-        this.userCardSettingScopeKey, 'UserCardSettings', settingKey);
-    },
     getSavedUserCardSettings() {
-      return this.getCardSetting(this.userCardFirstFieldSettingKey).then((firstFieldSetting) => {
-        return this.getCardSetting(this.userCardSecondFieldSettingKey).then((secondFieldSetting) => {
-          return this.getCardSetting(this.userCardThirdFieldSettingKey).then((thirdFieldSetting) => {
-            this.savedCardSettings = {
-              firstField: firstFieldSetting?.value,
-              secondField: secondFieldSetting?.value,
-              thirdField: thirdFieldSetting?.value
-            };
-          });
-        });
-      });
+      return this.$userService.getUserCardSettings().then(userCardSettings => this.userCardSettings = userCardSettings);
     },
     saveUserCardSettings(firstField, secondField, thirdField) {
       this.isSavingCardSettings = true;


### PR DESCRIPTION
Before this fix, we used the Setting Rest service to load the user card properties. This didn't work for simple users as this Rest service does not return settings when the Context is Global.
The fix creates a new Rest endpoint to return the card settings from User Rest service