### PR TITLE
feat: allow to synchronize multi valued attributes from LDAP/AD - Meeds-io/MIPs#112 - EXO-69857

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -429,7 +429,15 @@ public class EntityBuilder {
   
   private static void buildListManagers(ProfileEntity userEntity, Profile profile, String restPath) {
     @SuppressWarnings("unchecked")
-    ArrayList<HashMap<String, String>> userNames = (ArrayList<HashMap<String, String>>) profile.getProperty(MANAGER);
+    ArrayList<Map<String, String>> userNames = new ArrayList<>();
+    if(profile.getProperty(MANAGER) instanceof List<?>) {
+      userNames = (ArrayList<Map<String, String>>) profile.getProperty(MANAGER);
+    } else {
+      // In case of AD, the manager is a single value property
+      Map<String, String> value = new HashMap<>();
+      value.put(VALUE, (String) profile.getProperty(MANAGER));
+      userNames.add(value);
+    }
     List<DataEntity> managers = new ArrayList<>();
     userNames.forEach(property -> {
       Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, property.get(VALUE));


### PR DESCRIPTION
Receive and map correctly the multivalued profile property and avoid losing its list of values. the property manager is multi-value when users are stored in DB or in LDAP. But it is single value for Active directory. This fix makes sure to parse it correctly to get the value and convert it to the selected user.
