### PR TITLE
fix: [bug] search containing "-" gives no results in people page - EXO-74310 - Meeds-io/meeds#2410

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -573,9 +573,9 @@ public class ProfileSearchConnector {
   }
 
   public static String removeESReservedChars(String string) {
-    String [] ES_RESERVED_CHARS = new String []{"","+","-","=","&&","||",">","<","!","(",")","{","}","[","]","^","\"","~","*","?",":","\\","/"};
+    String [] ES_RESERVED_CHARS = new String []{"+","-","=","&&","||",">","<","!","(",")","{","}","[","]","^","\"","~","*","?",":","\\","/"};
     for(String c : ES_RESERVED_CHARS) {
-      string = string.replace(c, "");
+      string = string.replace(c, " ");
     }
     return string;
   }


### PR DESCRIPTION
Prior to this change, searching for users using advanced filter with keyword containing "-" gives no result more", The commit fix this bug by correcting ES query generated from the keyword.