### PR TITLE
feat: Upgrade Spring and replace Jcabi Plugin by AspectJ Maven Plugin - Meeds-io/meeds#2417

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -83,14 +83,4 @@
       <artifactId>jsoup</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <finalName>${project.artifactId}</finalName>
-    <plugins>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -60,7 +60,6 @@
       <plugin>
         <groupId>org.bsc.maven</groupId>
         <artifactId>maven-processor-plugin</artifactId>
-        <version>5.0</version>
         <executions>
           <execution>
             <id>process</id>
@@ -79,7 +78,7 @@
           <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>6.4.1.Final</version>
+            <version>6.5.3.Final</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/component/notification/pom.xml
+++ b/component/notification/pom.xml
@@ -50,10 +50,6 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/component/service/pom.xml
+++ b/component/service/pom.xml
@@ -29,7 +29,7 @@
   <name>Meeds:: PLF:: Social Service Component</name>
   <description>Meeds Social Service Component</description>
   <properties>
-    <exo.test.coverage.ratio>0.51</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.48</exo.test.coverage.ratio>
 
     <rest.api.doc.title>Social Rest Api</rest.api.doc.title>
     <rest.api.doc.version>1.0</rest.api.doc.version>
@@ -61,8 +61,20 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>io.meeds.portal</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>social-component-api</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,6 @@
   </dependencyManagement>
 
   <build>
-    <finalName>${project.artifactId}</finalName>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -235,6 +234,41 @@
 
   <!-- This profile is used to allow github action to build branches. The github action is used for sonar analysis -->
   <profiles>
+    <profile>
+      <activation>
+        <property>
+          <name>packaging</name>
+          <value>jar</value>
+        </property>
+        <file>
+          <missing>src/main/resources/no-aop</missing>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.meeds.portal</groupId>
+          <artifactId>portal.component.common</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>aspectj-maven-plugin</artifactId>
+            <configuration>
+              <aspectLibraries>
+                <aspectLibrary>
+                  <groupId>io.meeds.portal</groupId>
+                  <artifactId>portal.component.common</artifactId>
+                </aspectLibrary>
+              </aspectLibraries>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>project-repositories</id>
       <activation>


### PR DESCRIPTION
Prior to this change, the jcabi maven plugin was used to weave classes for annotation processing, especially  and  annotations. This plugin isn't maintained and should be replace by the default AspectJ libraries for Annotation Processing. In addition, the Jcabi plugin makes the build longer and takes a lot of time in addition to heigh I/O operations on disk. This change applies the required configuration (In addition to https://github.com/Meeds-io/maven-parent-pom/commit/bea09a8fcbc02b87ee8748cd9bbf9a524e4d74cd) in order to replace usage of Jcabi plugin.