### PR TITLE
fix: Fix Disaply of User Membership Date instead of user creation dat - MEED-7517 - Meeds-io/MIPs#147

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-invitation/components/drawer/SpaceInvitePendingDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-invitation/components/drawer/SpaceInvitePendingDrawer.vue
@@ -263,13 +263,13 @@ export default {
         if (users?.length) {
           if (reset) {
             this.users = users.slice(0, this.pageSize).map(m => m?.user && ({
-              createdDate: m.createdDate,
               ...m.user,
+              createdDate: m.createdDate,
             })).filter(u => u);
           } else {
             this.users.push(...users.slice(0, this.pageSize).map(m => m?.user && ({
-              createdDate: m.createdDate,
               ...m.user,
+              createdDate: m.createdDate,
             })).filter(u => u));
           }
           this.hasMore = users.length > this.pageSize;


### PR DESCRIPTION
Prior to this change, when the user is an admin and allowed to retrieve user 'createdDate' attribute, this attribute is used instead of the attribute of membership. This change will fix this behavior to allow considering the Membership creation date all time.