### PR TITLE
feat: Allow to add page kernel profiles from Space Template Application - MEED-7457 - Meeds-io/meeds#2377

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/SpaceApplication.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/SpaceApplication.java
@@ -53,6 +53,8 @@ public class SpaceApplication implements Cloneable {
 
   private List<String>        roles;
 
+  private String              profiles;
+
   @Override
   public SpaceApplication clone() {
     return new SpaceApplication(portletApp,
@@ -63,7 +65,8 @@ public class SpaceApplication implements Cloneable {
                                 uri,
                                 icon,
                                 preferences == null ? null : new HashMap<>(preferences),
-                                roles == null ? null : new ArrayList<String>(roles));
+                                roles == null ? null : new ArrayList<String>(roles),
+                                profiles);
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/DefaultSpaceApplicationHandler.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/DefaultSpaceApplicationHandler.java
@@ -38,6 +38,7 @@ import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.config.model.TransientApplicationState;
 import org.exoplatform.portal.module.ModuleRegistry;
+import org.exoplatform.portal.mop.PageType;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.navigation.NavigationContext;
 import org.exoplatform.portal.mop.navigation.NodeContext;
@@ -536,17 +537,22 @@ public class DefaultSpaceApplicationHandler implements SpaceApplicationHandler {
         page.setAccessPermissions(new String[] { "*:" + space.getGroupId() });
       }
       page.setEditPermission("manager:" + space.getGroupId());
+      page.setProfiles(spaceApplication.getProfiles());
 
       SiteKey siteKey = navContext.getKey();
       PageKey pageKey = new PageKey(siteKey, page.getName());
       PageState pageState = new PageState(page.getTitle(),
                                           page.getDescription(),
                                           page.isShowMaxWindow(),
+                                          page.isHideSharedLayout(),
                                           page.getFactoryId(),
+                                          page.getProfiles(),
                                           Arrays.asList(page.getAccessPermissions()),
                                           page.getEditPermission(),
                                           Arrays.asList(page.getMoveAppsPermissions()),
-                                          Arrays.asList(page.getMoveContainersPermissions()));
+                                          Arrays.asList(page.getMoveContainersPermissions()),
+                                          PageType.PAGE.name(),
+                                          null);
 
       pageStorage.savePage(new PageContext(pageKey, pageState));
       layoutService.save(page);

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceTemplateServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceTemplateServiceTest.java
@@ -5,7 +5,6 @@ import java.util.*;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.*;
 import org.exoplatform.portal.config.model.Page;
-import org.exoplatform.portal.mop.page.PageKey;
 import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
@@ -66,7 +65,7 @@ public class SpaceTemplateServiceTest extends AbstractCoreTest {
     assertTrue(Collections.unmodifiableList(Collections.EMPTY_LIST).getClass().isInstance(templates));
   }
 
-  public void testCreateSpaceWithRolesInApplication() {
+  public void testCreateSpaceWithRolesAndProfilesInApplication() {
     Space space = createSpace("Space Settings Test", "root");
     assertNotNull(space);
 
@@ -76,12 +75,14 @@ public class SpaceTemplateServiceTest extends AbstractCoreTest {
     assertNotNull(page.getAccessPermissions());
     assertEquals(1, page.getAccessPermissions().length);
     assertEquals("manager:" + space.getGroupId(), page.getAccessPermissions()[0]);
+    assertEquals("test", page.getProfiles());
 
     page = layoutService.getPage("group::" + space.getGroupId() + "::MembersPortlet");
     assertNotNull(page);
     assertNotNull(page.getAccessPermissions());
     assertEquals(1, page.getAccessPermissions().length);
     assertEquals("*:" + space.getGroupId(), page.getAccessPermissions()[0]);
+    assertNull(page.getProfiles());
   }
 
   /**

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -1360,6 +1360,9 @@
                     <field name="uri">
                       <string>settings</string>
                     </field>
+                    <field name="profiles">
+                      <string>test</string>
+                    </field>
                     <field name="roles">
                       <collection type="java.util.ArrayList">
                         <value>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
@@ -102,6 +102,13 @@
                     <field name="icon">
                       <string>fas fa-cog</string>
                     </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                   </object>
                 </value>
                 <value>
@@ -230,6 +237,13 @@
                     <field name="icon">
                       <string>fas fa-cog</string>
                     </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                   </object>
                 </value>
 
@@ -334,6 +348,13 @@
                     <field name="icon">
                       <string>fas fa-cog</string>
                     </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                   </object>
                 </value>
 
@@ -437,6 +458,13 @@
                     </field>
                     <field name="icon">
                       <string>fas fa-cog</string>
+                    </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
                     </field>
                   </object>
                 </value>


### PR DESCRIPTION
This change will allow to configure a profile on pages so that when uninstall an addon, the page isn't displayed anymore. In addition, this change will add the default roles of type 'manager' on 'settings' page.