### PR TITLE
fix: Internal users are marked as externals in organizational chart -EXO-76078 -Meeds-io/meeds#2691

### DIFF
--- a/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/ChartUserCompactCard.vue
+++ b/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/ChartUserCompactCard.vue
@@ -101,7 +101,7 @@ export default {
           && this.user?.managedUsersCount || '+99';
     },
     externalUser() {
-      return this.user?.external;
+      return this.user?.external === 'true';
     },
   }
 };


### PR DESCRIPTION
Before this change, Internal users were marked as external in the organizational chart, this is due to that the external property in the user object contain a string with values 'true' or 'false' and not a boolean. After this commit, the condition was changed to test the value of the string and the external label is not added for internal users.