### PR TITLE
fix: Fix dimensions of Unread Badge - MEED-7082 - Meeds-io/meeds#2184

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
@@ -6,7 +6,7 @@
       <v-btn
         v-show="displayBadge"
         :style="`z-index: ${zIndex};`"
-        class="unread-activity-badge"
+        class="unread-activity-badge content-box-sizing"
         absolute
         icon
         height="20"


### PR DESCRIPTION
Prior to this change, the Unread Badge box sizing is inherited from any parent modifying its own Box Sizing. This change forces the usage of content-box-sizing on unread badge to not having its size reduced when a parent container uses border-box-sizing.