### PR TITLE
fix: Delete CTAs for space members not able to post - MEED-7470 - Meeds-io/meeds#2384

### DIFF
--- a/component/service/src/main/resources/locale/social/Webui_en.properties
+++ b/component/service/src/main/resources/locale/social/Webui_en.properties
@@ -186,6 +186,7 @@ UIActivity.label.empty_stream_send_kudos=Value other's work
 UIActivity.label.empty_stream_start_poll=Start a Poll
 UIActivity.label.empty_stream_write_article=Write an Article
 UIActivity.label.empty_stream_join_spaces=Join Spaces
+UIActivity.label.empty_stream_only_admins_can_post=Only admins and redactors can add contents here
 UIActivity.label.paragraph_one=The {meeds association link} provides an employee recognition software implementation to its members.
 UIActivity.label.paragraph_two=Members embed this recognition and rewards engine into their software stacks to gamify them and to recognize their users contributions.
 UIActivity.label.paragraph_three=The software includes the following main components, social activity stream, people directory, spaces, apps launcher, gamification and rewards engine.

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -3,7 +3,7 @@
     <v-main class="application-body">
       <activity-stream-toolbar
         v-if="canPostInitialized"
-        :can-post="canPost"
+        :can-post="$root.canPost"
         :can-filter="canFilter"
         :filter="filter"
         :has-activities="hasActivities" />
@@ -34,7 +34,6 @@ export default {
     canPostInitialized: false,
     spaceId: eXo.env.portal.spaceId,
     forceReload: false,
-    canPost: false,
     hasActivities: false,
     activityId: null,
     activityTypes: {},
@@ -137,7 +136,7 @@ export default {
       return params.get(paramName);
     },
     canPostLoaded(canPost) {
-      this.canPost = canPost;
+      this.$root.canPost = !!canPost;
       this.canPostInitialized = true;
     },
   },

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessage.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/empty-stream/ActivityStreamEmptyMessage.vue
@@ -25,6 +25,7 @@
       <p v-sanitized-html="welcomeTitle" class="text-title"></p>
       <p v-sanitized-html="welcomeSubTitle" class="text-body"></p>
       <v-card
+        v-if="$root.canPost == true"
         :max-width="$root.isMobile && 250 || 'auto'"
         class="d-flex flex-column flex-sm-row flex-wrap align-center justify-center my-6"
         flat>
@@ -53,6 +54,10 @@
           :link="spacesLink"
           icon-index="3" />
       </v-card>
+      <p
+        v-else-if="spaceId && $root.canPost === false"
+        v-sanitized-html="$t('UIActivity.label.empty_stream_only_admins_can_post')"
+        class="text-body"></p>
     </div>
   </div>
 </template>

--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/main.js
@@ -61,6 +61,7 @@ export function init(maxFileSize) {
           activityBaseLink: activityBaseLink,
           selectedActivityId: null,
           selectedCommentId: null,
+          canPost: null,
           replyToComment: false,
           displayCommentActionTypes: []
         },


### PR DESCRIPTION
This change will hide Empty Stream Placeholder CTAs when the space member can't post on stream when it's a editorial space.