### PR TITLE
fix: wrong property name displayed in Org chart card - Meeds-io/meeds#2156 - EXO-72474

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
@@ -577,7 +577,7 @@ public class ProfileEntity extends BaseEntity {
     setProperty(PRIMARY_PROPERTY, primaryProperty);
     return this;
   }
-  public String getSecondaryCardProperty() {
+  public String getSecondaryProperty() {
     return getString(SECONDARY_PROPERTY);
   }
 
@@ -585,7 +585,7 @@ public class ProfileEntity extends BaseEntity {
     setProperty(SECONDARY_PROPERTY, secondaryProperty);
     return this;
   }
-  public String getTertiaryCardProperty() {
+  public String getTertiaryProperty() {
     return getString(TERTIARY_PROPERTY);
   }
 


### PR DESCRIPTION
Second and third properties were not displayed in the user card because the getter of those properties was not the expected one.
This fixes the getter to display correctly fields when retrieved.