### PR TITLE
fix: Fix Builders Space Templates Data Model - MEED-7743

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -1101,6 +1101,10 @@
     </createIndex>
   </changeSet>
 
+  <changeSet author="social" id="1.0.0-118.builders">
+    <sql>UPDATE SOC_SPACE_TEMPLATES SET LAYOUT = ID WHERE ID > 4</sql>
+  </changeSet>
+
   <changeSet author="social" id="1.0.0-118">
     <addUniqueConstraint
       tableName="SOC_SPACE_TEMPLATES"


### PR DESCRIPTION
A Space Template has been added using the old data model in Builders Hub. This change will migrate the old dataset of Space Templates to make it fit the new data model which adds a unique constraint on LAYOUT field.