### PR TITLE
fix: Update linkedin oauth to use openid endpoints - EXO-71792

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/linkedin/LinkedInPrincipalProcessor.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/linkedin/LinkedInPrincipalProcessor.java
@@ -15,6 +15,7 @@
  */
 package io.meeds.oauth.linkedin;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.impl.UserImpl;
 
@@ -27,14 +28,10 @@ public class LinkedInPrincipalProcessor implements OAuthPrincipalProcessor {
   public User convertToGateInUser(OAuthPrincipal principal) {
     String email = principal.getEmail();
     String username = principal.getUserName();
-    if (email != null) {
-      int index = email.indexOf('@');
-      if (index > 0) {
-        username = email.substring(0, index);
-      }
+    User gateinUser = new UserImpl();
+    if (StringUtils.isNotBlank(username)) {
+      gateinUser.setUserName(OAuthUtils.refineUserName(username));
     }
-
-    User gateinUser = new UserImpl(OAuthUtils.refineUserName(username));
     gateinUser.setFirstName(principal.getFirstName());
     gateinUser.setLastName(principal.getLastName());
     gateinUser.setEmail(email);

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/linkedin/LinkedinProcessorImpl.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/linkedin/LinkedinProcessorImpl.java
@@ -51,7 +51,7 @@ public class LinkedinProcessorImpl implements LinkedinProcessor {
 
   private final String              apiSecret;
 
-  private String                    scope = "r_liteprofile r_emailaddress w_member_social";
+  private String                    scope = "openid profile email";
 
   private final SecureRandomService secureRandomService;
 

--- a/component/oauth-auth/src/test/java/io/meeds/oauth/test/TestOAuthPrincipalProcessor.java
+++ b/component/oauth-auth/src/test/java/io/meeds/oauth/test/TestOAuthPrincipalProcessor.java
@@ -106,7 +106,7 @@ public class TestOAuthPrincipalProcessor extends AbstractKernelTest {
 
   public void testLinkedInGenerateGateInUser() {
     OAuthProviderType providerType = new OAuthProviderType("LINKEDIN", true, "", null, null, "", "");
-    OAuthPrincipal principal = new OAuthPrincipal("randomString",
+    OAuthPrincipal principal = new OAuthPrincipal("",
                                                   "firstName",
                                                   "lastName",
                                                   "displayName",
@@ -118,7 +118,7 @@ public class TestOAuthPrincipalProcessor extends AbstractKernelTest {
     User user = principalProcessor.convertToGateInUser(principal);
 
     assertNotNull(user);
-    assertEquals("linkedin_user", user.getUserName());
+    assertEquals(null, user.getUserName());
     assertEquals("linkedin_user@localhost.com", user.getEmail());
     assertEquals("firstName", user.getFirstName());
     assertEquals("lastName", user.getLastName());
@@ -129,7 +129,7 @@ public class TestOAuthPrincipalProcessor extends AbstractKernelTest {
 
     String apiKey = "86joj41np68x05";
     String apiSecret = "B6Sz1fAUPGxRSraC";
-    String scope = "r_liteprofile r_emailaddress w_member_social";
+    String scope = "profile email";
     String secretState = "secret999999";
     String redirectURL = "http://127.0.0.1:8080/portal/linkedinAuth";
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -146,7 +146,7 @@ public class TestOAuthPrincipalProcessor extends AbstractKernelTest {
     String state = linkedinProcessor.processOAuthInteraction(request, response).getState().name();
     assertEquals("AUTH", state);
     String redirect = linkedinProcessor.oAuth20Service.getAuthorizationUrl(secretState);
-    assertEquals("https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=86joj41np68x05&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fportal%2FlinkedinAuth&scope=r_liteprofile%20r_emailaddress%20w_member_social&state=secret999999",
+    assertEquals("https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=86joj41np68x05&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fportal%2FlinkedinAuth&scope=profile%20email&state=secret999999",
                  redirect);
 
   }


### PR DESCRIPTION
Before this fix, the linkedin oauth was not working because it use oauth url to get user info, and linkedin deactivate it in profit of openid url (/v2/userinfo) The commit update url to get user info, to make linkedin oauth implementation working

Resolves meeds-io/meeds#1996

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
