### PR TITLE
fix: Delete informative test in Space Roles Roles Selector Drawer - MEED-7575 - Meeds-io/meeds#2454

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/drawer/SpaceSettingUsersSelectionDrawer.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/space-settings/components/drawer/SpaceSettingUsersSelectionDrawer.vue
@@ -32,13 +32,7 @@
       {{ $t(`SpaceSettings.users.add.drawer.${role}.title`) }}
     </template>
     <template v-if="drawer" #content>
-      <div class="pa-4">
-        <div>
-          {{ $t('SpaceSettings.roles.restrictContentCreation.placeholder1') }}
-        </div>
-        <div class="pt-2">
-          {{ $t('SpaceSettings.roles.restrictContentCreation.placeholder2') }}
-        </div>
+      <div class="mx-4 pb-4 pt-1">
         <identity-suggester
           ref="suggester"
           id="userMemberSuggester"


### PR DESCRIPTION
This change will delete a wrong informative label displayed in all drawer roles selection context.