### PR TITLE
fix: Comments link are no longer considered to be displayed - EXO-76566 - Meeds-io/meeds#2771.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/ActivityStream.vue
@@ -72,7 +72,7 @@ export default {
     this.refreshActivityActions();
     this.refreshCommentActions();
     const queryParamId = this.getQueryParam('id');
-    if (queryParamId.includes('comment')) {
+    if (queryParamId && queryParamId.includes('comment')) {
       this.$root.selectedCommentId = queryParamId;
     }
     if (window.location.pathname.endsWith('/activity')) {
@@ -101,7 +101,7 @@ export default {
       this.loaded = false;
       this.$root.selectedActivityId = this.activityId = activityId;
       const urlHash = window.location.hash;
-      if (urlHash.includes('#comment') || commentId.includes('comment')){
+      if (urlHash && urlHash.includes('#comment') || commentId && commentId.includes('comment')){
         this.$root.selectedCommentId = window.location.hash.replace('#comment-reply-', '').replace('#comment-reply', '').replace('#comment-', '');
         if (commentId && !this.$root.selectedCommentId) {
           this.$root.selectedCommentId = commentId;


### PR DESCRIPTION
Before this change, when create a postX and comment it then get the comment link and open it in new tab, post is displayed. To resolve this problem, add a condition to the creation of the URL to check if the id in the parameter passed in the URL has a text comment if yes opens the comment drawer. After this change, the link is display post and having its comment drawer opened focusing on comment retrieved.