### PR TITLE
fix: Icons not aligned in the space drawer  - EXO-75819 -Meeds-io/meeds#2646

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
@@ -102,7 +102,7 @@
           parent-element="div"
           element="div"
           element-class="me-2 ms-0"
-          class="space-panel-action" />
+          class="space-panel-action d-flex" />
         <space-favorite-action
           :is-favorite="isFavorite"
           :space-id="spaceId"

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
@@ -95,6 +95,11 @@
             {{ $t('menu.spaces.markAsRead') }}
           </span>
         </v-tooltip>
+        <space-favorite-action
+          :is-favorite="isFavorite"
+          :space-id="spaceId"
+          entity-type="spaces_left_navigation"
+          class="me-2" />
         <extension-registry-components
           :params="params"
           name="SpacePopover"
@@ -103,11 +108,6 @@
           element="div"
           element-class="me-2 ms-0"
           class="space-panel-action d-flex" />
-        <space-favorite-action
-          :is-favorite="isFavorite"
-          :space-id="spaceId"
-          entity-type="spaces_left_navigation"
-          class="me-2" />
         <span
           v-for="extension in enabledExtensionComponents"
           :key="extension.key"


### PR DESCRIPTION
Before this change, Icons are not aligned when having more then one 'SpacePopover' extension in the space drawer.
After this change, Icons style is fixed to have all icons aligned. Also icon order changed to have favorites before extentions.