### PR TITLE
fix: Fix Accessing Space Form from Sidebar with Space Template - MEED-8321 - Meeds-io/meeds#2846

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -402,9 +402,6 @@ export default {
       this.open();
     },
     openByEvent(e) {
-      if (typeof e?.detail === 'number' && this.$root.id && this.$root.id !== e?.detail) {
-        return;
-      }
       this.openByRootEvent(e?.detail);
     },
     openByRootEvent(templateId) {


### PR DESCRIPTION
Prior to this change, when clicking on 'add' button from the second level in sidebar of a Space Template element, and when being in spaces page, the Space Form isn't displayed. This change will allow to display the form independently from the displayed page by user.

fixes Meeds-io/meeds#2846