### PR TITLE
feat: Allow to configure a Space Page Access Permission from Template - MEED-7457 - Meeds-io/meeds#2377

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/SpaceApplication.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/SpaceApplication.java
@@ -17,7 +17,9 @@
 
 package org.exoplatform.social.core.space;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 /**
  * Definition of space application model.
  *
@@ -25,162 +27,33 @@ import java.util.HashMap;
 import java.util.Map;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class SpaceApplication implements Cloneable {
-  private String portletApp;
-  private String portletName;
-  private String appTitle;
-  private boolean removable;
-  private int order;
-  private String uri;
-  private String icon;
+
+  private String              portletApp;
+
+  private String              portletName;
+
+  private String              appTitle;
+
+  private boolean             removable;
+
+  private int                 order;
+
+  private String              uri;
+
+  private String              icon;
+
   private Map<String, String> preferences;
 
-  /**
-   * Sets the portletApp - the war name file which has that portlet.
-   *
-   * @param portletApp
-   */
-  public void setPortletApp(String portletApp) {
-    this.portletApp = portletApp;
-  }
+  private List<String>        roles;
 
-  /**
-   * Gets the portletApp.
-   *
-   * @return
-   */
-  public String getPortletApp() {
-    return portletApp;
-  }
-
-  /**
-   * Sets portletName.
-   *
-   * @param portletName
-   */
-  public void setPortletName(String portletName) {
-    this.portletName = portletName;
-  }
-
-  /**
-   * Gets portletName.
-   *
-   * @return
-   */
-  public String getPortletName() {
-    return portletName;
-  }
-
-  /**
-   * Sets appTitle to be displayed on space's navigation.
-   *
-   * @param appTitle
-   */
-  public void setAppTitle(String appTitle) {
-    this.appTitle = appTitle;
-  }
-
-  /**
-   * Gets appTitle to be displayed on space's navigation.
-   *
-   * @return
-   */
-  public String getAppTitle() {
-    return appTitle;
-  }
-
-  /**
-   * Indicates if this application is removable or not.
-   *
-   * @param isRemovable
-   */
-  public void setRemovable(boolean isRemovable) {
-    this.removable = isRemovable;
-  }
-
-  /**
-   * Checks if this application is removable for not.
-   *
-   * @return
-   */
-  public boolean isRemovable() {
-    return removable;
-  }
-
-  /**
-   * Sets the order in the space's navigation.
-   *
-   * @param order
-   */
-  public void setOrder(int order) {
-    this.order = order;
-  }
-
-  /**
-   * Gets the order in the space's navigation.
-   *
-   * @return
-   */
-  public int getOrder() {
-    return order;
-  }
-
-  /**
-   * Sets the uri of this application page node.
-   *
-   * @param uri
-   */
-  public void setUri(String uri) {
-    this.uri = uri;
-  }
-
-  /**
-   * Gets the uri of the application page node.
-   *
-   * @return
-   */
-  public String getUri() {
-    return uri;
-  }
-
-  /**
-   * Sets the icon class for the application page node.
-   *
-   * @param icon
-   */
-  public void setIcon(String icon) {
-    this.icon = icon;
-  }
-
-  /**
-   * Gets the icon class for the application page node.
-   * @return
-   */
-  public String getIcon() {
-    return icon;
-  }
-
-  /**
-   * Sets preferences for this application when installed.
-   *
-   * @param preferences
-   */
-  public void setPreferences(Map<String, String> preferences) {
-    this.preferences = preferences;
-  }
-
-  /**
-   * Gets preferences for this application when installed.
-   *
-   * @return
-   */
-  public Map<String, String> getPreferences() {
-    return this.preferences;
-  }
+  private String              profiles;
 
   @Override
   public SpaceApplication clone() {
@@ -191,6 +64,9 @@ public class SpaceApplication implements Cloneable {
                                 order,
                                 uri,
                                 icon,
-                                preferences == null ? null : new HashMap<>(preferences));
+                                preferences == null ? null : new HashMap<>(preferences),
+                                roles == null ? null : new ArrayList<String>(roles),
+                                profiles);
   }
+
 }

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Meeds:: PLF:: Social Core Component</name>
   <description>Meeds Social Core Component: People and Space</description>
   <properties>
