### PR TITLE
fix: allow to define email as a field in the user card - Meeds-io/meeds#127 - EXO-71336

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
@@ -52,7 +52,7 @@
     <user-card-settings-drawer
       ref="userCardSettings"
       :user="user"
-      :settings="filteredSettings"
+      :settings="userCardFilteredFieldSettings"
       :is-saving-settings="isSavingCardSettings"
       :saved-settings="savedCardSettings"
       @closed="setMainPageSelected"
@@ -126,6 +126,14 @@ export default {
       return this.settings.filter(setting => !setting.multiValued && setting.propertyType === 'text'
                                                                   && !setting?.children?.length
                                                                   && !this.excludedSettingsProp?.includes(setting.propertyName))
+        .map(setting => {
+          return {label: this.getResolvedName(setting), value: setting.propertyName};
+        });
+    },
+    userCardFilteredFieldSettings() {
+      return this.settings.filter(setting => !setting.multiValued && setting.propertyType === 'text'
+                                                                  && !setting?.children?.length
+                                                                  && !this.unHiddenableProperties?.includes(setting.propertyName))
         .map(setting => {
           return {label: this.getResolvedName(setting), value: setting.propertyName};
         });


### PR DESCRIPTION
Allow the email field to be listed with proposed fields for the user card.