### PR TITLE
fix: align the components in quick search drawer - Meeds-io/meeds#2232 - EXO-70145

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/common/ProfileCard/Style-mobile.less
+++ b/webapp/portlet/src/main/webapp/skin/less/common/ProfileCard/Style-mobile.less
@@ -8,7 +8,7 @@
 .peopleAvatar {
   position: absolute;
   max-width: 60px;
-  margin: 6px 10px;
+  margin: 6px 12px;
 }
 
 .peopleToolbarIcons {


### PR DESCRIPTION
This fix makes sure that the placeholder text in the search toolbar is aligned with the resulted user avatars