### PR TITLE
fix: Fix Vue Mount Element Search Expression - MEED-7411 - Meeds-io/MIPs#156

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/initComponents.js
@@ -121,7 +121,9 @@ Vue.prototype.$updateApplicationVisibility = function(visible, element) {
 };
 
 Vue.createApp = function(params, el, appName) {
-  const element = typeof el === 'string' ? document.querySelector(el) : el;
+  const element = typeof el === 'string' ?
+    (document.querySelector(`body ${el}`) || document.querySelector(el))
+    : el;
   if (element) {
     if (!params.data) {
       params.data = {};


### PR DESCRIPTION
Prior to this change, when mounting an application into an element having the same id as an element added in <head>, then the element is mounted there and will not be displayed in the page consequently. This change ensure to add a <body> scope in searched element.