### PR TITLE
fix: Fix Space Favorite Status Update from sidebar - MEED-7880 - Meeds-io/meeds#2645

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
@@ -99,7 +99,9 @@
           :is-favorite="isFavorite"
           :space-id="spaceId"
           entity-type="spaces_left_navigation"
-          class="me-2" />
+          class="me-2"
+          @removed="space.isFavorite = 'false'"
+          @added="space.isFavorite = 'true'" />
         <extension-registry-components
           :params="params"
           name="SpacePopover"


### PR DESCRIPTION
Prior to this change, when setting the space as favorite, its status isn't updated in orginal object, thus the status will not be always the same when opened again. This change ensures to update the favorite status right after confirming the favorite option update.