### PR TITLE
feat: automatically reconnect user with OIDC if IDP session is still active - EXO-74622

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/openid/OpenIdProcessorImpl.java
@@ -22,11 +22,14 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SimpleTimeZone;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -87,6 +90,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
   private final String                applicationName;
 
   private String                      issuer;
+  private int                         oidcCookieLifetime;
 
   private final int                   chunkLength;
 
@@ -97,6 +101,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
   public OpenIdProcessorImpl(ExoContainerContext context, InitParams params, SecureRandomService secureRandomService) {
     this.clientID = params.getValueParam("clientId").getValue();
     this.clientSecret = params.getValueParam("clientSecret").getValue();
+    this.oidcCookieLifetime = Integer.parseInt(params.getValueParam("oidcCookieLifetime").getValue());
     String redirectURLParam = params.getValueParam("redirectURL").getValue();
     this.wellKnownConfigurationUrl = params.getValueParam("wellKnownConfigurationUrl").getValue();
     this.wellKnownConfigurationLoaded = false;
@@ -175,6 +180,12 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
       session.removeAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE);
       session.removeAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE);
 
+      SimpleDateFormat expireFormat = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss zzz");
+      expireFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
+      Date d = new Date();
+      d.setTime(d.getTime() + oidcCookieLifetime * 1000);
+      String cookieLifeTime = expireFormat.format(d);
+      response.setHeader("Set-Cookie", "OPENID_ACCESS_TOKEN="+tokenResponse.getAccessToken()+" ; Path=/portal/login; Expires=" + cookieLifeTime + "; Secure; HttpOnly; SameSite=strict");
       return new InteractionState<>(InteractionState.State.FINISH, accessTokenContext);
     }
 
