### PR TITLE
fix: replace special chars with spaces instead of empty strings - EXO-65931

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -574,9 +574,9 @@ public class ProfileSearchConnector {
   }
 
   public static String removeESReservedChars(String string) {
-    String [] ES_RESERVED_CHARS = new String []{"","+","-","=","&&","||",">","<","!","(",")","{","}","[","]","^","\"","~","*","?",":","\\","/"};
+    String [] ES_RESERVED_CHARS = new String []{"+","-","=","&&","||",">","<","!","(",")","{","}","[","]","^","\"","~","*","?",":","\\","/"};
     for(String c : ES_RESERVED_CHARS) {
-      string = string.replace(c, "");
+      string = string.replace(c, " ");
     }
     return string;
   }


### PR DESCRIPTION
While cleaning the search word from special characters, we replaced them with empty char and that caused having fewer results than expected.
Replacing those characters with a space returned the correct results.