### PR TITLE
fix: hide inactive/hidden properties from user card - Meeds-io/meeds#…

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -424,18 +424,36 @@ public class EntityBuilder {
     SettingValue<?> userCardThirdFieldSetting = getSettingService().get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new org.exoplatform.commons.api.settings.data.Scope(org.exoplatform.commons.api.settings.data.Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardThirdFieldSetting");
 
     if(userCardFirstFieldSetting != null) {
-      userEntity.setPrimaryProperty((String) profile.getProperty(String.valueOf(userCardFirstFieldSetting.getValue())));
+      String propertyName = String.valueOf(userCardFirstFieldSetting.getValue());
+      ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(propertyName);
+      if(propertySetting != null && propertySetting.isVisible() && !profilePropertyService.getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId())).contains(propertySetting.getId())) {
+        userEntity.setPrimaryProperty((String) profile.getProperty(propertyName));
+      } else {
+        userEntity.setPrimaryProperty("");
+      }
     } else {
       userEntity.setPrimaryProperty(userEntity.getPosition());
     }
     if(userCardSecondFieldSetting != null) {
-      userEntity.setSecondaryProperty((String) profile.getProperty(String.valueOf(userCardSecondFieldSetting)));
+      String propertyName = String.valueOf(userCardSecondFieldSetting.getValue());
+      ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(propertyName);
+      if(propertySetting != null && propertySetting.isVisible() && !profilePropertyService.getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId())).contains(propertySetting.getId())) {
+        userEntity.setSecondaryProperty((String) profile.getProperty(propertyName));
+      } else {
+        userEntity.setSecondaryProperty("");
+      }
     } else {
       userEntity.setSecondaryProperty(userEntity.getTeam());
     }
 
     if(userCardThirdFieldSetting != null) {
-      userEntity.setTertiaryProperty((String) profile.getProperty(String.valueOf(userCardThirdFieldSetting)));
+      String propertyName = String.valueOf(userCardThirdFieldSetting.getValue());
+      ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(propertyName);
+      if(propertySetting != null && propertySetting.isVisible() && !profilePropertyService.getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId())).contains(propertySetting.getId())) {
+        userEntity.setTertiaryProperty((String) profile.getProperty(propertyName));
+      } else {
+        userEntity.setTertiaryProperty("");
+      }
     } else {
       userEntity.setTertiaryProperty(userEntity.getCity());
     }

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -25,8 +25,7 @@
                 :user="user"
                 :space-members-extensions="spaceMembersActionExtensions"
                 :user-navigation-extensions="userExtensions"
-                :profile-action-extensions="profileActionExtensions"
-                :user-card-settings="userCardSettings" />
+                :profile-action-extensions="profileActionExtensions" />
             </v-col>
           </v-row>
           <div v-else-if="!loadingPeople" class="d-flex text-center noPeopleYetBlock">
@@ -154,7 +153,6 @@ export default {
     },
   },
   created() {
-    this.getSavedUserCardSettings();
     this.originalLimitToFetch = this.limitToFetch = this.limit;
 
     // To refresh menu when a new extension is ready to be used
@@ -172,9 +170,6 @@ export default {
     this.refreshUserExtensions();
   },
   methods: {
-    getSavedUserCardSettings() {
-      return this.$userService.getUserCardSettings().then(userCardSettings => this.userCardSettings = userCardSettings);
-    },
     resetFilters() {
       this.$root.$emit('reset-filter');
       this.$root.$emit('reset-advanced-filter');

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleCard.vue
@@ -6,7 +6,6 @@
       :user-navigation-extensions="userNavigationExtensions"
       :space-members-extensions="filteredSpaceMembersExtensions"
       :profile-action-extensions="profileActionExtensions"
-      :preferences="userCardSettings"
       :is-mobile="isMobile" />
     <people-user-compact-card
       v-else
@@ -43,10 +42,6 @@ export default {
     compactDisplay: {
       type: Boolean,
       default: false,
-    },
-    userCardSettings: {
-      type: Object,
-      default: () => ({}),
     },
   },
   data: () => ({

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -183,11 +183,6 @@ export default {
   data() {
     return {
       menu: false,
-      defaultPreferences: {
-        firstField: 'position',
-        secondField: 'team',
-        thirdField: 'city'
-      },
     };
   },
   props: {
@@ -211,10 +206,6 @@ export default {
       type: Array,
       default: () => []
     },
-    preferences: {
-      type: Object,
-      default: null
-    },
     isMobile: {
       type: Boolean,
       default: false
@@ -223,9 +214,6 @@ export default {
   computed: {
     showMenu() {
       return this.menu || this.isMobile;
-    },
-    preferencesObject() {
-      return this.preferences || this.defaultPreferences;
     },
     filteredUserNavigationExtensions() {
       return this.userNavigationExtensions.filter(extension => extension.enabled(this.user)
@@ -237,17 +225,14 @@ export default {
     isSameUser() {
       return this.user?.username === eXo?.env?.portal?.userName;
     },
-    fieldsToDisplay() {
-      return this.user?.properties?.filter(property => Object.values(this.preferencesObject).includes(property.propertyName));
-    },
     firstField() {
-      return this.fieldsToDisplay?.filter(property => property.propertyName === this.preferencesObject.firstField)[0]?.value;
+      return this.user?.primaryProperty;
     },
     secondField() {
-      return this.fieldsToDisplay?.filter(property => property.propertyName === this.preferencesObject.secondField)[0]?.value;
+      return this.user?.secondaryProperty;
     },
     thirdField() {
-      return this.fieldsToDisplay?.filter(property => property.propertyName === this.preferencesObject.thirdField)[0]?.value;
+      return this.user?.tertiaryProperty;
     },
     bannerUrl() {
       return this.user?.banner;


### PR DESCRIPTION
The properties that are hidden (by user) or inactive (by administrators) are still visible on the user card.
The fix checks the configured card properties and hide/show them based on the visibility configured by administrators and user preferences