### PR TITLE
fix: Fix click on right card carousel icon - MEED-7352 - Meeds-io/MIPs#155

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/CardCarousel.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/CardCarousel.vue
@@ -66,6 +66,7 @@ export default {
     childScrollIndex: 0,
     visibleChildrenPerPage: 1,
     computing: false,
+    initialized: false,
   }),
   mounted() {
     this.scrollElement = this.$el && this.$el.children && this.$el.children.length > 1 && this.$el.children[1];
@@ -113,6 +114,10 @@ export default {
           this.visibleChildrenPerPage = parseInt(parentWidth * childrenCount / contentWidth);
           this.displayLeftArrow = this.scrollElement && childrenCount && this.scrollElement.scrollLeft > children[0].offsetLeft;
           this.displayRightArrow = this.scrollElement && (this.scrollElement.scrollWidth - this.scrollElement.offsetWidth - this.scrollElement.scrollLeft) > 5;
+          if (!this.initialized && childrenCount) {
+            this.childScrollIndex = this.visibleChildrenPerPage >= children.length ? (children.length - 1) : this.visibleChildrenPerPage;
+            this.initialized = true;
+          }
           this.computing = false;
         }, 200);
       }


### PR DESCRIPTION
Prior to this change, when displaying right card caroussel icon and click it the first time, the click isn't considered and the user has to click on it a second time to consider scrolling. This change ensures to update scroll child index each time the UI is updated in order to ensure to consider the click events with the correct initialized values.