### PR TITLE
fix: Editing an activity with files removes the mention - MEED-6898 -Meeds-io/meeds#2029

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -211,14 +211,15 @@ export default {
   watch: {
     inputVal() {
       this.updateInput(this.inputVal);
-
-      if (this.supportsOembed) {
-        this.setOembedParams({
-          default_title: this.getContentToSave(this.inputVal),
-          comment: this.getContentNoEmbed(this.inputVal),
-        });
-      } else {
-        this.clearOembedParams();
+      if (this.editorReady) {
+        if (this.supportsOembed) {
+          this.setOembedParams({
+            default_title: this.getContentToSave(this.inputVal),
+            comment: this.getContentNoEmbed(this.inputVal),
+          });
+        } else {
+          this.clearOembedParams();
+        }
       }
     },
     oembedParams() {
@@ -228,6 +229,7 @@ export default {
       if (this.editorReady) {
         this.$emit('ready');
         this.initOembedParams();
+        this.updateInput(this.inputVal);
       } else {
         this.$emit('unloaded');
       }


### PR DESCRIPTION
Previously, tag mentions were not displayed correctly due to changes in the default title and comment in the oembedParam when the input value changed.
This fix resolves the issue by ensuring these values only change when the editor is ready