### PR TITLE
fix: Fix Shared Layout applications Loading - MEED-7392 - Meeds-io/meeds#2334

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/hamburgerMenu.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/hamburgerMenu.jsp
@@ -23,20 +23,23 @@
     <div class="v-application--wrap">
       <% if (sticky) { %>
       <script type="text/javascript">
-        if (window.innerWidth >= 1280) {
-          const siteStickyMenuHtml = sessionStorage.getItem('ParentSiteStickyMenu');
-          if (siteStickyMenuHtml) {
-            document.querySelector('#ParentSiteStickyMenu').innerHTML = siteStickyMenuHtml;
+        if (!window.siteStickyMenuLoaded) {
+          window.siteStickyMenuLoaded = true;
+          if (window.innerWidth >= 1280) {
+            window.siteStickyMenuHtml = sessionStorage.getItem('ParentSiteStickyMenu');
+            if (window.siteStickyMenuHtml) {
+              document.querySelector('#ParentSiteStickyMenu').innerHTML = window.siteStickyMenuHtml;
+            }
+          } else {
+            document.querySelector('#HamburgerNavigationMenu > .v-application--wrap').innerHTML = `
+            <a class="HamburgerNavigationMenuLink">
+              <div class="px-5 py-3">
+                <i aria-hidden="true"
+                  class="v-icon notranslate fa fa-bars theme--light"
+                  style="font-size: 24px;"></i>
+              </div>
+            </a>`;
           }
-        } else {
-          document.querySelector('#HamburgerNavigationMenu > .v-application--wrap').innerHTML = `
-          <a class="HamburgerNavigationMenuLink">
-            <div class="px-5 py-3">
-              <i aria-hidden="true"
-                class="v-icon notranslate fa fa-bars theme--light"
-                style="font-size: 24px;"></i>
-            </div>
-          </a>`;
         }
       </script>
       <% } else { %>
@@ -50,7 +53,10 @@
       <% } %>
     </div>
     <script type="text/javascript">
-      require(['PORTLET/social-portlet/HamburgerMenu'], app => app.init(<%=canCreateSpace%>));
+      if (!window.siteStickyMenuInitialized) {
+        window.siteStickyMenuInitialized = true;
+        require(['PORTLET/social-portlet/HamburgerMenu'], app => app.init(<%=canCreateSpace%>));
+      }
     </script>
   </div>
 </div>

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topBarMenu.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topBarMenu.jsp
@@ -14,13 +14,14 @@
       responseWrapper.addHeader("Link", "</portal/rest/v1/navigations/PORTAL?siteName=" + rcontext.getPortalOwner() + "&scope=children&visibility=displayed&visibility=temporal&exclude=global&expand=true>; rel=preload; as=fetch; crossorigin=use-credentials", false);
     %>
     <script type="text/javascript">
-      const topBarMenuHtml = sessionStorage.getItem('topBarMenu');
-      if (topBarMenuHtml) {
-        document.querySelector('#topBarMenu').innerHTML = topBarMenuHtml;
+      if (!window.topBarMenuLoaded) {
+        window.topBarMenuLoaded = true;
+        window.topBarMenuHtml = sessionStorage.getItem('topBarMenu');
+        if (window.topBarMenuHtml) {
+          document.querySelector('#topBarMenu').innerHTML = window.topBarMenuHtml;
+        }
+        require(['PORTLET/social-portlet/TopBarMenu'], app => app.init());
       }
-      require(['PORTLET/social-portlet/TopBarMenu'], app => {
-        app.init()
-      });
     </script>
     <% } %>
   </div>

--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topbarLogo.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topbarLogo.jsp
@@ -85,38 +85,6 @@
 
   String directionVuetifyClass = requestContext.getOrientation().isRT() ? "v-application--is-rtl" : "v-application--is-ltr";
 %>
-<script type="text/javascript" defer="defer">
-  let topbarLogoManagers = new Array();
-  <%
-   for (int i =0 ; i < managers.size(); i++) { %>
-   topbarLogoManagers.push({
-    id: `<%=managers.get(i).getId()%>`,
-    userName: `<%=managers.get(i).getIdentity().getRemoteId()%>`,
-    fullName: `<%=managers.get(i).getFullName()%>`,
-    avatar: `<%=managers.get(i).getAvatarUrl()%>`,
-  });
-  <%} %>
-  let params = {
-    id: `<%=spaceId%>`,
-    isFavorite: `<%=isFavorite%>`,
-    muted: `<%=muted%>`,
-    isMember: `<%=isMember%>`,
-    logoPath: `<%=logoPath%>`,
-    portalPath: `<%=portalPath%>`,
-    logoTitle: `<%=URLEncoder.encode(logoTitle.replace(" ", "._.")).replace("._.", " ")%>`,
-    membersNumber: `<%=membersNumber%>`,
-    spaceDescription: `<%=URLEncoder.encode(spaceDescription.replace(" ", "._.")).replace("._.", " ")%>`,
-    managers: topbarLogoManagers,
-    homePath: `<%=homePath%>`
-  };
-  document.addEventListener('spaceDetailUpdated', event => {
-    const space = event && event.detail;
-    if (space && space.displayName) {
-      document.querySelector('.logoTitle').innerText = space.displayName;
-      document.querySelector('.logoContainer .spaceAvatar').src = space.avatarUrl;
-    }
-  });
-</script>
 <div class="VuetifyApp">
   <div data-app="true"
        class="v-application border-box-sizing <%= directionVuetifyClass %> theme--light"
@@ -139,7 +107,29 @@
           <% } else { %>
           <div app-data="true" id="SpaceTopBannerLogo">
             <script type="text/javascript">
-              require(["SHARED/spaceBannerLogoPopover"], app => app.init(params));
+              window.topbarLogoManagers = new Array();
+              <%
+               for (int i =0 ; i < managers.size(); i++) { %>
+               window.topbarLogoManagers.push({
+                id: `<%=managers.get(i).getId()%>`,
+                userName: `<%=managers.get(i).getIdentity().getRemoteId()%>`,
+                fullName: `<%=managers.get(i).getFullName()%>`,
+                avatar: `<%=managers.get(i).getAvatarUrl()%>`,
+              });
+              <%} %>
+              require(["SHARED/spaceBannerLogoPopover"], app => app.init({
+                id: `<%=spaceId%>`,
+                isFavorite: `<%=isFavorite%>`,
+                muted: `<%=muted%>`,
+                isMember: `<%=isMember%>`,
+                logoPath: `<%=logoPath%>`,
+                portalPath: `<%=portalPath%>`,
+                logoTitle: `<%=URLEncoder.encode(logoTitle.replace(" ", "._.")).replace("._.", " ")%>`,
+                membersNumber: `<%=membersNumber%>`,
+                spaceDescription: `<%=URLEncoder.encode(spaceDescription.replace(" ", "._.")).replace("._.", " ")%>`,
+                managers: window.topbarLogoManagers,
+                homePath: `<%=homePath%>`
+              }));
             </script>
           </div>
           <% } %>

--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingFormDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/SpaceSettingFormDrawer.vue
@@ -254,10 +254,6 @@ export default {
           Object.assign(this.spaceToUpdate, space, {managers: this.spaceToUpdate.managers});
           this.spaceSaved = true;
 
-          document.dispatchEvent(new CustomEvent('spaceDetailUpdated', {
-            detail: this.spaceToUpdate,
-          }));
-
           window.setTimeout(() => {
             this.$refs.spaceFormDrawer.close();
           }, 200);


### PR DESCRIPTION
Prior to this change, when loading the shared layout applications twice or triggered twice, then some JS variables are already injected into global context and thus the execution of JS of the page is stopped. This change ensures to not re-execute the applications initialization once executed.