### PR TITLE
fix: Fix URL Target auto link using v-sanitized-html Vue directive - MEED-7594 - Meeds-io/meeds#2462

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -2592,7 +2592,7 @@
             replaceFn : function (match) {
               switch(match.getType()) {
                 case 'url' :
-                  if(match.getUrl().indexOf(window.location.origin) === 0) {
+                  if(match.getUrl().indexOf('/') === 0 || match.getUrl().indexOf(window.location.origin) === 0) {
                     return true;
                   } else {
                     const tag = match.buildTag();

--- a/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
@@ -27,7 +27,7 @@
       replaceFn : function (match) {
         switch(match.getType()) {
           case 'url' :
-            if(match.getUrl().indexOf(window.location.origin) === 0) {
+            if(match.getUrl().indexOf('/') === 0 || match.getUrl().indexOf(window.location.origin) === 0) {
               return true;
             } else {
               const tag = match.buildTag();


### PR DESCRIPTION
Prior to this change, the URLs of links of type '/portal' was sometimes turned to be displayed in a new tab. This change ensures to not force to open in a new tab, the URLs starting with '/'.