### PR TITLE
fix: disable invisible fields from Edit Profile Contact - Meeds-io/meeds#110 - EXO-70160

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/social/ProfileContactInformation_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/social/ProfileContactInformation_en.properties
@@ -41,3 +41,5 @@ profileContactInformation.hide.property.alt=Forbid the user to hide this attribu
 profileContactInformation.show.property.alt=Allow the user to hide this attribute
 profileContactInformation.quickSearch.noPeople=No People
 profileContactInformation.quickSearch.resetFilter=Reset
+profileContactInformation.invisible.property.cant.be.hidden.label=The attribute is already hidden by the administrator
+

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileHidePropertyButton.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileHidePropertyButton.vue
@@ -28,9 +28,9 @@
         class="d-inline-block">
         <v-btn
           v-if="!isHidden"
-          :disabled="!isHiddenable"
+          :disabled="!isHiddenable || !property.visible"
           icon
-          :aria-label="$t('profileContactInformation.hide.property.label')"
+          :aria-label="unhiddenableOrHiddenByAdminMessage"
           @click="hideProperty">
           <v-icon
             size="18"
@@ -53,6 +53,9 @@
     </template>
     <span v-if="!isHiddenable && !isNew">
       {{ $t('profileContactInformation.hiddenable.disabled') }}
+    </span>
+    <span v-else-if="!property.visible && !isNew">
+      {{ $t('profileContactInformation.invisible.property.cant.be.hidden.label') }}
     </span>
     <span v-else-if="!isHidden && !isNew">
       {{ $t('profileContactInformation.hide.property.label') }}
@@ -83,6 +86,9 @@ export default {
     },
     isNew() {
       return this.property?.isNew;
+    },
+    unhiddenableOrHiddenByAdminMessage() {
+      return !this.property?.visible ? this.$t('profileContactInformation.invisible.property.cant.be.hidden.label') : this.$t('profileContactInformation.hide.property.label');
     }
   },
   methods: {


### PR DESCRIPTION
If a field is hidden by an administrator, the user should not be able to re-hide it , and the Hide button should be disabled. 