### PR TITLE
fix: hide org chart pages when manager field became inactive - Meeds-io/MIPs#112 - EXO-71333

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListener.java
@@ -1,0 +1,57 @@
+package org.exoplatform.social.core.listeners;
+
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.mop.page.PageContext;
+import org.exoplatform.portal.mop.page.PageKey;
+
+import org.exoplatform.portal.mop.page.PageState;
+import org.exoplatform.portal.mop.storage.PageStorage;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
+
+import java.util.List;
+
+public class ManagerPropertySettingUpdatedListener extends Listener<ProfilePropertyService, ProfilePropertySetting> {
+
+  public static final List<String> orgChartPages = List.of("portal::mycraft::myteam", "portal::global::organizationalchart");
+  private static final List<String> ALL_USERS_PERMISSION = List.of("*:/platform/users");
+  private final PageStorage pageStorage;
+
+  public ManagerPropertySettingUpdatedListener(PageStorage pageStorage) {
+    this.pageStorage = pageStorage;
+  }
+
+  @Override
+  public void onEvent(Event<ProfilePropertyService, ProfilePropertySetting> event) throws Exception {
+    ProfilePropertySetting propertySetting = event.getData();
+    if ("manager".equalsIgnoreCase(event.getData().getPropertyName())) {
+      RequestLifeCycle.begin(PortalContainer.getInstance());
+      try {
+        for(String pageRefKey : orgChartPages) {
+          PageKey pageKey = PageKey.parse(pageRefKey);
+          PageContext pageContext = pageStorage.loadPage(pageKey);
+          if (pageContext != null) {
+            PageState page = pageContext.getState();
+            UserACL userACL = CommonsUtils.getService(UserACL.class);
+            PageState pageState = new PageState(page.getDisplayName(),
+                    page.getDescription(),
+                    page.getShowMaxWindow(),
+                    page.getFactoryId(),
+                    propertySetting.isActive() ? ALL_USERS_PERMISSION : List.of(userACL.getSuperUser()),
+                    page.getEditPermission(),
+                    page.getMoveAppsPermissions(),
+                    page.getMoveContainersPermissions());
+            pageStorage.savePage(new PageContext(pageKey, pageState));
+          }
+        }
+      } finally {
+        RequestLifeCycle.end();
+      }
+    }
+  }
+}

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListener.java
@@ -21,9 +21,11 @@ public class ManagerPropertySettingUpdatedListener extends Listener<ProfilePrope
   public static final List<String> orgChartPages = List.of("portal::mycraft::myteam", "portal::global::organizationalchart");
   private static final List<String> ALL_USERS_PERMISSION = List.of("*:/platform/users");
   private final PageStorage pageStorage;
+  private final UserACL userACL;
 
