### PR TITLE
fix: Allow emojis using MySQL in Profile Experience Fields - MEED-7512 - Meeds-io/meeds#2402

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -942,4 +942,14 @@
       </addColumn>
     </changeSet>
 
+  <changeSet
+    author="social"
+    id="1.0.0-99"
+    dbms="mysql">
+    <sql>
+      ALTER TABLE SOC_IDENTITY_EXPERIENCES MODIFY COLUMN COMPANY varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+      ALTER TABLE SOC_IDENTITY_EXPERIENCES MODIFY COLUMN POSITION varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
This change will allow  using emojis with MySQL as RDBMS, in Profile Experience UI for fields `COMPANY` and `POSITION`.