### PR TITLE
feat: Improve Profile Settings Performances - MEED-8012 - Meeds-io/meeds#2661

### DIFF
--- a/component/core/src/main/java/io/meeds/social/core/profileproperty/storage/CachedProfileSettingStorage.java
+++ b/component/core/src/main/java/io/meeds/social/core/profileproperty/storage/CachedProfileSettingStorage.java
@@ -1,0 +1,105 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.core.profileproperty.storage;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import org.exoplatform.commons.cache.future.FutureCache;
+import org.exoplatform.commons.cache.future.FutureExoCache;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+import org.exoplatform.social.core.jpa.storage.dao.jpa.ProfilePropertySettingDAO;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
+import org.exoplatform.social.core.profileproperty.storage.ProfileSettingStorage;
+
+public class CachedProfileSettingStorage extends ProfileSettingStorage {
+
+  private ExoCache<Long, ProfilePropertySetting>            cache;
+
+  private FutureCache<Long, ProfilePropertySetting, Object> futureCache;
+
+  private ExoCache<String, Long>                            idByNameCache;
+
+  private FutureCache<String, Long, Object>                 idByNameFutureCache;
+
+  private List<Long>                                        profileSettingIds;
+
+  public CachedProfileSettingStorage(CacheService cacheService,
+                                     ProfilePropertySettingDAO profilePropertySettingDAO) {
+    super(profilePropertySettingDAO);
+    cache = cacheService.getCacheInstance("social.profileSettings");
+    idByNameCache = cacheService.getCacheInstance("social.profileSettingIdsByName");
+    futureCache = new FutureExoCache<>((c, id) -> super.getProfileSettingById(id), cache);
+    idByNameFutureCache = new FutureExoCache<>((c, name) -> {
+      ProfilePropertySetting s = super.findProfileSettingByName(name);
+      return s == null ? 0l : s.getId();
+    }, idByNameCache);
+  }
+
+  @Override
+  public List<ProfilePropertySetting> getPropertySettings() {
+    if (profileSettingIds == null) {
+      List<ProfilePropertySetting> propertySettings = super.getPropertySettings();
+      profileSettingIds = CollectionUtils.isEmpty(propertySettings) ? Collections.emptyList() :
+                                                                    propertySettings.stream()
+                                                                                    .map(ProfilePropertySetting::getId)
+                                                                                    .toList();
+    }
+    return profileSettingIds.stream().map(this::getProfileSettingById).toList();
+  }
+
+  @Override
+  public ProfilePropertySetting findProfileSettingByName(String name) {
+    long id = idByNameFutureCache.get(null, name);
+    return id == 0l ? null : getProfileSettingById(id);
+  }
+
+  @Override
+  public ProfilePropertySetting getProfileSettingById(Long id) {
+    return futureCache.get(null, id);
+  }
+
+  @Override
+  public ProfilePropertySetting saveProfilePropertySetting(ProfilePropertySetting profilePropertySetting, boolean isNew) {
+    try {
+      return super.saveProfilePropertySetting(profilePropertySetting, isNew);
+    } finally {
+      clearCaches();
+    }
+  }
+
+  @Override
+  public void deleteProfilePropertySetting(Long id) {
+    try {
+      super.deleteProfilePropertySetting(id);
+    } finally {
+      clearCaches();
+    }
+  }
+
+  public void clearCaches() {
+    profileSettingIds = null;
+    cache.clearCache();
+    idByNameCache.clearCache();
+  }
+
+}

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
@@ -111,4 +111,5 @@ public class ProfileSettingStorage {
   public boolean hasChildProperties(Long parentId) {
     return !profilePropertySettingDAO.findChildProperties(parentId).isEmpty();
   }
+
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnectorTest.java
@@ -19,6 +19,8 @@ import org.exoplatform.social.core.manager.IdentityManagerImpl;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.test.AbstractCoreTest;
 
+import io.meeds.social.core.profileproperty.storage.CachedProfileSettingStorage;
+
 @RunWith(MockitoJUnitRunner.class)
 public class ProfileIndexingServiceConnectorTest extends AbstractCoreTest {
 
@@ -42,6 +44,8 @@ public class ProfileIndexingServiceConnectorTest extends AbstractCoreTest {
     super.setUp();
     identityManager = getService(IdentityManagerImpl.class);
     profilePropertyService = getService(ProfilePropertyService.class);
+    getService(CachedProfileSettingStorage.class).clearCaches();
+
     InitParams initParams = new InitParams();
     PropertiesParam params = new PropertiesParam();
     params.setName("constructor.params");

--- a/component/core/src/test/java/org/exoplatform/social/core/profile/ProfilePropertyServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/profile/ProfilePropertyServiceTest.java
@@ -30,6 +30,8 @@ import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.test.AbstractCoreTest;
 
+import io.meeds.social.core.profileproperty.storage.CachedProfileSettingStorage;
+
 public class ProfilePropertyServiceTest extends AbstractCoreTest {
 
   private ProfilePropertyService    profilePropertyService;
@@ -41,6 +43,7 @@ public class ProfilePropertyServiceTest extends AbstractCoreTest {
     super.setUp();
     profilePropertyService = getContainer().getComponentInstanceOfType(ProfilePropertyService.class);
     profilePropertySettingDAO = getContainer().getComponentInstanceOfType(ProfilePropertySettingDAO.class);
+    getService(CachedProfileSettingStorage.class).clearCaches();
   }
 
   @Override

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -375,8 +375,10 @@
   </component>
 
   <component>
-    <type>org.exoplatform.social.core.profileproperty.storage.ProfileSettingStorage</type>
+    <key>org.exoplatform.social.core.profileproperty.storage.ProfileSettingStorage</key>
+    <type>io.meeds.social.core.profileproperty.storage.CachedProfileSettingStorage</type>
   </component>
+
   <component>
     <type>org.exoplatform.social.core.profilelabel.storage.ProfileLabelStorage</type>
   </component>

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -184,7 +184,8 @@
     </component>
 
     <component>
-        <type>org.exoplatform.social.core.profileproperty.storage.ProfileSettingStorage</type>
+      <key>org.exoplatform.social.core.profileproperty.storage.ProfileSettingStorage</key>
+      <type>io.meeds.social.core.profileproperty.storage.CachedProfileSettingStorage</type>
     </component>
 
     <component>


### PR DESCRIPTION
This change will introduce a cache on a highly solicited entity, Profile settings. In fact, such an entity is requested each time a user profile is requested in front end or even in batch calls. This change will introduce three caches:
- A cache of ProfilePropertySetting by id
- A cache of Id by Name
- A single list of all Ids .

Resolves Meeds-io/meeds#2661