### PR TITLE
feat: Allow to not update portal config properties in Upgrade Plugin - MEED-7551 - Meeds-io/meeds#2433

### DIFF
--- a/component/core/src/main/java/io/meeds/social/upgrade/LayoutUpgradePlugin.java
+++ b/component/core/src/main/java/io/meeds/social/upgrade/LayoutUpgradePlugin.java
@@ -136,6 +136,15 @@ public class LayoutUpgradePlugin extends UpgradeProductPlugin {
   private boolean upgradePortalLayout(LayoutUpgrade upgrade, String portalType, String portalName) {
     String location = upgrade.getConfigPath();
     PortalConfig newPortalConfig = portalConfigService.getConfig(portalType, portalName, PortalConfig.class, location);
+    PortalConfig portalConfig = layoutService.getPortalConfig(portalType, portalName);
+    if (portalConfig == null) {
+      portalConfig = newPortalConfig;
+    } else if (upgrade.isUpdatePortalProperties()) {
+      newPortalConfig.setBannerFileId(portalConfig.getBannerFileId());
+      portalConfig = newPortalConfig;
+    } else {
+      portalConfig.setPortalLayout(newPortalConfig.getPortalLayout());
+    }
     if (newPortalConfig == null) {
       LOG.info("IGNORE:: Portal layout {}/{} wasn't found in path {}. The layout upgrade will be ignored",
                portalType,
@@ -144,7 +153,7 @@ public class LayoutUpgradePlugin extends UpgradeProductPlugin {
       return false;
     }
     LOG.info("Process:: Upgrade Portal Layout {}/{}", portalType, portalName);
-    PortalConfigImporter portalImporter = new PortalConfigImporter(getImportMode(upgrade), newPortalConfig, layoutService);
+    PortalConfigImporter portalImporter = new PortalConfigImporter(getImportMode(upgrade), portalConfig, layoutService);
     try {
       portalImporter.perform();
       return true;

--- a/component/core/src/main/java/io/meeds/social/upgrade/model/LayoutUpgrade.java
+++ b/component/core/src/main/java/io/meeds/social/upgrade/model/LayoutUpgrade.java
@@ -31,6 +31,8 @@ public class LayoutUpgrade {
 
   private boolean      updatePortalConfig;
 
+  private boolean      updatePortalProperties;
+
   private boolean      updatePageLayout;
 
   private boolean      updateNavigation;

--- a/component/core/src/test/java/io/meeds/social/upgrade/LayoutUpgradePluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/upgrade/LayoutUpgradePluginTest.java
@@ -109,6 +109,15 @@ public class LayoutUpgradePluginTest extends AbstractCoreTest {// NOSONAR
     layoutUpgradePlugin.processUpgrade(null, null);
     portalConfig = layoutService.getPortalConfig(PORTAL_NAME);
     assertNotNull(portalConfig);
+    assertEquals(PROP_VALUE, portalConfig.getProperty(PROP_KEY));
+    portalLayout = portalConfig.getPortalLayout();
+    assertNotNull(portalLayout);
+    assertEquals(5, portalLayout.getChildren().size());
+
+    layoutUpgrade.setUpdatePortalProperties(true);
+    layoutUpgradePlugin.processUpgrade(null, null);
+    portalConfig = layoutService.getPortalConfig(PORTAL_NAME);
+    assertNotNull(portalConfig);
     assertEquals(PROP_VALUE_MODIFIED, portalConfig.getProperty(PROP_KEY));
     portalLayout = portalConfig.getPortalLayout();
     assertNotNull(portalLayout);


### PR DESCRIPTION
Prior to this change, when upgrading the portal config layout, the portal properties such as banner and permissions are changed as well. This change allows to choose whether to update the portal config properties at the same time as the layout or just the site layout.

Resolves Meeds-io/meeds#2433