### PR TITLE
fix: [BUG] Unlimit the number of spaces to display in the External spaces portlet - EXO-61391 - Meeds-io/meeds#1828

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -50,7 +50,6 @@ export default {
     },
     loadMore() {
       this.loading=true;
-      this.limit += this.pageSize;
       this.offset += this.pageSize;
       this.getExternalSpacesList();
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileAttributeSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileAttributeSettings.vue
@@ -89,9 +89,6 @@ export default {
     },
     close() {
       this.$emit('back-to-main-page');
-    },
-    setFilter(filter) {
-      this.filter = filter;
     }
   }
 };


### PR DESCRIPTION
Prior to this change, The External Spaces displays 40 spaces (spaces where user is member and spaces where user is invited) at maximum and are sorted by default in alphabetical order. This creates a bad display and adds white space in the other widgets of snapshot page, The fix change this behaviour to show only 10 spaces by default and only spaces where user is member and add a load more botton to show more spaces if exists.