### PR TITLE
fix: display dynamically complementary filters based on drawer width - Meeds-io/meeds#2102 - EXO-72210

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/profileSettings.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/profileSettings.jsp
@@ -5,24 +5,26 @@
 <%@page import="org.exoplatform.web.application.RequestContext"%>
 <%@page import="org.json.JSONArray"%>
 <%@page import="java.util.Set"%>
-<%@page
-  import="org.exoplatform.portal.localization.LocaleContextInfoUtils"%>
+<%@page import="org.exoplatform.portal.localization.LocaleContextInfoUtils"%>
+
 <%
   Locale userLocale = RequestContext.getCurrentInstance().getLocale();
 
-			Set<Locale> locales = LocaleContextInfoUtils.getSupportedLocales();
-			List<Locale> localesList = new ArrayList(locales);
-			JSONArray localesJSON = new JSONArray();
-			for (Locale locale : localesList) {
-				JSONObject object = new JSONObject();
-				if (locale.toString().equals("ma")) {
-					continue;
-				} else {
-					object.put("value", locale.toString());
-					object.put("text", locale.getDisplayName(Locale.ENGLISH));
-				}
-				localesJSON.put(object);
-			}
+  Set<Locale> locales = LocaleContextInfoUtils.getSupportedLocales();
+  List<Locale> localesList = new ArrayList(locales);
+  JSONArray localesJSON = new JSONArray();
+  for (Locale locale : localesList) {
+    if(locale != null) {
+      JSONObject object = new JSONObject();
+      if ("ma".equals(locale.toString())) {
+          continue;
+      } else {
+        object.put("value", locale.toString());
+        object.put("text", locale.getDisplayName(Locale.ENGLISH));
+      }
+      localesJSON.put(object);
+    }
+  }
 %>
 <div class="VuetifyApp">
   <div data-app="true"

--- a/webapp/portlet/src/main/webapp/skin/less/portlet/ProfileContactInformation/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/ProfileContactInformation/Style.less
@@ -29,24 +29,6 @@
 
 #ProfileContactInformation {
 
-  #quickSearchUsersListDrawer {
-    .quickSearchResultExpanded {
-      @import "../../common/PeopleList/Style.less";
-    }
-
-    .quickSearchResultCollapsed {
-      @import "../../common/ProfileCard/Style-mobile.less";
-    }
-
-    .filter-message {
-      top: 2px;
-    }
-
-    .suggestion-selected {
-      border: 1px solid;
-    }
-  }
-
   .list-no-selection {
     .v-list-item--active::before {
       opacity: 0;
@@ -114,5 +96,22 @@
   .identitySuggester .v-input__control .v-select__selections {
     padding: 10px !important;
     min-height: auto !important;
+  }
+}
+#quickSearchUsersListDrawer {
+  .quickSearchResultExpanded {
+    @import "../../common/PeopleList/Style.less";
+  }
+
+  .quickSearchResultCollapsed {
+    @import "../../common/ProfileCard/Style-mobile.less";
+  }
+
+  .filter-message {
+    top: 2px;
+  }
+
+  .suggestion-selected {
+    border: 1px solid;
   }
 }

--- a/webapp/portlet/src/main/webapp/vue-apps/complementary-filter/components/ComplementaryFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/complementary-filter/components/ComplementaryFilter.vue
@@ -129,7 +129,6 @@ export default {
     },
     parentExpanded() {
       setTimeout(() => {
-        console.log('Delayed for 1 second.');
         this.displayedSuggestions();
       }, '500');
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
@@ -47,6 +47,7 @@
         :show-message="false"
         index-alias="profile_alias"
         :loading-call-back="loadingCallBack"
+        :parent-expanded="expanded"
         @build-suggestions-terminated="buildSuggestionsTerminated"
         @filter-changed="selectedSuggestionsUpdated"
         @filter-suggestion-unselected="unselectSuggestion"
@@ -115,7 +116,7 @@
         <v-btn
           :loading="isLoading"
           class="btn btn-primary width-full"
-          flat
+          text
           outlined
           @click="search(true)">
           {{ $t('Search.button.loadMore') }}


### PR DESCRIPTION
before this fix, suggested filters were displayed on 2 lines when they contain a long text and does not fit all the space when the drawer is expanded.
The fix will calculate the available space and fit the number of displayed filters to the whole space when the drawer is collapsed or expanded.