### PR TITLE
fix: Fix Importing default configuration of Sidebar in Empty Server - MEED-7965 - Meeds-io/meeds#2671

### DIFF
--- a/component/api/src/main/java/io/meeds/social/common/ContainerStartupTaskService.java
+++ b/component/api/src/main/java/io/meeds/social/common/ContainerStartupTaskService.java
@@ -1,0 +1,119 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.RootContainer.PortalContainerPostCreateTask;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.servlet.ServletContext;
+import lombok.Synchronized;
+
+/**
+ * A Service used to execute in an async way, server startup Tasks such as
+ * importing default data or configuration
+ */
+@Service
+public class ContainerStartupTaskService {
+
+  private static final String         DEFAULT_TASK_ID = "default";
+
+  private static final Log            LOG             = ExoLogger.getLogger(ContainerStartupTaskService.class);
+
+  @Autowired
+  private PortalContainer             container;
+
+  @Value("${meeds.start.threadCount:5}")
+  private int                         threadCount;
+
+  private ExecutorService             executorService;
+
+  private Map<String, List<Runnable>> tasksById       = new ConcurrentHashMap<>();
+
+  private Map<Runnable, Integer>      tasksOrder      = new ConcurrentHashMap<>();
+
+  @PostConstruct
+  public void init() {
+    executorService = Executors.newFixedThreadPool(threadCount);
+    PortalContainer.addInitTask(container.getPortalContext(), new PortalContainerPostCreateTask() {
+      @Override
+      public void execute(ServletContext context, PortalContainer portalContainer) {
+        CompletableFuture.runAsync(ContainerStartupTaskService.this::start);
+      }
+    });
+  }
+
+  public void start() {
+    tasksById.entrySet()
+             .parallelStream()
+             .forEach(entry -> entry.getValue()
+                                    .stream()
+                                    .sorted((t1, t2) -> tasksOrder.getOrDefault(t1, Integer.MAX_VALUE) -
+                                        tasksOrder.getOrDefault(t2, Integer.MAX_VALUE))
+                                    .forEachOrdered(r -> {
+                                      try {
+                                        Future<?> future = executorService.submit(r);
+                                        future.get();
+                                      } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                      } catch (Exception e) {
+                                        LOG.warn("Error while executing an asynchronous startup task ", e);
+                                      }
+                                    }));
+    tasksById.clear();
+    tasksOrder.clear();
+  }
+
+  public void addTask(Runnable task) {
+    addTask(DEFAULT_TASK_ID, task, Integer.MAX_VALUE);
+  }
+
+  public void addTask(Runnable task, int index) {
+    addTask(DEFAULT_TASK_ID, task, index);
+  }
+
+  @Synchronized
+  public void addTask(String id, Runnable task, int index) {
+    tasksById.computeIfAbsent(id, k -> Collections.synchronizedList(new ArrayList<>())).add(task);
+    tasksOrder.put(task, index);
+  }
+
+  @PreDestroy
+  public void stop() {
+    executorService.shutdown();
+  }
+
+}

