### PR TITLE
fix : When openid is not enabled, there is an error in server log during startup - EXO-76593

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
@@ -45,11 +45,21 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
   private static Log log = ExoLogger.getLogger(OpenIdAuthenticationFilter.class);
   private AuthenticationRegistry authenticationRegistry;
   private OpenIdProcessor openIdProcessor;
+
+  private boolean openIdEnabled;
   @Override
   protected void initImpl() {
-    authenticationRegistry = getExoContainer().getComponentInstanceOfType(AuthenticationRegistry.class);
-    OAuthProviderTypeRegistry oAuthProviderTypeRegistry = getExoContainer().getComponentInstanceOfType(OAuthProviderTypeRegistry.class);
-    openIdProcessor = (OpenIdProcessor) oAuthProviderTypeRegistry.getOAuthProvider(OAuthConstants.OAUTH_PROVIDER_KEY_OPEN_ID, OpenIdAccessTokenContext.class).getOauthProviderProcessor();
+    this.openIdEnabled = Boolean.parseBoolean(System.getProperty("exo.oauth.openid.enabled"));
+    if (this.openIdEnabled) {
+      authenticationRegistry = getExoContainer().getComponentInstanceOfType(AuthenticationRegistry.class);
+      OAuthProviderTypeRegistry
+          oAuthProviderTypeRegistry =
+          getExoContainer().getComponentInstanceOfType(OAuthProviderTypeRegistry.class);
+      openIdProcessor =
+          (OpenIdProcessor) oAuthProviderTypeRegistry.getOAuthProvider(OAuthConstants.OAUTH_PROVIDER_KEY_OPEN_ID,
+                                                                       OpenIdAccessTokenContext.class)
+                                                     .getOauthProviderProcessor();
+    }
   }
 
   @Override
@@ -60,7 +70,7 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
     HttpServletResponse response = (HttpServletResponse) servletResponse;
 
     // Simply continue with request if we are already authenticated
-    if (request.getRemoteUser() != null) {
+    if (!this.openIdEnabled || request.getRemoteUser() != null) {
       filterChain.doFilter(request, response);
       return;
     }


### PR DESCRIPTION
Before this fix, the new filter OpenIdAuthenticationFilter try to initialize even if openid is not enabled. This lead to a NPE.
This fix ensure to init the filter, and to execute it only when oidc is enabled.

Resolves meeds-io/meeds#2780

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
