### PR TITLE
fix: Use I18N of Vue Parent Node rather than destroyed child - MEED-7861 - Meeds-io/meeds#2627

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkApplyTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkApplyTemplate.vue
@@ -32,18 +32,13 @@
 </template>
 <script>
 export default {
-  data: () => ({
-    successMessage: null,
-  }),
   methods: {
     applyTemplate(params) {
-      // Workaround for context change, compute success message on processing start
-      this.successMessage = this.$t('social.spaces.administration.manageSpaces.spaceTemplateAppliedOnSpaces');
       this.$root.applyOperationInBulk(
         (space, options) => this.$spaceAdministrationService.applySpaceTemplate(space.id, options),
         params,
         () => {
-          this.$root.$emit('alert-message', this.successMessage, 'success');
+          this.$root.$emit('alert-message', this.$root.$t('social.spaces.administration.manageSpaces.spaceTemplateAppliedOnSpaces'), 'success');
           this.$root.$emit('spaces-administration-list-refresh', this.$root.isFilteredByTemplate);
         });
     },

--- a/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkDelete.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkDelete.vue
@@ -41,9 +41,6 @@
 </template>
 <script>
 export default {
-  data: () => ({
-    successMessage: null,
-  }),
   computed: {
     spacesCount() {
       return this.$root.allSpacesSelected ? this.$root.spacesSize : this.$root.selectedSpaces.length;
@@ -54,15 +51,13 @@ export default {
       window.setTimeout(() => this.$refs.dialog.open(), 200);
     },
     deleteSpaces() {
-      // Workaround for context change, compute success message on processing start
-      this.successMessage = this.$t('social.spaces.administration.manageSpaces.spacesDeletedSuccessfully', {
-        0: this.spacesCount
-      });
       this.$root.applyOperationInBulk(
         space => this.$spaceService.removeSpace(space.id),
         null,
         () => {
-          this.$root.$emit('alert-message', this.successMessage, 'success');
+          this.$root.$emit('alert-message', this.$root.$t('social.spaces.administration.manageSpaces.spacesDeletedSuccessfully', {
+            0: this.spacesCount
+          }), 'success');
           this.$root.$emit('spaces-administration-list-refresh');
         });
     },

--- a/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkPermissions.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkPermissions.vue
@@ -32,13 +32,9 @@
 </template>
 <script>
 export default {
-  data: () => ({
-    successMessage: null,
-  }),
   methods: {
     updatePermissions(params) {
       // Workaround for context change, compute success message on processing start
-      this.successMessage = this.$t('social.spaces.administration.manageSpaces.spacesPermissionsUpdatedSuccessfully');
       this.$root.applyOperationInBulk(
         async space => {
           const permissions = {};
@@ -49,7 +45,7 @@ export default {
         },
         null,
         () => {
-          this.$root.$emit('alert-message', this.successMessage, 'success');
+          this.$root.$emit('alert-message', this.$root.$t('social.spaces.administration.manageSpaces.spacesPermissionsUpdatedSuccessfully'), 'success');
           this.$root.$emit('spaces-administration-list-refresh');
         });
     },

--- a/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkSyncMembers.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-administration/components/bulk-action/SpacesAdministrationBulkSyncMembers.vue
@@ -32,13 +32,8 @@
 </template>
 <script>
 export default {
-  data: () => ({
-    successMessage: null,
-  }),
   methods: {
     syncMembers(groups) {
-      // Workaround for context change, compute success message on processing start
-      this.successMessage = this.$t('social.spaces.administration.manageSpaces.groupsBoundOnSpaces');
       this.$root.applyOperationInBulk(
         async space => {
           let spaceBoundGroups = await this.$spaceBindingService.getGroupSpaceBindings(space.id);
@@ -51,7 +46,7 @@ export default {
         },
         null,
         () => {
-          this.$root.$emit('alert-message', this.successMessage, 'success');
+          this.$root.$emit('alert-message', this.$root.$t('social.spaces.administration.manageSpaces.groupsBoundOnSpaces'), 'success');
           this.$root.$emit('spaces-administration-list-refresh');
         });
     },


### PR DESCRIPTION
Prior to this change, the I18N message was computed once a Space Administration action is triggered in a synchronous way in order to ensure having access to I18N translation object. Even this computing was making an error due to an intensive and instantly destroy of Button once it's not displayed anymore (Menu Closed). Thus, with this change, the access of I18N is made using the `this.$root.$t` rather than using `this.$t` to ensure that the access to I18N messages is always available even when the child Vue component is destroyed.