--- a/component/api/src/main/java/org/exoplatform/social/common/lifecycle/AbstractLifeCycle.java
+++ b/component/api/src/main/java/org/exoplatform/social/common/lifecycle/AbstractLifeCycle.java
@@ -18,7 +18,6 @@ package org.exoplatform.social.common.lifecycle;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
@@ -72,18 +71,16 @@ public abstract class AbstractLifeCycle<T extends LifeCycleListener<E>, E extend
     for (final T listener : listeners) {
       try {
         if (completionService.isAsync() || listener.getClass().isAnnotationPresent(Asynchronous.class)) {
-          completionService.addTask(new Callable<E>() {
-            public E call() throws Exception {
-              begin();
-              try {
-                dispatchEvent(listener, event);
-              } catch (Exception e) {
-                LOG.warn("Error dispatching event", e);
-              } finally {
-                end();
-              }
-              return event;
+          completionService.addTask(() -> {
+            begin();
+            try {
+              dispatchEvent(listener, event);
+            } catch (Exception e) {
+              LOG.warn("Error dispatching event", e);
+            } finally {
+              end();
             }
+            return event;
           });
         } else {
           dispatchEvent(listener, event);

--- a/component/core/src/main/java/io/meeds/social/navigation/service/NavigationConfigurationImportService.java
+++ b/component/core/src/main/java/io/meeds/social/navigation/service/NavigationConfigurationImportService.java
@@ -28,7 +28,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
 import io.meeds.common.ContainerTransactional;
+import io.meeds.social.common.ContainerStartupTaskService;
 import io.meeds.social.navigation.constant.SidebarMode;
 import io.meeds.social.navigation.model.NavigationConfiguration;
 import io.meeds.social.navigation.model.SidebarConfiguration;
@@ -42,10 +46,16 @@ import jakarta.annotation.PostConstruct;
  * A Service to inject Default Left Menu configuration on server startup
  */
 @Component
-public class NavigationConfigurationInitService {
+public class NavigationConfigurationImportService {
+
+  private static final Log               LOG =
+                                             ExoLogger.getLogger(NavigationConfigurationImportService.class);
 
   @Autowired
   private NavigationConfigurationService navigationConfigurationService;
+
+  @Autowired
+  private ContainerStartupTaskService    containerStartupTaskService;
 
   @Autowired
   private List<SidebarPlugin>            menuPlugins;
@@ -69,10 +79,17 @@ public class NavigationConfigurationInitService {
   private SidebarMode                    defaultMode;
 
   @PostConstruct
-  @ContainerTransactional
   public void init() {
+    containerStartupTaskService.addTask(this::importDefaultNavigationConfiguration, 10);
+  }
+
+  @ContainerTransactional
+  public void importDefaultNavigationConfiguration() {
     if (forceUpdate || navigationConfigurationService.getConfiguration() == null) {
+      long start = System.currentTimeMillis();
+      LOG.info("Importing Default Navigation Configuration");
       navigationConfigurationService.updateConfiguration(buildDefaultNavigationConfiguration());
+      LOG.info("Navigation Configuration imported successfully in {}ms", System.currentTimeMillis() - start);
     }
   }
 

--- a/component/core/src/main/java/io/meeds/social/space/template/service/injection/SpaceTemplateImportService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/injection/SpaceTemplateImportService.java
@@ -28,14 +28,11 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.api.settings.SettingService;
@@ -54,6 +51,7 @@ import org.exoplatform.social.attachment.model.UploadedAttachmentDetail;
 import org.exoplatform.upload.UploadResource;
 
 import io.meeds.common.ContainerTransactional;
+import io.meeds.social.common.ContainerStartupTaskService;
 import io.meeds.social.space.constant.SpaceRegistration;
 import io.meeds.social.space.constant.SpaceVisibility;
 import io.meeds.social.space.template.model.SpaceTemplate;
@@ -68,7 +66,6 @@ import jakarta.annotation.PostConstruct;
 import lombok.SneakyThrows;
 
 @Component
-@Order(Ordered.LOWEST_PRECEDENCE)
 public class SpaceTemplateImportService {
 
   private static final Scope                    SPACE_TEMPLATE_IMPORT_SCOPE = Scope.APPLICATION.id("SPACE_TEMPLATE_IMPORT");
@@ -92,6 +89,9 @@ public class SpaceTemplateImportService {
   private SpaceTemplateStorage                  spaceTemplateStorage;
 
   @Autowired
+  private ContainerStartupTaskService           containerStartupTaskService;
+
+  @Autowired
   private SettingService                        settingService;
 
   @Autowired
@@ -105,7 +105,7 @@ public class SpaceTemplateImportService {
 
   @PostConstruct
   public void init() {
-    CompletableFuture.runAsync(this::importSpaceTemplates);
+    containerStartupTaskService.addTask(this::importSpaceTemplates, 0);
   }
 
   @ContainerTransactional

--- a/component/core/src/test/java/io/meeds/social/AbstractSpringConfigurationTest.java
+++ b/component/core/src/test/java/io/meeds/social/AbstractSpringConfigurationTest.java
@@ -31,6 +31,7 @@ import org.exoplatform.social.core.jpa.test.AbstractCoreTest;
 import io.meeds.spring.AvailableIntegration;
 
 @SpringBootApplication(scanBasePackages = {
+  "io.meeds.social.common",
   "io.meeds.social.navigation",
   "io.meeds.social.category",
   "io.meeds.social.space.category",

--- a/component/core/src/test/java/io/meeds/social/navigation/AbstractNavigationConfigurationTest.java
+++ b/component/core/src/test/java/io/meeds/social/navigation/AbstractNavigationConfigurationTest.java
@@ -34,6 +34,7 @@ import io.meeds.social.navigation.plugin.PageSidebarPlugin;
 import io.meeds.social.navigation.plugin.SiteSidebarPlugin;
 import io.meeds.social.navigation.plugin.SpaceListSidebarPlugin;
 import io.meeds.social.navigation.plugin.SpaceTemplateSidebarPlugin;
+import io.meeds.social.navigation.service.NavigationConfigurationImportService;
 import io.meeds.social.navigation.service.NavigationConfigurationService;
 import io.meeds.social.space.template.entity.SpaceTemplateEntity;
 import io.meeds.social.space.template.model.SpaceTemplate;
@@ -45,46 +46,49 @@ import lombok.SneakyThrows;
 
 public abstract class AbstractNavigationConfigurationTest extends AbstractSpringConfigurationTest {
 
-  public static final String               MODULE_NAME      = "io.meeds.social.navigation";
+  public static final String                     MODULE_NAME      = "io.meeds.social.navigation";
 
-  protected static final String            SITE_NAME        = "contribute";
+  protected static final String                  SITE_NAME        = "contribute";
 
-  private SpaceTemplateDAO                 spaceTemplateDao = new SpaceTemplateDAO();
-
-  @Autowired
-  protected LayoutService                  layoutService;
+  private SpaceTemplateDAO                       spaceTemplateDao = new SpaceTemplateDAO();
 
   @Autowired
-  protected NavigationService              navigationService;
+  protected LayoutService                        layoutService;
 
   @Autowired
-  protected SpaceTemplateService           spaceTemplateService;
+  protected NavigationService                    navigationService;
 
   @Autowired
-  protected SpaceTemplateStorage           spaceTemplateStorage;
+  protected SpaceTemplateService                 spaceTemplateService;
 
   @Autowired
-  protected UserACL                        userAcl;
+  protected SpaceTemplateStorage                 spaceTemplateStorage;
 
   @Autowired
-  protected LinkSidebarPlugin              linkSidebarPlugin;
+  protected UserACL                              userAcl;
 
   @Autowired
-  protected PageSidebarPlugin              pageSidebarPlugin;
+  protected LinkSidebarPlugin                    linkSidebarPlugin;
 
   @Autowired
-  protected SiteSidebarPlugin              siteSidebarPlugin;
+  protected PageSidebarPlugin                    pageSidebarPlugin;
 
   @Autowired
-  protected SpaceListSidebarPlugin         spaceListSidebarPlugin;
+  protected SiteSidebarPlugin                    siteSidebarPlugin;
 
   @Autowired
-  protected SpaceTemplateSidebarPlugin     spaceTemplateSidebarPlugin;
+  protected SpaceListSidebarPlugin               spaceListSidebarPlugin;
 
   @Autowired
-  protected NavigationConfigurationService navigationConfigurationService;
+  protected SpaceTemplateSidebarPlugin           spaceTemplateSidebarPlugin;
 
-  protected SpaceTemplate                  spaceTemplate;
+  @Autowired
+  protected NavigationConfigurationService       navigationConfigurationService;
+
+  @Autowired
+  protected NavigationConfigurationImportService navigationConfigurationImportService;
+
+  protected SpaceTemplate                        spaceTemplate;
 
   protected AbstractNavigationConfigurationTest() {
     AbstractSpringTest.setTestClass(this.getClass());
@@ -94,6 +98,7 @@ public abstract class AbstractNavigationConfigurationTest extends AbstractSpring
   public void beforeEach() throws Exception {
     setUp();
     begin();
+    navigationConfigurationImportService.importDefaultNavigationConfiguration();
   }
 
   @After


### PR DESCRIPTION
Prior to this change, when starting a fresh server, two parallel thread was executed to import `1.SpaceTemplates` and `2.SidebarNavigationConfiguration` while the Sidebar default configuration depends on builtin Space Templates. This change introduces a new Service (`ContainerStartupTaskService`) which will execute **parallel tasks in startup** phase with the ability to **sequence some of them** by a unique identifier of the **execution chain**. This strategy has been used only for Space Templates and Side bar configuration importing for now, but should be generalized when there is a dependency between services in startup phase.