@@ -290,7 +301,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
       }.executeRequest(params);
 
       if (log.isTraceEnabled()) {
-        log.trace("Successfully obtained accessToken from openid: " + tokenResponse);
+        log.trace("Successfully obtained accessToken from openid: " + tokenResponse.toString());
       }
 
       return tokenResponse;

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
@@ -85,7 +85,6 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
     if (cookies != null) {
       for (Cookie cookie : cookies) {
         if (cookie.getName().equals("OPENID_ACCESS_TOKEN")) {
-          log.info("Cookie OPENID_ACCESS_TOKEN found, value={}",cookie.getValue());
           try {
             openIdProcessor.processOAuthInteraction(request, response);
           } catch (OAuthException | ExecutionException | InterruptedException | IOException ex) {

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
@@ -1,0 +1,99 @@
+package io.meeds.oauth.web.openid;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import io.meeds.oauth.common.OAuthConstants;
+import io.meeds.oauth.exception.OAuthException;
+import io.meeds.oauth.openid.OpenIdAccessTokenContext;
+import io.meeds.oauth.openid.OpenIdProcessor;
+import io.meeds.oauth.spi.OAuthPrincipal;
+import io.meeds.oauth.spi.OAuthProviderTypeRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.web.security.AuthenticationRegistry;
+import org.exoplatform.web.security.security.AbstractTokenService;
+import org.exoplatform.web.security.security.CookieTokenService;
+import org.gatein.sso.agent.filter.api.AbstractSSOInterceptor;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
+  private static Log log = ExoLogger.getLogger(OpenIdAuthenticationFilter.class);
+  private AuthenticationRegistry authenticationRegistry;
+  private OpenIdProcessor openIdProcessor;
+  @Override
+  protected void initImpl() {
+    authenticationRegistry = getExoContainer().getComponentInstanceOfType(AuthenticationRegistry.class);
+    OAuthProviderTypeRegistry oAuthProviderTypeRegistry = getExoContainer().getComponentInstanceOfType(OAuthProviderTypeRegistry.class);
+    openIdProcessor = (OpenIdProcessor) oAuthProviderTypeRegistry.getOAuthProvider(OAuthConstants.OAUTH_PROVIDER_KEY_OPEN_ID, OpenIdAccessTokenContext.class).getOauthProviderProcessor();
+  }
+
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws
+                                                                                                                IOException,
+                                                                                                                ServletException {
+    HttpServletRequest request = (HttpServletRequest) servletRequest;
+    HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+    // Simply continue with request if we are already authenticated
+    if (request.getRemoteUser() != null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    // Simply continue with request if we are in the middle of registration
+    // process
+    User oauthAuthenticatedUser =
+        (User) authenticationRegistry.getAttributeOfClient(request,
+                                                           OAuthConstants.ATTRIBUTE_AUTHENTICATED_PORTAL_USER);
+    if (oauthAuthenticatedUser != null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    User jaasAuthenticatedUser =
+        (User) authenticationRegistry.getAttributeOfClient(request,
+                                                           OAuthConstants.ATTRIBUTE_AUTHENTICATED_PORTAL_USER_FOR_JAAS);
+    if (jaasAuthenticatedUser != null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    OAuthPrincipal principal =
+        (OAuthPrincipal) authenticationRegistry.getAttributeOfClient(request,
+                                                                     OAuthConstants.ATTRIBUTE_AUTHENTICATED_OAUTH_PRINCIPAL);
+    if (principal != null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    checkAccessTokenInCookies(request,response);
+    filterChain.doFilter(request, response);
+  }
+
+  private void checkAccessTokenInCookies(HttpServletRequest request, HttpServletResponse response) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals("OPENID_ACCESS_TOKEN")) {
+          log.info("Cookie OPENID_ACCESS_TOKEN found, value={}",cookie.getValue());
+          try {
+            openIdProcessor.processOAuthInteraction(request, response);
+          } catch (OAuthException | ExecutionException | InterruptedException | IOException ex) {
+            log.error("Error during OAuth flow with: " + ex.getMessage(), ex);
+            return;
+          }
+        }
+      }
+    }
+  }
+}

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
@@ -1,6 +1,24 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 package io.meeds.oauth.web.openid;
 
-import com.github.scribejava.core.model.OAuth2AccessToken;
 import io.meeds.oauth.common.OAuthConstants;
 import io.meeds.oauth.exception.OAuthException;
 import io.meeds.oauth.openid.OpenIdAccessTokenContext;
@@ -18,8 +36,6 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.web.security.AuthenticationRegistry;
-import org.exoplatform.web.security.security.AbstractTokenService;
-import org.exoplatform.web.security.security.CookieTokenService;
 import org.gatein.sso.agent.filter.api.AbstractSSOInterceptor;
 
 import java.io.IOException;

--- a/component/oauth-auth/src/main/resources/conf/portal/configuration.xml
+++ b/component/oauth-auth/src/main/resources/conf/portal/configuration.xml
@@ -138,6 +138,10 @@
         <name>clientSecret</name>
         <value>${exo.oauth.openid.clientSecret}</value>
       </value-param>
+      <value-param>
+        <name>oidcCookieLifetime</name>
+        <value>${exo.oauth.openid.cookie.lifetime:86400}</value>
+      </value-param>
       <!-- URL to redirect from OpenId during Openid authentication -->
       <value-param>
         <name>redirectURL</name>
@@ -356,6 +360,30 @@
         <value-param>
           <name>loginUrl</name>
           <value>/@@portal.container.name@@/login</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>io.meeds.oauth.webapi.OAuthFilterIntegrator</target-component>
+    <component-plugin>
+      <name>OpenIdAuthenticationFilter</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.oauth.webapi.OAuthFilterIntegratorPlugin</type>
+      <init-params>
+        <value-param>
+          <name>filterClass</name>
+          <value>io.meeds.oauth.web.openid.OpenIdAuthenticationFilter</value>
+        </value-param>
+        <!-- It's always enable here but not used if all OAuthProviders (social networks) are disabled. See OAuthFilterIntegratorImpl -->
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>filterMapping</name>
+          <value>/login</value>
         </value-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
Add a cookie on OIDC successful login.
When the http session is expired, if the cookie exists, replay the OIDC authentication

Default cookie lifetime is 24h, configuration by property

Resolves https://github.com/Meeds-io/meeds/issues/2759