### PR TITLE
fix: Fix Web Notification Display in Mobile on Swipe - MEED-7301 - Meeds-io/meeds#2292

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
@@ -73,7 +73,7 @@
             'min-width': `${minWidth}px`,
             'padding-bottom': '9px !important',
           }"
-          class="d-flex pa-2"
+          class="d-flex border-box-sizing pa-2"
           v-touch="{
             start: moveStart,
             end: moveEnd,


### PR DESCRIPTION
Prior to this change, sometimes on some Web Notifications, when swiping to mark as read or deleting a Web Notification on Mobile, the content height changes dynamically while it's expected to be the same even when swiping. This change ensures to preserve the width and height of the Web Notification when swiping.

Resolves Meeds-io/meeds/issues/2292