### PR TITLE
fix: Fix Deleting Metadata Items When no Results - MEED-7918 - Meeds-io/meeds#2618

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -404,6 +404,9 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     long minId;
     try {
       Tuple tuple = minMaxIdQuery.getSingleResult();
+      if (tuple == null || tuple.get(0, Long.class) == null) {
+        return 0;
+      }
       minId = tuple.get(0, Long.class);
       maxId = tuple.get(1, Long.class);
       if (maxId == 0) {

--- a/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
@@ -1545,6 +1545,9 @@ public class MetadataServiceTest extends AbstractCoreTest {
 
     items = metadataService.getMetadataItemsByMetadataAndObject(metadataItem.getMetadata().key(), metadataItem.getObject());
     assertTrue(CollectionUtils.isEmpty(items));
+
+    deletedCount = metadataService.deleteByMetadataItemsTypeAndUntilCreationDate(type, System.currentTimeMillis() + 1000);
+    assertEquals(0, deletedCount);
   }
 
   public void testFindMetadataNamesByCreator() throws Exception { // NOSONAR


### PR DESCRIPTION
Prior to this change, an NPE is thrown when no Metadata Items was found to cleanup. This change will avoid to execute Delete Metadata items when no items found in selected period.

Resolves https://github.com/Meeds-io/meeds/issues/2618