### PR TITLE
fix: Fix Old space Menu Portlet Style - MEED-7106 - Meeds-io/meeds#2207

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/portlet/SpaceHeader/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/SpaceHeader/Style.less
@@ -34,3 +34,16 @@
     background: rgba(0, 0, 0, 0.2) !important;
   }
 }
+
+#MenuChildren {
+  width: @singlePageApplicationWidth;
+  padding: 24px 20px 0 !important;
+  margin: 0 auto !important;
+  max-width: 100% !important;
+  box-sizing: border-box !important;
+
+  .PORTLET-FRAGMENT {
+    padding-bottom: 0 !important;
+    margin-bottom: 0 !important;
+  }
+}


### PR DESCRIPTION
Prior to this change, the deprecated Space Menu and Header Portlet wasn't displayed with the right dimensions of Single Page Application Style. This change will rework the Space Header Style to enforce its display with the right dimensions by using Single Page Application Style.

Resolves https://github.com/Meeds-io/meeds/issues/2207