### PR TITLE
fix: fix different problems when using a profile property multivalued, linked to a group - EXO-72017

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/common/lifecycle/LifeCycleCompletionService.java
+++ b/component/api/src/main/java/org/exoplatform/social/common/lifecycle/LifeCycleCompletionService.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.picocontainer.Startable;
@@ -83,6 +84,7 @@ public class LifeCycleCompletionService implements Startable {
 
   public void addTask(Callable callable) {
     ecs.submit(callable);
+
   }
 
   public void waitCompletionFinished() {
@@ -98,6 +100,25 @@ public class LifeCycleCompletionService implements Startable {
 
   public boolean isAsync() {
     return this.configAsyncExecution;
+  }
+
+  public long getActiveTaskCount() {
+    if (executor instanceof ThreadPoolExecutor threadPoolExecutor) {
+      return threadPoolExecutor.getActiveCount();
+    }
+    return 0;
+  }
+
+  public void waitAllTaskFinished(long timeout) {
+    long start = System.currentTimeMillis();
+    try {
+      while (getActiveTaskCount() != 0 && System.currentTimeMillis() - start <= timeout) {
+        Thread.sleep(100);
+      }
+    }
+    catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public void start() {}

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1078,7 +1078,9 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
             && (profilePropertySettingEntity.getPropertyName() != null && !profilePropertySettingEntity.getPropertyName().isBlank()
             || profileProperty.isMultiValued())) {
               Map<String, String> childrenMap = new HashMap<>();
-              childrenMap.put("key", profilePropertySettingEntity.getPropertyName());
+              if (profilePropertySettingEntity.getPropertyName()!=null) {
+                childrenMap.put("key", profilePropertySettingEntity.getPropertyName());
+              }
               childrenMap.put("value", profilePropertySettingEntity.getValue());
               maps.add(childrenMap);
             }


### PR DESCRIPTION
Before this fix, when using a multivalued property linked to a group, there was differents problems
- 2 errors in logs
- when the property is edited, user is removed, then readd from the group
- when the value have more than one value, the user is not in all corresponding groups

Resolves meeds-io/meeds#2068

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
