### PR TITLE
feat: Provide to space left menu actions space editorial property - MEED-7636 - Meeds-io/meeds#2485

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
@@ -162,6 +162,9 @@ export default {
     spaceId() {
       return this.space?.id;
     },
+    spacePrettyName() {
+      return this.space?.prettyName;
+    },
     spaceDisplayName() {
       return this.space?.displayName;
     },
@@ -186,10 +189,15 @@ export default {
     isHomeLink() {
       return this.spaceURL === this.homeLink;
     },
+    canRedactOnSpace() {
+      return this.space?.canRedactOnSpace;
+    },
     params() {
       return {
         identityType: 'space',
-        identityId: this.spaceId
+        identityId: this.spaceId,
+        spacePrettyName: this.spacePrettyName,
+        canRedactOnSpace: this.canRedactOnSpace,
       };
     },
     enabledExtensionComponents() {


### PR DESCRIPTION
Prior to this change, the space left menu actions was missing information about editorial property of the space. This change will provide this information, same as space popover actions to allow filtering the display of extended actions.