### PR TITLE
fix: URL having Anchor element isn't displaying as expected - EXO-73493 - Meeds-io/meeds#2665.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -105,7 +105,11 @@ export default {
         }
       } else {
         this.$root.selectedCommentId = '';
-        window.history.replaceState('', '', `${window.location.pathname}${urlHash}`);
+        if (activityId) {
+          window.history.replaceState('', '', `${window.location.pathname}?id=${activityId}${urlHash}`);
+        } else {
+          window.history.replaceState('', '', `${window.location.pathname}${urlHash}`);
+        }
       }
       this.$nextTick().then(() => this.loaded = true);
     },


### PR DESCRIPTION
Before this change, on Activity stream, click on news URL having anchors, news displayed having comment drawer opened. To resolve this problem, in the mounted method of Vue add a function to scroll to the anchor. After this change, the news is displayed focusing on anchor without opening the comments.
