### PR TITLE
fix: Fix Space Banner Cropper Drawer Style - MEED-7591 - Meeds-io/meeds#2463

### DIFF
--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -37,6 +37,13 @@
 
   <portlet-skin>
     <application-name>social-portlet</application-name>
+    <portlet-name>SpaceBannerPortlet</portlet-name>
+    <skin-name>Enterprise</skin-name>
+    <additional-module>ImageCropper</additional-module>
+  </portlet-skin>
+
+  <portlet-skin>
+    <application-name>social-portlet</application-name>
     <portlet-name>HamburgerMenu</portlet-name>
     <skin-name>Enterprise</skin-name>
     <css-path>/skin/css/portlet/HamburgerMenu/Style.css</css-path>


### PR DESCRIPTION
Prior to this change, the Cropper Drawer isn't well displayed due to missing 'additional-module' skin definition. This change will introduce the definition of CropperDrawer Style as a dependency for SpaceBannerPortlet.

Resolves https://github.com/Meeds-io/meeds/issues/2463