### PR TITLE
fix: Notification are updated even if nothing modified - EXO-72161

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
@@ -126,11 +126,17 @@ public class SpaceNotificationImpl extends SpaceListenerPlugin {
     webNotificationFilter.setPluginKey(new PluginKey(pluginId));
     List<NotificationInfo> webNotifs = getWebNotificationService().getNotificationInfos(webNotificationFilter, 0, -1);
     for (NotificationInfo info : webNotifs) {
-      info.setTo(userId);
-      info.setRead(true);
-      info.setOwnerParameter(new HashMap<>(info.getOwnerParameter()));
-      info.getOwnerParameter().put("status", "accepted");
-      updateNotification(info);
+      if (!info.getTo().equals(userId) ||
+          !info.isRead() ||
+          !"accepted".equals(info.getOwnerParameter().get("status"))) {
+        //one element has changed, we need to update
+        info.setTo(userId);
+
+        info.setRead(true);
+        info.setOwnerParameter(new HashMap<>(info.getOwnerParameter()));
+        info.getOwnerParameter().put("status", "accepted");
+        updateNotification(info);
+      }
     }
   }
 


### PR DESCRIPTION
Before this fix, when updating a notification, we do not check if something change. This can lead to a notification refresh on front side (time updated, notification go in the top of the list), even if nothing change into. This commit add a check and persist the change only if it is needed

Resolves meeds-io/meeds#2075

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
