### PR TITLE
fix: Link should be opened in new tab yet it opens in the same tab - EXO-71860 - Meeds-io/meeds#2214.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-menu/components/SpaceMenu.vue
@@ -20,6 +20,7 @@
     </v-footer>    
     <v-tabs
       v-else
+      ref="spaceMenuTabs"
       :value="selectedNavigationUri"
       active-class="SelectedTab"
       class="mx-auto"
@@ -30,7 +31,7 @@
         v-for="nav in navigations"
         :key="nav.id"
         :value="nav.id"
-        :href="nav.uri"
+        :href="navUri(nav.uri, nav?.target)"
         @click="openUrl(nav.uri, nav?.target)"
         class="spaceNavigationTab">
         {{ nav.label }}
@@ -121,6 +122,11 @@ export default {
       target = target === 'SAME_TAB' && '_self' || '_blank' ;
       if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/) && this.isValidUrl(url) ) {
         url = `//${url}`;
+        const internalValue = this.$refs.spaceMenuTabs.internalValue;
+        window.setTimeout(() => {
+          this.$refs.spaceMenuTabs.internalLazyValue = internalValue;
+          this.$refs.spaceMenuTabs.internalValue = internalValue;
+        },300);       
       } else if (url.match(/^(\/portal\/)/)) {
         url = `${window.location.origin}${url}`;
       }
@@ -137,6 +143,12 @@ export default {
         'i'
       );
       return pattern.test(str);
+    },
+    navUri(url,target) {
+      if (target === 'NEW_TAB') {
+        return '';
+      }
+      return url;
     }
   },
 };


### PR DESCRIPTION
Before this change, when add a new node in space or home page of type link and select(New tab) in the option (Opens in) then add any link, save, click on the created node or click on ctrl+ the node having the link or any other node, two tabs are opened with the added link. After this change, current page is loaded nor redirected to the node link page and only one new tab is opened directing the node link page.