### PR TITLE
fix: Link settings are not correctly read from server and display an old config - EXO-71985

### DIFF
--- a/component/service/src/main/java/io/meeds/social/link/rest/LinkRest.java
+++ b/component/service/src/main/java/io/meeds/social/link/rest/LinkRest.java
@@ -73,8 +73,7 @@ public class LinkRest implements ResourceContainer {
   private static final Log          LOG                    = ExoLogger.getLogger(LinkRest.class);
 
   static {
-    CACHE_CONTROL.setMaxAge(CACHE_IN_SECONDS);
-    CACHE_CONTROL.setMustRevalidate(true);
+    CACHE_CONTROL.setNoCache(true);
     IMG_CACHE_CONTROL.setMaxAge(CACHE_IN_SECONDS);
   }
 


### PR DESCRIPTION
Before this fix, the links settings are server with Cache-Control = must-revalidate, and maxAge = 1year must-revalidate means : if the asset is expired in cache, revalidate it against the server. Else, serve the cache content. Firefox correctly implements this behaviour as Chrome revalidate assets for each request. This behaviour means that if an admin change the configuration of the setting, a user on FF could see an old version of the configuration, until his cache is refreshed or asset expired.

The commit change the cache control to no-cache, which means : revalidate the asset for each request. As the LinkSettings endpoint correctly implements Etag feature, if the settings did not change, the service return correctly a 304 and the browser serve the cached asset. If the configuration change, the service serves the new version of the configuration.

This value is different from no-store which means no cache at all.

Resolves meeds-io/meeds#71985

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
