### PR TITLE
fix: URL having Anchor element isn't displaying as expected - EXO-73493 - Meeds-io/meeds#2665.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -33,7 +33,6 @@ export default {
     loaded: false,
     canPostInitialized: false,
     spaceId: eXo.env.portal.spaceId,
-    forceReload: false,
     hasActivities: false,
     activityId: null,
     activityTypes: {},
@@ -79,16 +78,31 @@ export default {
       }
     }
     this.displayActivityDetail(this.$root.selectedActivityId, this.$root.selectedCommentId);
+    window.addEventListener('load', () => {
+      const urlHash = window.location.hash;
+      if (urlHash) {
+        const elementId = urlHash.substring(1);
+        const targetElement = document.getElementById(elementId);
+        if (targetElement) {
+          targetElement.scrollIntoView({behavior: 'smooth'});
+        }
+      }
+    });
   },
   methods: {
     displayActivityDetail(activityId, commentId) {
       this.loaded = false;
       this.$root.selectedActivityId = this.activityId = activityId;
-      this.$root.selectedCommentId = window.location.hash.replace('#comment-reply-', '').replace('#comment-reply', '').replace('#comment-', '');
-      if (commentId && !this.$root.selectedCommentId) {
-        this.$root.selectedCommentId = commentId;
-        window.history.replaceState('', window.document.title, `${window.location.pathname}?id=${activityId}#comment-${commentId}`);
-        this.forceReload = true;
+      const urlHash = window.location.hash;
+      if (urlHash.includes('#comment')){
+        this.$root.selectedCommentId = window.location.hash.replace('#comment-reply-', '').replace('#comment-reply', '').replace('#comment-', '');
+        if (commentId && !this.$root.selectedCommentId) {
+          this.$root.selectedCommentId = commentId;
+          window.history.replaceState('', window.document.title, `${window.location.pathname}?id=${activityId}#comment-${commentId}`);
+        }
+      } else {
+        this.$root.selectedCommentId = '';
+        window.history.replaceState('', '', `${window.location.pathname}?id=${activityId}${urlHash}`);
       }
       this.$nextTick().then(() => this.loaded = true);
     },


### PR DESCRIPTION
Before this change, on Activity stream, click on news URL having anchors, news displayed having comment drawer opened. To resolve this problem, add a condition before opening the comments drawer if the hash is not an id of the comment add the id of the hash in the URL without opening it from the drawer. After this change, the news is displayed focusing on anchor without opening the comments.