### PR TITLE
fix: Fix Importing default configuration of Sidebar in Empty Server - MEED-7965 - Meeds-io/meeds#2671

### DIFF
--- a/component/api/src/main/java/io/meeds/social/common/ContainerStartableService.java
+++ b/component/api/src/main/java/io/meeds/social/common/ContainerStartableService.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.common;
+
+public interface ContainerStartableService {
+
+  String DEFAULT_TASK_ID = "default";
+
+  void start();
+
+  int getOrder();
+
+  default String getId() {
+    return DEFAULT_TASK_ID;
+  }
+
+}

--- a/component/api/src/main/java/io/meeds/social/common/ContainerStartupTaskService.java
+++ b/component/api/src/main/java/io/meeds/social/common/ContainerStartupTaskService.java
@@ -1,0 +1,133 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.RootContainer.PortalContainerPostCreateTask;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.servlet.ServletContext;
+import lombok.Synchronized;
+
+/**
+ * A Service used to execute in an async way, server startup Tasks such as
+ * importing default data or configuration
+ */
+@Service
+public class ContainerStartupTaskService implements ApplicationContextAware {
+
+  private static final Log            LOG       = ExoLogger.getLogger(ContainerStartupTaskService.class);
+
+  @Autowired
+  private PortalContainer             container;
+
+  private ApplicationContext          applicationContext;
+
+  @Value("${meeds.startup.threadCount:5}")
+  private int                         threadCount;
+
+  private ExecutorService             executorService;
+
+  private Map<String, List<Runnable>> tasksById = new ConcurrentHashMap<>();
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+  }
+
+  @PostConstruct
+  public void init() {
+    List<ContainerStartableService> serviceList = applicationContext.getBeansOfType(ContainerStartableService.class)
+                                                                    .values()
+                                                                    .stream()
+                                                                    .sorted((a,
+                                                                             b) -> (a.getOrder() - b.getOrder()))
+                                                                    .toList();
+    serviceList.forEach(s -> addTask(s.getId(), s::start));
+
+    LOG.info("Run {} startup Tasks in asynchronous threads", serviceList.size());
+    this.executorService = Executors.newVirtualThreadPerTaskExecutor();
+    if (container.isStarted()) {
+      CompletableFuture.runAsync(ContainerStartupTaskService.this::start, executorService);
+    } else {
+      PortalContainer.addInitTask(container.getPortalContext(), new PortalContainerPostCreateTask() {
+        @Override
+        public void execute(ServletContext context, PortalContainer portalContainer) {
+          CompletableFuture.runAsync(ContainerStartupTaskService.this::start, executorService);
+        }
+      });
+    }
+  }
+
+  public void start() {
+    LOG.info("Run startup Tasks in dedicated threads");
+    long start = System.currentTimeMillis();
+    tasksById.entrySet()
+             .parallelStream()
+             .forEach(entry -> entry.getValue()
+                                    .stream()
+                                    .forEachOrdered(r -> {
+                                      long startup = System.currentTimeMillis();
+                                      LOG.info("Startup Asynchronous Task with chain id {}", entry.getKey());
+                                      try {
+                                        Future<?> future = executorService.submit(r);
+                                        future.get();
+                                      } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                      } catch (Exception e) {
+                                        LOG.warn("Error while executing an asynchronous startup task ", e);
+                                      }
+                                      LOG.info("Asynchronous Task with chain id {} finished within {}ms",
+                                               entry.getKey(),
+                                               System.currentTimeMillis() - startup);
+                                    }));
+    LOG.info("Startup Tasks finished within {}ms", System.currentTimeMillis() - start);
+    tasksById.clear();
+  }
+
+  @Synchronized
+  public void addTask(String id, Runnable task) {
+    tasksById.computeIfAbsent(id, k -> Collections.synchronizedList(new ArrayList<>())).add(task);
+  }
+
+  @PreDestroy
+  public void stop() {
+    executorService.shutdown();
+  }
+
+}

