### PR TITLE
fix: Unsearchable disabled users by their email or name-EXO-69348-Meeds-io/meeds#1827

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementToolbar.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementToolbar.vue
@@ -53,6 +53,7 @@
     <v-spacer />
     <v-scale-transition>
       <v-text-field
+        v-if="filter === 'ENABLED'"
         v-model="keyword"
         :placeholder="$t('UsersManagement.filterBy')"
         prepend-inner-icon="fa-filter"


### PR DESCRIPTION
Before this change, when create user with a First name different than his login, set user as a disabled user, select disabled filter and search for user by his name or his email, user isn't displayed in the result list.
To resolve this problem, we make a condition in the inputUserFilter component to display the component only if the filter is enabled.
After this change, Hide filter by name or email field when disabled users list displayed on user management application.