-    <exo.test.coverage.ratio>0.68</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.69</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <!-- These dependency is required to compile but reported as useless by mvn dependency:analyze -->

--- a/component/core/src/main/java/io/meeds/social/upgrade/SpaceNavigationIconUpgradePlugin.java
+++ b/component/core/src/main/java/io/meeds/social/upgrade/SpaceNavigationIconUpgradePlugin.java
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package io.meeds.social.core.upgrade;
+package io.meeds.social.upgrade;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/component/core/src/main/java/io/meeds/social/upgrade/SpaceSettingPermissionUpgradePlugin.java
+++ b/component/core/src/main/java/io/meeds/social/upgrade/SpaceSettingPermissionUpgradePlugin.java
@@ -1,0 +1,83 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.upgrade;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.jdbc.entity.PermissionEntity.TYPE;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+public class SpaceSettingPermissionUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log           LOG                   = ExoLogger.getExoLogger(SpaceSettingPermissionUpgradePlugin.class);
+
+  private static final String        SETTINGS_PAGE_NAME    = "SpaceSettingPortlet";
+
+  private static final String        PERMISSION_UPDATE_SQL =
+                                                           """
+                                                               UPDATE GateInPermission perm
+                                                               SET perm.permission = CONCAT('manager', SUBSTRING(perm.permission, 2, LENGTH(perm.permission)))
+                                                               WHERE perm.referenceType = 'org.exoplatform.portal.jdbc.entity.PageEntity'
+                                                                 AND perm.type = :permissionType
+                                                                 AND perm.permission LIKE '*:/spaces/%'
+                                                                 AND perm.referenceId IN
+                                                                    (
+                                                                     SELECT page.id FROM GateInPage page
+                                                                     WHERE page.name = :pageName
+                                                                    )
+                                                               """;
+
+  private final EntityManagerService entityManagerService;
+
+  public SpaceSettingPermissionUpgradePlugin(EntityManagerService entityManagerService,
+                                             InitParams initParams) {
+    super(initParams);
+    this.entityManagerService = entityManagerService;
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion, String previousVersion) {
+    return StringUtils.isNotBlank(previousVersion);
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startTime = System.currentTimeMillis();
+    LOG.info("Start:: Upgrade of 'settings' page of spaces to be accessible to managers only");
+    int migratedPages = executeUpdate();
+    LOG.info("End:: Upgrade of {} space pages finished successfully. It tooks {} ms",
+             migratedPages,
+             (System.currentTimeMillis() - startTime));
+  }
+
+  @ExoTransactional
+  public int executeUpdate() {
+    return entityManagerService.getEntityManager()
+                               .createQuery(PERMISSION_UPDATE_SQL)
+                               .setParameter("permissionType", TYPE.ACCESS)
+                               .setParameter("pageName", SETTINGS_PAGE_NAME)
+                               .executeUpdate();
+  }
+
+}

