### PR TITLE
fix: Fix Making Field Readonly when entering a I18N Key in Translation field - MEED-7313 - Meeds-io/meeds#2299

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationTextField.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/component-translation-field/components/TranslationTextField.vue
@@ -185,16 +185,18 @@ export default {
       type: Boolean,
       default: false,
     },
+    verifyI18n: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     defaultLanguageValue: null,
     valuesPerLanguage: {},
     translationConfiguration: null,
+    isI18N: false,
   }),
   computed: {
-    isI18N() {
-      return this.$te(this.defaultLanguageValue);
-    },
     noRulesValidation() {
       return !this.defaultLanguageValue || !this.rules?.length;
     },
@@ -261,6 +263,7 @@ export default {
       } else {
         this.defaultLanguageValue = this.fieldValue || this.valuesPerLanguage[this.defaultLocale] || '';
       }
+      this.isI18N = this.verifyI18n && this.defaultLanguageValue && this.$te(this.defaultLanguageValue);
       this.updateTranslationMap();
     },
     updateTranslationMap() {

--- a/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/login-page/LoginBranding.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/general-settings/components/login-page/LoginBranding.vue
@@ -96,7 +96,8 @@
               :placeholder="$t('generalSettings.loginTitle.placeholder')"
               :default-language="defaultLanguage"
               :supported-languages="supportedLanguages"
-              drawer-title="generalSettings.translateTitle" />
+              drawer-title="generalSettings.translateTitle"
+              verify-i18n />
           </v-card>
           <div class="text-header mb-0 mt-4">
             {{ $t('generalSettings.loginSubtitle.title') }}
@@ -111,7 +112,8 @@
               :placeholder="$t('generalSettings.loginSubtitle.placeholder')"
               :default-language="defaultLanguage"
               :supported-languages="supportedLanguages"
-              drawer-title="generalSettings.translateSubtitle" />
+              drawer-title="generalSettings.translateSubtitle"
+              verify-i18n />
           </v-card>
           <div class="text-header mb-0 mt-4">
             {{ $t('generalSettings.loginBackground.title') }}


### PR DESCRIPTION
Prior to this change, the 'Cancel' and 'Save' Keywords are automatically translated and makes the computed field  returns true when the user types an existing I18N existing translated key. This change ensures to detect whether the Text Field content is I18N or not at initialization only and makes sure to enable this feature only when needed.