--- a/component/api/src/main/java/org/exoplatform/social/common/lifecycle/AbstractLifeCycle.java
+++ b/component/api/src/main/java/org/exoplatform/social/common/lifecycle/AbstractLifeCycle.java
@@ -18,7 +18,6 @@ package org.exoplatform.social.common.lifecycle;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
@@ -72,18 +71,16 @@ public abstract class AbstractLifeCycle<T extends LifeCycleListener<E>, E extend
     for (final T listener : listeners) {
       try {
         if (completionService.isAsync() || listener.getClass().isAnnotationPresent(Asynchronous.class)) {
-          completionService.addTask(new Callable<E>() {
-            public E call() throws Exception {
-              begin();
-              try {
-                dispatchEvent(listener, event);
-              } catch (Exception e) {
-                LOG.warn("Error dispatching event", e);
-              } finally {
-                end();
-              }
-              return event;
+          completionService.addTask(() -> {
+            begin();
+            try {
+              dispatchEvent(listener, event);
+            } catch (Exception e) {
+              LOG.warn("Error dispatching event", e);
+            } finally {
+              end();
             }
+            return event;
           });
         } else {
           dispatchEvent(listener, event);

--- a/component/core/src/main/java/io/meeds/social/navigation/service/NavigationConfigurationImportService.java
+++ b/component/core/src/main/java/io/meeds/social/navigation/service/NavigationConfigurationImportService.java
@@ -28,7 +28,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
 import io.meeds.common.ContainerTransactional;
+import io.meeds.social.common.ContainerStartableService;
 import io.meeds.social.navigation.constant.SidebarMode;
 import io.meeds.social.navigation.model.NavigationConfiguration;
 import io.meeds.social.navigation.model.SidebarConfiguration;
@@ -36,13 +40,14 @@ import io.meeds.social.navigation.model.SidebarItem;
 import io.meeds.social.navigation.model.TopbarConfiguration;
 import io.meeds.social.navigation.plugin.SidebarPlugin;
 
-import jakarta.annotation.PostConstruct;
-
 /**
  * A Service to inject Default Left Menu configuration on server startup
  */
 @Component
-public class NavigationConfigurationInitService {
+public class NavigationConfigurationImportService implements ContainerStartableService {
+
+  private static final Log               LOG =
+                                             ExoLogger.getLogger(NavigationConfigurationImportService.class);
 
   @Autowired
   private NavigationConfigurationService navigationConfigurationService;
@@ -68,11 +73,19 @@ public class NavigationConfigurationInitService {
   @Value("${navigation.configuration.defaultMode:ICON}")
   private SidebarMode                    defaultMode;
 
-  @PostConstruct
+  @Override
+  public int getOrder() {
+    return 20;
+  }
+
+  @Override
   @ContainerTransactional
-  public void init() {
+  public void start() {
     if (forceUpdate || navigationConfigurationService.getConfiguration() == null) {
+      long start = System.currentTimeMillis();
+      LOG.info("Importing Default Navigation Configuration");
       navigationConfigurationService.updateConfiguration(buildDefaultNavigationConfiguration());
+      LOG.info("Navigation Configuration imported successfully in {}ms", System.currentTimeMillis() - start);
     }
   }
 

--- a/component/core/src/main/java/io/meeds/social/space/template/service/injection/SpaceTemplateImportService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/injection/SpaceTemplateImportService.java
@@ -28,14 +28,11 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.api.settings.SettingService;
@@ -54,6 +51,7 @@ import org.exoplatform.social.attachment.model.UploadedAttachmentDetail;
 import org.exoplatform.upload.UploadResource;
 
 import io.meeds.common.ContainerTransactional;
+import io.meeds.social.common.ContainerStartableService;
 import io.meeds.social.space.constant.SpaceRegistration;
 import io.meeds.social.space.constant.SpaceVisibility;
 import io.meeds.social.space.template.model.SpaceTemplate;
@@ -64,12 +62,10 @@ import io.meeds.social.space.template.service.injection.model.SpaceTemplateDescr
 import io.meeds.social.space.template.storage.SpaceTemplateStorage;
 import io.meeds.social.util.JsonUtils;
 
-import jakarta.annotation.PostConstruct;
 import lombok.SneakyThrows;
 
 @Component
-@Order(Ordered.LOWEST_PRECEDENCE)
-public class SpaceTemplateImportService {
+public class SpaceTemplateImportService implements ContainerStartableService {
 
   private static final Scope                    SPACE_TEMPLATE_IMPORT_SCOPE = Scope.APPLICATION.id("SPACE_TEMPLATE_IMPORT");
 
@@ -103,13 +99,14 @@ public class SpaceTemplateImportService {
   @Value("${meeds.space.template.import.version:2}")
   private long                                  version;
 
-  @PostConstruct
-  public void init() {
-    CompletableFuture.runAsync(this::importSpaceTemplates);
+  @Override
+  public int getOrder() {
+    return 10;
   }
 
+  @Override
   @ContainerTransactional
-  public void importSpaceTemplates() {
+  public void start() {
     LOG.info("Importing Space Templates");
     if (!forceReimportTemplates
         && getSettingValue(SPACE_TEMPLATE_VERSION) != version) {

--- a/component/core/src/test/java/io/meeds/social/navigation/AbstractNavigationConfigurationTest.java
+++ b/component/core/src/test/java/io/meeds/social/navigation/AbstractNavigationConfigurationTest.java
@@ -41,6 +41,7 @@ import io.meeds.social.navigation.plugin.PageSidebarPlugin;
 import io.meeds.social.navigation.plugin.SiteSidebarPlugin;
 import io.meeds.social.navigation.plugin.SpaceListSidebarPlugin;
 import io.meeds.social.navigation.plugin.SpaceTemplateSidebarPlugin;
+import io.meeds.social.navigation.service.NavigationConfigurationImportService;
 import io.meeds.social.navigation.service.NavigationConfigurationService;
 import io.meeds.social.space.template.entity.SpaceTemplateEntity;
 import io.meeds.social.space.template.model.SpaceTemplate;
@@ -53,6 +54,7 @@ import lombok.SneakyThrows;
 
 @SpringBootApplication(scanBasePackages = {
   AbstractNavigationConfigurationTest.MODULE_NAME,
+  "io.meeds.social.common", // TODO to delete once MIP-170 merged
   AvailableIntegration.KERNEL_TEST_MODULE,
   AvailableIntegration.JPA_MODULE,
 }, exclude = {
@@ -68,46 +70,49 @@ import lombok.SneakyThrows;
 @RunWith(SpringRunner.class)
 public abstract class AbstractNavigationConfigurationTest extends AbstractCoreTest {
 
-  public static final String               MODULE_NAME      = "io.meeds.social.navigation";
+  public static final String                     MODULE_NAME      = "io.meeds.social.navigation";
 
-  protected static final String            SITE_NAME        = "contribute";
+  protected static final String                  SITE_NAME        = "contribute";
 
-  private SpaceTemplateDAO                 spaceTemplateDao = new SpaceTemplateDAO();
-
-  @Autowired
-  protected LayoutService                  layoutService;
+  private SpaceTemplateDAO                       spaceTemplateDao = new SpaceTemplateDAO();
 
   @Autowired
-  protected NavigationService              navigationService;
+  protected LayoutService                        layoutService;
 
   @Autowired
-  protected SpaceTemplateService           spaceTemplateService;
+  protected NavigationService                    navigationService;
 
   @Autowired
-  protected SpaceTemplateStorage           spaceTemplateStorage;
+  protected SpaceTemplateService                 spaceTemplateService;
 
   @Autowired
-  protected UserACL                        userAcl;
+  protected SpaceTemplateStorage                 spaceTemplateStorage;
 
   @Autowired
-  protected LinkSidebarPlugin              linkSidebarPlugin;
+  protected UserACL                              userAcl;
 
   @Autowired
-  protected PageSidebarPlugin              pageSidebarPlugin;
+  protected LinkSidebarPlugin                    linkSidebarPlugin;
 
   @Autowired
-  protected SiteSidebarPlugin              siteSidebarPlugin;
+  protected PageSidebarPlugin                    pageSidebarPlugin;
 
   @Autowired
-  protected SpaceListSidebarPlugin         spaceListSidebarPlugin;
+  protected SiteSidebarPlugin                    siteSidebarPlugin;
 
   @Autowired
-  protected SpaceTemplateSidebarPlugin     spaceTemplateSidebarPlugin;
+  protected SpaceListSidebarPlugin               spaceListSidebarPlugin;
 
   @Autowired
-  protected NavigationConfigurationService navigationConfigurationService;
+  protected SpaceTemplateSidebarPlugin           spaceTemplateSidebarPlugin;
 
-  protected SpaceTemplate                  spaceTemplate;
+  @Autowired
+  protected NavigationConfigurationService       navigationConfigurationService;
+
+  @Autowired
+  protected NavigationConfigurationImportService navigationConfigurationImportService;
+
+  protected SpaceTemplate                        spaceTemplate;
 
   public AbstractNavigationConfigurationTest() {
     AbstractSpringTest.setTestClass(this.getClass());
@@ -117,6 +122,7 @@ public abstract class AbstractNavigationConfigurationTest extends AbstractCoreTe
   public void beforeEach() throws Exception {
     setUp();
     begin();
+    navigationConfigurationImportService.start();
   }
 
   @After


### PR DESCRIPTION
Prior to this change, when starting a fresh server, two parallel thread was executed to import `1.SpaceTemplates` and
`2.SidebarNavigationConfiguration` while the Sidebar default configuration depends on builtin Space Templates. This change introduces a new Service (`ContainerStartupTaskService`) which will execute **parallel tasks in startup** phase with the ability to **sequence some of them** by a unique identifier of the **execution chain**. This strategy has been used only for Space Templates and Side bar configuration importing for now, but should be generalized when there is a dependency between services in startup phase.

Resolves https://github.com/Meeds-io/meeds/issues/2671