--- a/component/core/src/test/java/io/meeds/social/upgrade/InitContainerTestSuite.java
+++ b/component/core/src/test/java/io/meeds/social/upgrade/InitContainerTestSuite.java
@@ -25,6 +25,7 @@ import org.exoplatform.commons.testing.ConfigTestCase;
 
 @SuiteClasses({
   LayoutUpgradePluginTest.class,
+  SpaceSettingPermissionUpgradePluginTest.class,
 })
 @ConfigTestCase(LayoutUpgradePluginTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/core/src/test/java/io/meeds/social/upgrade/SpaceNavigationIconUpgradePluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/upgrade/SpaceNavigationIconUpgradePluginTest.java
@@ -1,8 +1,9 @@
-package io.meeds.social.core.upgrade;
+package io.meeds.social.upgrade;
 import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/component/core/src/test/java/io/meeds/social/upgrade/SpaceSettingPermissionUpgradePluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/upgrade/SpaceSettingPermissionUpgradePluginTest.java
@@ -1,0 +1,116 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.upgrade;
+
+import org.junit.Test;
+
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.Utils;
+import org.exoplatform.portal.mop.dao.PageDAO;
+import org.exoplatform.portal.mop.dao.PageDAOImpl;
+import org.exoplatform.portal.mop.page.PageContext;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.portal.mop.storage.cache.CachePageStorage;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.core.test.AbstractCoreTest;
+
+@ConfiguredBy({
+  @ConfigurationUnit(scope = ContainerScope.ROOT,
+      path = "conf/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.ROOT,
+      path = "conf/exo.social.component.core-local-root-configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.PORTAL,
+      path = "conf/portal/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.PORTAL,
+      path = "conf/exo.social.component.core-local-configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.PORTAL,
+      path = "conf/social.component.core-local-portal-configuration.xml"),
+})
+public class SpaceSettingPermissionUpgradePluginTest extends AbstractCoreTest {
+
+  @Override
+  protected void setUp() {
+    begin();
+    spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
+  }
+
+  @Test
+  public void testProcessUpgrade() {
+    assertTrue(getContainer().getComponentInstanceOfType(PageDAO.class) instanceof PageDAOImpl);
+
+    Space space = createSpace("spaceWithSettings", "root");
+    LayoutService layoutService = getContainer().getComponentInstanceOfType(LayoutService.class);
+
+    Page page = layoutService.getPage("group::" + space.getGroupId() + "::SpaceSettingPortlet");
+    assertNotNull(page);
+    page.setAccessPermissions(new String[] { "*:" + space.getGroupId() });
+    layoutService.save(new PageContext(page.getPageKey(), Utils.toPageState(page)));
+    getContainer().getComponentInstanceOfType(CacheService.class).getCacheInstance(CachePageStorage.PAGE_CACHE_NAME).clearCache();
+    restartTransaction();
+
+    new SpaceSettingPermissionUpgradePlugin(getEntityManagerService(),
+                                            getInitParams()).processUpgrade(null, null);
+
+    page = layoutService.getPage("group::" + space.getGroupId() + "::SpaceSettingPortlet");
+    assertNotNull(page);
+    assertNotNull(page.getAccessPermissions());
+    assertEquals(1, page.getAccessPermissions().length);
+    assertEquals("manager:" + space.getGroupId(), page.getAccessPermissions()[0]);
+  }
+
+  private EntityManagerService getEntityManagerService() {
+    return getContainer().getComponentInstanceOfType(EntityManagerService.class);
+  }
+
+  private InitParams getInitParams() {
+    InitParams initParams = new InitParams();
+    ValueParam productGroupIdValueParam = new ValueParam();
+    productGroupIdValueParam.setName("product.group.id");
+    productGroupIdValueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(productGroupIdValueParam);
+    return initParams;
+  }
+
+  private Space createSpace(String spaceName, String creator) {
+    Space space = new Space();
+    space.setDisplayName(spaceName);
+    space.setPrettyName(spaceName);
+    space.setGroupId("/spaces/" + space.getPrettyName());
+    space.setRegistration(Space.OPEN);
+    space.setDescription("description of space" + spaceName);
+    space.setTemplate("template");
+    space.setVisibility(Space.PRIVATE);
+    space.setRegistration(Space.OPEN);
+    space.setPriority(Space.INTERMEDIATE_PRIORITY);
+    String[] managers = new String[] { creator };
+    String[] members = new String[] { creator };
+    space.setManagers(managers);
+    space.setMembers(members);
+    spaceService.createSpace(space, creator);
+    return space;
+  }
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/space/SpaceUtilsTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/SpaceUtilsTest.java
@@ -166,15 +166,17 @@ public class SpaceUtilsTest extends AbstractCoreTest {
 
     for (UserNode childNode : childNodes)
     {
-      pc = pageService.loadPage(childNode.getPageRef());
-      AppName = pc.getState().getDisplayName().split("-")[0].trim();
+      if (childNode.getPageRef() != null) {
+        pc = pageService.loadPage(childNode.getPageRef());
+        AppName = pc.getState().getDisplayName().split("-")[0].trim();
 
-      assertEquals("Space1", AppName);
-      SpaceUtils.changeAppPageTitle(childNode,"newspacetitle");
-      pc = pageService.loadPage(childNode.getPageRef());
-      AppName = pc.getState().getDisplayName().split("-")[0].trim();
+        assertEquals("Space1", AppName);
+        SpaceUtils.changeAppPageTitle(childNode,"newspacetitle");
+        pc = pageService.loadPage(childNode.getPageRef());
+        AppName = pc.getState().getDisplayName().split("-")[0].trim();
 
-      assertEquals("newspacetitle", AppName);
+        assertEquals("newspacetitle", AppName);
+      }
     }
 
   }

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceTemplateServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceTemplateServiceTest.java
@@ -4,6 +4,8 @@ import java.util.*;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.*;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.space.*;
@@ -63,17 +65,25 @@ public class SpaceTemplateServiceTest extends AbstractCoreTest {
     assertTrue(Collections.unmodifiableList(Collections.EMPTY_LIST).getClass().isInstance(templates));
   }
 
-  /**
-   * Test {@link SpaceTemplateService#getSpaceTemplates(String)} ()}
-   */
-//FIXME regression JCR to RDBMS migration
-//  public void testGetAllSpaceTemplates() throws Exception {
-//    // When
-//    List<SpaceTemplate> templates = spaceTemplateService.getSpaceTemplates("root");
-//    // Then
-//    assertEquals(1, templates.size());
-//    assertEquals("classic", templates.get(0).getName());
-//  }
+  public void testCreateSpaceWithRolesAndProfilesInApplication() {
+    Space space = createSpace("Space Settings Test", "root");
+    assertNotNull(space);
+
+    LayoutService layoutService = getContainer().getComponentInstanceOfType(LayoutService.class);
+    Page page = layoutService.getPage("group::" + space.getGroupId() + "::SpaceSettingPortlet");
+    assertNotNull(page);
+    assertNotNull(page.getAccessPermissions());
+    assertEquals(1, page.getAccessPermissions().length);
+    assertEquals("manager:" + space.getGroupId(), page.getAccessPermissions()[0]);
+    assertEquals("test", page.getProfiles());
+
+    page = layoutService.getPage("group::" + space.getGroupId() + "::MembersPortlet");
+    assertNotNull(page);
+    assertNotNull(page.getAccessPermissions());
+    assertEquals(1, page.getAccessPermissions().length);
+    assertEquals("*:" + space.getGroupId(), page.getAccessPermissions()[0]);
+    assertNull(page.getProfiles());
+  }
 
   /**
    * Test {@link SpaceTemplateService#getSpaceTemplates(String)} ()}
@@ -180,8 +190,7 @@ public class SpaceTemplateServiceTest extends AbstractCoreTest {
     objParam.setName("template");
     objParam.setObject(spaceTemplate);
     params.addParameter(objParam);
-    SpaceTemplateConfigPlugin spaceTemplateConfigPlugin = new SpaceTemplateConfigPlugin(params);
-    return spaceTemplateConfigPlugin;
+    return new SpaceTemplateConfigPlugin(params);
   }
 
   /**
@@ -222,49 +231,14 @@ public class SpaceTemplateServiceTest extends AbstractCoreTest {
     assertEquals("classic", spaceTemplateService.getDefaultSpaceTemplate());
   }
 
-  /**
-   * Test
-   * {@link SpaceTemplateService#initSpaceApplications(Space, SpaceApplicationHandler)}
-   */
-  public void testInitSpaceApplications() throws Exception {
-    // TODO
-  }
-
-  /**
-   * Test
-   * {@link SpaceTemplateService#setApp(Space, String, String, boolean, String)}
-   */
-//FIXME regression JCR to RDBMS migration
-//  public void testSetApp() throws Exception {
-//    startSessionAs("root");
-//    Space space = createSpace("mySpace", "root");
-//    assertNull(space.getApp());
-//    // when
-//    spaceTemplateService.setApp(space, "appId", "appName", true, Space.ACTIVE_STATUS);
-//    // then
-//    assertEquals("appId:appName:true:active", space.getApp());
-//  }
-
-  /**
-   * Test {@link SpaceTemplateService#getLabelledSpaceTemplates(String, String)}
-   */
-//FIXME regression JCR to RDBMS migration
-//  public void testGetLabelledSpaceTemplates() throws Exception {
-//    // when
-//    List<SpaceTemplate> list = spaceTemplateService.getLabelledSpaceTemplates("root", "en");
-//    // then
-//    assertEquals(1, list.size());
-//    assertEquals("Any in Administrators ", list.get(0).getPermissionsLabels());
-//  }
-
-  private Space createSpace(String spaceName, String creator) throws Exception {
+  private Space createSpace(String spaceName, String creator) {
     Space space = new Space();
     space.setDisplayName(spaceName);
     space.setPrettyName(spaceName);
     space.setGroupId("/spaces/" + space.getPrettyName());
     space.setRegistration(Space.OPEN);
     space.setDescription("description of space" + spaceName);
-    space.setTemplate(DefaultSpaceApplicationHandler.NAME);
+    space.setTemplate("template");
     space.setVisibility(Space.PRIVATE);
     space.setRegistration(Space.OPEN);
     space.setPriority(Space.INTERMEDIATE_PRIORITY);

--- a/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.social.core.test;
 
-import io.meeds.social.core.upgrade.SpaceNavigationIconUpgradePluginTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -36,6 +35,7 @@ import org.exoplatform.social.core.service.GettingStartedServiceTest;
 import org.exoplatform.social.core.storage.StorageUtilsTest;
 
 import io.meeds.social.image.plugin.ImageAttachmentPluginTest;
+import io.meeds.social.upgrade.SpaceNavigationIconUpgradePluginTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -1360,6 +1360,16 @@
                     <field name="uri">
                       <string>settings</string>
                     </field>
+                    <field name="profiles">
+                      <string>test</string>
+                    </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                     <!--<field name="icon"><string>SpaceSettingsIcon</string></field>-->
                   </object>
                 </value>

--- a/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-local-configuration.xml
@@ -253,6 +253,13 @@
                     <field name="uri">
                       <string>settings</string>
                     </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                   </object>
                 </value>
                 <value>
@@ -1157,6 +1164,8 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+
+  <import>jar:/conf/exo.portal.component.portal-configuration-local.xml</import>
 
   <remove-configuration>org.exoplatform.portal.resource.SkinResourceRequestHandler</remove-configuration>
   <remove-configuration>org.exoplatform.web.WebAppController</remove-configuration>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/upgrade-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/portal/upgrade-plugins-configuration.xml
@@ -21,9 +21,37 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
+      <name>SpaceSettingPermissionUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.SpaceSettingPermissionUpgradePlugin</type>
+      <description>Upgrade Space 'Settings' page access permission to be 'manager:/spaces/...' instead of '*:/spaces/...'</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <value>7.0.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>85</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>SpaceNavigationIconMigration</name>
       <set-method>addUpgradePlugin</set-method>
-      <type>io.meeds.social.core.upgrade.SpaceNavigationIconUpgradePlugin</type>
+      <type>io.meeds.social.upgrade.SpaceNavigationIconUpgradePlugin</type>
       <description>Configure space node icons</description>
       <init-params>
         <value-param>
@@ -34,7 +62,7 @@
         <value-param>
           <name>plugin.upgrade.target.version</name>
           <description>The plugin target version (will not be executed if previous version is equal or higher than 6.5.0)</description>
-          <value>6.6.0</value>
+          <value>7.0.0</value>
         </value-param>
         <value-param>
           <name>space.node.names</name>

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
@@ -102,6 +102,13 @@
                     <field name="icon">
                       <string>fas fa-cog</string>
                     </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                   </object>
                 </value>
                 <value>
@@ -230,6 +237,13 @@
                     <field name="icon">
                       <string>fas fa-cog</string>
                     </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                   </object>
                 </value>
 
@@ -334,6 +348,13 @@
                     <field name="icon">
                       <string>fas fa-cog</string>
                     </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
+                    </field>
                   </object>
                 </value>
 
@@ -437,6 +458,13 @@
                     </field>
                     <field name="icon">
                       <string>fas fa-cog</string>
+                    </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
                     </field>
                   </object>
                 </value>


### PR DESCRIPTION
Prior to this change, when creating a space, all pages access permissions are set to be accessible to all members. This change allows to configure specific role(s) to make the page accessible to specific membership type of space group.

Additionally, this change will allow, as well, to configure a profile on pages so that when uninstall an addon, the page isn't displayed anymore. In addition, this change will add the default roles of type 'manager' on 'settings' page.

In addition, this change will introduce a new Upgrade plugin to change space 'settings' page permissions to be accessible to 'manager' role only instead of '*' which was the case using a workaround in Space Menu Portlet and not embedded in Page permissions set.