### PR TITLE
fix: hide org chat button for the card of external users - Meeds-io/meeds#2209 - EXO-72074

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/extensions.js
@@ -5,7 +5,7 @@ export function registerExtension(title) {
     icon: 'fas fa-sitemap',
     class: 'fas fa-sitemap',
     order: 10,
-    enabled: (user) => eXo.env.portal.isExternal === 'false' && user.enabled,
+    enabled: (user) => eXo.env.portal.isExternal === 'false' && user.enabled && (!user.external || user.external === 'false'),
     click: (profile) => {
       const isCurrentUser = profile.id === eXo.env.portal.userIdentityId;
       const chartPage = isCurrentUser && 'dashboard/myteam' || 'organizationalchart';

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/extensions.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/extensions/extensions.js
@@ -5,7 +5,7 @@ export function registerExtension(title) {
     icon: 'fas fa-sitemap',
     class: 'fas fa-sitemap',
     order: 10,
-    enabled: (user) => eXo.env.portal.isExternal === 'false' && user.enabled && (!user.external || user.external === 'false'),
+    enabled: (user) => eXo.env.portal.isExternal === 'false' && user.enabled && user?.external !==  'true',
     click: (profile) => {
       const isCurrentUser = profile.id === eXo.env.portal.userIdentityId;
       const chartPage = isCurrentUser && 'dashboard/myteam' || 'organizationalchart';


### PR DESCRIPTION
When checking external users in the space members page, or hovering over their names in activities, those users should not have the Organizational chart button.