### PR TITLE
fix: Fix Home Path Computing in Topbar - MEED-7752 - Meeds-io/meeds#2565

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/topbarLogo.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/topbarLogo.jsp
@@ -55,9 +55,12 @@
     if (StringUtils.equals(requestContext.getPortalOwner(), "public")) {
       portalPath = "/portal/public";
     } else {
-      portalPath = portalConfigService.computePortalPath(requestContext.getRequest());
+      portalPath = portalConfigService.getUserHomePage(request.getRemoteUser());
       if (portalPath == null) {
-        portalPath = defaultHomePath;
+        portalPath = portalConfigService.computePortalPath(requestContext.getRequest());
+        if (portalPath == null) {
+          portalPath = defaultHomePath;
+        }
       }
     }
     titleClass = "company";


### PR DESCRIPTION
Prior to this change, the User Home Path wasn't computed in Topbar JSP file, the user will consequently have all time the Contribute Site as Home Path. This change will fix the regression of not using the User Home Path while displaying the Topbar Logo Portlet.