### PR TITLE
fix: External users aren't marked as INVITED in their own card in org chart - EXO-76129 -Meeds-io/meeds#2695

### DIFF
--- a/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -256,7 +256,7 @@ export default {
       return this.user?.enabled;
     },
     externalUser() {
-      return this.user?.external === 'true';
+      return this.user?.external === 'true' || this.user?.dataEntity?.external === 'true';
     },
     profileUrl() {
       return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.user?.username}`;


### PR DESCRIPTION
Before this change, External users aren't marked as INVITED in their own card in org chart, this is due to that the user card is not getting the good property from the profile object in this case. 
After this commit, the property is well tested and the label is shown for external users.