### PR TITLE
fix: [BUG] Unlimit the number of spaces to display in the External spaces portlet - EXO-61391 - Meeds-io/meeds#1828

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/portlet/SpacesListExternal/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/SpacesListExternal/Style.less
@@ -28,7 +28,11 @@
             width: 95%;
         }
     }
-    .spaceTitle {
+    .external-spaces-list {
+        max-height: 480px;     
+        overflow-y: auto;
+    }
+    .a.spaceTitle {
        font-size: 16px;
        font-family: @sansFontFamily;
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -1,15 +1,22 @@
 <template>
   <v-app v-if="isShown">
     <widget-wrapper :title="$t('externalSpacesList.title.yourSpaces')">
-      <v-list dense class="py-0">
+      <v-list dense class="py-0 external-spaces-list">
         <template>
           <external-space-item
             v-for="space in spacesList"
             :key="space.id"
             :space="space" />
-          <external-spaces-requests-items @invitationReplied="refreshSpaces" />
         </template>
       </v-list>
+      <v-btn
+        :loading="loading"
+        :disabled="!hasMore"
+        class="btn mx-auto mt-4 flex-grow-0 flex-shrink-0"
+        outlined
+        @click="loadMore()">
+        {{ $t('button.loadMore') }}
+      </v-btn> 
     </widget-wrapper>
   </v-app>
 </template>
@@ -20,7 +27,11 @@ export default {
   data () {
     return {
       spacesList: [],
-      spacesRequestsSize: 0,
+      hasMore: false,
+      loading: false,
+      pageSize: 10,
+      limit: 10,
+      offset: 0,
     };
   },
   computed: {
@@ -30,19 +41,23 @@ export default {
   },
   created() {
     this.getExternalSpacesList();
-    externalSpacesListService.getExternalSpacesRequests().then(
-      (data) => {
-        this.spacesRequestsSize = data.spacesMemberships.length;
-      }).finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     getExternalSpacesList() {
-      externalSpacesListService.getExternalSpacesList().then(data => {
-        this.spacesList = data.spaces;
+      externalSpacesListService.getExternalSpacesList(this.offset,this.limit).then(data => {
+        this.spacesList = this.spacesList.concat(data.spaces);
+        this.hasMore = data.spaces.length===this.pageSize;
+        this.loading=false;
       });
     },
     refreshSpaces(space) {
       this.spacesList.unshift(space);
+    },
+    loadMore() {
+      this.loading=true;
+      this.limit += this.pageSize;
+      this.offset += this.pageSize;
+      this.getExternalSpacesList();
     },
   }
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -52,7 +52,6 @@ export default {
     },
     loadMore() {
       this.loading=true;
-      this.limit += this.pageSize;
       this.offset += this.pageSize;
       this.getExternalSpacesList();
     },

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -50,9 +50,6 @@ export default {
         this.loading=false;
       });
     },
-    refreshSpaces(space) {
-      this.spacesList.unshift(space);
-    },
     loadMore() {
       this.loading=true;
       this.limit += this.pageSize;

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/externalSpacesListService.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/externalSpacesListService.js
@@ -1,5 +1,5 @@
-export function getExternalSpacesList() {
-  return fetch(`${Vue.prototype.$spacesConstants.SOCIAL_USER_API}${eXo.env.portal.userName}/spaces?limit=-1`, {
+export function getExternalSpacesList(offset,limit) {
+  return fetch(`${Vue.prototype.$spacesConstants.SOCIAL_USER_API}${eXo.env.portal.userName}/spaces?offset=${offset}&limit=${limit}`, {
     method: 'GET',
     credentials: 'include',
   }).then((resp) => {


### PR DESCRIPTION
Prior to this change, External Spaces displays 40 spaces (spaces where user is member and spaces where user is invited) at maximum and are sorted by default in alphabetical order. This creates a bad display and adds white space in the other widgets of snapshot page,
 The fix change this behaviour to show only 10 spaces by default and only spaces where user is member and add a load more button to show more spaces if exists.
