### PR TITLE
feat: Move Coediting API from Layout Addon - Meeds-io/MIPs#175

### DIFF
--- a/component/core/src/main/java/io/meeds/social/coediting/model/CoeditionObjectDraft.java
+++ b/component/core/src/main/java/io/meeds/social/coediting/model/CoeditionObjectDraft.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.coediting.model;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoeditionObjectDraft implements Serializable {
+
+  private static final long serialVersionUID = -5418473845746197207L;
+
+  private String revision;
+
+  private long   time;
+
+}

--- a/component/core/src/main/java/io/meeds/social/coediting/model/CoeditionObjectKey.java
+++ b/component/core/src/main/java/io/meeds/social/coediting/model/CoeditionObjectKey.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.coediting.model;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoeditionObjectKey implements Serializable {
+
+  private static final long serialVersionUID = -4760837621171717661L;
+
+  private String            objectType;
+
+  private String            objectId;
+
+}

--- a/component/core/src/main/java/io/meeds/social/coediting/model/CoeditionObjectLock.java
+++ b/component/core/src/main/java/io/meeds/social/coediting/model/CoeditionObjectLock.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.coediting.model;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoeditionObjectLock implements Serializable {
+
+  private static final long serialVersionUID = -9051607448488878750L;
+
+  private Map<String, Long> users            = new ConcurrentHashMap<>();
+
+}

--- a/component/core/src/main/java/io/meeds/social/coediting/service/CoeditingService.java
+++ b/component/core/src/main/java/io/meeds/social/coediting/service/CoeditingService.java
@@ -1,0 +1,143 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.coediting.service;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+
+import io.meeds.social.coediting.model.CoeditionObjectDraft;
+import io.meeds.social.coediting.model.CoeditionObjectKey;
+import io.meeds.social.coediting.model.CoeditionObjectLock;
+import io.meeds.social.util.JsonUtils;
+
+import jakarta.annotation.PostConstruct;
+import lombok.Setter;
+
+@Service
+public class CoeditingService {
+
+  private static final Scope                                COEDITION_SCOPE = Scope.APPLICATION.id("Coedition");
+
+  @Autowired
+  private SettingService                                    settingService;
+
+  @Autowired
+  private CacheService                                      cacheService;
+
+  @Value("${meeds.coediting.lockPeriod:20}")
+  private long                                              lockPeriod;
+
+  @Setter
+  private ExoCache<CoeditionObjectKey, CoeditionObjectLock> lockCache;
+
+  @PostConstruct
+  public void init() {
+    lockCache = cacheService.getCacheInstance("portal.coediting");
+    if (lockCache != null) {
+      lockCache.setLiveTime(lockPeriod);
+    }
+  }
+
+  public List<String> getLockHolders(CoeditionObjectKey key) {
+    CoeditionObjectLock lock = lockCache.get(key);
+    return lock == null ? Collections.emptyList() :
+                        lock.getUsers()
+                            .entrySet()
+                            .stream()
+                            .map(e -> {
+                              if (isLockTimeValid(e.getValue())) {
+                                return e.getKey();
+                              } else {
+                                return null;
+                              }
+                            })
+                            .filter(Objects::nonNull)
+                            .toList();
+  }
+
+  public CoeditionObjectDraft setLock(String username, CoeditionObjectKey key, String revision) {
+    CoeditionObjectLock lock = lockCache.get(key);
+    if (lock == null) {
+      lock = new CoeditionObjectLock();
+    } else {
+      cleanOutdatedLocks(lock);
+    }
+    lock.getUsers().put(username, System.currentTimeMillis());
+    lockCache.put(key, lock);
+
+    CoeditionObjectDraft draft = getRevision(username, key);
+    if (draft != null && StringUtils.equals(draft.getRevision(), revision)) {
+      return null;
+    } else {
+      setRevision(username, key, revision);
+      return draft;
+    }
+  }
+
+  public CoeditionObjectDraft getRevision(String username, CoeditionObjectKey key) {
+    SettingValue<?> value = settingService.get(Context.USER.id(username), COEDITION_SCOPE, String.valueOf(key.hashCode()));
+    return value == null
+           || value.getValue() == null ? null : JsonUtils.fromJsonString(value.getValue().toString(), CoeditionObjectDraft.class);
+  }
+
+  public void setRevision(String username, CoeditionObjectKey key, String versionReference) {
+    settingService.set(Context.USER.id(username),
+                       COEDITION_SCOPE,
+                       String.valueOf(key.hashCode()),
+                       SettingValue.create(JsonUtils.toJsonString(new CoeditionObjectDraft(versionReference, System.currentTimeMillis()))));
+  }
+
+  public void removeRevision(String username, CoeditionObjectKey key) {
+    settingService.remove(Context.USER.id(username),
+                          COEDITION_SCOPE,
+                          String.valueOf(key.hashCode()));
+  }
+
+  private boolean isLockTimeValid(long lockTime) {
+    return (lockTime + lockPeriod * 1000) > System.currentTimeMillis();
+  }
+
+  private void cleanOutdatedLocks(CoeditionObjectLock lock) {
+    Iterator<Entry<String, Long>> userLockIterator = lock.getUsers().entrySet().iterator();
+    while (userLockIterator.hasNext()) {
+      Map.Entry<String, Long> e = userLockIterator.next();
+      if (!isLockTimeValid(e.getValue())) {
+        userLockIterator.remove();
+      }
+    }
+  }
+
+}

