### PR TITLE
fix: display space long title on 2 lines and add hover effect on second menu level of a specific spcae - EXO-72639 - Meeds-io/meeds#2212.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
@@ -34,7 +34,7 @@
           class="fas fa-arrow-right"
           small />
       </v-list-item-icon>
-      <v-list-item class="width-min-content text-truncate pt-3">
+      <v-list-item class="width-min-content pt-3">
         <v-list-item-avatar
           class="spaceAvatar mt-0 mb-0 align-self-start"
           :width="avatarWidth"
@@ -44,7 +44,7 @@
             :src="avatar" />
         </v-list-item-avatar>
         <v-list-item-content class="pb-0 pt-0">
-          <a :href="spaceURL" class="font-weight-bold text-truncate primary--text mb-2">{{ spaceDisplayName }}</a>
+          <a :href="spaceURL" class="font-weight-bold text-truncate-2 primary--text mb-2">{{ spaceDisplayName }}</a>
           <v-list-item-subtitle>
             {{ membersCount }} {{ $t('space.logo.banner.popover.members') }}
           </v-list-item-subtitle>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -49,19 +49,17 @@
                 :src="`${logoPath}&size=60x60`" />
             </v-list-item-avatar>
             <v-list-item-content class="pb-0 pt-0">
-              <v-list-item-title>
                 <v-tooltip bottom>
                   <template #activator="{ on, attrs }">
                     <span
                       v-on="on"
                       v-bind="attrs"
-                      class="primary--text text--darken-3 font-weight-bold">
+                      class="primary--text text--darken-3 font-weight-bold text-truncate-2">
                       {{ logoTitle }}
                     </span>
                   </template>
                   <span>{{ logoTitle }}</span>
                 </v-tooltip>
-              </v-list-item-title>
               <v-list-item-subtitle>
                 {{ membersNumber }} {{ $t('space.logo.banner.popover.members') }}
               </v-list-item-subtitle>


### PR DESCRIPTION
Before this change, when create a space with long title (about 40 char) and hover on space name from hamburger menu in second level, not all title is displayed, instead there is an ellipsis. After this change, the title is displayed on 2 lines for the space pop hover card and second navigation level (space detail level).