### PR TITLE
fix: Fix Site Click on Mobile from Sidebar - MEED-7964 - Meeds-io/meeds#2681

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListHeader.vue
@@ -139,13 +139,15 @@ export default {
         urls: true,
         email: true,
         phone: true,
-      }) || this.$root.defaultUserPath;
+      });
     },
     defaultUserPath() {
       return this.defaultUserExternalPath || this.$root.defaultUserPath;
     },
     defaultUserPathTarget() {
-      return this.defaultUserExternalPath && '_blank' || '_self';
+      return this.defaultUserPath?.startsWith?.(window.location.origin)
+        || this.defaultUserPath?.startsWith?.('/')
+        || this.defaultUserPath?.startsWith?.('./') ? '_self' : '_blank';
     },
   },
   methods: {

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -259,7 +259,7 @@ export default {
       return this.drawerOpened && this.arrowIconLeft || this.arrowIconRight;
     },
     isUrl() {
-      return this.item.url && (this.$root.displaySequentially || (!this.isSpaces && !this.isSpaceTemplate && !this.isSpace));
+      return this.item.url && (this.$root.displaySequentially || (!this.isSpaces && !this.isSpaceTemplate && !this.isSpace && !this.isSite));
     },
     url() {
       return this.isUrl && this.item.url && this.$utils.toLinkUrl(this.item.url, {


### PR DESCRIPTION
Prior to this change, when clicking on site in Mobile, it doesn't display the second level like for space Templates and Spaces Directory item. In addition, when clicking on Header, the site is displayed in a new Tab. This change will consider Sites items as Spaces and Space templates in click behavior on Mobile. In addition, the target Window is fixed switch user Home URL.