### PR TITLE
fix: Improve Unread Activities Performances - MEED-7918 - Meeds-io/meeds#2618

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -627,6 +627,15 @@ public interface MetadataService {
   void deleteMetadataItemsByParentObject(MetadataObject object);
 
   /**
+   * deletes Metadata Items which creation date is before the signated date
+   * 
+   * @param metadataTypeName metadata name {@link Metadata} name
+   * @param untilDate date in milliseconds
+   * @return the number of deleted items
+   */
+  int deleteByMetadataItemsTypeAndUntilCreationDate(String metadataTypeName, long untilDate);
+
+  /**
    * Retrieves a {@link Set} of {@link Metadata} name matching the given
    * {@link MetadataType} and {@link Set} of audience {@link Identity} ids
    * 
@@ -676,4 +685,5 @@ public interface MetadataService {
   default List<MetadataItem> getMetadataItemsByFilter(MetadataFilter filter, long offset, long limit) {
     throw new UnsupportedOperationException();
   }
+
 }

--- a/component/api/src/main/java/org/exoplatform/social/notification/service/SpaceWebNotificationService.java
+++ b/component/api/src/main/java/org/exoplatform/social/notification/service/SpaceWebNotificationService.java
@@ -48,8 +48,8 @@ public interface SpaceWebNotificationService {
   /**
    * Dispatch notification info
    * 
-   * @param  notification
-   * @param  username
+   * @param notification
+   * @param username
    * @throws Exception
    */
   void dispatch(NotificationInfo notification, String username) throws Exception; // NOSONAR
@@ -57,7 +57,7 @@ public interface SpaceWebNotificationService {
   /**
    * Mark a space notification item as unread
    * 
-   * @param  notificationItem
+   * @param notificationItem
    * @throws Exception
    */
   void markAsUnread(SpaceWebNotificationItem notificationItem) throws Exception; // NOSONAR
@@ -65,7 +65,7 @@ public interface SpaceWebNotificationService {
   /**
    * Mark a space notification item as read
    * 
-   * @param  notificationItem
+   * @param notificationItem
    * @throws Exception
    */
   void markAsRead(SpaceWebNotificationItem notificationItem) throws Exception; // NOSONAR
@@ -74,8 +74,8 @@ public interface SpaceWebNotificationService {
    * Mark a list of unread items per application as read to a given
    * {@link MetadataItem} creatorId by a given {@link Space} identifier
    *
-   * @param  userIdentityId {@link MetadataItem} creatorId
-   * @param  spaceId        {@link Space} spaceId
+   * @param userIdentityId {@link MetadataItem} creatorId
+   * @param spaceId {@link Space} spaceId
    * @throws Exception
    */
   void markAllAsRead(long userIdentityId, long spaceId) throws Exception; // NOSONAR
@@ -84,21 +84,31 @@ public interface SpaceWebNotificationService {
    * Mark a list of unread items per application as read to a given
    * {@link MetadataItem} creatorId
    *
-   * @param  userIdentityId {@link MetadataItem} creatorId
+   * @param userIdentityId {@link MetadataItem} creatorId
    * @throws Exception
    */
   void markAllAsRead(long userIdentityId) throws Exception; // NOSONAR
 
   /**
+   * A cleanup operation of all unread which creation date is before the
+   * designated date
+   * 
+   * @param untilDate Date in milliseconds
+   */
+  default int markAllAsReadUntil(long untilDate) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Get a list of unread items per application to a given {@link MetadataItem}
    * creatorId by a given {@link Space} identifier
    *
-   * @param  creatorId {@link MetadataItem} creatorId
-   * @param  spaceId   {@link Space} spaceId
-   * @return           Map of application and unread items
+   * @param creatorId {@link MetadataItem} creatorId
+   * @param spaceId {@link Space} spaceId
+   * @return Map of application and unread items
    */
   Map<String, Long> countUnreadItemsByApplication(long creatorId, long spaceId);
-  
+
   /**
    * Get a list of unread items per space to a given {@link MetadataItem}
    *
@@ -123,7 +133,8 @@ public interface SpaceWebNotificationService {
    * @throws IllegalAccessException when user isn't member of space
    * @throws ObjectNotFoundException when space not found
    */
-  List<Long> getUnreadActivityIdsBySpace(String username, long spaceId, long offset, long limit) throws IllegalAccessException, ObjectNotFoundException;
+  List<Long> getUnreadActivityIdsBySpace(String username, long spaceId, long offset, long limit) throws IllegalAccessException,
+                                                                                                 ObjectNotFoundException;
 
   /**
    * @param username User {@link Identity} remote id

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -30,15 +30,20 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.jpa.storage.entity.MetadataItemEntity;
 import org.exoplatform.social.metadata.MetadataFilter;
 
+import jakarta.persistence.FlushModeType;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.Query;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
 
 public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long> {
+
+  private static final Log    LOG                  = ExoLogger.getLogger(MetadataItemDAO.class);
 
   private static final String PROPERTY_VALUE_PARAM = "propertyValue";
 
@@ -61,7 +66,7 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
   private static final String OBJECT_ID            = "objectId";
 
   private static final String SPACE_ID             = "spaceId";
-  
+
   private static final String SPACE_IDS            = "spaceIds";
 
   private static final String OBJECT_TYPE          = OBJECT_TYPE_PARAM;
@@ -81,7 +86,6 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
   private static final String CREATED_DATE         = "createdDate";
 
   private static final String ID                   = "id";
-
 
   public List<MetadataItemEntity> getMetadataItemsByObject(String objectType, String objectId) {
     TypedQuery<MetadataItemEntity> query = getEntityManager().createNamedQuery("SocMetadataItemEntity.getMetadataItemsByObject",
@@ -391,15 +395,46 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
 
   @ExoTransactional
   public int deleteByMetadataItemsTypeAndUntilCreationDate(long metadataType, long untilDate) {
-    Query query = getEntityManager().createNamedQuery("SocMetadataItemEntity.deleteByMetadataItemsTypeAndUntilCreationDate");
-    query.setParameter(CREATED_DATE, untilDate);
-    query.setParameter(METADATA_TYPE, metadataType);
-    return query.executeUpdate();
+    TypedQuery<Tuple> minMaxIdQuery =
+                                getEntityManager().createNamedQuery("SocMetadataItemEntity.getMinMaxIdByMetadataItemsTypeAndUntilCreationDate",
+                                                                    Tuple.class);
+    minMaxIdQuery.setParameter(CREATED_DATE, untilDate);
+    minMaxIdQuery.setParameter(METADATA_TYPE, metadataType);
+    long maxId;
+    long minId;
+    try {
+      Tuple tuple = minMaxIdQuery.getSingleResult();
+      minId = tuple.get(0, Long.class);
+      maxId = tuple.get(1, Long.class);
+      if (maxId == 0) {
+        return 0;
+      }
+    } catch (NoResultException e) {
+      return 0;
+    }
+
+    int totalUpdated = 0;
+    long offset = minId - 1;
+    LOG.info("Deleting Metadata items from '{}' until '{}' id which are of type '{}'", minId, maxId, metadataType);
+    while (offset < maxId) {
+      long endId = Math.min(offset + 10000, maxId);
+      Query query = getEntityManager().createNamedQuery("SocMetadataItemEntity.deleteByMetadataItemsTypeAndUntilCreationDate");
+      query.setParameter(METADATA_TYPE, metadataType);
+      query.setParameter("minId", offset);
+      query.setParameter("maxId", endId + 1);
+      query.setFlushMode(FlushModeType.AUTO);
+      int updated = query.executeUpdate();
+      LOG.info("'{}' Metadata items deleted in bulk", updated);
+      totalUpdated += updated;
+      offset = endId;
+    }
+    LOG.info("'{}' Metadata items deleted with type '{}'", totalUpdated, metadataType);
+    return totalUpdated;
   }
 
   private Query buildMetadataFilterQuery(MetadataFilter filter, long metadataType) {
 
-    String[] allowedSortFields = new String[] {"UPDATED_DATE", "CREATED_DATE"};
+    String[] allowedSortFields = new String[] { "UPDATED_DATE", "CREATED_DATE" };
     StringBuilder query = new StringBuilder();
     query.append("""
         SELECT metadataItems.* FROM SOC_METADATA_ITEMS metadataItems
@@ -420,7 +455,8 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
       query.append(filter.getCreatorId());
     }
     if (!CollectionUtils.isEmpty(filter.getMetadataObjectTypes())) {
-      String objectTypes = filter.getMetadataObjectTypes().stream()
+      String objectTypes = filter.getMetadataObjectTypes()
+                                 .stream()
                                  .map(s -> "'" + s + "'")
                                  .collect(Collectors.joining(","));
       query.append(" AND metadataItems.OBJECT_TYPE in (");
@@ -429,7 +465,8 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     }
     StringBuilder spaceIdsQuery = new StringBuilder();
     if (!CollectionUtils.isEmpty(filter.getMetadataSpaceIds())) {
-      String spaceIds = filter.getMetadataSpaceIds().stream()
+      String spaceIds = filter.getMetadataSpaceIds()
+                              .stream()
                               .map(String::valueOf)
                               .collect(Collectors.joining(","));
       spaceIdsQuery.append(" metadataItems.SPACE_ID in (");
@@ -461,8 +498,7 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     query.append(" GROUP BY metadataItems.METADATA_ITEM_ID");
     if (filter.getSortField() != null && Arrays.asList(allowedSortFields).contains(filter.getSortField())) {
       query.append(" ORDER BY metadataItems.%s DESC, metadataItems.METADATA_ID DESC".formatted(filter.getSortField()));
-    }
-    else {
+    } else {
       query.append(" ORDER BY metadataItems.CREATED_DATE DESC, metadataItems.METADATA_ID DESC");
     }
     return getEntityManager().createNativeQuery(query.toString(), MetadataItemEntity.class);
@@ -482,7 +518,7 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
       return;
     }
     StringBuilder whereClaus = new StringBuilder();
-    query.append(""" 
+    query.append("""
         ( metadataItems.METADATA_ITEM_ID IN (
         SELECT %s.METADATA_ITEM_ID FROM
         """.formatted(lastKey + lastValue));

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -389,6 +389,14 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     return items.size();
   }
 
+  @ExoTransactional
+  public int deleteByMetadataItemsTypeAndUntilCreationDate(long metadataType, long untilDate) {
+    Query query = getEntityManager().createNamedQuery("SocMetadataItemEntity.deleteByMetadataItemsTypeAndUntilCreationDate");
+    query.setParameter(CREATED_DATE, untilDate);
+    query.setParameter(METADATA_TYPE, metadataType);
+    return query.executeUpdate();
+  }
+
   private Query buildMetadataFilterQuery(MetadataFilter filter, long metadataType) {
 
     String[] allowedSortFields = new String[] {"UPDATED_DATE", "CREATED_DATE"};
@@ -499,4 +507,5 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     query.append(whereClaus);
     query.append(")");
   }
+
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -158,10 +158,20 @@ import jakarta.persistence.Table;
         + " AND mi.spaceId = :spaceId"
 )
 @NamedQuery(
+    name = "SocMetadataItemEntity.getMinMaxIdByMetadataItemsTypeAndUntilCreationDate",
+    query = """
+      SELECT MIN(item.id),MAX(item.id) FROM SocMetadataItemEntity item
+      INNER JOIN item.metadata sm
+      ON sm.type = :metadataType
+      WHERE item.createdDate < :createdDate
+    """
+)
+@NamedQuery(
     name = "SocMetadataItemEntity.deleteByMetadataItemsTypeAndUntilCreationDate",
     query = """
       DELETE FROM SocMetadataItemEntity item
-      WHERE item.createdDate < :createdDate
+      WHERE item.id < :maxId
+      AND item.id > :minId
       AND item.metadata.id IN
           (
            SELECT DISTINCT(m.id)

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -158,6 +158,19 @@ import jakarta.persistence.Table;
         + " AND mi.spaceId = :spaceId"
 )
 @NamedQuery(
+    name = "SocMetadataItemEntity.deleteByMetadataItemsTypeAndUntilCreationDate",
+    query = """
+      DELETE FROM SocMetadataItemEntity item
+      WHERE item.createdDate < :createdDate
+      AND item.metadata.id IN
+          (
+           SELECT DISTINCT(m.id)
+           FROM SocMetadataEntity m
+           WHERE m.type = :metadataType
+          )
+    """
+)
+@NamedQuery(
     name = "SocMetadataItemEntity.countMetadataItemsByMetadataTypeAndSpacesIdAndCreatorId",
     query = "SELECT item.spaceId, COUNT(DISTINCT item.id) FROM SocMetadataItemEntity item "
         + " INNER JOIN item.metadata sm"

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -46,17 +46,17 @@ import org.exoplatform.social.metadata.model.MetadataType;
 @SuppressWarnings("removal")
 public class MetadataServiceImpl implements MetadataService, Startable {
 
-  private static final String METADATA_TYPE_IS_MANDATORY_MESSAGE = "Metadata Type is mandatory";
+  private static final String             METADATA_TYPE_IS_MANDATORY_MESSAGE = "Metadata Type is mandatory";
 
-  private static final Log                LOG                 = ExoLogger.getLogger(MetadataServiceImpl.class);
+  private static final Log                LOG                                = ExoLogger.getLogger(MetadataServiceImpl.class);
 
   private MetadataStorage                 metadataStorage;
 
   private ListenerService                 listenerService;
 
-  private Map<String, MetadataTypePlugin> metadataTypePlugins = new HashMap<>();
+  private Map<String, MetadataTypePlugin> metadataTypePlugins                = new HashMap<>();
 
-  private List<MetadataInitPlugin>        metadataPlugins     = new ArrayList<>();
+  private List<MetadataInitPlugin>        metadataPlugins                    = new ArrayList<>();
 
   public MetadataServiceImpl(MetadataStorage metadataStorage, ListenerService listenerService) {
     this.metadataStorage = metadataStorage;
@@ -145,7 +145,7 @@ public class MetadataServiceImpl implements MetadataService, Startable {
                                                  properties);
     return createMetadataItem(metadataItem, userIdentityId, broadcast);
   }
-  
+
   @Override
   public MetadataItem createMetadataItem(MetadataObject metadataObject,
                                          MetadataKey metadataKey,
@@ -153,7 +153,7 @@ public class MetadataServiceImpl implements MetadataService, Startable {
                                          long userIdentityId) throws ObjectAlreadyExistsException {
     return createMetadataItem(metadataObject, metadataKey, properties, userIdentityId, true);
   }
-  
+
   @Override
   public MetadataItem createMetadataItem(MetadataObject metadataObject,
                                          MetadataKey metadataKey,
@@ -175,7 +175,7 @@ public class MetadataServiceImpl implements MetadataService, Startable {
                                          Map<String, String> properties) throws ObjectAlreadyExistsException {
     return createMetadataItem(metadataObject, metadataKey, properties, true);
   }
-  
+
   @Override
   public MetadataItem updateMetadataItem(MetadataItem metadataItem, long userIdentityId, boolean broadcast) {
     if (metadataItem == null) {
@@ -247,7 +247,10 @@ public class MetadataServiceImpl implements MetadataService, Startable {
     MetadataType metadataType = validateAndGetMetadataType(metadataTypeName);
     validateSpaceId(spaceId);
     validateUserIdentityId(userIdentityId);
-    List<MetadataItem> deletedMetadataItems = this.metadataStorage.deleteByMetadataTypeAndSpaceIdAndCreatorId(metadataType.getId(), spaceId, userIdentityId);
+    List<MetadataItem> deletedMetadataItems =
+                                            this.metadataStorage.deleteByMetadataTypeAndSpaceIdAndCreatorId(metadataType.getId(),
+                                                                                                            spaceId,
+                                                                                                            userIdentityId);
     if (CollectionUtils.isNotEmpty(deletedMetadataItems)) {
       for (MetadataItem metadataItem : deletedMetadataItems) {
         broadcastDeleted(metadataItem, userIdentityId);
@@ -259,7 +262,8 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   public void deleteByMetadataTypeAndCreatorId(String metadataTypeName, long userIdentityId) {
     MetadataType metadataType = validateAndGetMetadataType(metadataTypeName);
     validateUserIdentityId(userIdentityId);
-    List<MetadataItem> deletedMetadataItems = this.metadataStorage.deleteByMetadataTypeAndCreatorId(metadataType.getId(), userIdentityId);
+    List<MetadataItem> deletedMetadataItems = this.metadataStorage.deleteByMetadataTypeAndCreatorId(metadataType.getId(),
+                                                                                                    userIdentityId);
     if (CollectionUtils.isNotEmpty(deletedMetadataItems)) {
       for (MetadataItem metadataItem : deletedMetadataItems) {
         broadcastDeleted(metadataItem, userIdentityId);
@@ -275,6 +279,12 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   @Override
   public void deleteMetadataItemsByParentObject(MetadataObject object) {
     this.metadataStorage.deleteMetadataItemsByParentObject(object);
+  }
+
+  @Override
+  public int deleteByMetadataItemsTypeAndUntilCreationDate(String metadataTypeName, long untilDate) {
+    MetadataType metadataType = validateAndGetMetadataType(metadataTypeName);
+    return this.metadataStorage.deleteByMetadataItemsTypeAndUntilCreationDate(metadataType.getId(), untilDate);
   }
 
   @Override
@@ -369,7 +379,6 @@ public class MetadataServiceImpl implements MetadataService, Startable {
                                                                                  limit);
   }
 
-
   @Override
   public List<MetadataItem> getMetadataItemsByFilter(MetadataFilter filter, long offset, long limit) {
     return metadataStorage.getMetadataItemsByFilter(filter, offset, limit);
@@ -428,7 +437,7 @@ public class MetadataServiceImpl implements MetadataService, Startable {
     validateUserIdentityId(creatorId);
     return this.metadataStorage.countMetadataItemsByMetadataTypeAndAudienceId(metadataType.getId(), creatorId, spaceId);
   }
-  
+
   public Map<Long, Long> countMetadataItemsByMetadataTypeAndSpacesIdAndCreatorId(String metadataTypeName,
                                                                                  long creatorId,
                                                                                  List<Long> spacesId) {
@@ -517,10 +526,10 @@ public class MetadataServiceImpl implements MetadataService, Startable {
                            .anyMatch(registeredPlugin -> {
                              boolean sameIdWithdifferentName = !StringUtils.equals(registeredPlugin.getName(),
                                                                                    metadataTypePlugin.getName())
-                                 && registeredPlugin.getId() == metadataTypePlugin.getId();
+                                                               && registeredPlugin.getId() == metadataTypePlugin.getId();
                              boolean sameNameWithDifferentId = StringUtils.equals(registeredPlugin.getName(),
                                                                                   metadataTypePlugin.getName())
-                                 && registeredPlugin.getId() != metadataTypePlugin.getId();
+                                                               && registeredPlugin.getId() != metadataTypePlugin.getId();
                              return sameIdWithdifferentName || sameNameWithDifferentId;
                            })) {
       throw new UnsupportedOperationException("Overriding existing Metadata Type with different ID or Name is not allowed. Please verify the unicity of Metadata Type id and name.");
@@ -662,8 +671,8 @@ public class MetadataServiceImpl implements MetadataService, Startable {
                                   metadataKeyToShare,
                                   creatorId);
       } catch (ObjectAlreadyExistsException e) {
-        LOG.warn("The metadata object {} is already associated to Metadata with unique key {}."
-            + " This doesn't affect the expected result, so continue processing.",
+        LOG.warn("The metadata object {} is already associated to Metadata with unique key {}." +
+            " This doesn't affect the expected result, so continue processing.",
                  metadataObjectToShare,
                  metadataKeyToShare,
                  e);

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
@@ -272,6 +272,10 @@ public class MetadataStorage {
     return this.metadataItemDAO.deleteMetadataItemsByParentObject(object.getType(), object.getParentId());
   }
 
+  public int deleteByMetadataItemsTypeAndUntilCreationDate(long metadataType, long untilDate) {
+    return this.metadataItemDAO.deleteByMetadataItemsTypeAndUntilCreationDate(metadataType, untilDate);
+  }
+
   public void deleteMetadataItemsByMetadataTypeAndObject(String metadataTypeName, MetadataObject object) {
     List<MetadataItem> metadataItems = getMetadataItemsByMetadataTypeAndObject(metadataTypeName, object);
     for (MetadataItem metadataItem : metadataItems) {

--- a/component/core/src/main/resources/db/changelog/metadata-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/metadata-rdbms.db.changelog-1.0.0.xml
@@ -174,4 +174,11 @@
     </addColumn>
   </changeSet>
 
+  <changeSet author="metadata" id="1.0.0-mip-17-01">
+    <createIndex tableName="SOC_METADATA_ITEMS" indexName="IDX_SOC_METADATA_ITEMS_SPACE_ID_01">
+      <column name="METADATA_ID" type="BIGINT"></column>
+      <column name="SPACE_ID" type="BIGINT"></column>
+    </createIndex>
+  </changeSet>
+
 </databaseChangeLog>

--- a/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
@@ -26,7 +26,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -42,6 +44,8 @@ import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataKey;
 import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.metadata.model.MetadataType;
+
+import lombok.SneakyThrows;
 
 @SuppressWarnings("removal")
 public class MetadataServiceTest extends AbstractCoreTest {
@@ -1508,6 +1512,39 @@ public class MetadataServiceTest extends AbstractCoreTest {
     metadataItems = getMetadataItemsByObject(objectType2, objectId1);
     assertNotNull(metadataItems);
     assertEquals(1, metadataItems.size());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testDeleteByMetadataItemsTypeAndUntilCreationDate() {
+    long creatorId = Long.parseLong(johnIdentity.getId());
+    long audienceId1 = 10000l;
+
+    String type = userMetadataType.getName();
+
+    String objectType1 = "objectType110";
+    String objectId1 = "objectId15";
+    String metadataName1 = "testMetadata15";
+    String parentObjectId = "parentObjectId1";
+
+    MetadataItem metadataItem = createNewMetadataItem(type,
+                                                      metadataName1,
+                                                      objectType1,
+                                                      objectId1,
+                                                      parentObjectId,
+                                                      creatorId,
+                                                      audienceId1);
+    assertNotNull(metadataItem);
+
+    List<MetadataItem> items = metadataService.getMetadataItemsByMetadataAndObject(metadataItem.getMetadata().key(), metadataItem.getObject());
+    assertNotNull(items);
+    assertEquals(1, items.size());
+
+    int deletedCount = metadataService.deleteByMetadataItemsTypeAndUntilCreationDate(type, System.currentTimeMillis() + 1000);
+    assertEquals(1, deletedCount);
+
+    items = metadataService.getMetadataItemsByMetadataAndObject(metadataItem.getMetadata().key(), metadataItem.getObject());
+    assertTrue(CollectionUtils.isEmpty(items));
   }
 
   public void testFindMetadataNamesByCreator() throws Exception { // NOSONAR

--- a/component/notification/src/main/java/io/meeds/social/notification/job/SpaceWebNotificationCleanupJob.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/job/SpaceWebNotificationCleanupJob.java
@@ -38,9 +38,13 @@ import lombok.Synchronized;
 @EnableScheduling
 public class SpaceWebNotificationCleanupJob {
 
-  private static final Log            LOG       = ExoLogger.getLogger(SpaceWebNotificationCleanupJob.class);
+  private static final NumberFormat   INTEGER_FORMAT_INSTANCE   = NumberFormat.getIntegerInstance();
 
-  private static final int            DAY_IN_MS = 24 * 3600 * 1000;
+  private static final DateFormat     DATE_TIME_FORMAT_INSTANCE = DateFormat.getDateTimeInstance();
+
+  private static final Log            LOG                       = ExoLogger.getLogger(SpaceWebNotificationCleanupJob.class);
+
+  private static final int            DAY_IN_MS                 = 24 * 3600 * 1000;
 
   @Autowired
   private SpaceWebNotificationService spaceWebNotificationService;
@@ -53,15 +57,15 @@ public class SpaceWebNotificationCleanupJob {
   public void run() {
     long start = System.currentTimeMillis();
     long untilDate = start - keepAliveDays * DAY_IN_MS;
-    String untilFormatedDate = DateFormat.getDateTimeInstance().format(new Date(untilDate));
+    String untilFormatedDate = DATE_TIME_FORMAT_INSTANCE.format(new Date(untilDate));
     LOG.info("Delete unread activities created before {}", untilFormatedDate);
 
     int deletedUnreadNotifications = spaceWebNotificationService.markAllAsReadUntil(untilDate);
     if (deletedUnreadNotifications > 0) {
-      LOG.info("{} unread activities has been marked as read unti {}. Operation suceeded within {}ms",
-               deletedUnreadNotifications,
+      LOG.info("{} unread activities has been marked as read which was created before {}. Operation suceeded within {}ms",
+               INTEGER_FORMAT_INSTANCE.format(deletedUnreadNotifications),
                untilFormatedDate,
-               NumberFormat.getIntegerInstance().format(System.currentTimeMillis() - start));
+               INTEGER_FORMAT_INSTANCE.format(System.currentTimeMillis() - start));
     }
   }
 

--- a/component/notification/src/main/java/io/meeds/social/notification/job/SpaceWebNotificationCleanupJob.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/job/SpaceWebNotificationCleanupJob.java
@@ -54,7 +54,7 @@ public class SpaceWebNotificationCleanupJob {
     long start = System.currentTimeMillis();
     long untilDate = start - keepAliveDays * DAY_IN_MS;
     String untilFormatedDate = DateFormat.getDateTimeInstance().format(new Date(untilDate));
-    LOG.info("Delete unread activities until {}", untilFormatedDate);
+    LOG.info("Delete unread activities created before {}", untilFormatedDate);
 
     int deletedUnreadNotifications = spaceWebNotificationService.markAllAsReadUntil(untilDate);
     if (deletedUnreadNotifications > 0) {

--- a/component/notification/src/main/java/io/meeds/social/notification/job/SpaceWebNotificationCleanupJob.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/job/SpaceWebNotificationCleanupJob.java
@@ -1,0 +1,68 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.notification.job;
+
+import java.text.DateFormat;
+import java.text.NumberFormat;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.notification.service.SpaceWebNotificationService;
+
+import lombok.Synchronized;
+
+@Configuration
+@EnableScheduling
+public class SpaceWebNotificationCleanupJob {
+
+  private static final Log            LOG       = ExoLogger.getLogger(SpaceWebNotificationCleanupJob.class);
+
+  private static final int            DAY_IN_MS = 24 * 3600 * 1000;
+
+  @Autowired
+  private SpaceWebNotificationService spaceWebNotificationService;
+
+  @Value("${social.SpaceWebNotificationCleanupJob.keepAlive.days:30}")
+  private int                         keepAliveDays;
+
+  @Scheduled(cron = "${social.SpaceWebNotificationCleanupJob.expression:0 5 23 ? * *}")
+  @Synchronized
+  public void run() {
+    long start = System.currentTimeMillis();
+    long untilDate = start - keepAliveDays * DAY_IN_MS;
+    String untilFormatedDate = DateFormat.getDateTimeInstance().format(new Date(untilDate));
+    LOG.info("Delete unread activities until {}", untilFormatedDate);
+
+    int deletedUnreadNotifications = spaceWebNotificationService.markAllAsReadUntil(untilDate);
+    if (deletedUnreadNotifications > 0) {
+      LOG.info("{} unread activities has been marked as read unti {}. Operation suceeded within {}ms",
+               deletedUnreadNotifications,
+               untilFormatedDate,
+               NumberFormat.getIntegerInstance().format(System.currentTimeMillis() - start));
+    }
+  }
+
+}

--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
@@ -236,6 +236,11 @@ public class SpaceWebNotificationServiceImpl implements SpaceWebNotificationServ
   }
 
   @Override
+  public int markAllAsReadUntil(long untilDate) {
+    return metadataService.deleteByMetadataItemsTypeAndUntilCreationDate(METADATA_TYPE_NAME, untilDate);
+  }
+
+  @Override
   public Map<String, Long> countUnreadItemsByApplication(long userIdentityId, long spaceId) {
     return metadataService.countMetadataItemsByMetadataTypeAndAudienceId(METADATA_TYPE_NAME, userIdentityId, spaceId);
   }

--- a/component/notification/src/test/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceTest.java
@@ -142,6 +142,13 @@ public class SpaceWebNotificationServiceTest extends AbstractCoreTest {
   }
 
   @Test
+  public void testMarkAllAsReadUntil() {
+    long timeMillis = System.currentTimeMillis();
+    spaceWebNotificationService.markAllAsReadUntil(timeMillis);
+    verify(metadataService).deleteByMetadataItemsTypeAndUntilCreationDate(METADATA_TYPE_NAME, timeMillis);
+  }
+
+  @Test
   public void testDispatchNotification() throws Exception {
     SpaceWebNotificationItem spaceWebNotificationItem = new SpaceWebNotificationItem(METADATA_OBJECT_TYPE,
                                                                                      activityId,


### PR DESCRIPTION
Prior to this change, when the unread activities increases to be tens of millions of entries, the unread badge per space retrieval is very slow.
This change will introduce a new `DB index` which allows to make the DB query faster (For `20 millions` of unread, the count was taking around `20 seconds` and with the DB index it took around `60 milliseconds`).
In addition, functionally, the unread badge doesn't make sense when kept for more than one month. Thus, like for Web Notifications, a Cron Job has been added to delete unread badges which was created more than `a month` before (Duration may be changed through a System Property). This cleanup job will be executed **each night** (Can be changed by a System property) at `11:05PM`.