### PR TITLE
fix: disabled filter in members app ko- EXO-74907 - Meeds-io/meeds#2781.

### DIFF
--- a/component/api/src/main/java/io/meeds/social/space/constant/SpaceMembershipStatus.java
+++ b/component/api/src/main/java/io/meeds/social/space/constant/SpaceMembershipStatus.java
@@ -20,5 +20,5 @@
 package io.meeds.social.space.constant;
 
 public enum SpaceMembershipStatus {
-  MEMBER, MANAGER, REDACTOR, PENDING, INVITED, IGNORED, PUBLISHER;
+  MEMBER, MANAGER, REDACTOR, PENDING, INVITED, IGNORED, PUBLISHER, DISABLED;
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -96,6 +96,8 @@ public class SpaceUtils {
 
   public static final String  IGNORED                    = "ignored";
 
+  public static final String  DISABLED                    = "disabled";
+
   public static final String  MENU_CONTAINER             = "Menu";
 
   public static final String  APPLICATION_CONTAINER      = "Application";

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -116,6 +116,7 @@ import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.relationship.model.Relationship;
 import org.exoplatform.social.core.relationship.model.Relationship.Type;
 import org.exoplatform.social.core.service.LinkProvider;
+import org.exoplatform.social.core.space.SpaceUtils;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.utils.MentionUtils;
@@ -1040,11 +1041,11 @@ public class EntityBuilder {
                      .filter(Objects::nonNull)
                      .filter(Identity::isUser)
                      .map(identity -> buildSpaceMembership(spaceService,
-                                                           space,
-                                                           identity.getRemoteId(),
-                                                           membershipType,
-                                                           uriInfo.getPath(),
-                                                           expand))
+                             space,
+                             identity.getRemoteId(),
+                             membershipType,
+                             uriInfo.getPath(),
+                             expand))
                      .toList();
   }
 
@@ -1054,7 +1055,8 @@ public class EntityBuilder {
                                                  MembershipType membershipType,
                                                  String restPath,
                                                  String expand) {
-    if (getMembershipTypePredicate(spaceService, membershipType).test(space, userId)) {
+    if (SpaceUtils.DISABLED.equals(membershipType.getRole()) ||
+            getMembershipTypePredicate(spaceService, membershipType).test(space, userId)) {
       return buildSpaceMembershipEntity(space,
                                         userId,
                                         membershipType.getRole(),

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
@@ -81,7 +81,8 @@ public class SpaceMembershipRest implements ResourceContainer {
     MEMBER(SpaceUtils.MEMBER, SpaceMembershipStatus.MEMBER),
     MANAGER(SpaceUtils.MANAGER, SpaceMembershipStatus.MANAGER),
     PUBLISHER(SpaceUtils.PUBLISHER, SpaceMembershipStatus.PUBLISHER),
-    REDACTOR(SpaceUtils.REDACTOR, SpaceMembershipStatus.REDACTOR);
+    REDACTOR(SpaceUtils.REDACTOR, SpaceMembershipStatus.REDACTOR),
+    DISABLED(SpaceUtils.DISABLED, SpaceMembershipStatus.DISABLED);
 
     @Getter
     private final SpaceMembershipStatus status;


### PR DESCRIPTION
Before this change, when open member app of spacex from filter dropdown select disabled, the display doesn't change. To resolve this problem, add the disabled type to the SpaceMembershipStatus. After this change, disabled members list is displayed.