### PR TITLE
fix: Category permission selection altered on initialization - MEED-7990 - Meeds-io/MIPs#170

### DIFF
--- a/webapp/src/main/webapp/vue-apps/category-management/components/form/Permissions.vue
+++ b/webapp/src/main/webapp/vue-apps/category-management/components/form/Permissions.vue
@@ -113,11 +113,9 @@ export default {
     isCustomPermissions: false,
     specificGroupEntries: null,
     permissionIdentityIds: null,
+    initialized: false,
   }),
   computed: {
-    isSpecificGroup() {
-      return !!this.specificGroupEntries?.length;
-    },
     permissions() {
       const permissions = [];
       if (this.isUserPermissions) {
@@ -141,10 +139,14 @@ export default {
   },
   watch: {
     permissions() {
-      this.computePermissionIdentityIds();
+      if (this.initialized) {
+        this.computePermissionIdentityIds();
+      }
     },
     permissionIdentityIds() {
-      this.$emit('input', this.permissionIdentityIds);
+      if (this.initialized) {
+        this.$emit('input', this.permissionIdentityIds);
+      }
     },
   },
   async created() {
@@ -159,10 +161,11 @@ export default {
       && p !== this.$root.usersPermission
       && p !== this.$root.guestsPermission
     ) || null;
-    this.isCustomPermissions = !!specificGroupEntries?.length;
     if (specificGroupEntries?.length) {
-      specificGroupEntries.forEach(this.retrieveObject);
+      await Promise.all(specificGroupEntries.map(this.retrieveObject));
     }
+    this.isCustomPermissions = !!this.specificGroupEntries?.length;
+    this.initialized = true;
   },
   methods: {
     async retrieveObject(groupId) {


### PR DESCRIPTION
Prior to this change, the permissions list is altered when initializing the component so that it seems to not displayed prefiled permission when editing the category again. This change ensures to not trigger the watch directive on attributes only after Vue component initialization phase.