### PR TITLE
fix: check for nullity before getting the value of Card settings - Meeds-io/meeds#2070 - EXO-72158

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1560,16 +1560,28 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
     SettingValue<?> userCardThirdFieldSetting = settingService.get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new Scope(Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardThirdFieldSetting");
 
     JSONObject userCardSettings = new JSONObject();
-    userCardSettings.put("firstField", userCardFirstFieldSetting.getValue());
-    userCardSettings.put("secondField", userCardSecondFieldSetting.getValue());
-    userCardSettings.put("thirdField", userCardThirdFieldSetting.getValue());
+    if(userCardFirstFieldSetting != null) {
+      userCardSettings.put("firstField", userCardFirstFieldSetting.getValue());
+    } else {
+      userCardSettings.put("firstField", "position");
+    }
+    if(userCardSecondFieldSetting != null) {
+      userCardSettings.put("secondField", userCardSecondFieldSetting.getValue());
+    } else {
+      userCardSettings.put("secondField", "team");
+    }
+    if(userCardThirdFieldSetting != null) {
+      userCardSettings.put("thirdField", userCardThirdFieldSetting.getValue());
+    } else {
+      userCardSettings.put("thirdField", "city");
+    }
 
-    String eTagValue = String.valueOf(Objects.hash(userCardFirstFieldSetting.getValue(), userCardSecondFieldSetting.getValue(), userCardThirdFieldSetting.getValue()));
+    String eTagValue = String.valueOf(Objects.hash(userCardSettings.get("firstField"), userCardSettings.get("secondField"), userCardSettings.get("thirdField")));
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
     if (builder == null) {
       builder = Response.ok(userCardSettings.toString(), MediaType.APPLICATION_JSON);
-      builder.tag(eTag);
+      builder.tag(eTag);  
       builder.cacheControl(CACHE_CONTROL);
     }
     return builder.build();

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/UserCardSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/UserCardSettingsDrawer.vue
@@ -64,7 +64,7 @@
             outlined
             @blur="$refs.firstField.blur();" />
         </label>
-        <label for="firstField">
+        <label for="secondField">
           {{ $t('profileSettings.userCard.settings.secondField.label') }}
           <v-select
             ref="secondField"
@@ -78,7 +78,7 @@
             outlined
             @blur="$refs.secondField.blur();" />
         </label>
-        <label for="firstField">
+        <label for="thirdField">
           {{ $t('profileSettings.userCard.settings.thirdField.label') }}
           <v-select
             ref="thirdField"


### PR DESCRIPTION
Before this fix, when loading the user card settings, a NPE is thrown if those settings are not yet saved by administrators.
The fix checks for the nullity of those settings and returns the default values in that case.