### PR TITLE
fix: Fix Topbar Label Size - MEED-7543 - Meeds-io/meeds#273

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topbarLogo.jsp
+++ b/webapp/portlet/src/main/webapp/WEB-INF/jsp/portlet/topbarLogo.jsp
@@ -95,7 +95,7 @@
           <% if (space == null) { %>
           <% if (logoPath != null) { %>
           <a id="UserHomePortalLink" href="<%=portalPath%>" class="pe-3 logoContainer">
-            <img src="<%=logoPath%>" class="<%=imageClass%>" alt="<%= logoTitle%>">
+            <img src="<%=logoPath%>" height="36px" width="auto" class="<%=imageClass%>" alt="<%=logoTitle%>">
           </a>
           <% } %>
           <a href="<%=portalPath%>" title="<%=logoTitle%>"

--- a/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-top-bannerlogo/components/ExoSpaceLogoBanner.vue
@@ -21,7 +21,7 @@
             <v-list-item-avatar 
               v-if="logoPath"
               id="UserHomePortalLink"
-              size="30"
+              size="36"
               class="tile my-0 spaceAvatar ms-0 me-3"
               tile>
               <v-img :src="logoPath" :alt="$t('space.avatar.img.alt',{0:logoTitle})" />


### PR DESCRIPTION
Prior to this change, the navigation button displayed in topbar was having a small size comparing to top bar buttons. This change allow to adjust the size of Topbar to be the same as other buttons displayed in the Topbar.

Resolves Meeds-io/meeds#273