### PR TITLE
Right to left display of ko in admin interface and some labels are in English instead of Arabic - EXO-73560 - Meeds-io/meeds#2308

### DIFF
--- a/webapp/portlet/src/main/webapp/skin/less/portlet/VerticalMenu/Style.less
+++ b/webapp/portlet/src/main/webapp/skin/less/portlet/VerticalMenu/Style.less
@@ -35,3 +35,6 @@
   position: fixed !important;
   .specific-scrollbar()
 }
+.right-0 {
+  right: 0 !important;
+}

--- a/webapp/portlet/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuApp.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuApp.vue
@@ -16,7 +16,7 @@
 -->
 <template>
   <v-app>
-    <vertical-menu-content v-if="fullDisplayAllowed" extra-class="VerticalMenu" />
+    <vertical-menu-content v-if="fullDisplayAllowed" :extra-class="extraClass" />
     <template v-else>
       <vertical-menu-button />
       <vertical-menu-drawer />
@@ -28,6 +28,9 @@ export default {
   computed: {
     fullDisplayAllowed() {
       return this.$vuetify.breakpoint.width >= this.$vuetify.breakpoint.thresholds.lg;
+    },
+    extraClass() {
+      return eXo.env.portal.orientation === 'rtl' ? 'VerticalMenu right-0' : 'VerticalMenu';
     },
   }
 };


### PR DESCRIPTION
Before this change, when you set the language to Arabic as a plf admin and access the admin site, the platform settings menu is positioned on the left and is not fully displayed due to an overlap with the main settings block. After this change, the right to left display in the platform settings menu without overlap is displayed correctly.

(cherry picked from commit 674f40ddb8cc893757fec488052b90352fd5e17c)