### PR TITLE
fix: Fix Space URL computing using new Web Controller Handler - MEED-7568 - Meeds-io/MIPs#158

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
@@ -190,11 +190,10 @@ export default {
       return this.space?.avatarUrl || (this.prettyName && `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/spaces/${this.prettyName}/avatar`);
     },
     url() {
-      if (!this.groupId) {
+      if (!this.space?.id) {
         return '#';
       }
-      const uri = this.groupId.replace(/\//g, ':');
-      return `${eXo.env.portal.context}/g/${uri}/`;
+      return `${eXo.env.portal.context}/s/${this.space?.id}`;
     },
     spaceMembersCount() {
       return this.space && this.space.membersCount;


### PR DESCRIPTION
Prior to this change, when the given space object to the identity provider popover directive, doesn't specify the groupId of the space, then the URL can't be built and a '#' is used instead. This change uses the new Spaces Handler to allow access space through its technical Identifier only.