### PR TITLE
fix: [Profile Group Sync] When emptying a synced property, a group with empty name is created - EXO-74087

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/GroupSynchronizationSocialProfileListener.java
@@ -122,7 +122,9 @@ public class GroupSynchronizationSocialProfileListener extends ProfileListenerPl
     String propertyName = property.getKey();
     List<String> propertyValues = new ArrayList<>();
     if (property.getValue() instanceof String) {
-      propertyValues.add((String) property.getValue());
+      if (!((String) property.getValue()).isEmpty()) {
+        propertyValues.add((String) property.getValue());
+      }
     } else {
       ((List<HashMap<String,String>>) property.getValue()).stream().forEach(val -> val.entrySet().stream().filter(entry -> entry.getKey().equals("value")).forEach(entry -> propertyValues.add(entry.getValue())));
     }


### PR DESCRIPTION
Before this fix, when a user empty a field which is group synchronized in his profile, a group with empty name is created This commit ensure to not take in account the property if the value is empty

Resolves meeds-io/meeds#2375

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
