### PR TITLE
fix: plan view is ko in language different from EN & FR - EXO-72317 - Meeds-io/meeds#2140

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/search/main.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/search/main.js
@@ -7,7 +7,7 @@ let initialized = false;
 
 // Handle Tag Link click
 document.onclick = (event) => {
-  if (event && event.target && event.target.className && event.target.className.includes('metadata-tag')) {
+  if (event && event.target && event.target.className && JSON.stringify(event.target.className).includes('metadata-tag')) {
     const tagName = event.target.innerText;
     if (tagName) {
       event.stopPropagation();


### PR DESCRIPTION
Before this change, when set plf langue to langue except english or french then open tasks project and create tasks with start and end date then open plan view, nothing displayed in plan view and error in browser console. After this change, plan view is available as it is the case for French & English.

(cherry picked from commit 91b9705f028303219b3daabd3740d4ac1aa4714a)