### PR TITLE
feat: Redefine Parent applications Classes to fit layout style properties - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/gettingStarted.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/gettingStarted.jsp
@@ -31,7 +31,7 @@
     <div data-app="true"
       class="v-application v-application--is-ltr theme--light" id="app">
       <div class="v-application--wrap">
-        <div class="flex hiddenable-widget d-flex xs12 sm12">
+        <div class="flex hiddenable-widget application-body d-flex xs12 sm12">
           <div class="layout row wrap mx-0">
             <div class="flex d-flex xs12">
               <div class="flex v-card v-card--flat v-sheet card-border-radius pa-5 theme--light">

--- a/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -221,6 +221,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/spaceMenu.jsp</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -270,6 +274,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/activityStream.jsp</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-background-color no-layout-border-radius no-layout-border</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
       <portlet-mode>view</portlet-mode>
@@ -291,6 +299,10 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/activityStream.jsp</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-background-color no-layout-border-radius no-layout-border</value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>
@@ -363,6 +375,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/hamburgerMenu.jsp</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -428,6 +444,10 @@
       <name>preload.resource.rest</name>
       <value><![CDATA[/portal/rest/v1/social/identities/{userId}?expand=]]></value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -442,6 +462,10 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/topbarPreview.html</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
     </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
@@ -460,6 +484,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/topbarLogin.jsp</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -474,6 +502,10 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/topBarPublishSite.jsp</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>
@@ -558,6 +590,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/topbarNotification.jsp</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -572,6 +608,10 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/topbarFavorites.html</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
     </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
@@ -743,6 +783,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/search.jsp</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -786,6 +830,10 @@
       <name>js-manager-jsModule</name>
       <value>SHARED/popover</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
     <supports>
@@ -805,6 +853,10 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/topBarMenu.jsp</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>
@@ -879,6 +931,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/drawersOverlay.html</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
     <supports>
@@ -916,6 +972,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/verticalMenu.html</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
     <supports>
@@ -951,7 +1011,11 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/platformSettings.jsp</value>
-    </init-param>    
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>

--- a/webapp/portlet/src/main/webapp/skin/less/portlet/SpaceHeader/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/SpaceHeader/Style.less
@@ -47,3 +47,7 @@
     margin-bottom: 0 !important;
   }
 }
+
+#SpacePage #MenuChildren {
+  display: none;
+}

--- a/webapp/portlet/src/main/webapp/skin/less/portlet/SpaceSettings/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/SpaceSettings/Style.less
@@ -28,8 +28,6 @@
 }
 
 #SpaceSettings {
