### PR TITLE
fix: Display last comments when activity is not read - MEED-7022 - Meeds-io/Meeds#2117

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -245,7 +245,7 @@ export default {
                                      && actionType.length
                                      && this.$root.displayCommentActionTypes.indexOf(actionType) >= 0;
         this.isCollapsed = this.unreadMetadata && !isLikeAction && !isNewActivityComment;
-        this.hasNewComment = isNewActivityComment;
+        this.hasNewComment = isNewActivityComment || this.unreadMetadata;
       }
     },
   },


### PR DESCRIPTION
Before this change, the last two comments in an activity were hidden, even if the activity was unread. 
This fix ensures the comments section is displayed when the activity is unread