### PR TITLE
fix: Fix URL Target auto link using v-sanitized-html Vue directive - MEED-7594 - Meeds-io/meeds#2462

### DIFF
--- a/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/portlet/src/main/webapp/js/ExtendedDomPurify.js
@@ -55,7 +55,7 @@
         // add noopener attribute to external links to eliminate vulnerabilities
         if (nodeLink) {
           // Open external links in a new Browser Tab
-          if (nodeLink.indexOf(window.location.origin) === -1) {
+          if (nodeLink.indexOf('/') !== 0 && nodeLink.indexOf(window.location.origin) === -1) {
             node.setAttribute('target', '_blank');
             node.setAttribute('rel', 'nofollow noopener noreferrer');
           }


### PR DESCRIPTION
Prior to this change, the URLs of links of type '/portal' was sometimes turned to be displayed in a new tab. This change ensures to not force to open in a new tab, the URLs starting with '/'.