### PR TITLE
fix: Delete preloading of fetch resources - Meeds-io/meeds#2188

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topBarMenu.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topBarMenu.jsp
@@ -11,7 +11,7 @@
     if (space == null) {
       PortalRequestContext rcontext = (PortalRequestContext) PortalRequestContext.getCurrentInstance();
       PortalHttpServletResponseWrapper responseWrapper = (PortalHttpServletResponseWrapper) rcontext.getResponse();
-      responseWrapper.addHeader("Link", "</portal/rest/v1/navigations/PORTAL?siteName=" + rcontext.getPortalOwner() + "&scope=children&visibility=displayed&visibility=temporal&exclude=global>; rel=preload; as=fetch; crossorigin=use-credentials", false);
+      responseWrapper.addHeader("Link", "</portal/rest/v1/navigations/PORTAL?siteName=" + rcontext.getPortalOwner() + "&scope=children&visibility=displayed&visibility=temporal&exclude=global&expand=true>; rel=preload; as=fetch; crossorigin=use-credentials", false);
     %>
     <script type="text/javascript">
       const topBarMenuHtml = sessionStorage.getItem('topBarMenu');

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -426,7 +426,7 @@
     </init-param>
     <init-param>
       <name>preload.resource.rest</name>
-      <value><![CDATA[/portal/rest/v1/social/identities/{userId}]]></value>
+      <value><![CDATA[/portal/rest/v1/social/identities/{userId}?expand=]]></value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>
@@ -626,10 +626,6 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/spacesList.jsp</value>
     </init-param>
-    <init-param>
-      <name>preload.resource.rest</name>
-      <value><![CDATA[/portal/rest/v1/social/spaces?q=&offset=0&limit=20&filterType=all&returnSize=true&expand=managers,favorite|/portal/rest/v1/social/spaceTemplates/templates]]></value>
-    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -679,10 +675,6 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/peopleList.jsp</value>
-    </init-param>
-    <init-param>
-      <name>preload.resource.rest</name>
-      <value><![CDATA[|/portal/rest/v1/social/users?q=&offset=0&limit=21&expand=all,spacesCount,relationshipStatus,connectionsCount,binding&returnSize=true]]></value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>


### PR DESCRIPTION
Prior to this change, the fetched resources URLs changes by introducing/modifying features. This change deletes the prefetched resources to ensure not preloading outdated URLs when JS fetch URLs changes. At the same time, this will update some generic prefetched resources in order to improve performances.

( Resolves Meeds-io/meeds#2188 )