### PR TITLE
feat: Display Empty Spaces List when no access permission to filtered categories - MEED-8053 - Meeds-io/meeds#2726

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/SpaceFilter.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/SpaceFilter.java
@@ -55,6 +55,9 @@ public class SpaceFilter implements Cloneable {
 
   private List<Long>            categoryIds;
 
+public List<Long> getCategoryIds() {
+  return categoryIds;
+}
   private List<Long>            managingTemplateIds;
 
   private SpaceMembershipStatus status;

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRest.java
@@ -49,6 +49,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -94,6 +95,7 @@ import org.exoplatform.web.login.recovery.PasswordRecoveryService;
 
 import io.meeds.portal.security.constant.UserRegistrationType;
 import io.meeds.portal.security.service.SecuritySettingService;
+import io.meeds.social.category.service.CategoryService;
 import io.meeds.social.space.constant.SpaceRegistration;
 import io.meeds.social.space.constant.SpaceVisibility;
 import io.meeds.social.space.service.SpaceLayoutService;
@@ -155,6 +157,8 @@ public class SpaceRest implements ResourceContainer {
 
   private final SpaceService           spaceService;
 
+  private final CategoryService        categoryService;
+
   private final SpaceLayoutService     spaceLayoutService;
 
   private final SecuritySettingService securitySettingService;
@@ -167,12 +171,14 @@ public class SpaceRest implements ResourceContainer {
 
   public SpaceRest(SpaceService spaceService,
                    SpaceLayoutService spaceLayoutService,
+                   CategoryService categoryService,
                    IdentityManager identityManager,
                    UploadService uploadService,
                    ImageThumbnailService imageThumbnailService,
                    SecuritySettingService securitySettingService) {
     this.spaceService = spaceService;
     this.spaceLayoutService = spaceLayoutService;
+    this.categoryService = categoryService;
     this.identityManager = identityManager;
     this.uploadService = uploadService;
     this.imageThumbnailService = imageThumbnailService;
@@ -270,7 +276,19 @@ public class SpaceRest implements ResourceContainer {
     spaceFilter.setTagNames(tagNames);
     spaceFilter.setTemplateIds(templateIds);
     spaceFilter.setExcludedIds(excludedIds);
-    spaceFilter.setCategoryIds(categoryIds);
+    if (CollectionUtils.isNotEmpty(categoryIds)) {
+      spaceFilter.setCategoryIds(categoryIds.stream()
+                                            .filter(id -> categoryService.canAccess(id, authenticatedUser))
+                                            .toList());
+      if (CollectionUtils.isEmpty(spaceFilter.getCategoryIds())) {
+        CollectionEntity collectionSpace = new CollectionEntity(Collections.emptyList(),
+                                                                EntityBuilder.SPACES_TYPE,
+                                                                offset,
+                                                                limit);
+        return EntityBuilder.getResponseBuilder(collectionSpace, uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK)
+                            .build();
+      }
+    }
     spaceFilter.setRegistration(registration);
     spaceFilter.setVisibility(visibility);
 

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
@@ -42,14 +42,12 @@ import org.exoplatform.social.service.test.AbstractResourceTest;
 import org.exoplatform.upload.UploadService;
 
 import io.meeds.portal.security.service.SecuritySettingService;
+import io.meeds.social.category.service.CategoryService;
 import io.meeds.social.space.service.SpaceLayoutService;
 
 public class SpaceRestResourcesTest extends AbstractResourceTest {
-  private IdentityManager        identityManager;
 
   private OrganizationService    organizationService;
-
-  private UserACL                userACL;
 
   private ActivityManager        activityManager;
 
@@ -81,6 +79,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
     identityManager = getContainer().getComponentInstanceOfType(IdentityManager.class);
     activityManager = getContainer().getComponentInstanceOfType(ActivityManager.class);
     spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
+    CategoryService categoryService = getContainer().getComponentInstanceOfType(CategoryService.class);
     organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
     uploadService = (MockUploadService) getContainer().getComponentInstanceOfType(UploadService.class);
     imageThumbnailService = getContainer().getComponentInstanceOfType(ImageThumbnailService.class);
@@ -94,6 +93,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
 
     spaceRestResources = new SpaceRest(spaceService,
                                        spaceLayoutService,
+                                       categoryService,
                                        identityManager,
                                        uploadService,
                                        imageThumbnailService,


### PR DESCRIPTION
This change will avoid listing spaces of user when the Spaces Directory Application filters applies a category which isn't accessible.
Thus, the spaces Directory will simply display a placeholder when no access to filtered categories.