### PR TITLE
fix: Delete useless ResourceRequestFilter mappings - MEED-7004 - Meeds-io/meeds#2109

### DIFF
--- a/extension/war/src/main/webapp/WEB-INF/web.xml
+++ b/extension/war/src/main/webapp/WEB-INF/web.xml
@@ -36,7 +36,10 @@
 
   <filter-mapping>
     <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>/*</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 
 

--- a/webapp/portlet/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/web.xml
@@ -49,7 +49,10 @@
 
   <filter-mapping>
     <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>/*</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 
   <!-- ================================================================== -->


### PR DESCRIPTION
Prior to this change, any URL was cached while the Cache HTTP Header should be applied systematically on static resources only. This change changes the Filter mapping list in order to include static resources only.

(Resolves Meeds-io/meeds#2109)