### PR TITLE
Fix : re-arrange the UX/UI of the space card - EXO-72642 - Meeds-io/meeds#2212

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/spaces-list/components/ExoSpaceCardFront.vue
@@ -185,17 +185,12 @@
         <a
           :href="url"
           :title="space.displayName"
-          :class="isMobile && 'text-truncate-2 mt-0' || 'text-truncate d-block'"
+          :class="isMobile && 'text-truncate-2 mt-0' || 'text-truncate-2'"
           class="spaceDisplayName">
           {{ space.displayName }}
         </a>
-        <a 
-          :href="url"
-          class="spaceMembersLabel py-0 my-0 my-sm-auto">
-          {{ $t('spacesList.label.members', {0: space.membersCount}) }}
-        </a>
       </v-card-text>
-      <v-card-actions v-if="!isMobile" class="spaceCardActions">
+      <v-list-item v-if="!isMobile" class="spaceCardActions pa-2">
         <exo-confirm-dialog
           ref="confirmDialog"
           :title="confirmTitle"
@@ -307,7 +302,7 @@
             </span>
           </v-btn>
         </div>
-      </v-card-actions>
+      </v-list-item>
     </v-card>
   </v-hover>
 </template>


### PR DESCRIPTION
Before this change, when you create a space, access the space interface and check its card, the number of members is displayed and there is a margin between the bottom of the card and the join/leave button. After this change, remove the number of members information from the space and set the join/leave button at the bottom of the card.

(cherry picked from commit 9ce35ad12991662566c17a4bde99f1d7d9cf7da0)