### PR TITLE
feat: Enhance createAttachment method accessibility - EXO-75694 - Meeds-io/MIPs#145

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/attachment/AttachmentService.java
+++ b/component/api/src/main/java/org/exoplatform/social/attachment/AttachmentService.java
@@ -303,4 +303,27 @@ public interface AttachmentService {
    * @param userIdentityId            the ID of the user performing the operation
    */
   void moveAttachments(String sourceObjectType, String sourceObjectId, String destinationObjectType, String destinationObjectId, String destinationParentObjectId, long userIdentityId);
+
+  /**
+   * Creates an attachment for a specified object.
+   * 
+   * @param fileId the identifier of the file to be attached
+   * @param objectType the type of the object
+   * @param objectId the identifier of the object to which the attachment is being
+   *          added.
+   * @param parentObjectId the parent object identifier
+   * @param userIdentityId user
+   *          {@link org.exoplatform.social.core.identity.model.Identity} id
+   * @param properties the attachment properties
+   * @throws ObjectNotFoundException when the object identified by its id doesn't
+   *           exist
+   * @throws ObjectAlreadyExistsException when attachment already exists for given
+   *           object
+   */
+  void createAttachment(String fileId,
+                        String objectType,
+                        String objectId,
+                        String parentObjectId,
+                        long userIdentityId,
+                        Map<String, String> properties) throws ObjectNotFoundException, ObjectAlreadyExistsException;
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/attachment/AttachmentServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/attachment/AttachmentServiceImpl.java
@@ -373,6 +373,31 @@ public class AttachmentServiceImpl implements AttachmentService {
     }
   }
 
+  @Override
+  public void createAttachment(String fileId,
+                               String objectType,
+                               String objectId,
+                               String parentObjectId,
+                               long userIdentityId,
+                               Map<String, String> properties) throws ObjectNotFoundException, ObjectAlreadyExistsException {
+    MetadataKey metadataKey = null;
+    metadataKey = new MetadataKey(METADATA_TYPE.getName(), fileId, getAudienceId(objectType, objectId));
+    MetadataObject object = new MetadataObject(objectType,
+            objectId,
+            parentObjectId,
+            getSpaceId(objectType, objectId));
+    metadataService.createMetadataItem(object,
+            metadataKey,
+            properties,
+            userIdentityId);
+    broadcastAttachmentChange(ATTACHMENT_CREATED_EVENT,
+            fileId,
+            objectType,
+            objectId,
+            getUserName(userIdentityId));
+  }
+
+
   private org.exoplatform.social.core.identity.model.Identity checkAccessPermission(String objectType,
                                                                                     String objectId,
                                                                                     String fileId,
@@ -501,29 +526,6 @@ public class AttachmentServiceImpl implements AttachmentService {
       LOG.warn("Error attaching uploaded file", e);
       report.addError(uploadedAttachmentDetail.getUploadedResource().getUploadId(), "attachment.uploadIdNotAttachedError");
     }
-  }
-
-  private void createAttachment(String fileId,
-                                String objectType,
-                                String objectId,
-                                String parentObjectId,
-                                long userIdentityId,
-                                Map<String, String> properties) throws ObjectNotFoundException, ObjectAlreadyExistsException {
-    MetadataKey metadataKey = null;
-    metadataKey = new MetadataKey(METADATA_TYPE.getName(), fileId, getAudienceId(objectType, objectId));
-    MetadataObject object = new MetadataObject(objectType,
-                                               objectId,
-                                               parentObjectId,
-                                               getSpaceId(objectType, objectId));
-    metadataService.createMetadataItem(object,
-                                       metadataKey,
-                                       properties,
-                                       userIdentityId);
-    broadcastAttachmentChange(ATTACHMENT_CREATED_EVENT,
-                              fileId,
-                              objectType,
-                              objectId,
-                              getUserName(userIdentityId));
   }
 
   private void updateAttachment(String fileId,


### PR DESCRIPTION
The createAttachment method was previously a private utility within the AttachmentService implementation, limiting its accessibility. This change enhances the flexibility and reusability of the method within the service layer.