### PR TITLE
fix: Esure to launch profile listener once when profile fields are updated by API - EXO-74026

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -1092,7 +1092,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
       }
       try {
         if (!(profileProperty.isMultiValued() || !profileProperty.getChildren().isEmpty())) {
-          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), true);
+          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), false);
           updateProfilePropertyVisibility(profileProperty);
           if (profileProperty.getPropertyName().equals(Profile.FIRST_NAME) || profileProperty.getPropertyName().equals(Profile.LAST_NAME) ) {
             profile = getUserIdentity(username).getProfile();
@@ -1111,7 +1111,7 @@ public class UserRestResourcesV1 implements UserRestResources, Startable {
               maps.add(childrenMap);
             }
           });
-          updateProfileField(profile, profileProperty.getPropertyName(), maps, true);
+          updateProfileField(profile, profileProperty.getPropertyName(), maps, false);
           updateProfilePropertyVisibility(profileProperty);
         }
       } catch (IllegalAccessException e) {


### PR DESCRIPTION
Before this fix, when the profile is updated by api, profile listeners are launch once by field modification : if you update 3 fields, listeners are launch 3 times This leads to potential concurrent exceptions

This fix ensure to launch profile listeners once, even if more than one field is modified.

Resolved meeds-io/meeds#2372

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
