### PR TITLE
fix: Comments link are no longer considered to be displayed - EXO-76566 - Meeds-io/meeds#2771.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -71,8 +71,12 @@ export default {
     this.refreshActivityTypes();
     this.refreshActivityActions();
     this.refreshCommentActions();
+    const queryParamId = this.getQueryParam('id');
+    if (queryParamId.includes('comment')) {
+      this.$root.selectedCommentId = queryParamId;
+    }
     if (window.location.pathname.endsWith('/activity')) {
-      this.$root.selectedActivityId = this.getQueryParam('id');
+      this.$root.selectedActivityId = queryParamId;
       if (window.location.hash) {
         this.$root.selectedCommentId = window.location.hash.replace('#comment-reply-', '').replace('#comment-reply', '').replace('#comment-', '');
       }
@@ -97,12 +101,12 @@ export default {
       this.loaded = false;
       this.$root.selectedActivityId = this.activityId = activityId;
       const urlHash = window.location.hash;
-      if (urlHash.includes('#comment')){
+      if (urlHash.includes('#comment') || commentId.includes('comment')){
         this.$root.selectedCommentId = window.location.hash.replace('#comment-reply-', '').replace('#comment-reply', '').replace('#comment-', '');
         if (commentId && !this.$root.selectedCommentId) {
           this.$root.selectedCommentId = commentId;
-          window.history.replaceState('', window.document.title, `${window.location.pathname}?id=${activityId}#comment-${commentId}`);
         }
+        window.history.replaceState('', window.document.title, `${window.location.pathname}?id=${activityId}#comment-${commentId}`);
       } else {
         this.$root.selectedCommentId = '';
         if (activityId) {


### PR DESCRIPTION
Before this change, when create a postX and comment it then get the comment link and open it in new tab, post is displayed. To resolve this problem, add a condition to the creation of the URL to check if the id in the parameter passed in the URL has a text comment if yes opens the comment drawer. After this change, the link is display post and having its comment drawer opened focusing on comment retrieved.
