### PR TITLE
feat: Allow to Sort Categories when retrieved using Tree View - MEED-7934 - Meeds-io/MIPs#170

### DIFF
--- a/component/api/src/main/java/io/meeds/social/category/model/CategoryFilter.java
+++ b/component/api/src/main/java/io/meeds/social/category/model/CategoryFilter.java
@@ -27,14 +27,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CategoryFilter {
 
-  private long ownerId;
+  private long    ownerId;
 
-  private long parentId;
+  private long    parentId;
 
-  private long depth;
+  private long    depth;
 
-  private long offset;
+  private long    offset;
 
-  private long limit;
+  private long    limit;
+
+  private boolean sortByName;
 
 }

--- a/component/api/src/main/java/io/meeds/social/category/model/CategoryTree.java
+++ b/component/api/src/main/java/io/meeds/social/category/model/CategoryTree.java
@@ -31,6 +31,12 @@ public class CategoryTree extends Category {
 
   private List<CategoryTree> categories;
 
+  private long               offset;
+
+  private long               limit;
+
+  private long               size;
+
   public CategoryTree(Category category) {
     super(category.getId(),
           category.getParentId(),

--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryService.java
@@ -73,7 +73,7 @@ public interface CategoryService {
    * @param limit Request limit. Can be 0 to retrieve all
    * @return {@link List} of Sub category ids
    */
-  List<Long> getSubCategoryIds(long categoryId, long offset, long limit);
+  List<Long> getSubcategoryIds(long categoryId, long offset, long limit);
 
   /**
    * Creates a new {@link Category}

--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -615,6 +615,13 @@ public interface MetadataService {
   List<Metadata> getMetadatasByProperty(String propertyKey, String propertyValue, long limit);
 
   /**
+   * @param  propertyKey   {@link Metadata} property key
+   * @param  propertyValue {@link Metadata} property value
+   * @return count of found {@link Metadata}
+   */
+  long countMetadataIdsByProperty(String propertyKey, String propertyValue);
+
+  /**
    * @param propertyKey {@link Metadata} property key
    * @param propertyValue {@link Metadata} property value
    * @param offset offset of results to retrieve

--- a/component/core/src/main/java/io/meeds/social/category/listener/CategoryModifiedIndexingListener.java
+++ b/component/core/src/main/java/io/meeds/social/category/listener/CategoryModifiedIndexingListener.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.search.index.IndexingService;
-import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.ListenerBase;
 import org.exoplatform.services.listener.ListenerService;
@@ -41,7 +40,6 @@ import io.meeds.social.category.storage.elasticsearch.CategoryIndexingConnector;
 import jakarta.annotation.PostConstruct;
 
 @Component
-@Asynchronous
 public class CategoryModifiedIndexingListener implements ListenerBase<Category, Object> {
 
   @Autowired
@@ -83,7 +81,7 @@ public class CategoryModifiedIndexingListener implements ListenerBase<Category, 
 
   private void reindexTree(long id) {
     indexingService.reindex(CategoryIndexingConnector.TYPE, String.valueOf(id));
-    List<Long> subCategoryIds = categoryService.getSubCategoryIds(id, 0, -1);
+    List<Long> subCategoryIds = categoryService.getSubcategoryIds(id, 0, -1);
     if (CollectionUtils.isNotEmpty(subCategoryIds)) {
       subCategoryIds.forEach(this::reindexTree);
     }

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -37,6 +36,8 @@ import org.springframework.stereotype.Service;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.SpaceUtils;
@@ -57,6 +58,8 @@ import lombok.SneakyThrows;
 public class CategoryServiceImpl implements CategoryService {
 
   public static final String ADMINISTRATORS_GROUP = "/platform/administrators";
+
+  private static final Log   LOG                  = ExoLogger.getLogger(CategoryServiceImpl.class);
 
   private static final long  MAX_LIMIT            = 100l;
 
@@ -91,6 +94,7 @@ public class CategoryServiceImpl implements CategoryService {
                              locale,
                              filter.getOffset(),
                              limit,
+                             filter.isSortByName(),
                              filter.getDepth(),
                              0);
   }
@@ -106,37 +110,18 @@ public class CategoryServiceImpl implements CategoryService {
     if (category == null || !canAccess(category, username)) {
       return Collections.emptyList();
     }
-    org.exoplatform.services.security.Identity userAclIdentity = userAcl.getUserIdentity(username);
-    if (userAclIdentity == null) {
+    List<Long> identityIds = getUserMemberIdentityIds(username);
+    if (CollectionUtils.isEmpty(identityIds)) {
       return Collections.emptyList();
-    } else {
-      Set<String> groups = userAclIdentity.getGroups();
-      List<Long> identityIds = groups.stream()
-                                     .map(groupId -> {
-                                       if (StringUtils.startsWith(groupId, SpaceUtils.SPACE_GROUP_PREFIX)) {
-                                         Space space = spaceService.getSpaceByGroupId(groupId);
-                                         if (space == null) {
-                                           return null;
-                                         } else {
-                                           Identity identity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
-                                           return Long.parseLong(identity.getId());
-                                         }
-                                       } else {
-                                         Identity identity = identityManager.getOrCreateGroupIdentity(groupId);
-                                         return Long.parseLong(identity.getId());
-                                       }
-                                     })
-                                     .filter(Objects::nonNull)
-                                     .toList();
-      filter = filter.clone();
-      filter.setLimit(limit);
-      return categoryStorage.findCategories(filter, identityIds, locale);
     }
+    filter = filter.clone();
+    filter.setLimit(limit);
+    return categoryStorage.findCategories(filter, identityIds, locale);
   }
 
   @Override
-  public List<Long> getSubCategoryIds(long categoryId, long offset, long limit) {
-    return categoryStorage.getSubCategoryIds(categoryId, offset, limit);
+  public List<Long> getSubcategoryIds(long categoryId, long offset, long limit) {
+    return categoryStorage.getSubcategoryIds(categoryId, offset, limit);
   }
 
   @Override
@@ -215,6 +200,7 @@ public class CategoryServiceImpl implements CategoryService {
   public Category deleteCategory(long categoryId, String username) throws ObjectNotFoundException, IllegalAccessException {
     Category category = checkCategoryExists(categoryId);
     checkCanEdit(category, username);
+    translationService.deleteTranslationLabels(CategoryTranslationPlugin.OBJECT_TYPE, categoryId);
     return categoryStorage.deleteCategory(categoryId);
   }
 
@@ -262,9 +248,7 @@ public class CategoryServiceImpl implements CategoryService {
   }
 
   private long checkLimit(long limit) {
-    if (limit > MAX_LIMIT) {
-      throw new IllegalArgumentException(String.format("Max categories to retrieve is %s, found %s", MAX_LIMIT, limit));
-    } else if (limit <= 0) {
+    if (limit <= 0) {
       limit = MAX_LIMIT;
     }
     return limit;
@@ -337,48 +321,79 @@ public class CategoryServiceImpl implements CategoryService {
     }
   }
 
-  private CategoryTree buildCategoryTree(Category category,
+  private CategoryTree buildCategoryTree(Category category, // NOSONAR
                                          String username,
                                          Locale locale,
                                          long offset,
                                          long limit,
+                                         boolean sortByName,
                                          long depthLimit,
                                          long depth) {
     CategoryTree categoryTree = new CategoryTree(category);
+    long categoryId = categoryTree.getId();
+    long size = categoryStorage.countSubcategories(categoryId);
     String name = translationService.getTranslationLabelOrDefault(CategoryTranslationPlugin.OBJECT_TYPE,
                                                                   category.getId(),
                                                                   CategoryTranslationPlugin.NAME_FIELD,
                                                                   locale);
     categoryTree.setName(name);
     if (depth < depthLimit) {
-      long categoryId = categoryTree.getId();
-      List<CategoryTree> categories = buildSubCategories(categoryId, username, locale, offset, limit, depthLimit, depth);
-      categoryTree.setCategories(categories);
+      categoryTree.setOffset(offset);
+      categoryTree.setLimit(limit);
+      if (size > 0) {
+        List<CategoryTree> categories = buildSubCategories(categoryId,
+                                                           username,
+                                                           locale,
+                                                           offset,
+                                                           limit,
+                                                           size,
+                                                           sortByName,
+                                                           depthLimit,
+                                                           depth);
+        categoryTree.setCategories(categories);
+        if (categories.size() < limit) {
+          categoryTree.setSize(offset + categories.size());
+        } else if (canEdit(categoryTree, username)) {
+          categoryTree.setSize(size);
+        } else {
+          categoryTree.setSize(categoryStorage.countSubcategories(new CategorySearchFilter(null, 0, categoryId, 0, 0, false),
+                                                                  getUserMemberIdentityIds(username),
+                                                                  locale));
+        }
+      }
     }
     return categoryTree;
   }
 
-  private List<CategoryTree> buildSubCategories(long categoryId,
+  private List<CategoryTree> buildSubCategories(long categoryId, // NOSONAR
                                                 String username,
                                                 Locale locale,
                                                 long offset,
                                                 long limit,
+                                                long size,
+                                                boolean sortByName,
                                                 long depthLimit,
                                                 long depth) {
-    List<Long> ids = categoryStorage.getSubCategoryIds(categoryId, offset, limit);
+    boolean sortByNameSubcategories = sortByName && size > limit;
+    List<Long> ids = getSubcategoryIds(categoryId, offset, limit, username, locale, sortByNameSubcategories);
+    long loadedCount = ids == null ? 0 : ids.size();
+    List<CategoryTree> categories;
     if (CollectionUtils.isNotEmpty(ids)) {
-      List<CategoryTree> categories = toCategories(ids, username, locale, offset, limit, depthLimit, depth + 1);
+      categories = toCategories(ids, username, locale, offset, limit, sortByName, depthLimit, depth + 1);
       long offsetToFetch = offset;
       long limitToFetch = Math.max(limit, 10);
       boolean limitReached = categories.size() == ids.size() || ids.size() < limit;
       while (!limitReached) {
+        // Loop in order to filter on user permissions
         offsetToFetch += limitToFetch;
-        ids = categoryStorage.getSubCategoryIds(categoryId, offset, limitToFetch);
+        ids = getSubcategoryIds(categoryId, offset, limitToFetch, username, locale, sortByNameSubcategories);
+        loadedCount += ids.size();
         List<CategoryTree> additionalCategories = toCategories(ids,
                                                                username,
                                                                locale,
                                                                offsetToFetch,
                                                                limitToFetch,
+                                                               sortByName,
                                                                depthLimit,
                                                                depth + 1);
         if (CollectionUtils.isNotEmpty(additionalCategories)) {
@@ -389,17 +404,31 @@ public class CategoryServiceImpl implements CategoryService {
         }
         limitReached = categories.size() >= limit || ids.size() < limitToFetch;
       }
-      return categories;
     } else {
-      return Collections.emptyList();
+      categories = Collections.emptyList();
     }
+    boolean sortApplied = true;
+    if (sortByName
+        && locale != null
+        && categories.size() < limit
+        && loadedCount < (size - offset)) {
+      LOG.info("Incoherent result from Elasticsearch while retrieving categories. Thus retrieve data from DB");
+      sortApplied = false;
+      categories = buildSubCategories(categoryId, username, locale, offset, limit, size, false, depthLimit, depth);
+    }
+    if ((!sortApplied || !sortByNameSubcategories) && CollectionUtils.isNotEmpty(categories)) {
+      categories = new ArrayList<>(categories);
+      categories.sort((c1, c2) -> StringUtils.compare(c1.getName(), c2.getName()));
+    }
+    return categories;
   }
 
-  private List<CategoryTree> toCategories(List<Long> categoryIds,
+  private List<CategoryTree> toCategories(List<Long> categoryIds, // NOSONAR
                                           String username,
                                           Locale locale,
                                           long offset,
                                           long limit,
+                                          boolean sortByName,
                                           long depthLimit,
                                           long depth) {
     return categoryIds.stream()
@@ -410,9 +439,29 @@ public class CategoryServiceImpl implements CategoryService {
                                                     locale,
                                                     offset,
                                                     limit,
+                                                    sortByName,
                                                     depthLimit,
                                                     depth))
                       .toList();
+  }
+
+  private List<Long> getSubcategoryIds(long categoryId,
+                                       long offset,
+                                       long limit,
+                                       String username,
+                                       Locale locale,
+                                       boolean sortByName) {
+    if (sortByName && locale != null) {
+      List<Long> identityIds = getUserMemberIdentityIds(username);
+      if (CollectionUtils.isEmpty(identityIds)) {
+        return Collections.emptyList();
+      }
+      return categoryStorage.findCategoryIds(new CategorySearchFilter(null, 0, categoryId, offset, limit, false),
+                                             identityIds,
+                                             locale);
+    } else {
+      return categoryStorage.getSubcategoryIds(categoryId, offset, limit);
+    }
   }
 
   private boolean canAccess(Category category, String username, boolean checkAncestors) {
@@ -430,6 +479,32 @@ public class CategoryServiceImpl implements CategoryService {
                                                        userAcl,
                                                        id,
                                                        username)));
+    }
+  }
+
+  private List<Long> getUserMemberIdentityIds(String username) {
+    org.exoplatform.services.security.Identity userAclIdentity = userAcl.getUserIdentity(username);
+    if (userAclIdentity == null) {
+      return Collections.emptyList();
+    } else {
+      return userAclIdentity.getGroups()
+                            .stream()
+                            .map(groupId -> {
+                              if (StringUtils.startsWith(groupId, SpaceUtils.SPACE_GROUP_PREFIX)) {
+                                Space space = spaceService.getSpaceByGroupId(groupId);
+                                if (space == null) {
+                                  return null;
+                                } else {
+                                  Identity identity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+                                  return Long.parseLong(identity.getId());
+                                }
+                              } else {
+                                Identity identity = identityManager.getOrCreateGroupIdentity(groupId);
+                                return Long.parseLong(identity.getId());
+                              }
+                            })
+                            .filter(Objects::nonNull)
+                            .toList();
     }
   }
 

--- a/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
@@ -20,7 +20,9 @@ package io.meeds.social.category.storage;
 
 import static io.meeds.social.category.service.CategoryService.EVENT_SOCIAL_CATEGORY_CREATED;
 import static io.meeds.social.category.service.CategoryService.EVENT_SOCIAL_CATEGORY_DELETED;
-import static io.meeds.social.category.service.CategoryService.*;
+import static io.meeds.social.category.service.CategoryService.EVENT_SOCIAL_CATEGORY_ITEM_LINKED;
+import static io.meeds.social.category.service.CategoryService.EVENT_SOCIAL_CATEGORY_ITEM_UNLINKED;
+import static io.meeds.social.category.service.CategoryService.EVENT_SOCIAL_CATEGORY_UPDATED;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,13 +37,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.social.common.ObjectAlreadyExistsException;
 import org.exoplatform.social.metadata.MetadataService;
 import org.exoplatform.social.metadata.model.Metadata;
 import org.exoplatform.social.metadata.model.MetadataItem;
@@ -54,8 +55,10 @@ import io.meeds.social.category.storage.elasticsearch.CategorySearchConnector;
 
 import lombok.SneakyThrows;
 
-@Component
-@SuppressWarnings("removal")
+/**
+ * TODO change to component when CategoryIndexingConnector moved to be managed by Spring
+ */
+@Service
 public class CategoryStorage {
 
   private static final Log          LOG                     = ExoLogger.getLogger(CategoryStorage.class);
@@ -98,7 +101,7 @@ public class CategoryStorage {
 
   @CacheEvict(cacheNames = "social.category")
   public Category deleteCategory(long id) {
-    List<Long> ids = getSubCategoryIds(id, 0, -1);
+    List<Long> ids = getSubcategoryIds(id, 0, -1);
     if (CollectionUtils.isNotEmpty(ids)) {
       ids.forEach(this::deleteCategory);
     }
@@ -127,13 +130,25 @@ public class CategoryStorage {
     return rootId == 0 ? null : getCategory(rootId);
   }
 
-  public List<Long> getSubCategoryIds(long categoryId, long offset, long limit) {
+  public List<Long> getSubcategoryIds(long categoryId, long offset, long limit) {
     return metadataService.getMetadataIdsByProperty(PROP_PARENT_ID, String.valueOf(categoryId), offset, limit);
   }
 
+  public long countSubcategories(long categoryId) {
+    return metadataService.countMetadataIdsByProperty(PROP_PARENT_ID, String.valueOf(categoryId));
+  }
+
   public List<Category> findCategories(CategorySearchFilter filter, List<Long> identityIds, Locale locale) {
-    List<Long> ids = searchConnector.search(filter, identityIds, locale);
+    List<Long> ids = findCategoryIds(filter, identityIds, locale);
     return ids.stream().map(this::getCategory).toList();
+  }
+
+  public List<Long> findCategoryIds(CategorySearchFilter filter, List<Long> identityIds, Locale locale) {
+    return searchConnector.search(filter, identityIds, locale);
+  }
+
+  public int countSubcategories(CategorySearchFilter filter, List<Long> identityIds, Locale locale) {
+    return searchConnector.count(filter, identityIds, locale);
   }
 
   public boolean isLinked(long categoryId, CategoryObject object) {

--- a/component/core/src/main/java/io/meeds/social/category/storage/elasticsearch/CategoryIndexingConnector.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/elasticsearch/CategoryIndexingConnector.java
@@ -28,14 +28,13 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.search.domain.Document;
 import org.exoplatform.commons.search.index.impl.ElasticIndexingServiceConnector;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.container.xml.PropertiesParam;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.LocaleConfig;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.social.core.search.DocumentWithMetadata;
@@ -48,14 +47,13 @@ import io.meeds.social.translation.service.TranslationService;
 
 import lombok.SneakyThrows;
 
-@Component
 public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
 
-  private static final String CATEGORY_INDEX_ALIAS = "category_alias";
+  private static final Log    LOG          = ExoLogger.getLogger(CategoryIndexingConnector.class);
 
-  public static final String  TYPE                 = "category";
+  public static final String  TYPE         = "category";
 
-  public static final String  ES_MAPPING           = """
+  public static final String  ES_MAPPING   = """
           {
              "properties" : {
               "id" : {"type" : "keyword"},
@@ -71,7 +69,7 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
           }
       """;
 
-  public static final String  NAME_MAPPING         = """
+  public static final String  NAME_MAPPING = """
         "@name@" : {
           "type" : "text",
           "analyzer": "ngram_analyzer",
@@ -85,23 +83,18 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
         }
       """;
 
-  @Autowired
   private CategoryStorage     categoryStorage;
 
-  @Autowired
   private TranslationService  translationService;
 
-  @Autowired
   private LocaleConfigService localeConfigService;
 
-  public CategoryIndexingConnector(
-                                   @Value("${meeds.social.index.category.previous:}")
-                                   String indexPrevious,
-                                   @Value("${meeds.social.index.category.current:category_v1}")
-                                   String indexCurrent,
-                                   @Value("${meeds.social.index.category.reindexOnUpgrade:false}")
-                                   String reindexOnUpgrade) {
-    super(initParams(indexPrevious, indexCurrent, reindexOnUpgrade));
+  public CategoryIndexingConnector(TranslationService translationService,
+                                   LocaleConfigService localeConfigService,
+                                   InitParams initParams) {
+    super(initParams);
+    this.translationService = translationService;
+    this.localeConfigService = localeConfigService;
   }
 
   @Override
@@ -115,7 +108,7 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
       throw new IllegalArgumentException("id is mandatory");
     }
 
-    Category category = categoryStorage.getCategory(Long.parseLong(id));
+    Category category = getCategoryStorage().getCategory(Long.parseLong(id));
     if (category == null) {
       return null;
     }
@@ -136,6 +129,7 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
     List<Long> linkPermissionIds = getLinkPermissionIds(category, accessPermissionIds);
     document.addListField("linkPermissionIds", linkPermissionIds.stream().map(String::valueOf).toList());
     addTranslatedNames(category, document);
+    LOG.info("Category document generated for id={}", id);
     return document;
   }
 
@@ -156,6 +150,13 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
                                              .map(l -> NAME_MAPPING.replace("@name@", "name." + toLanguageTag(l)))
                                              .collect(Collectors.joining(",\n"));
     return ES_MAPPING.replace("@name_mappings@", nameMappings);
+  }
+
+  private CategoryStorage getCategoryStorage() {
+    if (categoryStorage == null) {
+      categoryStorage = ExoContainerContext.getService(CategoryStorage.class);
+    }
+    return categoryStorage;
   }
 
   @SneakyThrows
@@ -194,7 +195,7 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
 
   private List<Long> getLinkPermissionIds(Category category, List<Long> accessPermissionIds) {
     List<Long> linkPermissionIds = category.getLinkPermissionIds() == null ? new ArrayList<>() :
-      new ArrayList<>(category.getLinkPermissionIds());
+                                                                           new ArrayList<>(category.getLinkPermissionIds());
     linkPermissionIds.retainAll(accessPermissionIds);
     if (!linkPermissionIds.contains(category.getOwnerId())) {
       linkPermissionIds.add(category.getOwnerId());
@@ -212,23 +213,11 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
     return accessPermissionIds;
   }
 
-  private static InitParams initParams(String indexPrevious, String indexCurrent, String reindexOnUpgrade) {
-    InitParams initParams = new InitParams();
-    PropertiesParam param = new PropertiesParam();
-    param.setName("constructor.params");
-    param.setProperty("index_alias", CATEGORY_INDEX_ALIAS);
-    param.setProperty("index_previous", indexPrevious);
-    param.setProperty("index_current", indexCurrent);
-    param.setProperty("reindexOnUpgrade", reindexOnUpgrade);
-    initParams.addParameter(param);
-    return initParams;
-  }
-
   private void deleteNonParentPermissions(long parentId, List<Long> accessPermissionIds) {
     if (parentId <= 0) {
       return;
     }
-    Category parentCategory = categoryStorage.getCategory(parentId);
+    Category parentCategory = getCategoryStorage().getCategory(parentId);
     accessPermissionIds.retainAll(parentCategory.getAccessPermissionIds());
     deleteNonParentPermissions(parentCategory.getParentId(), accessPermissionIds);
   }

--- a/component/core/src/main/java/io/meeds/social/category/storage/elasticsearch/CategorySearchConnector.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/elasticsearch/CategorySearchConnector.java
@@ -43,26 +43,21 @@ import io.meeds.social.category.model.CategorySearchFilter;
 @Component
 public class CategorySearchConnector {
 
-  private static final String    CATEGORY_INDEX                = "category_alias";
+  private static final String    CATEGORY_INDEX                   = "category_alias";
 
-  private static final Log       LOG                           = ExoLogger.getLogger(CategorySearchConnector.class);
+  private static final Log       LOG                              = ExoLogger.getLogger(CategorySearchConnector.class);
 
-  private static final String    SEARCH_QUERY_TERM             = """
+  private static final String    SEARCH_QUERY_TERM                = """
           {
             "from": "@offset@",
             "size": "@limit@",
+            "sort" : [
+              { "@sort_field@.raw" : "@sort_direction@" }
+            ],
             "query":{
               "bool":{
-                "must":{
-                  "query_string":{
-                    "fields": ["@name_field@"],
-                    "default_operator": "AND",
-                    "query": "@term@~",
-                    "fuzziness": 1,
-                    "phrase_slop": 1
-                  }
-                },
-                "filter":[
+                @term_query@
+                "must":[
                   @owner_id_query@
                   @parent_id_query@
                   @permissions_query@
@@ -74,23 +69,50 @@ public class CategorySearchConnector {
           }
       """;
 
-  public static final String     OWNER_ID_QUERY                = """
+  private static final String    COUNT_QUERY_TERM                 = """
+          {
+            "query":{
+              "bool":{
+                @term_query@
+                "must":[
+                  @owner_id_query@
+                  @parent_id_query@
+                  @permissions_query@
+                ]
+              }
+            }
+          }
+      """;
+
+  public static final String     TERM_QUERY                       = """
+        "filter":{
+          "query_string":{
+            "fields": ["@name_field@"],
+            "default_operator": "AND",
+            "query": "@term@~",
+            "fuzziness": 1,
+            "phrase_slop": 1
+          }
+        },
+      """;
+
+  public static final String     OWNER_ID_QUERY                   = """
       {
-        "terms":{
+        "term":{
           "ownerId": @ownerId@
         }
       }
       """;
 
-  public static final String     PARENT_ID_QUERY               = """
+  public static final String     PARENT_ID_QUERY                  = """
       {
-        "terms":{
+        "term":{
           "parentId": @parentId@
         }
       }
       """;
 
-  public static final String     PERMISSIONS_QUERY             = """
+  public static final String     PERMISSIONS_QUERY                = """
       {
         "terms":{
           "@permissions_field@": [@permissions@]
@@ -98,44 +120,67 @@ public class CategorySearchConnector {
       }
       """;
 
-  private static final String    OFFSET_REPLACEMENT            = "@offset@";
+  private static final String    OFFSET_REPLACEMENT               = "@offset@";
 
-  private static final String    LIMIT_REPLACEMENT             = "@limit@";
+  private static final String    LIMIT_REPLACEMENT                = "@limit@";
 
-  private static final String    NAME_REPLACEMENT              = "@name_field@";
+  private static final String    NAME_REPLACEMENT                 = "@name_field@";
 
-  private static final String    TERM_REPLACEMENT              = "@term@";
+  private static final String    TERM_REPLACEMENT                 = "@term@";
 
-  private static final String    OWNER_ID_REPLACEMENT          = "@ownerId@";
+  private static final String    TERM_QUERY_REPLACEMENT           = "@term_query@";
 
-  private static final String    OWNER_ID_QUERY_REPLACEMENT    = "@owner_id_query@";
+  private static final String    OWNER_ID_REPLACEMENT             = "@ownerId@";
 
-  private static final String    PARENT_ID_REPLACEMENT         = "@parentId@";
+  private static final String    OWNER_ID_QUERY_REPLACEMENT       = "@owner_id_query@";
 
-  private static final String    PARENT_ID_QUERY_REPLACEMENT   = "@parent_id_query@";
+  private static final String    PARENT_ID_REPLACEMENT            = "@parentId@";
 
-  private static final String    PERMISSIONS_REPLACEMENT       = "@permissions@";
+  private static final String    PARENT_ID_QUERY_REPLACEMENT      = "@parent_id_query@";
 
-  private static final String    PERMISSIONS_FIELD_REPLACEMENT = "@permissions_field@";
+  private static final String    PERMISSIONS_REPLACEMENT          = "@permissions@";
 
-  private static final String    PERMISSIONS_QUERY_REPLACEMENT = "@permissions_query@";
+  private static final String    PERMISSIONS_FIELD_REPLACEMENT    = "@permissions_field@";
+
+  private static final String    PERMISSIONS_QUERY_REPLACEMENT    = "@permissions_query@";
+
+  private static final String    SORT_FIELD_QUERY_REPLACEMENT     = "@sort_field@";
+
+  private static final String    SORT_DIRECTION_QUERY_REPLACEMENT = "@sort_direction@";
+
+  private static final String    STRING_VALUE_FORMAT              = "\"%s\"";
+
+  private static final String    NAME_FORMAT                      = "name.%s";
 
   @Autowired
   private ElasticSearchingClient client;
 
   public List<Long> search(CategorySearchFilter filter, List<Long> identityIds, Locale locale) {
-    String esQuery = SEARCH_QUERY_TERM.replace(NAME_REPLACEMENT, "name." + locale.toLanguageTag())
-                                      .replace(TERM_REPLACEMENT, filter.getTerm())
-                                      .replace(OFFSET_REPLACEMENT, String.valueOf(filter.getOffset()))
-                                      .replace(LIMIT_REPLACEMENT, String.valueOf(filter.getLimit()));
+    String esQuery = buildSearchQuery(SEARCH_QUERY_TERM, filter, identityIds, locale);
+    String jsonResponse = this.client.sendRequest(esQuery, CATEGORY_INDEX);
+    return buildResult(jsonResponse);
+  }
+
+  public int count(CategorySearchFilter filter, List<Long> identityIds, Locale locale) {
+    String esQuery = buildSearchQuery(COUNT_QUERY_TERM, filter, identityIds, locale);
+    String jsonResponse = this.client.countRequest(esQuery, CATEGORY_INDEX);
+    return buildCount(jsonResponse);
+  }
+
+  private String buildSearchQuery(String queryBase, CategorySearchFilter filter, List<Long> identityIds, Locale locale) {
+    String esQuery = queryBase.replace(OFFSET_REPLACEMENT, String.valueOf(filter.getOffset()))
+                              .replace(LIMIT_REPLACEMENT, String.valueOf(filter.getLimit()));
     String append = "";
     if (filter.getParentId() > 0) {
       esQuery = esQuery.replace(PARENT_ID_QUERY_REPLACEMENT,
-                                PARENT_ID_QUERY.replace(PARENT_ID_REPLACEMENT, String.valueOf(filter.getParentId())));
+                                PARENT_ID_QUERY.replace(PARENT_ID_REPLACEMENT,
+                                                        String.format(STRING_VALUE_FORMAT, filter.getParentId())));
+      esQuery = esQuery.replace(OWNER_ID_QUERY_REPLACEMENT, "");
       append = ",";
     } else if (filter.getOwnerId() > 0) {
       esQuery = esQuery.replace(OWNER_ID_QUERY_REPLACEMENT,
-                                OWNER_ID_QUERY.replace(OWNER_ID_REPLACEMENT, String.valueOf(filter.getParentId())));
+                                OWNER_ID_QUERY.replace(OWNER_ID_REPLACEMENT,
+                                                       String.format(STRING_VALUE_FORMAT, filter.getParentId())));
       esQuery = esQuery.replace(PARENT_ID_QUERY_REPLACEMENT, "");
       append = ",";
     } else {
@@ -143,16 +188,27 @@ public class CategorySearchConnector {
       esQuery = esQuery.replace(OWNER_ID_QUERY_REPLACEMENT, "");
     }
     if (CollectionUtils.isNotEmpty(identityIds)) {
-      esQuery = append + esQuery.replace(PERMISSIONS_QUERY_REPLACEMENT,
-                                         PERMISSIONS_QUERY.replace(PERMISSIONS_REPLACEMENT, StringUtils.join(identityIds, ","))
+      esQuery = esQuery.replace(PERMISSIONS_QUERY_REPLACEMENT,
+                                append + PERMISSIONS_QUERY
+                                                          .replace(PERMISSIONS_REPLACEMENT,
+                                                                   String.format(STRING_VALUE_FORMAT,
+                                                                                 StringUtils.join(identityIds, "\",\"")))
                                                           .replace(PERMISSIONS_FIELD_REPLACEMENT,
                                                                    filter.isLinkPermission() ? "linkPermissionIds" :
                                                                                              "accessPermissionIds"));
     } else {
       esQuery = esQuery.replace(PERMISSIONS_QUERY_REPLACEMENT, "");
     }
-    String jsonResponse = this.client.sendRequest(esQuery, CATEGORY_INDEX);
-    return buildResult(jsonResponse);
+    if (StringUtils.isNotBlank(filter.getTerm())) {
+      esQuery = esQuery.replace(TERM_QUERY_REPLACEMENT,
+                                TERM_QUERY.replace(NAME_REPLACEMENT, String.format(NAME_FORMAT, locale.toLanguageTag()))
+                                          .replace(TERM_REPLACEMENT, filter.getTerm()));
+    } else {
+      esQuery = esQuery.replace(TERM_QUERY_REPLACEMENT, "");
+    }
+    esQuery = esQuery.replace(SORT_FIELD_QUERY_REPLACEMENT, String.format(NAME_FORMAT, locale.toLanguageTag()));
+    esQuery = esQuery.replace(SORT_DIRECTION_QUERY_REPLACEMENT, "asc");
+    return esQuery;
   }
 
   @SuppressWarnings({ "rawtypes" })
@@ -183,6 +239,18 @@ public class CategorySearchConnector {
       }
     }
     return results;
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private int buildCount(String jsonResponse) {
+    JSONParser parser = new JSONParser();
+    try {
+      Map json = (Map) parser.parse(jsonResponse);
+      String countString = json.getOrDefault("count", "0").toString();
+      return Integer.parseInt(countString);
+    } catch (ParseException e) {
+      throw new ElasticSearchException("Unable to parse JSON response", e);
+    }
   }
 
   private Long parseLong(JSONObject hitSource, String key) {

--- a/component/core/src/main/java/io/meeds/social/translation/storage/TranslationStorage.java
+++ b/component/core/src/main/java/io/meeds/social/translation/storage/TranslationStorage.java
@@ -21,6 +21,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -123,7 +126,7 @@ public class TranslationStorage {
     if (CollectionUtils.isNotEmpty(metadataItems)) {
       metadataItems.stream()
                    .filter(item -> MapUtils.isNotEmpty(item.getProperties())
-                       && StringUtils.equals(item.getProperties().get(LOCALE_PROPERTY_NAME), locale.toLanguageTag()))
+                                   && StringUtils.equals(item.getProperties().get(LOCALE_PROPERTY_NAME), locale.toLanguageTag()))
                    .map(MetadataItem::getId)
                    .forEach(id -> {
                      try {
@@ -174,9 +177,15 @@ public class TranslationStorage {
     } else {
       return metadataItems.stream()
                           .filter(item -> MapUtils.isNotEmpty(item.getProperties()))
+                          .filter(distinctByKey(item -> Locale.forLanguageTag(item.getProperties().get(LOCALE_PROPERTY_NAME))))
                           .collect(Collectors.toMap(item -> Locale.forLanguageTag(item.getProperties().get(LOCALE_PROPERTY_NAME)),
                                                     item -> item.getProperties().get(LABEL_PROPERTY_NAME)));
     }
+  }
+
+  public <T> Predicate<T> distinctByKey(Function<? super T, Object> keyExtractor) {
+    Map<Object, Boolean> map = new ConcurrentHashMap<>();
+    return t -> map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataDAO.java
@@ -82,11 +82,11 @@ public class MetadataDAO extends GenericDAOJPAImpl<MetadataEntity, Long> {
   }
 
   public List<String> getMetadataNamesByUser(long metadataTypeId,
-                                                long creatorIdentityId,
-                                                Set<Long> audienceIds,
-                                                long limit) {
+                                             long creatorIdentityId,
+                                             Set<Long> audienceIds,
+                                             long limit) {
     TypedQuery<String> query = getEntityManager().createNamedQuery("SocMetadataEntity.getMetadataNamesByUser",
-            String.class);
+                                                                   String.class);
     query.setParameter(METADATA_TYPE, metadataTypeId);
     query.setParameter(AUDIENCE_IDS, audienceIds);
     query.setParameter(CREATOR_ID, creatorIdentityId);
@@ -140,7 +140,12 @@ public class MetadataDAO extends GenericDAOJPAImpl<MetadataEntity, Long> {
       return result.stream().distinct().collect(Collectors.toList());
     }
   }
-  public List<String> findMetadataNamesByUserAndQuery(String term, long metadataTypeId, long creatorIdentityId, Set<Long> audienceIds, long limit) {
+
+  public List<String> findMetadataNamesByUserAndQuery(String term,
+                                                      long metadataTypeId,
+                                                      long creatorIdentityId,
+                                                      Set<Long> audienceIds,
+                                                      long limit) {
     TypedQuery<String> query = getEntityManager().createNamedQuery("SocMetadataEntity.findMetadataNameByUserAndQuery",
                                                                    String.class);
     query.setParameter(METADATA_TYPE, metadataTypeId);
@@ -185,7 +190,11 @@ public class MetadataDAO extends GenericDAOJPAImpl<MetadataEntity, Long> {
     }
   }
 
-  public List<Long> getMetadataIdsByProperty(String propertyKey, String propertyValue, long offset, long limit, boolean orderByName) {
+  public List<Long> getMetadataIdsByProperty(String propertyKey,
+                                             String propertyValue,
+                                             long offset,
+                                             long limit,
+                                             boolean orderByName) {
     TypedQuery<Long> query = getEntityManager().createNamedQuery(orderByName ?
                                                                              "SocMetadataEntity.getMetadatasByPropertyOrderByName" :
                                                                              "SocMetadataEntity.getMetadatasByPropertyOrderById",
@@ -199,6 +208,18 @@ public class MetadataDAO extends GenericDAOJPAImpl<MetadataEntity, Long> {
     query.setParameter("propertyName", propertyKey);
     query.setParameter("propertyValue", propertyValue);
     return query.getResultList();
+  }
+
+  public long countMetadataIdsByProperty(String propertyKey, String propertyValue) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("SocMetadataEntity.countMetadataIdsByProperty", Long.class);
+    query.setParameter("propertyName", propertyKey);
+    query.setParameter("propertyValue", propertyValue);
+    try {
+      Long result = query.getSingleResult();
+      return result == null ? 0l : result.longValue();
+    } catch (NoResultException e) {
+      return 0l;
+    }
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataEntity.java
@@ -116,6 +116,15 @@ import jakarta.persistence.Table;
     ORDER BY sm.id DESC
   """
 )
+@NamedQuery(
+  name = "SocMetadataEntity.countMetadataIdsByProperty",
+  query = """
+    SELECT COUNT(sm.id) FROM SocMetadataEntity sm
+    INNER JOIN sm.properties prop
+    ON key(prop) = :propertyName
+    AND value(prop) = :propertyValue
+  """
+)
 public class MetadataEntity implements Serializable {
 
   private static final long   serialVersionUID = -743950558885709009L;

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -576,6 +576,11 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   }
 
   @Override
+  public long countMetadataIdsByProperty(String propertyKey, String propertyValue) {
+    return metadataStorage.countMetadataIdsByProperty(propertyKey, propertyValue);
+  }
+
+  @Override
   public List<Long> getMetadataIdsByProperty(String propertyKey, String propertyValue, long offset, long limit) {
     return metadataStorage.getMetadataIdsByProperty(propertyKey, propertyValue, offset, limit, false);
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
@@ -445,6 +445,11 @@ public class MetadataStorage {
     return metadataDAO.getMetadataIdsByProperty(propertyKey, propertyValue, offset, limit, orderByName);
   }
 
+  public long countMetadataIdsByProperty(String propertyKey,
+                                               String propertyValue) {
+    return metadataDAO.countMetadataIdsByProperty(propertyKey, propertyValue);
+  }
+
   public MetadataType getMetadataType(String name) {
     return metadataTypes.stream()
                         .filter(metadataType -> StringUtils.equals(metadataType.getName(), name))

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
@@ -77,7 +77,7 @@ public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
     assertThrows(ObjectAlreadyExistsException.class, () -> categoryLinkService.link(rootCategory.getId(), object, ROOT_USER));
 
     buildCategoryTree();
-    CategoryFilter filter = new CategoryFilter(0, 0, 1, 0, 1);
+    CategoryFilter filter = new CategoryFilter(0, 0, 1, 0, 1, false);
     CategoryTree categoryTree = categoryService.getCategoryTree(filter, MARY_USER, Locale.FRENCH);
     CategoryTree category = categoryTree.getCategories().get(0);
     category.setLinkPermissionIds(Collections.singletonList(getUsersGroupIdentityId()));

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryServiceTest.java
@@ -63,7 +63,7 @@ public class CategoryServiceTest extends AbstractCategoryConfigurationTest {
     long depth = 1;
     long offset = 0;
     long limit = 1;
-    CategoryFilter filter = new CategoryFilter(ownerId, parentId, depth, offset, limit);
+    CategoryFilter filter = new CategoryFilter(ownerId, parentId, depth, offset, limit, false);
     CategoryTree categoryTree = categoryService.getCategoryTree(filter, MARY_USER, Locale.FRENCH);
     assertNotNull(categoryTree);
     assertNotNull(categoryTree.getCategories());
@@ -71,7 +71,7 @@ public class CategoryServiceTest extends AbstractCategoryConfigurationTest {
     assertEquals(1, categoryTree.getCategories().size());
 
     limit = 10;
-    filter = new CategoryFilter(ownerId, parentId, depth, offset, limit);
+    filter = new CategoryFilter(ownerId, parentId, depth, offset, limit, false);
     categoryTree = categoryService.getCategoryTree(filter, MARY_USER, Locale.FRENCH);
     assertNotNull(categoryTree);
     assertNotNull(categoryTree.getCategories());
@@ -89,7 +89,7 @@ public class CategoryServiceTest extends AbstractCategoryConfigurationTest {
 
     parentId = categoryTree1.getId();
     depth = 10;
-    filter = new CategoryFilter(ownerId, parentId, depth, offset, limit);
+    filter = new CategoryFilter(ownerId, parentId, depth, offset, limit, false);
     categoryTree = categoryService.getCategoryTree(filter, MARY_USER, Locale.FRENCH);
     assertEquals(categoryTree1.getId(), categoryTree.getId());
     assertEquals(categoryTree1.getName(), categoryTree.getName());
@@ -247,7 +247,7 @@ public class CategoryServiceTest extends AbstractCategoryConfigurationTest {
     long depth = 10;
     long offset = 0;
     long limit = 1;
-    CategoryFilter filter = new CategoryFilter(ownerId, parentId, depth, offset, limit);
+    CategoryFilter filter = new CategoryFilter(ownerId, parentId, depth, offset, limit, false);
     CategoryTree categoryTree = categoryService.getCategoryTree(filter, MARY_USER, Locale.FRENCH);
 
     CategoryTree categoryTree13 = categoryTree.getCategories()

--- a/component/core/src/test/java/io/meeds/social/navigation/plugin/SpaceCategorySidebarPluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/navigation/plugin/SpaceCategorySidebarPluginTest.java
@@ -66,7 +66,7 @@ public class SpaceCategorySidebarPluginTest extends AbstractCategoryConfiguratio
     assertFalse(spaceCategorySidebarPlugin.itemExists(item, ROOT_USER));
 
     buildCategoryTree();
-    CategoryFilter filter = new CategoryFilter(0, 0, 5, 0, 2);
+    CategoryFilter filter = new CategoryFilter(0, 0, 5, 0, 2, false);
     CategoryTree categoryTree = categoryService.getCategoryTree(filter, JOHN_USER, Locale.ENGLISH);
     CategoryTree subCategory1 = categoryTree.getCategories().get(0);
     item.setProperties(Collections.singletonMap(SPACE_CATEGORY_ID_PROP_NAME, String.valueOf(subCategory1.getId())));
@@ -82,7 +82,7 @@ public class SpaceCategorySidebarPluginTest extends AbstractCategoryConfiguratio
   @Test
   public void testResolveProperties() {
     buildCategoryTree();
-    CategoryFilter filter = new CategoryFilter(0, 0, 5, 0, 2);
+    CategoryFilter filter = new CategoryFilter(0, 0, 5, 0, 2, false);
     CategoryTree categoryTree = categoryService.getCategoryTree(filter, JOHN_USER, Locale.ENGLISH);
     CategoryTree subCategory1 = categoryTree.getCategories().get(0);
     CategoryTree subCategory2 = categoryTree.getCategories().get(1);

--- a/component/service/src/main/java/io/meeds/social/category/rest/CategoryRest.java
+++ b/component/service/src/main/java/io/meeds/social/category/rest/CategoryRest.java
@@ -79,7 +79,7 @@ public class CategoryRest {
                                       @Parameter(description = "Sub Categories Limit per level")
                                       @RequestParam(name = "limit", required = false, defaultValue = "0")
                                       long limit) {
-    return categoryService.getCategoryTree(new CategoryFilter(ownerId, parentId, depth, offset, limit),
+    return categoryService.getCategoryTree(new CategoryFilter(ownerId, parentId, depth, offset, limit, true),
                                            request.getRemoteUser(),
                                            request.getLocale());
   }

--- a/component/service/src/test/java/io/meeds/social/category/rest/CategoryRestTest.java
+++ b/component/service/src/test/java/io/meeds/social/category/rest/CategoryRestTest.java
@@ -110,7 +110,7 @@ public class CategoryRestTest {
     ResultActions response = mockMvc.perform(get("/categories?ownerId=1&parentId=2&depth=3&offset=4&limit=5")
                                                                                                              .with(testSimpleUser()));
     response.andExpect(status().isOk());
-    verify(categoryService).getCategoryTree(new CategoryFilter(1, 2, 3, 4, 5), SIMPLE_USER, Locale.ENGLISH);
+    verify(categoryService).getCategoryTree(new CategoryFilter(1, 2, 3, 4, 5, true), SIMPLE_USER, Locale.ENGLISH);
   }
 
   @Test

--- a/webapp/src/main/resources/locale/portlet/CategoryManagement_en.properties
+++ b/webapp/src/main/resources/locale/portlet/CategoryManagement_en.properties
@@ -57,3 +57,4 @@ categoryManagement.moveCategoryDrawer.category=Category
 categoryManagement.moveCategoryDrawer.currentPosition=Current Position
 categoryManagement.moveCategoryDrawer.destinationPosition=Destination
 categoryManagement.moveCategoryDrawer.position=Position
+categoryManagement.loadMore=Load more...

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/indexing-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/indexing-configuration.xml
@@ -121,6 +121,21 @@
         </properties-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>CategoryIndexingConnector</name>
+      <set-method>addConnector</set-method>
+      <type>io.meeds.social.category.storage.elasticsearch.CategoryIndexingConnector</type>
+      <description>Category ElasticSearch Indexing Connector</description>
+      <init-params>
+        <properties-param>
+          <name>constructor.params</name>
+          <property name="index_alias" value="category_alias" />
+          <property name="index_previous" value="${meeds.social.index.category.previous:}" />
+          <property name="index_current" value="${meeds.social.index.category.current:category_v1}" />
+          <property name="reindexOnUpgrade" value="${meeds.social.index.category.reindexOnUpgrade:false}" />
+        </properties-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/webapp/src/main/webapp/vue-apps/category-management/components/drawer/CategoryMoveDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/category-management/components/drawer/CategoryMoveDrawer.vue
@@ -33,7 +33,7 @@
     <template v-if="drawer && category" #content>
       <div class="pa-5">
         <div class="mb-2 text-header">{{ $t('categoryManagement.moveCategoryDrawer.category') }}</div>
-        <div class="mb-4 font-weight-bold">{{ category.name }}</div>
+        <div class="mb-4 font-weight-bold text-truncate">{{ category.name }}</div>
         <div class="mb-2 text-header">{{ $t('categoryManagement.moveCategoryDrawer.currentPosition') }}</div>
         <v-card
           class="d-flex flex-wrap mb-4"
@@ -94,34 +94,54 @@
             transition
             dense>
             <template #label="{ item, open, active }">
-              <div v-if="item.id !== category.id" class="d-flex align-center">
-                <v-btn
-                  :disabled="!item.hasSubcategories"
-                  icon>
+              <div v-if="!item.loadMore" class="d-flex align-center">
+                <v-card
+                  color="transparent"
+                  min-width="24"
+                  flat>
                   <v-icon
-                    v-show="item.hasSubcategories"
+                    v-show="!item.limit || item.size"
                     :class="{
                       'fa-rotate-90': open && !$vuetify.rtl,
                       'fa-rotate-270': open && $vuetify.rtl,
                     }"
-                    size="12">
+                    size="16">
                     {{ $root.chevonIcon }}
                   </v-icon>
-                </v-btn>
+                </v-card>
                 <v-card
-                  class="d-flex align-center flex-grow-1"
+                  :title="item.name || ''"
+                  class="d-flex align-center flex-grow-1 flex-shrink-1 overflow-hidden"
                   color="transparent"
                   height="36"
                   flat
                   @keypress.enter="setActive(item)"
                   @click.prevent.stop="setActive(item)">
-                  <v-icon size="16" class="me-1">{{ item.id === $root.categoryRootId && 'fa-home' || item.icon }}</v-icon>
+                  <v-card
+                    class="d-flex align-center justify-center me-2"
+                    color="transparent"
+                    min-width="16"
+                    flat>
+                    <v-icon size="16">{{ item.id === $root.categoryRootId && 'fa-home' || item.icon }}</v-icon>
+                  </v-card>
                   <div
                     :class="active && 'primary--text font-weight-bold'"
                     class="text-truncate">
                     {{ item.id === $root.categoryRootId && $t('categoryManagement.rootName') || item.name }}
                   </div>
                 </v-card>
+              </div>
+              <div v-else class="d-flex align-center">
+                <v-btn
+                  :title="$t('categoryManagement.loadMore')"
+                  :loading="item.loading"
+                  color="transparent"
+                  class="ms-10 px-0"
+                  elevation="0"
+                  link
+                  @click.prevent.stop="$root.loadMore(item.parentId)">
+                  <span class="text-link">{{ $t('categoryManagement.loadMore') }}</span>
+                </v-btn>
               </div>
             </template>
           </v-treeview>
@@ -203,8 +223,7 @@ export default {
       try {
         await this.$categoryService.updateCategory(this.category);
         this.$root.$emit('alert-message', this.$t('categoryManagement.categoryMovedSuccessfully'), 'success');
-        this.$root.$emit('category-updated', this.parent);
-        this.$root.$emit('category-updated', this.destinationParent);
+        this.$root.$emit('category-moved', this.category, this.parent, this.destinationParent);
         this.close();
       } catch (e) {
         this.$root.$emit('alert-message', this.$t('categoryManagement.categoryMovedError'), 'success');
@@ -231,11 +250,10 @@ export default {
       return categories
         .filter(cat => cat?.id && cat?.id !== this.category?.id)
         .map(cat => {
-          const filteredCategories = this.filterTree(cat.categories);
-          if (cat.categories?.length && !filteredCategories?.length) {
-            cat.hasSubcategories = false;
+          cat.categories = this.filterTree(cat.categories);
+          if (cat.limit && !cat.categories?.length && cat.size) {
+            cat.size = 0;
           }
-          cat.categories = filteredCategories;
           return cat;
         });
     },

--- a/webapp/src/main/webapp/vue-apps/category-management/components/list/Tree.vue
+++ b/webapp/src/main/webapp/vue-apps/category-management/components/list/Tree.vue
@@ -51,25 +51,42 @@
         transition
         dense>
         <template #label="{ item, open }">
-          <div class="d-flex align-center">
-            <div class="d-flex me-2">
-              <v-btn
-                :disabled="!item.hasSubcategories"
-                icon>
-                <v-icon
-                  v-show="item.hasSubcategories"
-                  :class="{
-                    'fa-rotate-90': open && !$vuetify.rtl,
-                    'fa-rotate-270': open && $vuetify.rtl,
-                  }"
-                  size="20">
-                  {{ $root.chevonIcon }}
-                </v-icon>
-              </v-btn>
-              <v-icon size="28" class="ms-2 me-1">{{ item.icon }}</v-icon>
-            </div>
+          <div v-if="!item.loadMore" class="d-flex align-center">
+            <v-card
+              color="transparent"
+              min-width="36"
+              flat>
+              <v-icon
+                v-show="!item.limit || item.size"
+                :class="{
+                  'fa-rotate-90': open && !$vuetify.rtl,
+                  'fa-rotate-270': open && $vuetify.rtl,
+                }"
+                size="20">
+                {{ $root.chevonIcon }}
+              </v-icon>
+            </v-card>
+            <v-card
+              class="d-flex align-center justify-center ms-1 me-2"
+              color="transparent"
+              min-width="28"
+              flat>
+              <v-icon size="28">{{ item.icon }}</v-icon>
+            </v-card>
             <div class="text-truncate">{{ item.name }}</div>
             <category-management-item-menu :category="item" />
+          </div>
+          <div v-else class="d-flex align-center">
+            <v-btn
+              :title="$t('categoryManagement.loadMore')"
+              :loading="item.loading"
+              color="transparent"
+              class="ms-10 px-0"
+              elevation="0"
+              link
+              @click.prevent.stop="$root.loadMore(item.parentId)">
+              <span class="text-link">{{ $t('categoryManagement.loadMore') }}</span>
+            </v-btn>
           </div>
           <v-divider :class="$vuetify.rtl && 'r-0' || 'l-0'" class="position-absolute full-width b-0" />
         </template>
@@ -117,15 +134,17 @@ export default {
   },
   created() {
     this.init();
-    this.$root.$on('category-created', this.handleCategoryRefresh);
-    this.$root.$on('category-updated', this.handleCategoryRefresh);
-    this.$root.$on('category-deleted', this.handleCategoryRefresh);
+    this.$root.$on('category-created', this.handleCategoryCreated);
+    this.$root.$on('category-updated', this.handleCategoryUpdated);
+    this.$root.$on('category-deleted', this.handleCategoryDeleted);
+    this.$root.$on('category-moved', this.handleCategoryMoved);
     this.$root.$on('category-delete', this.deleteCategoryConfirm);
   },
   beforeDestroy() {
-    this.$root.$off('category-created', this.handleCategoryRefresh);
-    this.$root.$off('category-updated', this.handleCategoryRefresh);
-    this.$root.$off('category-deleted', this.handleCategoryRefresh);
+    this.$root.$off('category-created', this.handleCategoryCreated);
+    this.$root.$off('category-updated', this.handleCategoryUpdated);
+    this.$root.$off('category-deleted', this.handleCategoryDeleted);
+    this.$root.$off('category-moved', this.handleCategoryMoved);
     this.$root.$off('category-delete', this.deleteCategoryConfirm);
   },
   methods: {
@@ -143,14 +162,53 @@ export default {
     filter(item, search, textKey) {
       return item[textKey].indexOf(search) > -1;
     },
-    async handleCategoryRefresh(item) {
-      const parent = item.parentId && this.$root.getCategory(item.parentId) || item;
-      this.loading = true;
-      try {
-        await this.$root.refreshTree(parent, this.$root.depth - (parent.depth || 0));
-      } finally {
-        this.loading = false;
+    async handleCategoryCreated(item) {
+      const parentCategory = this.$root.getCategory(item.parentId);
+      if (parentCategory) {
+        if (parentCategory.limit) {
+          const category = await this.$categoryService.getCategoryTree({
+            parentId: item.id,
+            depth: 0,
+          });
+          if (!parentCategory.categories?.length) {
+            parentCategory.categories = [category];
+            parentCategory.size = 1;
+          } else {
+            const index = parentCategory.categories.findIndex(cat => category.name.localeCompare(cat.name) <= 0);
+            if (index >= 0) {
+              parentCategory.categories.splice(index, 0, category);
+            } else {
+              parentCategory.categories.push(category);
+            }
+            parentCategory.limit++;
+            parentCategory.size++;
+          }
+        }
       }
+    },
+    async handleCategoryUpdated(item) {
+      item = await this.$categoryService.getCategory(item.id);
+      const category = this.$root.getCategory(item.id);
+      category.name = item.name;
+      category.icon = item.icon;
+      category.linkPermissionIds = item.linkPermissionIds;
+      category.accessPermissionIds = item.accessPermissionIds;
+    },
+    handleCategoryDeleted(item) {
+      const parentCategory = this.$root.getCategory(item.parentId);
+      if (parentCategory.limit && parentCategory.categories?.length) {
+        const index = parentCategory.categories.findIndex(cat => cat.id === item.id);
+        parentCategory.categories.splice(index, 1);
+        parentCategory.limit--;
+        parentCategory.size--;
+      }
+    },
+    handleCategoryMoved(item, fromCategory) {
+      this.handleCategoryDeleted({
+        id: item.id,
+        parentId: fromCategory.id,
+      });
+      this.handleCategoryCreated(item);
     },
     deleteCategoryConfirm(category) {
       this.categoryToDelete = category;
@@ -158,15 +216,18 @@ export default {
         this.$refs.deleteConfirmDialog.open();
       }
     },
-    deleteCategory(category) {
+    async deleteCategory(category) {
       this.loading = true;
-      this.$categoryService.deleteCategory(category.id)
-        .then(() => {
-          this.$root.$emit('category-deleted', category);
-          this.$root.$emit('alert-message', this.$t('categoryManagement.categoryDeletedSuccessfully'), 'success');
-        })
-        .catch(() => this.$root.$emit('alert-message', this.$t('categoryManagement.categoryDeleteError'), 'error'))
-        .finally(() => this.loading = false);
+      try {
+        await this.$categoryService.deleteCategory(category.id);
+        this.$translationService.deleteTranslations('category', category.id);
+        this.$root.$emit('category-deleted', category);
+        this.$root.$emit('alert-message', this.$t('categoryManagement.categoryDeletedSuccessfully'), 'success');
+      } catch (e) {
+        this.$root.$emit('alert-message', this.$t('categoryManagement.categoryDeleteError'), 'error');
+      } finally {
+        this.loading = false;
+      }
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/category-management/main.js
+++ b/webapp/src/main/webapp/vue-apps/category-management/main.js
@@ -42,6 +42,7 @@ export function init() {
         identityIdPerGroup: {},
         groupPerIdentityId: {},
         depth: 4,
+        pageSize: 10,
       },
       computed: {
         isMobile() {
@@ -64,7 +65,6 @@ export function init() {
             if (!cat.categories) {
               cat.categories = [];
             }
-            cat.hasSubcategories = cat?.categories?.length || (!cat.subcategoriesLoaded && cat.depth > (this.depth - 1));
           });
         },
       },
@@ -81,22 +81,21 @@ export function init() {
         },
         async loadChildren(item) {
           const category = this.getCategory(item.id);
-          if (category.depth < (this.depth - 1) || item.subcategoriesLoaded) {
-            return item.categories;
+          if (category.limit) {
+            return category.categories;
           } else {
-            const categoryTree = await this.refreshTree(item, 1);
-            categoryTree.subcategoriesLoaded = true;
-            categoryTree.hasSubcategories = categoryTree?.categories?.length > 0;
-            return categoryTree;
+            return await this.refreshTree(item, 1);
           }
         },
-        async refreshTree(item, depth) {
+        async refreshTree(item, depth, offset, limit) {
           const parentId = item?.id || this.categoryRootId || 0;
           const ownerId = item?.ownerId || this.categoryOwnerId || 0;
           const categoryTree = await this.$categoryService.getCategoryTree({
             parentId,
             ownerId,
             depth,
+            offset: offset || 0,
+            limit: limit || this.pageSize,
           });
           if (!parentId) {
             this.categoryTree = categoryTree;
@@ -106,20 +105,38 @@ export function init() {
             return item;
           }
         },
+        async loadMore(id) {
+          const category = this.getCategory(id);
+          category.loading = true;
+          category.limit += this.pageSize;
+          try {
+            await this.refreshTree(category, Math.max(this.depth - category.depth, 1), 0, category.limit);
+          } finally {
+            category.loading = false;
+          }
+        },
         getCategory(id) {
           if (id === this.categoryTree?.id) {
             return this.categoryTree;
           }
           return this.categories.find(cat => cat.id === id);
         },
-        addSubcategories(item, result, depth) {
+        addSubcategories(item, result, depth, itemIndex) {
           if (!item) {
             return;
           }
+          item.index = itemIndex || 0;
           result.push(item);
           item.depth = depth || 0;
           if (item?.categories) {
-            item.categories.forEach(cat => this.addSubcategories(cat, result, item.depth + 1));
+            item.categories.forEach((cat, index) => this.addSubcategories(cat, result, item.depth + 1, index));
+            if (item.size > item.limit && !item.categories.find(i => i.loadMore)) {
+              item.categories.push({
+                id: item.id + 100000,
+                parentId: item.id,
+                loadMore: true,
+              });
+            }
           }
         },
       },


### PR DESCRIPTION
Prior to this change, the retrieved tree of categories wasn't sorted using the name but id.

This change will use `Elasticsearch` for sorting categories before retrieving it from `database`. When the result retrieved from `Elasticsearch` isn't coherent comparing to `database` data (compared using `count` result), the result is retrieved directly from `database` to ensure to get a coherent result displayed in the UI with a simple sort algorithm on retrieved categories using the `name` field.

In addition, this change will allow to paginate (`Load More`) the categories result allowing to have a better UX and performances while loading a big Tree of categories.