### PR TITLE
fix: non editable properties should be reindexed - EXO-72733 - Meeds-io/meeds#2237

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -250,7 +250,7 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     Date createdDate = new Date(profile.getCreatedTime());
 
     for (ProfilePropertySetting profilePropertySetting : profilePropertyService.getPropertySettings()) {
-      if (profilePropertySetting.isVisible() && profilePropertySetting.isEditable() && !fields.containsKey(profilePropertySetting.getPropertyName())) {
+      if (profilePropertySetting.isVisible() && !fields.containsKey(profilePropertySetting.getPropertyName())) {
         // Avoid indexing invisible and not editable properties
         if (profile.getProperty(profilePropertySetting.getPropertyName()) != null && profile.getProperty(profilePropertySetting.getPropertyName()) instanceof String value) {
           if (StringUtils.isNotEmpty(value)) {


### PR DESCRIPTION
Before this fix, the non-editable properties were not indexed and thus when searching on them no results are displayed.
This will cause losing values of non editable properties and the Quick search won't show results 