### PR TITLE
fix: Display mention user ko if username has email format - EXO-72863 - Meeds-io/meeds#2342

### DIFF
--- a/webapp/portlet/src/main/webapp/js/suggester.js
+++ b/webapp/portlet/src/main/webapp/js/suggester.js
@@ -227,7 +227,7 @@
         _a = decodeURI("%C3%80");
         _y = decodeURI("%C3%BF");
         space = acceptSpaceBar ? "\ " : "";
-        regexp = new RegExp(flag + "([A-Za-z" + _a + "-" + _y + "0-9_" + space + "\'\.\+\-]*)$|" + flag + "([^\\x00-\\xff]*)$", 'gi');
+        regexp = new RegExp(flag + "([A-Za-z" + _a + "-" + _y + "0-9_" + space + "\'\.\@\+\-]*)$|" + flag + "([^\\x00-\\xff]*)$", 'gi');
         match = regexp.exec(subtext);
         if (match) {
           var a = match[2] || match[1];


### PR DESCRIPTION
Before this change, when create userX having username user@user.com then add userX to spaceX which has task app and create task and mention userX in comment then save, userX's username displayed isn't clickable and content isn't expected. After this change, userX's username is displayed and clickable.

(cherry picked from commit acf79181da8daa7f2d685e736efe312b2051f512)