### PR TITLE
fix: [BUG] Invitation to join space : notification is never updated -EXO-75048 - Meeds-io/meeds#2531

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.notification.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.*;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
@@ -126,7 +127,7 @@ public class SpaceNotificationImpl extends SpaceListenerPlugin {
     webNotificationFilter.setPluginKey(new PluginKey(pluginId));
     List<NotificationInfo> webNotifs = getWebNotificationService().getNotificationInfos(webNotificationFilter, 0, -1);
     for (NotificationInfo info : webNotifs) {
-      if (info.getTo().equals(to) && info.getFrom().equals(from) && !"accepted".equals(info.getOwnerParameter().get("status"))) {
+      if (info.getTo().equals(to) && (StringUtils.isEmpty(info.getFrom()) || info.getFrom().equals(from)) && !"accepted".equals(info.getOwnerParameter().get("status"))) {
         //one element has changed, we need to update
         info.setTo(to);
         info.setFrom(from);


### PR DESCRIPTION
Prior to this change, if a user is invited to join a space, and he accepts, the join notification is never updated. This commit fix this bug by correcting the update notification method since the condition to check if the notification should be updated or not was wrong.