### PR TITLE
fix: Fix Activity Composer Label Style when not redactor - MEED-7527 -  Meeds-io/meeds#2424

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -41,7 +41,7 @@
             @click="openComposerDrawer(true)">
             <span class="pa-2 text-truncate"> {{ composerButtonLabel }} </span>
           </v-btn>
-          <span v-else class="text-subtitle my-auto">
+          <span v-else class="my-auto text-subtitle-color">
             {{ $t('activity.toolbar.title') }}
           </span>
           <div class="my-auto ms-auto d-flex flex-row">


### PR DESCRIPTION
Prior to this change, when a redactor is identified in a space and the member displays the activity stream, then the composer label font size is reduced. This change ensures to use the same size as a normal composer by preserving the subtitle color.