-  public ManagerPropertySettingUpdatedListener(PageStorage pageStorage) {
+  public ManagerPropertySettingUpdatedListener(PageStorage pageStorage, UserACL userACL) {
     this.pageStorage = pageStorage;
+    this.userACL = userACL;
   }
 
   @Override
@@ -37,7 +39,6 @@ public class ManagerPropertySettingUpdatedListener extends Listener<ProfilePrope
           PageContext pageContext = pageStorage.loadPage(pageKey);
           if (pageContext != null) {
             PageState page = pageContext.getState();
-            UserACL userACL = CommonsUtils.getService(UserACL.class);
             PageState pageState = new PageState(page.getDisplayName(),
                     page.getDescription(),
                     page.getShowMaxWindow(),

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListener.java
@@ -1,8 +1,21 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exoplatform.social.core.listeners;
 
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.component.RequestLifeCycle;
+import io.meeds.common.ContainerTransactional;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.mop.page.PageContext;
 import org.exoplatform.portal.mop.page.PageKey;
@@ -29,29 +42,25 @@ public class ManagerPropertySettingUpdatedListener extends Listener<ProfilePrope
   }
 
   @Override
+  @ContainerTransactional
   public void onEvent(Event<ProfilePropertyService, ProfilePropertySetting> event) throws Exception {
     ProfilePropertySetting propertySetting = event.getData();
     if ("manager".equalsIgnoreCase(event.getData().getPropertyName())) {
-      RequestLifeCycle.begin(PortalContainer.getInstance());
-      try {
-        for(String pageRefKey : orgChartPages) {
-          PageKey pageKey = PageKey.parse(pageRefKey);
-          PageContext pageContext = pageStorage.loadPage(pageKey);
-          if (pageContext != null) {
-            PageState page = pageContext.getState();
-            PageState pageState = new PageState(page.getDisplayName(),
-                    page.getDescription(),
-                    page.getShowMaxWindow(),
-                    page.getFactoryId(),
-                    propertySetting.isActive() ? ALL_USERS_PERMISSION : List.of(userACL.getSuperUser()),
-                    page.getEditPermission(),
-                    page.getMoveAppsPermissions(),
-                    page.getMoveContainersPermissions());
-            pageStorage.savePage(new PageContext(pageKey, pageState));
-          }
+      for(String pageRefKey : orgChartPages) {
+        PageKey pageKey = PageKey.parse(pageRefKey);
+        PageContext pageContext = pageStorage.loadPage(pageKey);
+        if (pageContext != null) {
+          PageState page = pageContext.getState();
+          PageState pageState = new PageState(page.getDisplayName(),
+                  page.getDescription(),
+                  page.getShowMaxWindow(),
+                  page.getFactoryId(),
+                  propertySetting.isActive() ? ALL_USERS_PERMISSION : List.of(userACL.getSuperUser()),
+                  page.getEditPermission(),
+                  page.getMoveAppsPermissions(),
+                  page.getMoveContainersPermissions());
+          pageStorage.savePage(new PageContext(pageKey, pageState));
         }
-      } finally {
-        RequestLifeCycle.end();
       }
     }
   }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
@@ -17,6 +17,7 @@
 package org.exoplatform.social.core.jpa.test;
 
 import org.exoplatform.social.core.jpa.search.ComplementaryFilterSearchConnectorTest;
+import org.exoplatform.social.core.listeners.ManagerPropertySettingUpdatedListenerTest;
 import org.exoplatform.social.core.plugin.OrganizationalChartHeaderTranslationTest;
 import org.exoplatform.social.core.upgrade.UserPasswordHashMigrationTest;
 import org.exoplatform.social.core.utils.MentionUtilsTest;
@@ -139,7 +140,8 @@ import io.meeds.social.translation.service.TranslationServiceTest;
   ProfileSearchConnectorTest.class,
   ComplementaryFilterSearchConnectorTest.class,
   ProfileIndexingServiceConnectorTest.class,
-  OrganizationalChartHeaderTranslationTest.class
+  OrganizationalChartHeaderTranslationTest.class,
+  ManagerPropertySettingUpdatedListenerTest.class
 })
 @ConfigTestCase(AbstractCoreTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListenerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListenerTest.java
@@ -1,0 +1,66 @@
+package org.exoplatform.social.core.listeners;
+
+import org.exoplatform.portal.mop.page.PageContext;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.page.PageState;
+import org.exoplatform.portal.mop.storage.PageStorage;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+
+public class ManagerPropertySettingUpdatedListenerTest {
+
+  @Mock
+  PageStorage pageStorage;
+
+  @Mock
+  ProfilePropertyService profilePropertyService;
+
+  @Test
+  public void testOnEvent() {
+    ManagerPropertySettingUpdatedListener managerPropertySettingUpdatedListener = new ManagerPropertySettingUpdatedListener(pageStorage);
+    ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting("testProperty", "text", true, true, null, 1L, true, false, false, true, false, 1L, System.currentTimeMillis());
+    Event<ProfilePropertyService, ProfilePropertySetting> event = new Event<>("profile-property-setting-updated", profilePropertyService, profilePropertySetting);
+    try {
+      managerPropertySettingUpdatedListener.onEvent(event);
+    } catch (Exception e) {
+      fail();
+    }
+    verify(pageStorage, times(0)).savePage(any());
+
+    PageState pageState = new PageState("MyTeam",
+                                        "myteam page",
+                                        false,
+                                        "PagesFactory",
+                                        List.of("/platform/users"),
+                                        "/platform/administrators",
+                                        List.of("/platform/administrators"),
+                                        List.of("/platform/administrators"),
+                                        "page",
+                                        "/myteam");
+    PageContext pageContext = new PageContext(PageKey.parse("portal::global::organizationalChart"), pageState);
+    when(pageStorage.loadPage(any())).thenReturn(pageContext);
+    profilePropertySetting = new ProfilePropertySetting("manager", "text", true, true, null, 1L, true, false, false, true, false, 1L, System.currentTimeMillis());
+    event = new Event<>("profile-property-setting-updated", profilePropertyService, profilePropertySetting);
+    try {
+      managerPropertySettingUpdatedListener.onEvent(event);
+    } catch (Exception e) {
+      fail();
+    }
+
+    verify(pageStorage, times(1)).savePage(any());
+  }
+
+}

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
@@ -150,6 +150,13 @@
       <type>org.exoplatform.social.core.listeners.UpdateLoginTimeListenerImpl</type>
       <description>Update Last Login Time for user profile</description>
     </component-plugin>
+
+    <component-plugin>
+      <name>profile-property-setting-updated</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.core.listeners.ManagerPropertySettingUpdatedListener</type>
+      <description>Updates visibility of pages containing Organization chart application</description>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION
When the manager field is inactive, we need to hide the MyTeam and Organizational chart pages.
This fix introduces a listener for changes on Profile property settings to hide/show those pages when the manager field is updated. It uses pages permission to perform this action.