### PR TITLE
fix: Fix Search Application Caching - MEED-7942 - Meeds-io/meeds#2674

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/search.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/search.jsp
@@ -61,11 +61,11 @@
       </button>
       <textarea id="searchConnectorsDefaultValue" aria-hidden="true" class="d-none"><%= jsonSearchConnectors%></textarea>
       <textarea id="searchSkinUrlsDefaultValue" aria-hidden="true" class="d-none"><%= skinUrlsString%></textarea>
-      <% if (rcontext.getRequestURI().endsWith("/search") || rcontext.getRequestURI().equals("search")) { %>
       <script type="text/javascript">
-        require(['PORTLET/social/Search'], app => app.init());
+        if (window.location.pathname?.endsWith?.('/search')) {
+          require(['PORTLET/social/Search'], app => app.init());
+        }
       </script>
-      <% } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Prior to this change, the Private Portlet Cache of Search was making the Search application not displayed in Standalone Mode (direct Link Access). This change ensures to have all time the same HTML response for the same user to ensure that the Search Application is efficient and doesn't affect the features of the Application.

Resolves Meeds-io/meeds#2674