### PR TITLE
fix: refresh cache after changing configured card properties - Meeds-io/meeds#2156 - EXO-72474

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -559,8 +559,31 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
                                                                                                        Long.parseLong(identity.getId()))));
     }
 
+    // Get configured properties for cache
+    // Get values of properties configured for the user card
+    List<String> configuredCardProperties = new ArrayList<>();
+    SettingValue<?> userCardFirstFieldSetting = settingService.get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new org.exoplatform.commons.api.settings.data.Scope(org.exoplatform.commons.api.settings.data.Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardFirstFieldSetting");
+    SettingValue<?> userCardSecondFieldSetting = settingService.get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new org.exoplatform.commons.api.settings.data.Scope(org.exoplatform.commons.api.settings.data.Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardSecondFieldSetting");
+    SettingValue<?> userCardThirdFieldSetting = settingService.get(org.exoplatform.commons.api.settings.data.Context.GLOBAL, new org.exoplatform.commons.api.settings.data.Scope(org.exoplatform.commons.api.settings.data.Scope.GLOBAL.getName(), USER_CARD_SETTINGS), "UserCardThirdFieldSetting");
+    if(userCardFirstFieldSetting != null) {
+      configuredCardProperties.add((String) userCardFirstFieldSetting.getValue());
+    } else {
+      configuredCardProperties.add("position");
+    }
+    if(userCardSecondFieldSetting != null) {
+      configuredCardProperties.add((String) userCardSecondFieldSetting.getValue());
+    } else {
+      configuredCardProperties.add("team");
+    }
+    if(userCardThirdFieldSetting != null) {
+      configuredCardProperties.add((String) userCardThirdFieldSetting.getValue());
+    } else {
+      configuredCardProperties.add("city");
+    }
+
+
     long cacheTime = identity.getCacheTime();
-    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expandedSettings));
+    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expandedSettings, configuredCardProperties));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);

--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/profile/ProfileHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/profile/ProfileHamburgerNavigation.vue
@@ -101,11 +101,10 @@ export default {
   },
   methods: {
     retrieveUserInformation() {
-      this.profile = this.$currentUserIdentity && this.$currentUserIdentity.profile;
-      if (!this.profile) {
-        return this.$identityService.getIdentityById(eXo.env.portal.userIdentityId)
-          .then(data => this.profile = data && data.profile);
-      }
+      return this.$identityService.getIdentityById(eXo.env.portal.userIdentityId)
+        .then(data => {
+          this.profile = data && data.profile;
+        });
     },
     changeMenuStickiness(event) {
       if (event) {


### PR DESCRIPTION
Before this fix, the retrieved user identity was not updated after changing the user card properties, thus the old properties remain unless we do a hard reload of the page or do a logout/login
The fix includes the value of the card properties to change the Etag when the properties change, and avoid to use the old user identity in the hamburger menu 