--- a/component/core/src/test/java/io/meeds/social/coediting/service/CoeditingServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/coediting/service/CoeditingServiceTest.java
@@ -1,0 +1,142 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.coediting.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+
+import io.meeds.social.coediting.model.CoeditionObjectKey;
+import io.meeds.social.coediting.model.CoeditionObjectLock;
+
+@SpringBootTest(classes = {
+  CoeditingService.class,
+})
+@RunWith(SpringRunner.class)
+public class CoeditingServiceTest {
+
+  private static final String                               REVISION = "revision";
+
+  private static final String                               USERNAME = "username";
+
+  @MockBean
+  private SettingService                                    settingService;
+
+  @MockBean
+  private CacheService                                      cacheService;
+
+  @Autowired
+  private CoeditingService                                  coeditingService;
+
+  @Mock
+  private ExoCache<CoeditionObjectKey, CoeditionObjectLock> lockCache;
+
+  @Mock
+  private CoeditionObjectKey                                key;
+
+  @Mock
+  private CoeditionObjectLock                               lock;
+
+  @Value("${meeds.coediting.lockPeriod:20}")
+  private long                                              lockPeriod;
+
+  @Before
+  public void setup() {
+    coeditingService.setLockCache(lockCache);
+  }
+
+  @Test
+  public void getLockHoldersEmpty() {
+    List<String> lockHolders = coeditingService.getLockHolders(key);
+    assertNotNull(lockHolders);
+    assertEquals(0, lockHolders.size());
+  }
+
+  @Test
+  public void getLockHoldersWithOutdatedLocks() {
+    when(lockCache.get(key)).thenReturn(lock);
+    when(lock.getUsers()).thenReturn(Collections.singletonMap(USERNAME, System.currentTimeMillis() - 20001));
+    List<String> lockHolders = coeditingService.getLockHolders(key);
+    assertNotNull(lockHolders);
+    assertEquals(0, lockHolders.size());
+  }
+
+  @Test
+  public void getLockHolders() {
+    when(lockCache.get(key)).thenReturn(lock);
+    when(lock.getUsers()).thenReturn(Collections.singletonMap(USERNAME, System.currentTimeMillis()));
+    List<String> lockHolders = coeditingService.getLockHolders(key);
+    assertNotNull(lockHolders);
+    assertEquals(1, lockHolders.size());
+  }
+
+  @Test
+  public void setLockWithNotExisting() {
+    coeditingService.setLock(USERNAME, key, REVISION);
+    verify(lockCache).put(eq(key),
+                          argThat(l -> l.getUsers().size() == 1
+                                       && l.getUsers().get(USERNAME) != null
+                                       && l.getUsers().get(USERNAME) > (System.currentTimeMillis() - 1000)));
+    verify(settingService).set(any(), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public void setLockWithExisting() {
+    when(lockCache.get(key)).thenReturn(lock);
+    Map<String, Long> users = new ConcurrentHashMap<>();
+    users.put(USERNAME, System.currentTimeMillis());
+    users.put(USERNAME + "2", System.currentTimeMillis() - 20001);
+    when(lock.getUsers()).thenReturn(users);
+    when(settingService.get(any(),
+                            any(),
+                            any())).thenReturn((SettingValue) SettingValue.create("{\"revision\": \"" + REVISION + "2" + "\"}"));
+
+    coeditingService.setLock(USERNAME, key, REVISION);
+
+    verify(lockCache).put(key, lock);
+    verify(settingService).set(any(), any(), any(), any());
+    assertEquals(1, lock.getUsers().size());
+  }
+
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
@@ -36,6 +36,7 @@ import org.exoplatform.social.core.storage.StorageUtilsTest;
 
 import io.meeds.social.authorization.AuthorizationManagerTest;
 import io.meeds.social.category.service.CategoryServiceUnitTest;
+import io.meeds.social.coediting.service.CoeditingServiceTest;
 import io.meeds.social.image.plugin.ImageAttachmentPluginTest;
 import io.meeds.social.search.SpaceSearchConnectorTest;
 import io.meeds.social.space.administration.service.SpaceAdministrationServiceTest;
@@ -70,6 +71,7 @@ import io.meeds.social.upgrade.SpaceNavigationIconUpgradePluginTest;
     SpaceTemplateStorageTest.class,
     SpaceTemplateServiceTest.class,
     CategoryServiceUnitTest.class,
+    CoeditingServiceTest.class,
 })
 public class NoContainerTestSuite {
 

--- a/component/service/src/main/java/io/meeds/social/coediting/rest/CoeditingRest.java
+++ b/component/service/src/main/java/io/meeds/social/coediting/rest/CoeditingRest.java
@@ -1,0 +1,115 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.coediting.rest;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.meeds.social.coediting.model.CoeditionObjectDraft;
+import io.meeds.social.coediting.model.CoeditionObjectKey;
+import io.meeds.social.coediting.service.CoeditingService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/coediting")
+@Tag(name = "/coediting", description = "Managing coedition of any object")
+public class CoeditingRest {
+
+  @Autowired
+  private CoeditingService coeditingService;
+
+  @GetMapping("/{objectType}/{objectId}/locks")
+  @Secured("users")
+  @Operation(summary = "Retrieve object lock holders", method = "GET")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled") })
+  public List<String> getLockHolders(
+                                     @Parameter(description = "Object Type: navigation, page layout ...")
+                                     @PathVariable("objectType")
+                                     String objectType,
+                                     @Parameter(description = "Object Type's specific element identifier")
+                                     @PathVariable("objectId")
+                                     String objectId) {
+    return coeditingService.getLockHolders(new CoeditionObjectKey(objectType, objectId));
+  }
+
+  @PostMapping(value = "/{objectType}/{objectId}", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+  @Secured("users")
+  @Operation(summary = "Set a lock on current object being edited", method = "POST")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled") })
+  public void setLock(
+                      HttpServletRequest request,
+                      @Parameter(description = "Object Type: navigation, page layout ...")
+                      @PathVariable("objectType")
+                      String objectType,
+                      @Parameter(description = "Object Type's specific element identifier")
+                      @PathVariable("objectId")
+                      String objectId,
+                      @Parameter(description = "Current revision being edited by current user")
+                      @RequestParam("revision")
+                      String revision) {
+    coeditingService.setLock(request.getRemoteUser(), new CoeditionObjectKey(objectType, objectId), revision);
+  }
+
+  @GetMapping("/{objectType}/{objectId}")
+  @Secured("users")
+  @Operation(summary = "Retrieve object revision for current user", method = "GET")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled") })
+  public CoeditionObjectDraft getRevision(
+                                          HttpServletRequest request,
+                                          @Parameter(description = "Object Type: navigation, page layout ...")
+                                          @PathVariable("objectType")
+                                          String objectType,
+                                          @Parameter(description = "Object Type's specific element identifier")
+                                          @PathVariable("objectId")
+                                          String objectId) {
+    return coeditingService.getRevision(request.getRemoteUser(), new CoeditionObjectKey(objectType, objectId));
+  }
+
+  @DeleteMapping("/{objectType}/{objectId}")
+  @Secured("users")
+  @Operation(summary = "Delete object revision for current user", method = "DELETE")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled") })
+  public void removeRevision(
+                             HttpServletRequest request,
+                             @Parameter(description = "Object Type: navigation, page layout ...")
+                             @PathVariable("objectType")
+                             String objectType,
+                             @Parameter(description = "Object Type's specific element identifier")
+                             @PathVariable("objectId")
+                             String objectId) {
+    coeditingService.removeRevision(request.getRemoteUser(), new CoeditionObjectKey(objectType, objectId));
+  }
+
+}

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -3055,4 +3055,28 @@
     </depends>
   </module>
 
+  <module>
+    <name>coediting</name>
+    <load-group>coeditingGRP</load-group>
+    <script>
+      <minify>false</minify>
+      <path>/js/coediting.bundle.js</path>
+    </script>
+    <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>commonVueComponents</module>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
+
 </gatein-resources>

--- a/webapp/src/main/webapp/vue-apps/coediting/components/Coediting.vue
+++ b/webapp/src/main/webapp/vue-apps/coediting/components/Coediting.vue
@@ -1,0 +1,296 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <div v-if="initialized">
+    <slot v-if="display"></slot>
+    <exo-confirm-dialog
+      ref="confirmDialog"
+      v-else-if="locked"
+      :title="lockConfirmTitle"
+      :message="lockMessage"
+      :ok-label="lockConfirmOkLabel"
+      persistent
+      @ok="confirmLock" />
+    <exo-confirm-dialog
+      ref="confirmDialog"
+      v-else-if="hasDraft"
+      :title="draftConfirmTitle"
+      :message="draftMessage"
+      :ok-label="draftConfirmOkLabel"
+      :cancel-label="draftConfirmCancelLabel"
+      persistent
+      @ok="confirmDraft"
+      @dialog-closed="cancelDraft" />
+    <div v-if="outdatedRevision" class="mask-color absolute-full-size z-index-two d-flex align-center justify-center">
+      <v-icon size="24" color="white">fa-lock</v-icon>
+      <v-card
+        max-width="200px"
+        class="transparent pa-5"
+        flat>
+        {{ editingInOtherWindow }}
+      </v-card>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    value: { // revision
+      type: String,
+      default: null,
+    },
+    objectType: {
+      type: String,
+      default: null,
+    },
+    objectId: {
+      type: String,
+      default: null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    messages: {
+      type: Object,
+      default: () => ({
+        editingInOtherWindow: null,
+        lockConfirmTitle: null,
+        lockConfirmMessage: null,
+        lockConfirmQuestion: null,
+        lockConfirmOkLabel: null,
+        draftConfirmTitle: null,
+        draftConfirmMessage: null,
+        draftConfirmQuestion: null,
+        draftConfirmOkLabel: null,
+        draftConfirmCancelLabel: null,
+      }),
+    },
+  },
+  data: () => ({
+    lockingUsers: null,
+    lockingUserIdentities: null,
+    draft: null,
+    initialized: false,
+    outdatedRevision: false,
+    revisionUpdatePeriod: 10000,
+    revisionUpdateInterval: 0,
+    draftConfirmed: false,
+    dateFormat: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    },
+  }),
+  computed: {
+    revision() {
+      return this.draft?.revision;
+    },
+    revisionTime() {
+      return this.draft?.time;
+    },
+    lockHolders() {
+      return this.lockingUsers?.filter?.(u => u !== eXo.env.portal.userName);
+    },
+    lockingUserNames() {
+      return this.lockingUserIdentities?.map?.(identity => identity?.profile?.fullname) || [];
+    },
+    locked() {
+      return !!this.lockHolders?.length;
+    },
+    hasDraft() {
+      return this.revision && String(this.revision) !== String(this.value);
+    },
+    display() {
+      return this.disabled || (this.initialized && !this.locked && !this.hasDraft);
+    },
+    editingInOtherWindow() {
+      return this.$t(this.messages.editingInOtherWindow);
+    },
+    lockConfirmTitle() {
+      return this.$t(this.messages.lockConfirmTitle);
+    },
+    lockConfirmMessage() {
+      return this.$t(this.messages.lockConfirmMessage, {
+        0: `<strong>${this.lockingUserNames.join(', ')}</strong>`,
+      });
+    },
+    lockConfirmQuestion() {
+      return this.$t(this.messages.lockConfirmQuestion);
+    },
+    lockMessage() {
+      return `${this.lockConfirmMessage}<br><br>${this.lockConfirmQuestion}`;
+    },
+    lockConfirmOkLabel() {
+      return this.$t(this.messages.lockConfirmOkLabel);
+    },
+    draftConfirmTitle() {
+      return this.$t(this.messages.draftConfirmTitle);
+    },
+    draftConfirmMessage() {
+      return this.$t(this.messages.draftConfirmMessage, {
+        0: `<strong>${this.revisionTime && this.$dateUtil.formatDateObjectToDisplay(new Date(this.revisionTime), this.dateFormat) || ''}</strong>`,
+      });
+    },
+    draftConfirmQuestion() {
+      return this.$t(this.messages.draftConfirmQuestion);
+    },
+    draftMessage() {
+      return `${this.draftConfirmMessage}<br><br>${this.draftConfirmQuestion}`;
+    },
+    draftConfirmOkLabel() {
+      return this.$t(this.messages.draftConfirmOkLabel);
+    },
+    draftConfirmCancelLabel() {
+      return this.$t(this.messages.draftConfirmCancelLabel);
+    },
+  },
+  watch: {
+    initialized() {
+      if (this.initialized) {
+        this.$nextTick().then(() => {
+          this.$refs?.confirmDialog?.open?.();
+        });
+      }
+    },
+    lockingUsers() {
+      if (this.lockingUsers?.length) {
+        Promise.all(this.lockingUsers.map(u => this.$identityService.getIdentityByProviderIdAndRemoteId('organization', u)))
+          .then(identities => this.lockingUserIdentities = identities);
+      }
+    },
+    locked() {
+      if (this.locked) {
+        this.$emit('locked');
+      }
+    },
+    hasDraft() {
+      if (!this.locked && this.hasDraft) {
+        this.$emit('draft-detected');
+      }
+    },
+    display() {
+      if (this.display) {
+        this.setPingRevisionInterval();
+        this.$emit('initialized');
+      }
+    },
+  },
+  created() {
+    if (!this.disabled) {
+      this.init();
+      this.$root.$on('coediting-set-lock', this.setRevision);
+      this.$root.$on('coediting-remove-revision', this.removeLock);
+    }
+  },
+  beforeDestroy() {
+    this.$root.$off('coediting-set-lock', this.setRevision);
+    this.$root.$off('coediting-remove-revision', this.removeLock);
+    this.clearPingRevisionInterval();
+  },
+  methods: {
+    init() {
+      return this.getLockHolders()
+        .then(() => this.getRevision())
+        .finally(() => this.initialized = true);
+    },
+    getRevision() {
+      return this.$coeditingService.getRevision(this.objectType, this.objectId)
+        .then(data => this.draft = data);
+    },
+    setRevision() {
+      this.setLock();
+      this.setPingRevisionInterval();
+    },
+    setLock(revision) {
+      if (revision) {
+        this.$emit('input', revision);
+      }
+      revision = revision || this.value;
+      if (revision) {
+        return this.$coeditingService.getRevision(this.objectType, this.objectId)
+          .then(data => {
+            if (!data?.revision || String(revision) === String(data.revision)) {
+              return this.$coeditingService.setLock(this.objectType, this.objectId, `${revision}`)
+                .then(() => this.draft = {revision});
+            } else {
+              this.outdatedRevision = true;
+            }
+          });
+      }
+    },
+    removeLock() {
+      this.removeRevision();
+      this.clearPingRevisionInterval();
+    },
+    removeRevision() {
+      return this.$coeditingService.removeRevision(this.objectType, this.objectId)
+        .then(() => this.draft = null);
+    },
+    getLockHolders() {
+      return this.$coeditingService.getLockHolders(this.objectType, this.objectId)
+        .then(data => this.lockingUsers = data);
+    },
+    confirmLock() {
+      this.$emit('canceled');
+    },
+    confirmDraft() {
+      this.draftConfirmed = true;
+      return this.$coeditingService.setLock(this.objectType, this.objectId, this.revision)
+        .then(() => {
+          this.draft = {revision: this.revision};
+          this.$emit('input', this.revision);
+          this.setPingRevisionInterval();
+        });
+    },
+    cancelDraft() {
+      if (this.draftConfirmed) {
+        return;
+      }
+      return this.removeRevision()
+        .then(() => {
+          this.draft = null;
+          this.$emit('input', null);
+          this.setPingRevisionInterval();
+        });
+    },
+    clearPingRevisionInterval() {
+      if (this.revisionUpdateInterval) {
+        window.clearInterval(this.revisionUpdateInterval);
+        this.revisionUpdateInterval = null;
+      }
+    },
+    setPingRevisionInterval() {
+      if (!this.revisionUpdateInterval) {
+        this.revisionUpdateInterval = window.setInterval(() => this.pingRevision(), this.revisionUpdatePeriod);
+      }
+    },
+    pingRevision() {
+      if (this.initialized && this.value && this.display) {
+        this.setLock();
+      }
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/coediting/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/coediting/initComponents.js
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import Coediting from './components/Coediting.vue';
+
+const components = {
+  'coediting': Coediting,
+};
+
+for (const key in components) {
+  Vue.component(key, components[key]);
+}

--- a/webapp/src/main/webapp/vue-apps/coediting/js/CoeditingService.js
+++ b/webapp/src/main/webapp/vue-apps/coediting/js/CoeditingService.js
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+export function getLockHolders(objectType, objectId) {
+  return fetch(`/social/rest/coediting/${objectType}/${objectId}/locks`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (resp?.ok) {
+      return resp.json();
+    } else {
+      throw new Error('Error when checking whether Object is locked or not');
+    }
+  });
+}
+
+export function getRevision(objectType, objectId) {
+  return fetch(`/social/rest/coediting/${objectType}/${objectId}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (resp?.ok) {
+      return resp.json().catch(() => null);
+    } else {
+      throw new Error('Error when getting Object revision');
+    }
+  });
+}
+
+export function setLock(objectType, objectId, revision) {
+  return fetch(`/social/rest/coediting/${objectType}/${objectId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    credentials: 'include',
+    body: `revision=${revision}`,
+  }).then(resp => {
+    if (!resp?.ok) {
+      throw new Error('Error when setting currently editing revision for current user');
+    }
+  });
+}
+
+export function removeRevision(objectType, objectId) {
+  return fetch(`/social/rest/coediting/${objectType}/${objectId}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp?.ok) {
+      throw new Error('Error when removing locked Object');
+    }
+  });
+}

--- a/webapp/src/main/webapp/vue-apps/coediting/main.js
+++ b/webapp/src/main/webapp/vue-apps/coediting/main.js
@@ -1,0 +1,22 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import './initComponents.js';
+import './services.js';

--- a/webapp/src/main/webapp/vue-apps/coediting/services.js
+++ b/webapp/src/main/webapp/vue-apps/coediting/services.js
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import * as coeditingService from './js/CoeditingService.js';
+
+if (!Vue.prototype.$coeditingService) {
+  window.Object.defineProperty(Vue.prototype, '$coeditingService', {
+    value: coeditingService,
+  });
+}

--- a/webapp/webpack.common.js
+++ b/webapp/webpack.common.js
@@ -20,6 +20,7 @@ let config = {
   entry: {
     animationComponents: './src/main/webapp/vue-apps/animations/main.js',
     applicationToolbarComponent: './src/main/webapp/vue-apps/application-toolbar/main.js',
+    coediting: './src/main/webapp/vue-apps/coediting/main.js',
     commonVueComponents: './src/main/webapp/vue-apps/common/main.js',
     categoryManagement: './src/main/webapp/vue-apps/category-management/main.js',
     categoryVueComponents: './src/main/webapp/vue-apps/category-components/main.js',


### PR DESCRIPTION
This change will move the co-edition Reusable Component from Layout to allow use it in other editors such as notes and news which relies on Draft management.