### PR TITLE
fix: Avoid Group Navigation Menu to be clickable - MEED-7561 - Meeds-io/meeds#2437

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -107,7 +107,7 @@ export default {
       return !!this.navigation?.pageKey;
     },
     navigationNodeUri() {
-      return this.navigation?.pageLink || `${this.baseSiteUri}${this.navigation.uri}`;
+      return this.navigation?.pageLink || (this.hasPage && `${this.baseSiteUri}${this.navigation.uri}`);
     },
     navigationNodeTarget() {
       return this.navigation?.target === 'SAME_TAB' && '_self' || '_blank';
@@ -183,12 +183,14 @@ export default {
       return childrenHasPage;
     },
     openUrl(url, target) {
-      if (!url.match(/^(https?:\/\/|javascript:|\/portal\/)/)) {
-        url = `//${url}`;
-      } else if (url.match(/^(\/portal\/)/)) {
-        url = `${window.location.origin}${url}`;
+      if (url) {
+        if (!url?.match?.(/^(https?:\/\/|javascript:|\/portal\/)/)) {
+          url = `//${url}`;
+        } else if (url?.match?.(/^(\/portal\/)/)) {
+          url = `${window.location.origin}${url}`;
+        }
+        window.open(url, target);
       }
-      window.open(url, target);
     },
   }
 };

--- a/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -120,7 +120,7 @@ export default {
     navigationNodeUri() {
       return this.navigation?.pageLink
         && this.urlVerify(this.navigation?.pageLink)
-        || `${this.baseSiteUri}${this.navigation.uri}`;
+        || (this.hasPage && `${this.baseSiteUri}${this.navigation.uri}`);
     },
     isSelected() {
       return this.navigationNodeUri === this.selectedPath;
@@ -143,6 +143,9 @@ export default {
       this.positionX = window.innerWidth - (window.innerWidth - this.$el.getBoundingClientRect().right);
       this.positionY = this.$el.getBoundingClientRect().top;
       this.$root.$emit('close-sibling-drop-menus-children', this);
+    },
+    hasPage() {
+      return !!this.navigation?.pageKey;
     },
   },
   created() {
@@ -183,7 +186,7 @@ export default {
       return url ;
     },
     handleCloseSiblingMenus(emitter) {
-      if (!emitter.navigation.pageLink && !emitter.navigationNodeUri.includes(this.navigationNodeUri) && this.showMenu) {
+      if (!emitter?.navigation?.pageLink && !emitter?.navigationNodeUri?.includes?.(this.navigationNodeUri) && this.showMenu) {
         this.showMenu = false;
       }
     },


### PR DESCRIPTION
Prior to this change, when a group link is added in topbar menu, and when clicking on it, it redirects to a blank page. This change ensures to not making the menu entry clickable when no page associated to it nor an external link.