### PR TITLE
fix: Make Spaces Search Lowercase - MEED-7753 - Meeds-io/meeds#2566

### DIFF
--- a/component/core/src/main/java/io/meeds/social/search/SpaceSearchConnector.java
+++ b/component/core/src/main/java/io/meeds/social/search/SpaceSearchConnector.java
@@ -194,7 +194,7 @@ public class SpaceSearchConnector {
                                      String query,
                                      long offset,
                                      long limit) {
-    String termQuery = buildTermQueryStatement(filter.getTerm());
+    String termQuery = buildTermQueryStatement(StringUtils.lowerCase(filter.getTerm()));
     String favoriteQuery = buildFavoriteQueryStatement(metadataFilters.get(FavoriteService.METADATA_TYPE.getName()));
     String permissionsQuery = buildPermissionsQuery(filter);
     String tagsQuery = buildTagsQueryStatement(metadataFilters.get(TagService.METADATA_TYPE.getName()));

--- a/component/core/src/test/java/io/meeds/social/search/SpaceSearchConnectorTest.java
+++ b/component/core/src/test/java/io/meeds/social/search/SpaceSearchConnectorTest.java
@@ -49,7 +49,6 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PropertiesParam;
 import org.exoplatform.container.xml.ValueParam;
 
-import io.meeds.social.search.SpaceSearchConnector;
 import io.meeds.social.search.model.SpaceSearchFilter;
 import io.meeds.social.search.model.SpaceSearchResult;
 import io.meeds.social.space.constant.SpaceMembershipStatus;


### PR DESCRIPTION
Prior to this change, the spaces search isn't made in lowercase, thus the returned matching spaces doesn't search all time with the correct characters case. In fact, the used Elasticsearch tokenizer will use a lowercase transformation on Spaces display Name to index in order to optimize the stored search keywords. Thus, the input text to use in search has to be all time in lowercase. This change will transform the searched term to be lowercase to use the correct case that fits the configured custom tokenizer requirements.