### PR TITLE
fix: [Space drawer] Icons not aligned in the space drawer  - EXO-75819 -Meeds-io/meeds#2646

### DIFF
--- a/webapp/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
+++ b/webapp/src/main/webapp/vue-apps/hamburger-menu/components/recent-spaces/SpacePanelHamburgerNavigation.vue
@@ -106,7 +106,7 @@
           parent-element="div"
           element="div"
           element-class="me-2 ms-0"
-          class="space-panel-action" />
+          class="space-panel-action d-flex" />
         <space-favorite-action
           :is-favorite="isFavorite"
           :space-id="spaceId"


### PR DESCRIPTION
Before this change, Icons are not aligned when having more than one 'SpacePopover' extension in the space drawer. After this change, Icons style is fixed to have all icons aligned