### PR TITLE
fix: display primary property of card setting in the popover & the card of users - Meeds-io/meeds#2089 - EXO-71744

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -60,6 +60,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.notification.model.UserSetting;
 import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
@@ -123,6 +125,7 @@ import org.exoplatform.ws.frameworks.json.impl.JsonDefaultHandler;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.exoplatform.ws.frameworks.json.impl.JsonParserImpl;
 import org.exoplatform.ws.frameworks.json.impl.ObjectBuilder;
+import org.json.JSONObject;
 
 public class EntityBuilder {
 
@@ -202,9 +205,14 @@ public class EntityBuilder {
 
   public static final String              SETTINGS                                   = "settings";
 
+  public static final String              USER_CARD_SETTINGS                         = "UserCardSettings";
+
+
   private static UserPortalConfigService  userPortalConfigService;
 
   private static LayoutService            layoutService;
+
+  private static SettingService           settingService;
 
   private static UserACL                  userACL;
   
@@ -409,6 +417,29 @@ public class EntityBuilder {
     if (expandAttributes.contains("managedUsersCount")) {
       buildManagedUsersCount(userEntity);
     }
+
+    // Get values of properties configured for the user card
+    SettingValue<?> userCardFirstFieldSetting = getSettingService().get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new org.exoplatform.commons.api.settings.data.Scope(org.exoplatform.commons.api.settings.data.Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardFirstFieldSetting");
+    SettingValue<?> userCardSecondFieldSetting = getSettingService().get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new org.exoplatform.commons.api.settings.data.Scope(org.exoplatform.commons.api.settings.data.Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardSecondFieldSetting");
+    SettingValue<?> userCardThirdFieldSetting = getSettingService().get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new org.exoplatform.commons.api.settings.data.Scope(org.exoplatform.commons.api.settings.data.Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardThirdFieldSetting");
+
+    if(userCardFirstFieldSetting != null) {
+      userEntity.setPrimaryProperty((String) profile.getProperty(String.valueOf(userCardFirstFieldSetting.getValue())));
+    } else {
+      userEntity.setPrimaryProperty(userEntity.getPosition());
+    }
+    if(userCardSecondFieldSetting != null) {
+      userEntity.setSecondaryProperty((String) profile.getProperty(String.valueOf(userCardSecondFieldSetting)));
+    } else {
+      userEntity.setSecondaryProperty(userEntity.getTeam());
+    }
+
+    if(userCardThirdFieldSetting != null) {
+      userEntity.setTertiaryProperty((String) profile.getProperty(String.valueOf(userCardThirdFieldSetting)));
+    } else {
+      userEntity.setTertiaryProperty(userEntity.getCity());
+    }
+
     return userEntity;
   }
 
@@ -2027,6 +2058,13 @@ public class EntityBuilder {
       layoutService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(LayoutService.class);
     }
     return layoutService;
+  }
+
+  private static SettingService getSettingService() {
+    if (settingService == null) {
+      settingService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(SettingService.class);
+    }
+    return settingService;
   }
   
   private static TranslationService getTranslationService() {

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
@@ -24,79 +24,85 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.social.core.identity.model.Profile;
 
 public class ProfileEntity extends BaseEntity {
-  public static final String IMS                 = "ims";
+  public static final String IMS                     = "ims";
 
-  public static final String EXPERIENCES         = "experiences";
+  public static final String EXPERIENCES             = "experiences";
 
-  public static final String PHONES              = "phones";
+  public static final String PHONES                  = "phones";
 
-  public static final String ABOUT_ME            = "aboutMe";
+  public static final String ABOUT_ME                = "aboutMe";
 
-  public static final String TIME_ZONE           = "timeZone";
+  public static final String TIME_ZONE               = "timeZone";
 
-  public static final String TIME_ZONE_DST       = "timeZoneDSTSavings";
+  public static final String TIME_ZONE_DST           = "timeZoneDSTSavings";
 
-  public static final String BANNER              = "banner";
+  public static final String BANNER                  = "banner";
 
-  public static final String AVATAR              = "avatar";
+  public static final String AVATAR                  = "avatar";
 
-  public static final String DEFAULT_AVATAR      = "isDefaultAvatar";
+  public static final String DEFAULT_AVATAR          = "isDefaultAvatar";
 
-  public static final String POSITION            = "position";
+  public static final String POSITION                = "position";
 
-  public static final String EMAIL               = "email";
+  public static final String EMAIL                   = "email";
 
-  public static final String GENDER              = "gender";
+  public static final String GENDER                  = "gender";
 
-  public static final String FULLNAME            = "fullname";
+  public static final String FULLNAME                = "fullname";
 
-  public static final String LASTNAME            = "lastname";
+  public static final String LASTNAME                = "lastname";
 
-  public static final String FIRSTNAME           = "firstname";
+  public static final String FIRSTNAME               = "firstname";
 
-  public static final String USERNAME            = "username";
+  public static final String USERNAME                = "username";
 
-  public static final long   serialVersionUID    = -3241490307391015454L;
+  public static final long   serialVersionUID        = -3241490307391015454L;
 
-  public static final String IDENTITY            = "identity";
+  public static final String IDENTITY                = "identity";
 
-  public static final String URLS                = "urls";
+  public static final String URLS                    = "urls";
 
-  public static final String DELETED             = "deleted";
+  public static final String DELETED                 = "deleted";
 
-  public static final String ENABLED             = "enabled";
+  public static final String ENABLED                 = "enabled";
 
-  public static final String IS_INTERNAL         = "isInternal";
+  public static final String IS_INTERNAL             = "isInternal";
 
-  public static final String COMPANY             = "company";
+  public static final String COMPANY                 = "company";
 
-  public static final String LOCATION            = "location";
+  public static final String LOCATION                = "location";
 
-  public static final String DEPARTMENT          = "department";
+  public static final String DEPARTMENT              = "department";
 
-  public static final String TEAM                = "team";
+  public static final String TEAM                    = "team";
 
-  public static final String PROFESSION          = "profession";
+  public static final String PROFESSION              = "profession";
 
-  public static final String COUNTRY             = "country";
+  public static final String COUNTRY                 = "country";
 
-  public static final String CITY                = "city";
+  public static final String CITY                    = "city";
 
-  public static final String EXTERNAL            = "external";
+  public static final String EXTERNAL                = "external";
 
-  public static final String LAST_LOGIN_TIME     = "lastLoginTime";
+  public static final String LAST_LOGIN_TIME         = "lastLoginTime";
 
-  public static final String ENROLLMENT_DATE     = "enrollmentDate";
+  public static final String ENROLLMENT_DATE         = "enrollmentDate";
 
-  public static final String SYNCHRONIZED_DATE   = "synchronizedDate";
+  public static final String SYNCHRONIZED_DATE       = "synchronizedDate";
 
-  public static final String CREATED_DATE        = "createdDate";
+  public static final String CREATED_DATE            = "createdDate";
 
-  public static final String IS_ADMIN            = "isAdmin";
+  public static final String IS_ADMIN                = "isAdmin";
 
-  public static final String MANAGERS            = "managers";
+  public static final String MANAGERS                = "managers";
 
-  public static final String MANAGED_USERS_COUNT = "managedUsersCount";
+  public static final String MANAGED_USERS_COUNT     = "managedUsersCount";
+
+  public static final String PRIMARY_PROPERTY   = "primaryProperty";
+
+  public static final String SECONDARY_PROPERTY = "secondaryProperty";
+
+  public static final String TERTIARY_PROPERTY  = "tertiaryProperty";
 
   public ProfileEntity() {
   }
@@ -560,6 +566,31 @@ public class ProfileEntity extends BaseEntity {
 
   public ProfileEntity setManagedUsersCount(int managedUsersCount) {
     setProperty(MANAGED_USERS_COUNT, managedUsersCount);
+    return this;
+  }
+
+  public String getPrimaryProperty() {
+    return getString(PRIMARY_PROPERTY);
+  }
+
+  public ProfileEntity setPrimaryProperty(String primaryProperty) {
+    setProperty(PRIMARY_PROPERTY, primaryProperty);
+    return this;
+  }
+  public String getSecondaryCardProperty() {
+    return getString(SECONDARY_PROPERTY);
+  }
+
+  public ProfileEntity setSecondaryProperty(String secondaryProperty) {
+    setProperty(SECONDARY_PROPERTY, secondaryProperty);
+    return this;
+  }
+  public String getTertiaryCardProperty() {
+    return getString(TERTIARY_PROPERTY);
+  }
+
+  public ProfileEntity setTertiaryProperty(String tertiaryProperty) {
+    setProperty(TERTIARY_PROPERTY, tertiaryProperty);
     return this;
   }
   

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -342,8 +342,8 @@ export default {
     userFullname() {
       return this.userIdentity?.fullname || this.name;
     },
-    position() {
-      return this.userIdentity?.position;
+    primaryProperty() {
+      return this.userIdentity?.primaryProperty;
     },
     userAvatarUrl() {
       return this.userIdentity?.enabled ? (this.userIdentity.avatar || this.avatarUrl || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.username || this.profileId}/avatar`) : (this.avatarUrl  || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/default-image/avatar`);
@@ -389,7 +389,7 @@ export default {
         enabled: this.enabled,
         deleted: this.deleted,       
         fullName: this.userFullname,
-        position: this.position,
+        primaryProperty: this.primaryProperty,
         avatar: this.userAvatarUrl,
         external: this.isExternal,
         allowAnimation: this.compact && this.allowAnimation,
@@ -406,7 +406,7 @@ export default {
           || !this.identity.avatar
           || !this.identity.hasOwnProperty('enabled')
           || !this.identity.hasOwnProperty('deleted')
-          || !this.identity.hasOwnProperty('position')
+          || !this.identity.hasOwnProperty('primaryProperty')
           || !this.identity.hasOwnProperty('external');
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/PopoverMenu.vue
@@ -92,7 +92,7 @@ export default {
           username: data?.username,
           fullname: data?.fullName,
           avatar: data?.avatar,
-          position: data?.position,
+          primaryProperty: data?.primaryProperty,
           external: data?.external,
         };
         localStorage.setItem('popover-identity-type', 'USER_TIPTIP');

--- a/webapp/portlet/src/main/webapp/vue-apps/popover/components/UserPopoverContent.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/popover/components/UserPopoverContent.vue
@@ -36,9 +36,9 @@
             :popover="false"
             bold-title
             link-style>
-            <template v-if="position" slot="subTitle">
+            <template v-if="primaryProperty" slot="subTitle">
               <span class="caption text-bold">
-                {{ position }}
+                {{ primaryProperty }}
               </span>
             </template>
           </exo-user-avatar>
@@ -109,8 +109,8 @@ export default {
     username() {
       return this.identity?.username;
     },
-    position() {
-      return this.identity?.position;
+    primaryProperty() {
+      return this.identity?.primaryProperty;
     },
     isCurrentUser() {
       return eXo.env.portal.userName === this.username;

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderText.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderText.vue
@@ -11,10 +11,10 @@
         {{ userFullname }}
       </div>
       <div
-        id="profileHeaderUserPosition"
-        v-if="userPosition"
+        id="profileHeaderUserPrimaryProperty"
+        v-if="primaryProperty"
         class="subtitle text-sub-title text-break text-wrap">
-        {{ userPosition || '' }}
+        {{ primaryProperty || '' }}
       </div>
     </div>
   </v-card>
@@ -32,8 +32,8 @@ export default {
     userFullname() {
       return this.user?.fullname && `${this.user.fullname}${this.external}${this.disabled}`;
     },
-    userPosition() {
-      return this.user?.position;
+    primaryProperty() {
+      return this.user?.primaryProperty;
     },
     external() {
       if (this.user && this.user.external === 'true') {

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
@@ -259,7 +259,7 @@ export default {
         this.userCardSettingScopeKey, 'UserCardSettings', settingKey, settingValue);
     },
     getSavedUserCardSettings() {
-      return this.$userService.getUserCardSettings().then(userCardSettings => this.userCardSettings = userCardSettings);
+      return this.$userService.getUserCardSettings().then(userCardSettings => this.savedCardSettings = userCardSettings);
     },
     saveUserCardSettings(firstField, secondField, thirdField) {
       this.isSavingCardSettings = true;

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/UserCardSettingsDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/drawers/UserCardSettingsDrawer.vue
@@ -72,7 +72,7 @@
             :items="settings"
             item-text="label"
             item-value="value"
-            name="firstField"
+            name="secondField"
             class="pt-1"
             dense
             outlined
@@ -86,7 +86,7 @@
             :items="settings"
             item-text="label"
             item-value="value"
-            name="firstField"
+            name="thirdField"
             class="pt-1"
             dense
             outlined


### PR DESCRIPTION
This fix allows to use the primary property of the card settings in the user card and the user popover.
The property is available in the Rest entity representation of the User returned by the Rest call getUserById