### PR TITLE
feat: Allow Links Header up to 50 instead of 25 - MEED-3872 - Meeds-io/meeds#1842

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
@@ -289,7 +289,7 @@ export default {
     showHeader: false,
     seeMore: false,
     valid: false,
-    maxHeaderLength: 25,
+    maxHeaderLength: 50,
     settingsHeader: null,
   }),
   computed: {


### PR DESCRIPTION
Allow Links Header to have 50 characters instead of 25.