### PR TITLE
fix: [ExoDrawer component] When using attribute attached on a second level drawer, the drawer is not attached to the application

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -261,7 +261,7 @@ export default {
   },
   methods: {
     open() {
-      if (!this.attached || eXo.openedDrawers.length) {
+      if (!this.attached) {
         // Re-append the drawer to open in order
         // to ensure to attribute an adequate z-index
         // Which makes it displayed on top of other already


### PR DESCRIPTION
Before this fix, when the ExoDrawerComponent is used with attached parameter, with a second level drawer, the drawer is not attached to the application. This is due to a test which verify if there is more that one opened drawer. This test comes from olf part of the code and is no more necessary.

Resolved meeds-io/meeds#2226

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
