### PR TITLE
fix: enable the menu in the user card for logged-in user - Meeds-io/meeds#2197 - EXO-71739

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCompactCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCompactCard.vue
@@ -46,7 +46,7 @@
             fas fa-ellipsis-v
           </v-icon>
         </div>
-        <template v-else-if="canUseActionsMenu && !isSameUser">
+        <template v-else-if="canUseActionsMenu">
           <v-menu
             ref="actionMenu"
             v-model="displayActionMenu"
@@ -207,7 +207,7 @@ export default {
       return this.user?.id && `userMenuParent-${this.user.id}` || 'userMenuParent';
     },
     canUseActionsMenu() {
-      return this.user && this.enabledProfileActionExtensions.length;
+      return this.user && (this.enabledProfileActionExtensions.length || this.userNavigationExtensions.length);
     },
     usernameClass() {
       return `${(!this.user.enabled || this.user.deleted) && 'text-sub-title' || 'primary--text text-truncate-2 mt-0'}`;


### PR DESCRIPTION
the curent fix will enable the menu in the user card for the logged in user to display the Organizational chart button