### PR TITLE
TASK-72551: Support download translation from main crowdin branch to …

### DIFF
--- a/.github/workflows/download-crowdin-develop.yml
+++ b/.github/workflows/download-crowdin-develop.yml
@@ -1,0 +1,15 @@
+name: Crowdin download Action for develop
+
+on:
+  workflow_dispatch:
+
+jobs:
+  download-crowdin-develop:
+    name: CI Build
+    uses: exoplatform/swf-scripts/.github/workflows/download-crowdin-develop.yml@master
+    secrets:
+      CROWDIN_GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      SWF_GPG_PRIVATE_KEY: ${{ secrets.SWF_GPG_PRIVATE_KEY }}
+      SWF_GPG_PASSPHRASE: ${{ secrets.SWF_GPG_PASSPHRASE }}


### PR DESCRIPTION
Before this PR, develop branch was not directly synchronised with crowdin project.
To avoid dealing with daily rebase conflict, this PR allow to have a github action which will sync with crowdin project's main branch when needed. The archis will take care to apply it and deal with the potential rebases conflicts. Its usage will not be frequent and will allow to get translation up to date 