### PR TITLE
fix: Poll's Post button is always disabled - EXO-71446 - Meeds-io/meeds#2403 

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -229,7 +229,7 @@ export default {
           || this.loading
           || (!!this.activityId && !this.activityBodyEdited && !this.activityAttachmentsEdited)
           || (!this.activityAttachmentsEdited && !this.messageLength && !this.activityBodyEdited)
-          || (this.postInYourSpacesChoice && !this.spaceId)
+          || (this.postInYourSpacesChoice && !(this.spaceId || this.activityType?.toString()?.includes('poll') && eXo.env.portal.spaceId))
           || (!this.postToNetwork && !eXo.env.portal.spaceId && !this.spaceId && !this.messageEdited);
     },
     metadataObjectId() {


### PR DESCRIPTION
Before this change, when set property exo.feature.PostToNetwork.enabled=false, launch server and create spaceX then on spaceX AS and choose poll then create poll and save, POST button is disabled.
After this change, As poll is created&saved, Poll button is enabled and once submitted poll is posted.

(cherry picked from commit cb95f81bb45d947034d5e6dd66656de6f57dcdcd)