### PR TITLE
fix: Fix Application Border Radius - MEED-6880 - Meeds-io/meeds#2015

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
@@ -1,8 +1,7 @@
 <template>
   <v-app
     v-if="displayApp"
-    :class="owner && 'profileAboutMe' || 'profileAboutMeOther'"
-    class="white">
+    :class="owner && 'profileAboutMe' || 'profileAboutMeOther'">
     <widget-wrapper :title="title">
       <template #action>
         <v-btn

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -20,8 +20,7 @@
 
 <template>
   <v-app
-    :class="owner && 'profileContactInformation' || 'profileContactInformationOther'"
-    class="white">
+    :class="owner && 'profileContactInformation' || 'profileContactInformationOther'">
     <widget-wrapper :title="title">
       <template #action>
         <v-btn

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperiences.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperiences.vue
@@ -1,8 +1,7 @@
 <template>
   <v-app
     v-if="displayApp"
-    :class="owner && 'profileWorkExperience' || 'profileWorkExperienceOther'"
-    class="white">
+    :class="owner && 'profileWorkExperience' || 'profileWorkExperienceOther'">
     <widget-wrapper :title="title">
       <template v-if="owner" #action>
         <v-btn


### PR DESCRIPTION
Prior to this change, profile page widgets was displayed without border radius as defined in Branding. This change deletes the 'white' class introduced on application main element to let the application display inherit the border radius as defined in branding using 'card-border-radius'.