### PR TITLE
fix: Refresh Notification Extensions when loading is deferred - MEED-7896 - Meeds-io/MIPs#159

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotification.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotification.vue
@@ -37,15 +37,19 @@ export default {
       default: null,
     },
   },
+  data: () => ({
+    refresh: 1,
+  }),
   computed: {
     extension() {
-      return Object.values(this.$root.notificationExtensions)
-        .sort((ext1, ext2) => (ext1.rank || 0) - (ext2.rank || 0))
-        .find(extension => extension.match && extension.match(this.notification) || extension.type === this.notification.plugin)
+      return this.refresh > 0
+        && Object.values(this.$root.notificationExtensions)
+          .sort((ext1, ext2) => (ext1.rank || 0) - (ext2.rank || 0))
+          .find(extension => extension.match && extension.match(this.notification) || extension.type === this.notification.plugin)
         || null;
     },
     extensionComponent() {
-      return this.extension && {
+      return this.$root.notificationExtensions && this.extension?.vueComponent && {
         componentName: 'notification-extension',
         componentOptions: {
           vueComponent: this.extension.vueComponent,
@@ -56,6 +60,17 @@ export default {
       return {
         notification: this.notification,
       };
+    },
+  },
+  created() {
+    document.addEventListener('notification-extensions-refresh', this.forceRefreshExtension);
+  },
+  beforeDestroy() {
+    document.removeEventListener('notification-extensions-refresh', this.forceRefreshExtension);
+  },
+  methods: {
+    refreshExtension() {
+      this.refresh++;
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
@@ -23,9 +23,10 @@
     <v-flex>
       <v-layout>
         <v-btn
+          :title="$t('UIIntranetNotificationsPortlet.title.notifications')"
+          :loading="loading"
           icon
           class="text-xs-center"
-          :title="$t('UIIntranetNotificationsPortlet.title.notifications')"
           @click="openDrawer">
           <v-badge
             :value="badge > 0"
@@ -50,6 +51,7 @@ export default {
   data: () => ({
     badge: 0,
     open: false,
+    loading: false,
   }),
   watch: {
     open() {
@@ -73,12 +75,20 @@ export default {
   methods: {
     openDrawer() {
       this.$root.initialized = false;
+      this.loading = true;
       this.$root.lastLoadedNotificationIndex = 0;
       window.require(['SHARED/notificationExtensions'], () => {
         Promise.all([
           this.$utils.includeExtensions('NotificationPopoverExtension'),
           this.$utils.includeExtensions('NotificationExtension')
-        ]).then(() => this.open = true);
+        ]).then(async () => {
+          await this.$nextTick();
+          this.open = true;
+          await this.$nextTick();
+          window.setTimeout(() => {
+            this.loading = false;
+          }, 50);
+        });
       });
     },
     updateBadgeByEvent(event) {

--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/main.js
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/main.js
@@ -60,12 +60,18 @@ export function init(badge) {
         },
         methods: {
           refreshNotificationExtensions() {
+            const notificationExtensions = {};
             const extensions = extensionRegistry.loadExtensions('WebNotification', 'notification-content-extension');
             extensions.forEach(extension => {
-              if (extension.type) {
-                this.$set(this.notificationExtensions, extension.type, extension);
+              if (extension.type && !this.notificationExtensions[extension.type]) {
+                notificationExtensions[extension.type] = extension;
               }
             });
+            this.notificationExtensions = {
+              ...this.notificationExtensions,
+              ...notificationExtensions
+            };
+            document.dispatchEvent(new CustomEvent('notification-extensions-refresh'));
           },
         },
       }, `#${appId}`, 'Topbar Notifications');


### PR DESCRIPTION
Prior to this change, when the Notification Extensions are loaded in a deferred way, the associated extension of a notification type didn't refresh to get the right associated Notification Extension due to missing Vue Listener on Vue Object attributes.
This change will force the refresh by introducing a listener event triggered when the extensions list is refreshed.
In addition, a loading visual effect is added to notification button to enhance user UX while opening the notifications Drawer.