### PR TITLE
fix: Internal user marked as external in people and space members pages - EXO-71462 - Meeds-io/meeds#2572.

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/portlet/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -256,7 +256,7 @@ export default {
       return this.user?.enabled;
     },
     externalUser() {
-      return this.user?.external;
+      return this.user?.external === 'true';
     },
     profileUrl() {
       return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.user?.username}`;


### PR DESCRIPTION
Before this change, the user is marked as external on his card or people page and space members after remove the user from /platform/externals. To resolve this problem, change the display condition value of this component from boolean to String. After this change, the user is marked as external on his hard for people page and space members.