### PR TITLE
fix: Fix ZIndex of Notification Menu - MEED-7074 - Meeds-io/meeds#2158

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationMenu.vue
@@ -30,6 +30,7 @@
     :right="$vuetify.rtl"
     :attach="!absolute"
     :absolute="absolute"
+    class="z-index-modal"
     offset-y
     bottom>
     <template #activator="{ on, attrs }">


### PR DESCRIPTION
Prior to this change, the right click menu of notifications is added on bottom of drawer. This change ensures to use the right zindex for menu to keep it as a modal on top of all displayed elements.

(Resolves Meeds-io/meeds#2158)