### PR TITLE
fix: Fix Extra Margin In Page Not Found UI - Meeds-io/MIPs#175

### DIFF
--- a/webapp/src/main/webapp/html/pageNotFound.html
+++ b/webapp/src/main/webapp/html/pageNotFound.html
@@ -1,6 +1,6 @@
 <div class="VuetifyApp">
     <div data-app="true"
-         class="v-application transparent v-application--is-ltr theme--light singlePageApplication"
+         class="v-application transparent v-application--is-ltr theme--light"
          id="PageNotFound">
         <script type="text/javascript">
             require(['PORTLET/social/PageNotFound'],

--- a/webapp/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
+++ b/webapp/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
@@ -19,9 +19,10 @@
 
 -->
 <template>
-  <v-app class="singlePageApplication">
+  <v-app class="application-body">
     <v-card
       class="pageNotFoundInfo py-12 text-center"
+      color="transparent"
       flat>
       <v-card-text>
         <v-icon color="primary" class="fa-7x">


### PR DESCRIPTION
This change will delete an extra margin added in `Page Not Found` UI due to a deprecated class used in parent node of portlet.