### PR TITLE
fix: number of user results message isn't showing the good message if filter applied - EXO-76620 - Meeds-io/meeds#2790.

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
@@ -184,7 +184,7 @@ public class SpaceMembershipRest implements ResourceContainer {
                                                              uriInfo,
                                                              expand);
       if (returnSize) {
-        size = listAccess.getSize();
+        size = spaceMemberships.size();
       }
     } else {
       SpaceFilter spaceFilter = new SpaceFilter();

--- a/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -257,10 +257,13 @@ export default {
           space: this.spaceId,
           returnSize: true,
           signal: this.abortController.signal,
-        }).then(data => ({
-          size: data.size || 0,
-          users: data?.spacesMemberships?.map?.(m => m.user),
-        }));
+        }).then(data => { 
+          this.$root.space.membersCount = data.size;
+          return {
+            size: data.size || 0,
+            users: data?.spacesMemberships?.map?.(m => m.user),
+          };
+        });
       } else if (profileSettings) {
         this.advancedFilterSettings = profileSettings;
         searchUsersFunction = this.$userService.getUsersByAdvancedFilter(this.advancedFilterSettings, this.offset, this.limitToFetch + 1, this.fieldsToRetrieve,this.filter, this.keyword, false, this.abortController.signal);

--- a/webapp/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/space-members/components/SpaceMembersToolbar.vue
@@ -22,8 +22,13 @@
         <space-invite-buttons-group
           v-if="isManager"
           class="me-4" />
-        <div class="showingPeopleText text-subtitle d-none my-auto d-sm-flex">
+        <div v-if="peopleCount"
+          class="showingPeopleText text-subtitle d-none my-auto d-sm-flex">
           {{ $t('peopleList.label.peopleCount', {0: peopleCount}) }}
+        </div>
+        <div v-else
+          class="showingPeopleText text-subtitle d-none my-auto d-sm-flex">
+          {{ $t('Search.noResults')}}
         </div>
       </div>
     </template>


### PR DESCRIPTION
Before this change, when apply disbaled members filter in space members app, message displayed (Showing 3 results) although no result displayed. To resolve this problem, reassign the size of the list of members returned by getSpaceMemberships. After this change, the results message displayed correctly.