### PR TITLE
fix: add hover effect to display space name in hamburger menu - EXO-72640 - Meeds-io/meeds#2212

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpaceNavigationItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpaceNavigationItem.vue
@@ -56,6 +56,7 @@
     :href="spaceLink"
     :class="homeIcon && (homeLink === spaceLink && 'UserPageLinkHome' || 'UserPageLink')"
     :arial-label="$t('space.avatar.href.title',{0:space.prettyName})"
+    :title="spaceDisplayName"
     class="px-2 spaceItem"
     role="link"
     @mouseover="showItemActions = true"


### PR DESCRIPTION
Before this change, when create a space with long title (about 40 char) and hover on space name from hamburger menu in first level and second level, no hover popup effect. After this change, display a popup displaying the whole name.

(cherry picked from commit bf4aacb3cd6de716e1a9ef70fe37d37155c34d89)