-  margin-bottom: 58px;
-
   .v-alert.error {
     position: absolute;
     top: 80px;

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsApp.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-app>
+  <div>
     <activity-reactions
       :activity-id="activityId"
       :likers="likers"
       :likers-number="likersNumber"
       :comment-number="commentNumber" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -1,20 +1,22 @@
 <template>
-  <v-app v-if="loaded" role="main">
-    <activity-stream-toolbar
-      v-if="canPostInitialized"
-      :can-post="canPost"
-      :can-filter="canFilter"
-      :filter="filter"
-      :has-activities="hasActivities" />
-    <activity-stream-list
-      :activity-id="activityId"
-      :activity-types="activityTypes"
-      :activity-actions="activityActions"
-      :comment-types="commentTypes"
-      :comment-actions="commentActions"
-      @has-activities="hasActivities = $event"
-      @activity-select="displayActivityDetail"
-      @can-post-loaded="canPostLoaded($event)" />
+  <v-app v-if="loaded">
+    <v-main class="application-body">
+      <activity-stream-toolbar
+        v-if="canPostInitialized"
+        :can-post="canPost"
+        :can-filter="canFilter"
+        :filter="filter"
+        :has-activities="hasActivities" />
+      <activity-stream-list
+        :activity-id="activityId"
+        :activity-types="activityTypes"
+        :activity-actions="activityActions"
+        :comment-types="commentTypes"
+        :comment-actions="commentActions"
+        @has-activities="hasActivities = $event"
+        @activity-select="displayActivityDetail"
+        @can-post-loaded="canPostLoaded($event)" />
+    </v-main>
     <extension-registry-components
       :params="drawerParams"
       name="ActivityStream"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -3,7 +3,7 @@
     :id="id"
     :unread-metadata="unreadMetadata"
     :space-id="spaceId"
-    class="white card-border-radius activity-detail flex flex-column"
+    class="application-background-color application-border application-border-radius activity-detail flex flex-column"
     @read="markAsRead">
     <div v-if="displayLoading" class="d-flex">
       <v-progress-circular

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamLoader.vue
@@ -2,7 +2,7 @@
   <div
     v-if="activityLoading"
     :key="activity.id"
-    class="white border-radius activity-detail flex d-flex flex-column mb-5 contentBox">
+    class="application-background-color application-border application-border-radius activity-detail flex d-flex flex-column mb-5 contentBox">
     <v-progress-circular
       color="primary"
       size="32"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityEmbeddedHTML.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityEmbeddedHTML.vue
@@ -2,7 +2,7 @@
   <div
     v-if="embeddedHTML"
     :style="parentStyle"
-    class="d-flex flex-column flex activity-embedded-box mt-3 mx-auto card-border-radius overflow-hidden light-grey-background-color hover-elevation mb-4">
+    class="d-flex flex-column flex activity-embedded-box mt-3 mx-auto border-radius overflow-hidden light-grey-background-color hover-elevation mb-4">
     <div
       v-if="elementReady"
       v-html="embeddedHTML"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -29,7 +29,7 @@
             class="my-auto"
             loading="lazy"
             width="auto"
-            height="auto" >
+            height="auto">
           <v-icon
             v-else
             :size="defaultIconSize"
@@ -305,7 +305,7 @@ export default {
       return !!this.activityTypeExtension?.addMargin;
     },
     mainClass() {
-      return `${!this.useEmbeddedLinkView && 'd-flex flex-no-wrap' || 'activity-thumbnail-box light-grey-background-color overflow-hidden hover-elevation card-border-radius border-color mb-4 d-block d-sm-flex flex-sm-nowrap'} ${this.addMargin && 'my-4' || ''}`;
+      return `${!this.useEmbeddedLinkView && 'd-flex flex-no-wrap' || 'activity-thumbnail-box light-grey-background-color overflow-hidden hover-elevation border-radius border-color mb-4 d-block d-sm-flex flex-sm-nowrap'} ${this.addMargin && 'my-4' || ''}`;
     },
     imageMobileStyle() {
       return {

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -26,7 +26,7 @@
     </template>
     <div
       v-else-if="loading"
-      class="white border-radius activity-detail flex d-flex flex-column mb-5 contentBox">
+      class="application-background-color application-border application-border-radius activity-detail flex d-flex flex-column mb-5 contentBox">
       <v-progress-circular
         color="primary"
         size="32"
@@ -46,7 +46,7 @@
       :loading="loading"
       :disabled="loading"
       block
-      class="btn pa-0"
+      class="btn pa-0 application-background-color application-border application-border-radius"
       @click="loadMore">
       {{ $t('Search.button.loadMore') }}
     </v-btn>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageFilter.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageFilter.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="d-flex flex-column white card-border-radius">
+  <div class="d-flex flex-column application-background-color application-border application-border-radius">
     <v-flex class="d-flex my-auto border-box-sizing">
       <div class="d-flex flex-column ma-auto py-10 text-center text-sub-title">
         <v-icon

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageSpace.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="d-flex flex-column white card-border-radius">
+  <div class="d-flex flex-column application-background-color application-border application-border-radius">
     <img
       :height="height"
       :style="{maxHeight: height}"

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageUser.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessageUser.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="d-flex flex-column white card-border-radius">
+  <div class="d-flex flex-column application-background-color application-border application-border-radius">
     <div class="mx-4 my-4">
       <p v-sanitized-html="welcomeTitle"></p>
       <v-card

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/pinned-activity/ActivityStreamPinnedActivity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/pinned-activity/ActivityStreamPinnedActivity.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="pinnedActivity card-border-radius">
+  <div class="pinnedActivity application-background-color application-border application-border-radius">
     <div
       class="my-auto flex-grow-1 py-2 ps-4 pe-1">
       <v-icon

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -19,8 +19,7 @@
     <v-toolbar
       v-if="displayToolbar"
       id="activityComposer"
-      class="activityComposer activityComposerApp pa-0 card-border-radius"
-      color="white mb-5"
+      class="activityComposer activityComposerApp pa-0 application-background-color application-border application-border-radius mb-5"
       height="auto"
       flat
       dense>

--- a/webapp/portlet/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
@@ -20,7 +20,7 @@
 
 -->
 <template>
-  <v-toolbar class="z-index-one app-background-color" flat>
+  <v-toolbar class="z-index-one" flat>
     <div id="applicationToolbar" class="d-flex flex-grow-1 align-center content-box-sizing position-relative">
       <!-- Left Content -->
       <div

--- a/webapp/portlet/src/main/webapp/vue-apps/breadcrumb/components/Breadcrumb.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/breadcrumb/components/Breadcrumb.vue
@@ -3,7 +3,7 @@
     <div
       v-if="breadcrumbToDisplay.length"
       id="breadcrumbParent"
-      class="white px-2 py-2 card-border-radius d-flex">
+      class="px-2 py-2 application-body d-flex">
       <div
         v-for="(breadcrumb, index) in breadcrumbToDisplay"
         :key="index"

--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/Widget.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/Widget.vue
@@ -19,7 +19,7 @@
     :class="extraClass"
     :height="height"
     :min-width="minWidth"
-    class="d-flex flex-column card-border-radius app-background-color"
+    class="d-flex flex-column"
     flat>
     <div class="d-flex flex-column flex-grow-1 pa-5">
       <div 

--- a/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/external-spaces-list/components/ExternalSpacesList.vue
@@ -1,6 +1,9 @@
 <template>
   <v-app>
-    <widget-wrapper v-if="isShown" :title="$t('externalSpacesList.title.yourSpaces')">
+    <widget-wrapper
+      v-if="isShown"
+      :title="$t('externalSpacesList.title.yourSpaces')"
+      extra-class="application-body">
       <v-list dense class="py-0 external-spaces-list">
         <template>
           <external-space-item

--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/GeneralSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/GeneralSettings.vue
@@ -22,8 +22,7 @@
   <v-app>
     <v-main>
       <v-card
-        min-height="calc(100vh - 160px)"
-        class="px-6 card-border-radius overflow-hidden app-background-color"
+        class="px-6 application-body"
         flat>
         <template v-if="intialized">
           <v-expand-transition>

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/components/GroupsManagement.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-groups-management/components/GroupsManagement.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <v-card class="d-flex flex py-2 card-border-radius app-background-color" flat>
+    <v-card class="d-flex flex py-5 application-body" flat>
       <v-flex class="sm12 md4" flat>
         <groups-management-tree-toolbar />
         <groups-management-tree />

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/components/MembershipTypesManagement.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-membership-types-management/components/MembershipTypesManagement.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app class="app-background-color">
+  <v-app class="application-body">
     <v-card flat>
       <membership-types-management-toolbar />
       <membership-types-management-list />

--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagement.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagement.vue
@@ -1,11 +1,11 @@
 <template>
   <v-app>
-    <v-card class="card-border-radius app-background-color overflow-hidden" flat>
+    <v-card class="application-body" flat>
       <users-management-toolbar />
       <users-management-list />
-      <users-management-user-form-drawer />
-      <users-management-user-membership-drawer />
-      <users-management-filter-drawer />
     </v-card>
+    <users-management-user-form-drawer />
+    <users-management-user-membership-drawer />
+    <users-management-filter-drawer />
   </v-app>
 </template>

--- a/webapp/portlet/src/main/webapp/vue-apps/image/components/ImageApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/image/components/ImageApp.vue
@@ -19,11 +19,11 @@
 
 -->
 <template>
-  <v-app ref="app" class="overflow-hidden position-relative">
+  <v-app ref="app">
     <v-hover v-model="hover" :disabled="!canEdit">
       <v-card
         :color="$root.hasImages && 'transparent' || 'primary'"
-        class="card-border-radius app-background-color"
+        class="application-body application-border-radius"
         min-width="100%"
         flat>
         <v-responsive :aspect-ratio="$root.imageAspectRatio">

--- a/webapp/portlet/src/main/webapp/vue-apps/image/components/view/ImageView.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/image/components/view/ImageView.vue
@@ -21,14 +21,13 @@
 <template>
   <img
     v-if="$root.imageUrl"
-    id="spaceAvatarImg"
     :src="$root.imageUrl"
     :alt="$root.imageAltText"
     :width="$root.fixedHeight && `${width}px` || '100%'"
     :height="$root.fixedHeight && `${$root.fixedHeight}px` || '100%'"
     :class="cssClass"
     :style="cssStyle"
-    class="border-box-sizing">
+    class="application-border-radius border-box-sizing">
 </template>
 <script>
 export default {

--- a/webapp/portlet/src/main/webapp/vue-apps/links/components/LinksApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/links/components/LinksApp.vue
@@ -25,8 +25,7 @@
       <v-card
         min-width="100%"
         max-width="100%"
-        min-height="72"
-        class="d-flex flex-column align-center border-box-sizing pa-5 overflow-hidden position-relative card-border-radius app-background-color"
+        class="d-flex flex-column align-center border-box-sizing pa-5 position-relative application-body"
         flat>
         <links-header
           v-if="$root.initialized"

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-administration/components/NotificationAdministration.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-administration/components/NotificationAdministration.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <v-main v-if="notificationSettings">
-      <v-card class="pa-5 card-border-radius app-background-color overflow-hidden" flat>
+      <v-card class="pa-5 application-body" flat>
         <h4 class="font-weight-bold my-0">
           {{ $t('NotificationAdmin.title') }}
         </h4>

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotifications.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotifications.vue
@@ -6,7 +6,7 @@
       @back="closeDetail" />
     <v-card
       v-else
-      class="card-border-radius app-background-color"
+      class="application-body"
       flat>
       <v-list @click="openNotificationSettingDetail">
         <v-list-item>

--- a/webapp/portlet/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationsWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationsWindow.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="settings"
-    class="card-border-radius overflow-hidden white">
+    class="application-body">
     <v-toolbar
       class="border-box-sizing"
       flat>

--- a/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/OrganizationalChartApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/organizational-chart/components/OrganizationalChartApp.vue
@@ -23,7 +23,7 @@
     <v-hover v-slot="{ hover }">
       <v-card
         outlined
-        class="border-radius pa-5 card-border-radius app-background-color">
+        class="pa-5 application-body">
         <div
           v-if="isLoading"
           class="width-full d-flex full-height">

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="app-background-color" flat>
+  <v-card flat>
     <v-progress-linear
       v-if="loadingPeople"
       indeterminate

--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/PeopleList.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app 
-    class="transparent peopleList card-border-radius overflow-hidden"
+    class="peopleList application-body"
     flat>
     <people-toolbar
       :filter="filter"

--- a/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverview.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-overview/components/PeopleOverview.vue
@@ -1,6 +1,8 @@
 <template>
   <v-app>
-    <widget-wrapper :title="$t('peopleOverview.label.title')">
+    <widget-wrapper
+      :title="$t('peopleOverview.label.title')"
+      extra-class="application-body">
       <v-card flat>
         <div class="d-flex flex-row justify-space-around" v-if="invitations > 0 || pending > 0">
           <people-overview-card

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-about-me/components/ProfileAboutMe.vue
@@ -2,7 +2,9 @@
   <v-app
     v-if="displayApp"
     :class="owner && 'profileAboutMe' || 'profileAboutMeOther'">
-    <widget-wrapper :title="title">
+    <widget-wrapper
+      :title="title"
+      extra-class="application-body">
       <template #action>
         <v-btn
           v-if="owner"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -21,7 +21,9 @@
 <template>
   <v-app
     :class="owner && 'profileContactInformation' || 'profileContactInformationOther'">
-    <widget-wrapper :title="title">
+    <widget-wrapper
+      :title="title"
+      extra-class="application-body">
       <template #action>
         <v-btn
           v-if="owner"

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app :class="owner && 'profileHeaderOwner' || 'profileHeaderOther'">
     <v-hover>
-      <div slot-scope="{ hover }" class="overflow-hidden card-border-radius app-background-color">
+      <div slot-scope="{ hover }" class="application-body">
         <v-card
           height="13vw"
           max-height="175"
@@ -12,7 +12,7 @@
             alt=""
             width="100%"
             height="auto"
-            class="profileBannerImg position-absolute"
+            class="profileBannerImg position-absolute application-border-radius-top"
             lazy>
           <profile-header-banner-button
             v-if="owner"
@@ -23,7 +23,7 @@
             @refresh="refresh" />
         </v-card>
         <v-card
-          class="d-flex flex-column flex-md-row border-color app-background-color px-4" 
+          class="d-flex flex-column flex-md-row border-color px-4" 
           flat
           tile>
           <v-card

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
@@ -22,7 +22,7 @@
   <v-app>
     <v-main>
       <v-card
-        class="px-4 py-6 mb-12 mb-sm-0 card-border-radius app-background-color"
+        class="px-4 py-6 mb-12 mb-sm-0 application-body"
         flat>
         <v-list
           v-if="mainPageSelected">

--- a/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperiences.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/profile-work-experience/components/ProfileWorkExperiences.vue
@@ -2,7 +2,9 @@
   <v-app
     v-if="displayApp"
     :class="owner && 'profileWorkExperience' || 'profileWorkExperienceOther'">
-    <widget-wrapper :title="title">
+    <widget-wrapper
+      :title="title"
+      extra-class="application-body">
       <template v-if="owner" #action>
         <v-btn
           icon

--- a/webapp/portlet/src/main/webapp/vue-apps/space-access/components/SpaceAccess.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-access/components/SpaceAccess.vue
@@ -21,7 +21,7 @@
 <template>
   <v-app class="singlePageApplication">
     <v-card
-      class="spaceAccessInfo app-background-color py-12 text-center"
+      class="spaceAccessInfo application-body py-12 text-center"
       flat>
       <v-card-text>
         <v-icon color="primary" class="fa-7x">{{ spaceNotAccessible && 'fa-door-closed' || 'fa-door-open' }}</v-icon>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-header/components/SpaceHeader.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-header/components/SpaceHeader.vue
@@ -1,8 +1,7 @@
 <template>
   <v-app :class="hasNavigations && 'hasNavigations' | ''">
     <v-card
-      color="transparent"
-      class="card-border-radius overflow-hidden"
+      class="application-body"
       flat>
       <v-hover>
         <v-img
@@ -15,7 +14,7 @@
           id="spaceAvatarImg"
           height="auto"
           min-width="100%"
-          class="d-flex"
+          class="d-flex application-border-radius"
           eager>
           <div
             v-if="admin"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-infos-app/components/ExoSpaceInfos.vue
@@ -1,6 +1,8 @@
 <template>
   <v-app>
-    <widget-wrapper :title="$t('social.space.description.title')">
+    <widget-wrapper
+      :title="$t('social.space.description.title')"
+      extra-class="application-body">
       <p 
         id="spaceDescription"
         v-sanitized-html="description"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-members/components/SpaceMembers.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app 
-    class="transparent card-border-radius overflow-hidden"
+    class="application-body"
     flat>
     <space-members-toolbar
       :keyword="keyword"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
@@ -1,21 +1,23 @@
 <template>
   <v-app
+    v-if="displayed"
     id="SpaceSettings"
     class="transparent"
-    flat
-    v-if="displayed">
-    <space-setting-general :space-id="spaceId" class="mb-5" />
-    <template>
-      <extension-registry-components
-        :key="spaceApplications"
-        :params="extensionParams"
-        name="SpaceSettings"
-        type="space-settings-components"
-        parent-element="div"
-        element="div"
-        class="mb-6"
-        element-class="mb-6" />
-    </template>
+    flat>
+    <div class="application-body">
+      <space-setting-general :space-id="spaceId" />
+      <template>
+        <extension-registry-components
+          :key="spaceApplications"
+          :params="extensionParams"
+          name="SpaceSettings"
+          type="space-settings-components"
+          parent-element="div"
+          element="div"
+          class="my-6"
+          element-class="mb-6" />
+      </template>
+    </div>
   </v-app>
 </template>
 

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationSpaces.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-administration/components/ExoSpacesAdministrationSpaces.vue
@@ -2,12 +2,11 @@
   <v-app
     class="spacesAdministration"
     flat>
-    <main>
+    <main class="application-body">
       <v-layout>
         <v-flex>
           <v-tabs
             v-model="selectedTab"
-            class="card-border-radius app-background-color overflow-hidden"
             slider-size="4">
             <v-tab key="manage" href="#manage">
               {{ $t('social.spaces.administration.manageSpaces') }}
@@ -26,7 +25,7 @@
             </v-tab>
           </v-tabs>
 
-          <v-tabs-items v-model="selectedTab" class="mt-2 card-border-radius app-background-color overflow-hidden">
+          <v-tabs-items v-model="selectedTab" class="mt-2">
             <v-tab-item
               id="manage"
               value="manage"

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesList.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpacesList.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app class="transparent card-border-radius overflow-hidden" flat>
+  <v-app class="application-body" flat>
     <exo-spaces-toolbar
       :keyword="keyword"
       :filter="filter"

--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/components/SpacesOverview.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-overview/components/SpacesOverview.vue
@@ -1,6 +1,8 @@
 <template>
   <v-app>
-    <widget-wrapper :title="$t('spacesOverview.label.title')">
+    <widget-wrapper 
+      :title="$t('spacesOverview.label.title')"
+      extra-class="application-body">
       <v-card flat>
         <div
           v-if="(invitations > 0 || sentRequests > 0 || receivedRequests > 0 || managing > 0) && displayPlaceholder"

--- a/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleAndSpace.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/suggestions-people-space/components/ExoSuggestionsPeopleAndSpace.vue
@@ -1,9 +1,9 @@
 <template>
   <v-app class="hiddenable-widget">
-    <widget-wrapper 
+    <widget-wrapper
       v-if="isVisible"
       :title="$t('suggestions.label')"
-      :extra-class="'suggestions-wrapper'">
+      extra-class="suggestions-wrapper application-body">
       <v-list
         v-if="peopleSuggestionsList.length > 0 && suggestionsType !== 'space'"
         dense

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app v-if="displayed">
-    <div class="card-border-radius overflow-hidden">
-      <v-list class="app-background-color" two-line>
+    <div class="application-body">
+      <v-list two-line>
         <v-list-item>
           <v-list-item-content>
             <v-list-item-title class="title text-color">

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
@@ -6,7 +6,7 @@
         @back="closeSecurityDetail" />
       <v-card
         v-else
-        class="card-border-radius app-background-color"
+        class="application-body"
         flat>
         <v-list>
           <v-list-item>

--- a/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurityWindow.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="card-border-radius overflow-hidden" flat>
+  <v-card class="application-body" flat>
     <v-toolbar
       class="border-box-sizing"
       flat>

--- a/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/who-is-online-app/components/ExoWhoIsOnline.vue
@@ -3,7 +3,7 @@
     <widget-wrapper 
       v-if="display"
       :title="$t('header.label')"
-      :extra-class="'onlinePortlet'">
+      extra-class="onlinePortlet application-body">
       <div id="onlineList" class="d-flex align-center justify-center flex-wrap">
         <exo-user-avatar
           v-for="user in users"


### PR DESCRIPTION
This change will apply **application-background** class to the main body of applications to make sure to apply layout specific CSS styles, such as disabling default Vuetify White Background applied on v-card. At the same time, for Top Toolbar applications, this will disable branding styling to avoid having border radius and other styles applied on small buttons added in Top bar as applications.