### PR TITLE
fix: News display in activity stream isn't ok on mobile view - EXO-71947 - Meeds-io/meeds#2111

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -203,7 +203,7 @@ export default {
       return this.defaultIcon && this.defaultIcon.size || 58;
     },
     useMobileView() {
-      return this.$vuetify.breakpoint.name === 'xs' && !this.useSameViewForMobile;
+      return this.$vuetify.breakpoint.name === 'sm' && !this.useSameViewForMobile;
     },
     htmlElement() {
       return this.sourceLink && this.sourceLink !== '#' && 'a' || 'div';


### PR DESCRIPTION
Before this change, when post few news articles in space each has an illustration and content, display spaceX activity stream or global stream and switch to mobile view, articles' activity display ion mobile isn't the good one, the title and description are displayed on the right side along article illustration. After this change on mobile view, articles activities display illustration and belwo their title.

(cherry picked from commit 0ace8daa771505e2eaf9937c796e5f8af803f21b)