### PR TITLE
fix: external users should not edit properties of type 'user' - Meeds-io/MIPs#112 - EXO-71284

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -173,7 +173,7 @@ export default {
       return this.$userService.getUser(eXo.env.portal.profileOwner, 'settings')
         .then(userdataEntity => {
           this.user = userdataEntity;
-          this.properties = userdataEntity?.properties.filter(item => item.active).sort((s1, s2) => ((s1.order > s2.order) ? 1 : (s1.order < s2.order) ? -1 : 0));
+          this.properties = userdataEntity?.properties.filter(item => item.active && !(item.propertyType === 'user' && eXo.env.portal.isExternal === 'true')).sort((s1, s2) => ((s1.order > s2.order) ? 1 : (s1.order < s2.order) ? -1 : 0));
           this.$nextTick().then(() => this.$root.$emit('application-loaded'));
           if (broadcast){
             document.dispatchEvent(new CustomEvent('userModified', {detail: this.user}));


### PR DESCRIPTION
External users could edit their personal profiles, but they should not have access to the list of users on the platform.
If the profile contain a property of type user, they could get the list of users, thus those type of fields will be disabled for them by the current fix.