### PR TITLE
fix: Editing an activity with files removes the mention - MEED-6898 - Meeds-io/meeds#2029

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -211,7 +211,6 @@ export default {
   watch: {
     inputVal() {
       this.updateInput(this.inputVal);
-
       if (this.supportsOembed) {
         this.setOembedParams({
           default_title: this.getContentToSave(this.inputVal),
@@ -409,6 +408,7 @@ export default {
               });
 
             self.setEditorReady();
+            self.inputVal = textValue && self.getContentToSave(textValue);
             if (this.autofocus) {
               window.setTimeout(() => self.setFocus(), 50);
             }

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -226,6 +226,7 @@ export default {
     editorReady() {
       if (this.editorReady) {
         this.$emit('ready');
+        this.updateInput(this.inputVal);
         this.initOembedParams();
       } else {
         this.$emit('unloaded');
@@ -408,7 +409,6 @@ export default {
               });
 
             self.setEditorReady();
-            self.inputVal = textValue && self.getContentToSave(textValue);
             if (this.autofocus) {
               window.setTimeout(() => self.setFocus(), 50);
             }


### PR DESCRIPTION
Before this change, editing an activity attachment without changing the activity text impacted user mentions.
This fix ensures that when the editor is ready, the suggester's HTML is automatically converted to text.