### PR TITLE
feat: Display Shared layout on sites included in Sidebar only - MEED-7875 - Meeds-io/MIPs#159

### DIFF
--- a/component/api/src/main/java/io/meeds/social/navigation/model/SidebarConfiguration.java
+++ b/component/api/src/main/java/io/meeds/social/navigation/model/SidebarConfiguration.java
@@ -47,8 +47,8 @@ public class SidebarConfiguration implements Cloneable {
     return new SidebarConfiguration(allowUserCustomHome,
                                     defaultMode,
                                     userMode,
-                                    new ArrayList<>(allowedModes),
-                                    new ArrayList<>(items));
+                                    allowedModes == null ? null : new ArrayList<>(allowedModes),
+                                    items == null ? null : items.stream().map(SidebarItem::clone).toList());
   }
 
 }

--- a/component/api/src/main/java/io/meeds/social/navigation/model/SidebarItem.java
+++ b/component/api/src/main/java/io/meeds/social/navigation/model/SidebarItem.java
@@ -18,6 +18,7 @@
  */
 package io.meeds.social.navigation.model;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +31,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class SidebarItem {
+public class SidebarItem implements Cloneable {
 
   private String              name;
 
@@ -50,6 +51,18 @@ public class SidebarItem {
 
   public SidebarItem(SidebarItemType type) {
     this.type = type;
+  }
+
+  @Override
+  public SidebarItem clone() { // NOSONAR
+    return new SidebarItem(name,
+                           url,
+                           target,
+                           avatar,
+                           icon,
+                           type,
+                           items == null ? null : items.stream().map(SidebarItem::clone).toList(),
+                           properties == null ? null : new HashMap<>(properties));
   }
 
 }

--- a/component/core/src/main/java/io/meeds/social/navigation/listener/NavigationConfigurationSiteDisplayListener.java
+++ b/component/core/src/main/java/io/meeds/social/navigation/listener/NavigationConfigurationSiteDisplayListener.java
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.navigation.listener;
+
+import static io.meeds.social.navigation.plugin.AbstractLayoutSidebarPlugin.SITE_NAME_PROP_NAME;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerBase;
+import org.exoplatform.services.listener.ListenerService;
+
+import io.meeds.social.navigation.constant.SidebarItemType;
+import io.meeds.social.navigation.model.NavigationConfiguration;
+import io.meeds.social.navigation.service.NavigationConfigurationService;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class NavigationConfigurationSiteDisplayListener
+    implements ListenerBase<NavigationConfiguration, NavigationConfiguration> {
+
+  @Autowired
+  private ListenerService listenerService;
+
+  @Autowired
+  private LayoutService   layoutService;
+
+  @PostConstruct
+  public void init() {
+    listenerService.addListener(NavigationConfigurationService.NAVIGATION_CONFIGURATION_UPDATED_EVENT, this);
+  }
+
+  @Override
+  public void onEvent(Event<NavigationConfiguration, NavigationConfiguration> event) throws Exception {
+    NavigationConfiguration oldConfiguration = event.getSource();
+    NavigationConfiguration newConfiguration = event.getData();
+
+    List<String> oldSiteNames = oldConfiguration == null ?
+                                                         Collections.emptyList() :
+                                                         getSiteNames(oldConfiguration);
+    List<String> newSiteNames = getSiteNames(newConfiguration);
+
+    List<String> sitesWithoutSharedLayout = new ArrayList<>(oldSiteNames);
+    sitesWithoutSharedLayout.removeAll(newSiteNames);
+    sitesWithoutSharedLayout.forEach(siteName -> {
+      PortalConfig site = layoutService.getPortalConfig(SiteKey.portal(siteName));
+      if (site != null) {
+        site.setDisplayed(false);
+        layoutService.save(site);
+      }
+    });
+
+    newSiteNames.forEach(siteName -> {
+      PortalConfig site = layoutService.getPortalConfig(SiteKey.portal(siteName));
+      if (site != null && !site.isDisplayed()) {
+        site.setDisplayed(true);
+        layoutService.save(site);
+      }
+    });
+  }
+
+  private List<String> getSiteNames(NavigationConfiguration configuration) {
+    return configuration.getSidebar()
+                        .getItems()
+                        .stream()
+                        .filter(item -> item.getType() == SidebarItemType.SITE)
+                        .map(item -> item.getProperties().get(SITE_NAME_PROP_NAME))
+                        .toList();
+  }
+
+}

--- a/component/core/src/main/java/io/meeds/social/navigation/plugin/SidebarPluginUtils.java
+++ b/component/core/src/main/java/io/meeds/social/navigation/plugin/SidebarPluginUtils.java
@@ -29,6 +29,10 @@ import io.meeds.social.navigation.model.SidebarItem;
 
 public class SidebarPluginUtils {
 
+  private SidebarPluginUtils() {
+    // Static methods only
+  }
+
   public static String getNameFromProperties(LocaleConfigService localeConfigService,
                                              SidebarItem item,
                                              String propName,

--- a/component/core/src/main/java/io/meeds/social/navigation/service/NavigationConfigurationService.java
+++ b/component/core/src/main/java/io/meeds/social/navigation/service/NavigationConfigurationService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.exoplatform.commons.addons.AddOnService;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.TransientApplicationState;
+import org.exoplatform.services.listener.ListenerService;
 
 import io.meeds.common.ContainerTransactional;
 import io.meeds.social.navigation.constant.SidebarItemType;
@@ -54,13 +55,15 @@ import lombok.SneakyThrows;
 @Service
 public class NavigationConfigurationService {
 
-  private static final String            TOPBAR_APPLICATION_ENABLED_PATTERN = "social.topbar.application.%s.enabled";
+  public static final String             NAVIGATION_CONFIGURATION_UPDATED_EVENT = "social.navigation.configuration.updated";
 
-  private static final String            TOPBAR_APPLICATION_MOBILE_PATTERN  = "social.topbar.application.%s.mobile";
+  private static final String            TOPBAR_APPLICATION_ENABLED_PATTERN     = "social.topbar.application.%s.enabled";
 
-  private static final String            TOP_NAVIGATION_ADDON_CONTAINER     = "middle-topNavigation-container";
+  private static final String            TOPBAR_APPLICATION_MOBILE_PATTERN      = "social.topbar.application.%s.mobile";
 
-  private static final SidebarPlugin     DEFAULT_MENU_PLUGIN                = new DefaultSidebarPlugin();
+  private static final String            TOP_NAVIGATION_ADDON_CONTAINER         = "middle-topNavigation-container";
+
+  private static final SidebarPlugin     DEFAULT_MENU_PLUGIN                    = new DefaultSidebarPlugin();
 
   @Autowired
   private NavigationConfigurationStorage navigationConfigurationStorage;
@@ -72,7 +75,10 @@ public class NavigationConfigurationService {
   private AddOnService                   addonContainerService;
 
   @Autowired
-  Environment                            environment;
+  private Environment                    environment;
+
+  @Autowired
+  private ListenerService                listenerService;
 
   @Autowired
   private List<SidebarPlugin>            menuPlugins;
@@ -112,7 +118,7 @@ public class NavigationConfigurationService {
                    .setItems(configuration.getSidebar()
                                           .getItems()
                                           .stream()
-                                          .filter(item -> getPlugin(item.getType()).itemExists(item, username))
+                                          .filter(item -> !resolve || getPlugin(item.getType()).itemExists(item, username))
                                           .map(item -> resolve ? expandSidebarItem(item, username, locale) : item)
                                           .toList());
       return configuration;
@@ -171,8 +177,10 @@ public class NavigationConfigurationService {
    * @param navigationConfiguration
    */
   public void updateConfiguration(NavigationConfiguration navigationConfiguration) {
+    NavigationConfiguration existingConfiguration = getConfiguration();
     try {
       navigationConfigurationStorage.updateConfiguration(navigationConfiguration);
+      listenerService.broadcast(NAVIGATION_CONFIGURATION_UPDATED_EVENT, existingConfiguration, navigationConfiguration);
     } finally {
       userPortalConfigService.setAllowUserHome(navigationConfiguration.getSidebar().isAllowUserCustomHome());
     }

--- a/component/core/src/test/java/io/meeds/social/navigation/AbstractNavigationConfigurationTest.java
+++ b/component/core/src/test/java/io/meeds/social/navigation/AbstractNavigationConfigurationTest.java
@@ -66,7 +66,7 @@ import lombok.SneakyThrows;
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/social.component.core-local-navigation-portal-configuration.xml"),
 })
 @RunWith(SpringRunner.class)
-public class AbstractNavigationConfigurationTest extends AbstractCoreTest {
+public abstract class AbstractNavigationConfigurationTest extends AbstractCoreTest {
 
   public static final String               MODULE_NAME      = "io.meeds.social.navigation";
 

--- a/component/core/src/test/java/io/meeds/social/navigation/InitContainerTestSuite.java
+++ b/component/core/src/test/java/io/meeds/social/navigation/InitContainerTestSuite.java
@@ -26,6 +26,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 
+import io.meeds.social.navigation.listener.NavigationConfigurationSiteDisplayListenerTest;
 import io.meeds.social.navigation.plugin.LinkSidebarPluginTest;
 import io.meeds.social.navigation.plugin.PageSidebarPluginTest;
 import io.meeds.social.navigation.plugin.SiteSidebarPluginTest;
@@ -41,6 +42,7 @@ import io.meeds.social.navigation.service.NavigationConfigurationServiceTest;
   SpaceListSidebarPluginTest.class,
   SpaceTemplateSidebarPluginTest.class,
   NavigationConfigurationServiceTest.class,
+  NavigationConfigurationSiteDisplayListenerTest.class,
 })
 public class InitContainerTestSuite {
 

--- a/component/core/src/test/java/io/meeds/social/navigation/listener/NavigationConfigurationSiteDisplayListenerTest.java
+++ b/component/core/src/test/java/io/meeds/social/navigation/listener/NavigationConfigurationSiteDisplayListenerTest.java
@@ -1,0 +1,83 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.navigation.listener;
+
+import static io.meeds.social.navigation.plugin.AbstractLayoutSidebarPlugin.SITE_NAME_PROP_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteFilter;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.SiteType;
+
+import io.meeds.social.navigation.AbstractNavigationConfigurationTest;
+import io.meeds.social.navigation.constant.SidebarItemType;
+import io.meeds.social.navigation.model.NavigationConfiguration;
+import io.meeds.social.navigation.model.SidebarItem;
+
+public class NavigationConfigurationSiteDisplayListenerTest extends AbstractNavigationConfigurationTest {
+
+  @Test
+  public void testUpdateSiteDisplayedStatusByConfiguration() {
+    NavigationConfiguration configuration = navigationConfigurationService.getConfiguration();
+    assertNotNull(configuration);
+    assertNotNull(configuration.getTopbar());
+    assertNotNull(configuration.getSidebar());
+
+    SiteFilter siteFilter = new SiteFilter();
+    siteFilter.setSiteType(SiteType.PORTAL);
+    List<PortalConfig> sites = layoutService.getSites(siteFilter);
+    assertNotNull(sites);
+
+    List<String> siteNames = getSiteNames(configuration);
+    String siteName = siteNames.get(0);
+
+    List<SidebarItem> originalSidebarItems = configuration.getSidebar().getItems();
+    List<SidebarItem> sidebarItems = new ArrayList<>(originalSidebarItems);
+    sidebarItems.removeIf(item -> item.getType() == SidebarItemType.SITE && siteName.equals(item.getProperties().get(SITE_NAME_PROP_NAME)));
+
+    configuration.getSidebar().setItems(sidebarItems);
+    navigationConfigurationService.updateConfiguration(configuration);
+
+    SiteKey standaloneSiteKey = SiteKey.portal(siteName);
+
+    PortalConfig updatedSite = layoutService.getPortalConfig(standaloneSiteKey);
+    assertFalse(updatedSite.isDisplayed());
+
+    configuration.getSidebar().setItems(originalSidebarItems);
+    navigationConfigurationService.updateConfiguration(configuration);
+
+    updatedSite = layoutService.getPortalConfig(standaloneSiteKey);
+    assertTrue(updatedSite.isDisplayed());
+  }
+
+  private List<String> getSiteNames(NavigationConfiguration configuration) {
+    return configuration.getSidebar()
+                        .getItems()
+                        .stream()
+                        .filter(item -> item.getType() == SidebarItemType.SITE)
+                        .map(item -> item.getProperties().get(SITE_NAME_PROP_NAME))
+                        .toList();
+  }
+
+}

--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -4,6 +4,7 @@
   ],
   "rules": {
     "vue/multi-word-component-names": "off",
+    "vuejs-accessibility/no-autofocus": "off",
     "no-prototype-builtins": ["warn"],
     "vue/no-mutating-props": ["warn"]
   },

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -269,9 +269,7 @@ export default {
     itemActions() {
       const actions = {};
       if (!this.isUrl) {
-        if (this.isSite) {
-          actions.click = this.openOrCloseDrawer;
-        } else if (this.isSpace) {
+        if (this.isSite || this.isSpace) {
           actions.click = this.openOrCloseDrawer;
         }
       } else if (this.url?.includes?.('#')) {

--- a/webapp/src/main/webapp/vue-apps/sidebar/main.js
+++ b/webapp/src/main/webapp/vue-apps/sidebar/main.js
@@ -209,10 +209,14 @@ export function init(
             }
           },
           updateParentStyle() {
-            if (this.icon) {
-              document.querySelector('#UISiteBody').style[this.$vuetify.rtl && 'marginRight' || 'marginLeft'] = '70px';
+            if (document.querySelector('#UISiteBody')?.style) {
+              if (this.icon) {
+                document.querySelector('#UISiteBody').style[this.$vuetify.rtl && 'marginRight' || 'marginLeft'] = '70px';
+              } else {
+                document.querySelector('#UISiteBody').style[this.$vuetify.rtl && 'marginRight' || 'marginLeft'] = '';
+              }
             } else {
-              document.querySelector('#UISiteBody').style[this.$vuetify.rtl && 'marginRight' || 'marginLeft'] = '';
+              window.setTimeout(() => this.updateParentStyle(), 50);
             }
           },
           updateUserHome() {


### PR DESCRIPTION
This change will allow to remove the inputs from layout addon which asks the user to choose whether to display or not the Shared Layout for a Site in addition to the fact to choose whether the site is displayed in Sidebar or not, with its display order. Thus, with this change, the Shared layout will be displayed automatically only when the Site is a designated item added in the Sidebar configuration.

In addition, this will fix some Sonar Checks and will fix the display phase which may fail when PWA Application is used.