### PR TITLE
fix: User (with a capital letter in the username) cannot post to a space from the global stream - MEED-7905

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceListAccess.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceListAccess.java
@@ -298,7 +298,7 @@ public class SpaceListAccess implements ListAccess<Space> {
             || type == ACCESSIBLE
             || type == VISIBLE
             || statusType != null)) {
-      return new SpaceSearchFilter(username,
+      return new SpaceSearchFilter(username.toLowerCase(),
                                    filter.getIdentityId(),
                                    filter.getTemplateId(),
                                    filter.getManagingTemplateIds(),


### PR DESCRIPTION
The space member is tokenized and indexed in lowercase. This change will ensure that the username is passed in lowercase to work around these use cases.