### PR TITLE
fix: Allow to an administrator to access Spaces with no templates - MEED-7938 - Meeds-io/meeds#2668

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
@@ -18,6 +18,7 @@
  */
 package io.meeds.social.space.template.service;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -131,7 +132,17 @@ public class SpaceTemplateService {
 
   public List<Long> getManagingSpaceTemplates(String username) {
     List<SpaceTemplate> spaceTemplates = spaceTemplateStorage.getSpaceTemplates(Pageable.unpaged());
-    return spaceTemplates.stream().filter(t -> canManageSpacesWithTemplate(t, username)).map(SpaceTemplate::getId).toList();
+    List<Long> spaceTemplateIds = spaceTemplates.stream()
+                                                .filter(t -> canManageSpacesWithTemplate(t, username))
+                                                .map(SpaceTemplate::getId)
+                                                .toList();
+    if (canManageTemplates(username)) {
+      spaceTemplateIds = new ArrayList<>(spaceTemplateIds);
+      // Include spaces not having an associated template Id
+      // which should be visible to an administrator
+      spaceTemplateIds.add(0L);
+    }
+    return spaceTemplateIds;
   }
 
   public SpaceTemplate getSpaceTemplate(long templateId) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
@@ -369,6 +369,13 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
           parameterNames.add(PARAM_HIDDEN_VISIBILITY);
           parameterNames.add(PARAM_USER_ID);
           parameterNames.add(PARAM_STATUSES);
+        } else if (spaceFilter.getManagingTemplateIds().contains(0l)) {
+          suffixes.add("SpacePrivateOrStatusesOrManagingOrTemplateNull");
+          predicates.add("(s.visibility <> :hiddenVisibility OR s.templateId IS NULL OR s.templateId IN :managingTemplateIds OR (sm.userId = :userId AND sm.status IN :statuses))");
+          parameterNames.add(PARAM_HIDDEN_VISIBILITY);
+          parameterNames.add(PARAM_USER_ID);
+          parameterNames.add(PARAM_STATUSES);
+          parameterNames.add(PARAM_MANAGING_TEMPLATE_IDS);
         } else {
           suffixes.add("SpacePrivateOrStatusesOrManaging");
           predicates.add("(s.visibility <> :hiddenVisibility OR s.templateId IN :managingTemplateIds OR (sm.userId = :userId AND sm.status IN :statuses))");
@@ -387,6 +394,12 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
           predicates.add("sm.userId = :userId AND sm.status IN :statuses");
           parameterNames.add(PARAM_USER_ID);
           parameterNames.add(PARAM_STATUSES);
+        } else if (spaceFilter.getManagingTemplateIds().contains(0l)) {
+          suffixes.add("SpaceWithStatusesOrManagingOrTemplateNull");
+          predicates.add("(s.templateId IS NULL OR s.templateId IN :managingTemplateIds OR (sm.userId = :userId AND sm.status IN :statuses))");
+          parameterNames.add(PARAM_USER_ID);
+          parameterNames.add(PARAM_STATUSES);
+          parameterNames.add(PARAM_MANAGING_TEMPLATE_IDS);
         } else {
           suffixes.add("SpaceWithStatusesOrManaging");
           predicates.add("(s.templateId IN :managingTemplateIds OR (sm.userId = :userId AND sm.status IN :statuses))");

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -400,6 +400,37 @@ public class SpaceServiceTest extends AbstractCoreTest {
     assertEquals(0, allSpaces.getSize());
   }
 
+  public void testGetVisibleSpacesWithNoSpaceTemplateAsAdmin() throws Exception {
+    SpaceTemplate spaceTemplate = mockSpaceTemplate();
+
+    int count = 5;
+    Space firstSpace = null;
+    for (int i = 0; i < count; i++) {
+      Space space = this.getSpaceInstance(i);
+      if (i == 0) {
+        firstSpace = space;
+        spaceService.removeMember(space, TOM_NAME);
+        spaceTemplate.setAdminPermissions(Collections.singletonList(space.getGroupId()));
+      } else if (i % 2 == 0) {
+        space.setVisibility(Space.HIDDEN);
+        space.setTemplateId(spaceTemplate.getId());
+        space = spaceService.updateSpace(space);
+        spaceService.removeMember(space, DEMO_NAME);
+        spaceService.removeMember(space, TOM_NAME);
+      }
+    }
+    ListAccess<Space> allSpaces = spaceService.getVisibleSpacesWithListAccess(ROOT_NAME, new SpaceFilter());
+    assertEquals(count, allSpaces.getSize());
+
+    assertNotNull(firstSpace);
+    firstSpace.setTemplateId(0l); // NOSONAR
+    firstSpace.setVisibility(Space.HIDDEN);
+    spaceService.updateSpace(firstSpace);
+
+    allSpaces = spaceService.getVisibleSpacesWithListAccess(ROOT_NAME, new SpaceFilter());
+    assertEquals(count, allSpaces.getSize());
+  }
+
   public void testGetEditableSpacesWithSpaceTemplateAdmin() throws Exception {
     SpaceTemplate spaceTemplate = mockSpaceTemplate();
 
@@ -2316,7 +2347,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
     String[] members = new String[] { DEMO_NAME, RAUL_NAME, GHOST_NAME, DRAGON_NAME };
     String[] invitedUsers = new String[] { REGISTER1_NAME, MARY_NAME };
     String[] pendingUsers = new String[] { JAME_NAME, PAUL_NAME, HACKER_NAME };
-    Space createdSpace = this.spaceService.createSpace(space, ROOT_NAME);
+    Space createdSpace = this.spaceService.createSpace(space, DEMO_NAME);
     Arrays.stream(pendingUsers).forEach(u -> spaceService.addPendingUser(createdSpace, u));
     Arrays.stream(invitedUsers).forEach(u -> spaceService.addInvitedUser(createdSpace, u));
     Arrays.stream(members).forEach(u -> spaceService.addMember(createdSpace, u));
@@ -2403,7 +2434,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
     spaceService.addMember(space4, OTHER_USER_NAME);
     spaceService.addMember(space5, OTHER_USER_NAME);
 
-    ListAccess<Space> resultListCommonSpacesAccessList1 = spaceService.getCommonSpaces(ROOT_NAME, OTHER_USER_NAME);
+    ListAccess<Space> resultListCommonSpacesAccessList1 = spaceService.getCommonSpaces(DEMO_NAME, OTHER_USER_NAME);
     assertEquals(5, resultListCommonSpacesAccessList1.getSize());
     Space[] spaceArray = resultListCommonSpacesAccessList1.load(0, 2);
     assertEquals(2, spaceArray.length);


### PR DESCRIPTION
Prior to this change, when having a space without an associated template and which is have 'Hidden' visibility, then the Space isn't listed in spaces Administration UI. This change ensures to let Platform Administrators to access the list of Spaces they manage even when it doesn't have an associated template.