### PR TITLE
feat: Improve ProfilePropertySetting API and Caching - MEED-8362 - Meeds-io/meeds#2904

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
@@ -44,16 +44,16 @@ public interface ProfilePropertyService {
   List<ProfilePropertySetting> getSynchronizedPropertySettings();
 
   /**
-   * Retrieves the ProfileProperty item with given {@link ProfilePropertySetting}
-   * propertyName
+   * Retrieves the ProfileProperty item with given
+   * {@link ProfilePropertySetting} propertyName
    *
    * @return {@link ProfilePropertySetting} if exist or null if not
    */
   ProfilePropertySetting getProfileSettingById(Long id);
 
   /**
-   * Retrieves the ProfileProperty item with given {@link ProfilePropertySetting}
-   * propertyName
+   * Retrieves the ProfileProperty item with given
+   * {@link ProfilePropertySetting} propertyName
    *
    * @return {@link ProfilePropertySetting} if exist or null if not
    */
@@ -82,12 +82,13 @@ public interface ProfilePropertyService {
   void deleteProfilePropertySetting(Long id);
 
   /**
-   * Checks if the given {@link ProfilePropertySetting} object can be synchronized
-   * with a group
-   *
+   * Checks if the given {@link ProfilePropertySetting} object can be
+   * synchronized with a group
+   * 
+   * @param id {@link ProfilePropertySetting} identifier
    * @return {@link Boolean}
    */
-  boolean isGroupSynchronizedEnabledProperty(ProfilePropertySetting profilePropertySetting);
+  boolean isGroupSynchronizedEnabledProperty(Long id);
 
   /**
    * Retreive the list {@link List} of {@link String} of property settings names
@@ -99,16 +100,10 @@ public interface ProfilePropertyService {
   void addProfilePropertyPlugin(ComponentPlugin profilePropertyInitPlugin);
 
   /**
-   * Checks if the current property has child properties
+   * Checks if the current property is a default property
+   * 
    * @param propertySetting
-   * @return Boolean : true if the current property has child properties
-   */
-  boolean hasChildProperties(ProfilePropertySetting propertySetting);
-
-  /**
-   * Checks if the current property is a default propertie
-   * @param propertySetting
-   * @return Boolean : true if the current property is a default propertie
+   * @return Boolean : true if the current property is a default property
    */
   boolean isDefaultProperties(ProfilePropertySetting propertySetting);
 
@@ -129,10 +124,10 @@ public interface ProfilePropertyService {
   /**
    * Checks if property is hiddenable
    *
-   * @param propertySetting profile property setting
+   * @param id {@link ProfilePropertySetting} identifier
    * @return true if property is hiddenbale and false otherwise
    */
-  boolean isPropertySettingHiddenable(ProfilePropertySetting propertySetting);
+  boolean isPropertySettingHiddenable(Long id);
 
   /**
    * Hide profile property setting
@@ -141,7 +136,6 @@ public interface ProfilePropertyService {
    * @param profilePropertyId profile property id
    */
   void hidePropertySetting(long userIdentityId, long profilePropertyId);
-
 
   /**
    * Show profile property setting

--- a/component/api/src/main/java/org/exoplatform/social/core/profileproperty/model/ProfilePropertySetting.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profileproperty/model/ProfilePropertySetting.java
@@ -31,35 +31,37 @@ import java.util.List;
 @AllArgsConstructor
 public class ProfilePropertySetting {
 
-  private Long                       id;
+  private Long                        id;
 
-  private String                     propertyName;
+  private String                      propertyName;
 
-  private String                     propertyType;
+  private String                      propertyType;
 
-  private boolean                    isDropdownList;
+  private boolean                     isDropdownList;
 
-  private boolean                    isVisible;
+  private boolean                     isVisible;
 
-  private boolean                    isEditable;
+  private boolean                     isEditable;
 
-  private Long                       parentId;
+  private Long                        parentId;
 
-  private Long                       order;
+  private Long                        order;
 
-  private boolean                    isActive;
+  private boolean                     isActive;
 
-  private boolean                    isGroupSynchronized;
+  private boolean                     isGroupSynchronized;
 
-  private boolean                    isHiddenbale;
+  private boolean                     isHiddenbale;
 
-  private boolean                    indexInAnalytics;
+  private boolean                     indexInAnalytics;
 
-  private boolean                    isRequired;
+  private boolean                     isRequired;
 
-  private boolean                    isMultiValued;
+  private boolean                     isMultiValued;
+
+  private boolean                     hasChildProperties;
 
   private List<ProfilePropertyOption> propertyOptions;
 
-  private Long                       updated;
+  private Long                        updated;
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -180,7 +180,7 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
   public String getMapping() {
     StringBuilder profileSettingsFieldsMapping = new StringBuilder();
     for(ProfilePropertySetting propertySetting : profilePropertyService.getPropertySettings()) {
-      if(propertySetting.isVisible() && propertySetting.isEditable() && !propertySetting.isMultiValued() && propertySetting.getParentId() == null && !profilePropertyService.hasChildProperties(propertySetting) && !"email".equals(propertySetting.getPropertyName())) {
+      if(propertySetting.isVisible() && propertySetting.isEditable() && !propertySetting.isMultiValued() && propertySetting.getParentId() == null && !propertySetting.isHasChildProperties() && !"email".equals(propertySetting.getPropertyName())) {
         profileSettingsFieldsMapping.append("    \"").append(propertySetting.getPropertyName().equals("fullName")? "name" : propertySetting.getPropertyName()).append("\" : {")
                 .append("      \"type\" : \"text\",")
                 .append("      \"index_options\": \"offsets\",")

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ProfilePropertySettingDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ProfilePropertySettingDAO.java
@@ -55,11 +55,15 @@ public class ProfilePropertySettingDAO extends GenericDAOJPAImpl<ProfileProperty
     return query.getResultList();
   }
 
-  public List<ProfilePropertySettingEntity> findChildProperties(Long parentId) {
-    TypedQuery<ProfilePropertySettingEntity> query =
-            getEntityManager().createNamedQuery("SocProfileSettingEntity.findChildProperties",
-                    ProfilePropertySettingEntity.class)
-                    .setParameter("parentId", parentId);
-    return query.getResultList();
+  public boolean hasChildProperties(Long id) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("SocProfileSettingEntity.countChildProperties", Long.class)
+                                               .setParameter("id", id);
+    try {
+      Long count = query.getSingleResult();
+      return count != null && count.longValue() > 0;
+    } catch (NoResultException e) {
+      return false;
+    }
   }
+
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ProfilePropertySettingEntity.java
@@ -31,16 +31,18 @@ import org.hibernate.annotations.BatchSize;
 @Entity(name = "SocProfileSettingEntity")
 @Table(name = "SOC_PROFILE_PROPERTY_SETTING ")
 
-@NamedQuery(name = "SocProfileSettingEntity.findProfileSettingByName", query = "SELECT c FROM SocProfileSettingEntity c WHERE propertyName = :name")
-@NamedQuery(name = "SocProfileSettingEntity.findSynchronizedSettings", query = "SELECT c FROM SocProfileSettingEntity c WHERE isGroupSynchronized = true")
+@NamedQuery(name = "SocProfileSettingEntity.findProfileSettingByName", query = "SELECT c FROM SocProfileSettingEntity c WHERE c.propertyName = :name")
+@NamedQuery(name = "SocProfileSettingEntity.findSynchronizedSettings", query = "SELECT c FROM SocProfileSettingEntity c WHERE c.isGroupSynchronized = true")
 @NamedQuery(name = "SocProfileSettingEntity.findOrderedSettings", query = "SELECT c FROM SocProfileSettingEntity c order by c.order")
-@NamedQuery(name = "SocProfileSettingEntity.findChildProperties", query = "SELECT c FROM SocProfileSettingEntity c WHERE parentId = :parentId order by c.order")
+@NamedQuery(name = "SocProfileSettingEntity.countChildProperties", query = "SELECT COUNT(c) FROM SocProfileSettingEntity c WHERE c.parentId = :id")
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
 public class ProfilePropertySettingEntity implements Serializable {
+
+  private static final long                 serialVersionUID = -2657229462239171339L;
 
   @Id
   @SequenceGenerator(name = "SEQ_SOC_PROPERTY_SETTING_ID", sequenceName = "SEQ_SOC_PROPERTY_SETTING_ID", allocationSize = 1)

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
@@ -20,15 +20,14 @@
 
 package org.exoplatform.social.core.profileproperty;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
-import io.meeds.social.translation.model.TranslationField;
-import io.meeds.social.translation.service.TranslationService;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.exception.ObjectNotFoundException;
-import org.exoplatform.social.core.profileproperty.model.ProfilePropertyOption;
 import org.picocontainer.Startable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -46,8 +45,12 @@ import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.jpa.search.ProfileIndexingServiceConnector;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertyOption;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.profileproperty.storage.ProfileSettingStorage;
+
+import io.meeds.social.translation.model.TranslationField;
+import io.meeds.social.translation.service.TranslationService;
 
 public class ProfilePropertyServiceImpl implements ProfilePropertyService, Startable {
 
@@ -61,7 +64,7 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   private final IndexingService                      indexingService;
 
   private final ListenerService                      listenerService;
-  
+
   private final TranslationService                   translationService;
 
   private static final String                        SYNCHRONIZED_DISABLED_PROPERTIES       = "synchronizationDisabledProperties";
@@ -72,16 +75,6 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
 
   private static final String                        EXCLUDED_ANALYTICS_INDEX_PROPERTIES    = "excludedAnalyticsIndexProperties";
 
-  protected List<ProfilePropertyDatabaseInitializer> profielPropertyPlugins                 = new ArrayList<>();
-
-  private List<String>                               synchronizedGroupDisabledProperties    = new ArrayList<>();
-
-  private static List<String>                        nonHiddenableProps                     = new ArrayList<>();
-
-  private static List<String>                        excludedQuickSearchProps               = new ArrayList<>();
-  
-  private static List<String>                        excludedAnalyticsIndexProps           = new ArrayList<>();
-
   private static final Scope                         HIDDEN_PROFILE_PROPERTY_SETTINGS_SCOPE =
                                                                                             Scope.APPLICATION.id("ProfilePropertySettings");
 
@@ -90,18 +83,29 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   private static final String                        PROFILE_PROPERTY_FIELD_NAME            = "optionValue";
 
   private static final String                        PROFILE_PROPERTY_OBJECT_TYPE           = "propertySettingOption";
-  
+
+  protected List<ProfilePropertyDatabaseInitializer> profielPropertyPlugins                 = new ArrayList<>();
+
+  private List<String>                               synchronizedGroupDisabledProperties    = new ArrayList<>();
+
+  private List<String>                               nonHiddenableProps                     = new ArrayList<>();
+
+  private List<String>                               excludedQuickSearchProps               = new ArrayList<>();
+
+  private List<String>                               excludedAnalyticsIndexProps            = new ArrayList<>();
+
   public ProfilePropertyServiceImpl(InitParams params,
                                     ProfileSettingStorage profileSettingStorage,
                                     SettingService settingService,
                                     IndexingService indexingService,
-                                    ListenerService listenerService, TranslationService translationService) {
+                                    ListenerService listenerService,
+                                    TranslationService translationService) {
     this.profileSettingStorage = profileSettingStorage;
     this.settingService = settingService;
     this.indexingService = indexingService;
     this.listenerService = listenerService;
     this.translationService = translationService;
-      if (params != null) {
+    if (params != null) {
       try {
         synchronizedGroupDisabledProperties = Arrays.asList(params.getValueParam(SYNCHRONIZED_DISABLED_PROPERTIES)
                                                                   .getValue()
@@ -155,43 +159,40 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   }
 
   @Override
-  public boolean isPropertySettingHiddenable(ProfilePropertySetting propertySetting) {
-    if (nonHiddenableProps.contains(propertySetting.getPropertyName()) || hasChildProperties(propertySetting)) {
-      return false;
-    }
-    return propertySetting.isHiddenbale();
+  public boolean isPropertySettingHiddenable(Long id) {
+    return isPropertySettingHiddenable(getProfileSettingById(id));
   }
 
   @Override
   public ProfilePropertySetting createPropertySetting(ProfilePropertySetting profilePropertySetting) throws ObjectAlreadyExistsException {
 
     validatePropertySetting(profilePropertySetting);
-    
+
     ProfilePropertySetting storedProfilePropertySetting =
                                                         profileSettingStorage.findProfileSettingByName(profilePropertySetting.getPropertyName());
     if (storedProfilePropertySetting != null) {
       throw new ObjectAlreadyExistsException(storedProfilePropertySetting,
                                              "A profile property with the provided name already exists.");
     }
-    
+
     if (!isGroupSynchronizedEnabledProperty(profilePropertySetting)) {
       profilePropertySetting.setGroupSynchronized(false);
     }
 
     profilePropertySetting.setUpdated(System.currentTimeMillis());
     storedProfilePropertySetting = profileSettingStorage.saveProfilePropertySetting(profilePropertySetting,
-                                                                                                          true);
+                                                                                    true);
     savePropertyOptionsTranslations(storedProfilePropertySetting, profilePropertySetting.getPropertyOptions(), false);
     if (storedProfilePropertySetting.getOrder() == null) {
       storedProfilePropertySetting.setOrder(storedProfilePropertySetting.getId());
       storedProfilePropertySetting = profileSettingStorage.saveProfilePropertySetting(storedProfilePropertySetting, false);
     }
-    
+
     try {
       listenerService.broadcast("profile-property-setting-created", this, storedProfilePropertySetting);
     } catch (Exception e) {
       LOG.error("An error occurred while broadcasting the creation event for the property setting '{}'.",
-              storedProfilePropertySetting.getPropertyName(),
+                storedProfilePropertySetting.getPropertyName(),
                 e);
     }
     return storedProfilePropertySetting;
@@ -199,9 +200,9 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
 
   @Override
   public void updatePropertySetting(ProfilePropertySetting profilePropertySetting) {
-    
+
     validatePropertySetting(profilePropertySetting);
-    
+
     if (profilePropertySetting.isHiddenbale()
         && getUnhiddenableProfileProperties().contains(profilePropertySetting.getPropertyName())) {
       throw new IllegalArgumentException(String.format("%s cannot be hidden", profilePropertySetting.getPropertyName()));
@@ -214,20 +215,24 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     if (createdProfilePropertySetting != null && isDefaultProperties(profilePropertySetting)) {
       profilePropertySetting.setMultiValued(createdProfilePropertySetting.isMultiValued());
     }
-    // Prevent any attempt to update the property type of created property setting
+    // Prevent any attempt to update the property type of created property
+    // setting
     if (createdProfilePropertySetting != null) {
       profilePropertySetting.setPropertyType(createdProfilePropertySetting.getPropertyType());
     }
     profilePropertySetting.setUpdated(System.currentTimeMillis());
-    ProfilePropertySetting updatedPropertySetting = profileSettingStorage.saveProfilePropertySetting(profilePropertySetting, false);
+    ProfilePropertySetting updatedPropertySetting =
+                                                  profileSettingStorage.saveProfilePropertySetting(profilePropertySetting, false);
     savePropertyOptionsTranslations(updatedPropertySetting, profilePropertySetting.getPropertyOptions(), true);
     try {
       listenerService.broadcast("profile-property-setting-updated", this, updatedPropertySetting);
     } catch (Exception e) {
-      LOG.error("An error occurred when broadcasting the update event of the property setting {}", updatedPropertySetting.getPropertyName(), e);
+      LOG.error("An error occurred when broadcasting the update event of the property setting {}",
+                updatedPropertySetting.getPropertyName(),
+                e);
     }
   }
-  
+
   @Override
   public void deleteProfilePropertySetting(Long id) {
     if (id <= 0) {
@@ -237,15 +242,8 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   }
 
   @Override
-  public boolean isGroupSynchronizedEnabledProperty(ProfilePropertySetting profilePropertySetting) {
-    if (synchronizedGroupDisabledProperties.contains(profilePropertySetting.getPropertyName())) {
-      return false;
-    }
-    if (profilePropertySetting.getParentId() != null && profilePropertySetting.getParentId() > 0) {
-      ProfilePropertySetting parent = profileSettingStorage.getProfileSettingById(profilePropertySetting.getParentId());
-      return parent == null || !synchronizedGroupDisabledProperties.contains(parent.getPropertyName());
-    }
-    return true;
+  public boolean isGroupSynchronizedEnabledProperty(Long id) {
+    return isGroupSynchronizedEnabledProperty(getProfileSettingById(id));
   }
 
   @Override
@@ -258,7 +256,8 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
    */
   @Override
   public void hidePropertySetting(long userIdentityId, long profilePropertyId) {
-    List<Long> hiddenProperties = getHiddenProfilePropertyIds(userIdentityId);hiddenProperties.remove(profilePropertyId);
+    List<Long> hiddenProperties = getHiddenProfilePropertyIds(userIdentityId);
+    hiddenProperties.remove(profilePropertyId);
     hiddenProperties.add(profilePropertyId);
     settingService.set(Context.USER.id(String.valueOf(userIdentityId)),
                        HIDDEN_PROFILE_PROPERTY_SETTINGS_SCOPE,
@@ -280,7 +279,6 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
                        SettingValue.create(hiddenProperties.toString()));
     indexingService.reindex(ProfileIndexingServiceConnector.TYPE, String.valueOf(userIdentityId));
   }
-
 
   /**
    * {@inheritDoc}
@@ -331,11 +329,6 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   }
 
   @Override
-  public boolean hasChildProperties(ProfilePropertySetting propertySetting) {
-    return profileSettingStorage.hasChildProperties(propertySetting.getId());
-  }
-
-  @Override
   public boolean isDefaultProperties(ProfilePropertySetting propertySetting) {
     for (ProfilePropertyDatabaseInitializer plugin : profielPropertyPlugins) {
       if (plugin.getConfig().getProfileProperties() != null && !plugin.getConfig().getProfileProperties().isEmpty()
@@ -348,7 +341,7 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     }
     return false;
   }
-  
+
   private void validatePropertySetting(ProfilePropertySetting profilePropertySetting) {
     if (profilePropertySetting == null) {
       throw new IllegalArgumentException("Profile property setting object is mandatory.");
@@ -400,4 +393,24 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
       }
     }
   }
+
+  private boolean isPropertySettingHiddenable(ProfilePropertySetting propertySetting) {
+    return propertySetting != null
+           && !nonHiddenableProps.contains(propertySetting.getPropertyName())
+           && !propertySetting.isHasChildProperties()
+           && propertySetting.isHiddenbale();
+  }
+
+  private boolean isGroupSynchronizedEnabledProperty(ProfilePropertySetting profilePropertySetting) {
+    if (profilePropertySetting == null
+        || synchronizedGroupDisabledProperties.contains(profilePropertySetting.getPropertyName())) {
+      return false;
+    }
+    if (profilePropertySetting.getParentId() != null && profilePropertySetting.getParentId() > 0) {
+      ProfilePropertySetting parent = profileSettingStorage.getProfileSettingById(profilePropertySetting.getParentId());
+      return parent == null || !synchronizedGroupDisabledProperties.contains(parent.getPropertyName());
+    }
+    return true;
+  }
+
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/storage/ProfileSettingStorage.java
@@ -75,10 +75,6 @@ public class ProfileSettingStorage {
     profilePropertySettingDAO.delete(profilePropertySettingDAO.find(id));
   }
 
-  public boolean hasChildProperties(Long parentId) {
-    return !profilePropertySettingDAO.findChildProperties(parentId).isEmpty();
-  }
-  
   public List<ProfilePropertyOption> getProfilePropertyOptions(Long propertySettingId, int offset, int limit) {
     return toPropertyOptions(profilePropertyOptionDAO.findPropertyOptionsBySettingId(propertySettingId, offset, limit));
   }
@@ -128,6 +124,7 @@ public class ProfileSettingStorage {
     profilePropertySetting.setPropertyType(profilePropertySettingEntity.getPropertyType());
     profilePropertySetting.setPropertyOptions(toPropertyOptions(profilePropertySettingEntity.getPropertyOptions()));
     profilePropertySetting.setUpdated(profilePropertySettingEntity.getUpdatedDate().getTime());
+    profilePropertySetting.setHasChildProperties(hasChildProperties(profilePropertySettingEntity.getId()));
     return profilePropertySetting;
   }
 
@@ -141,6 +138,10 @@ public class ProfileSettingStorage {
                                            profilePropertyOption.getPropertySettingId() != null ? profilePropertySettingDAO.find(profilePropertyOption.getPropertySettingId())
                                                                                                 : profilePropertySettingEntity);
 
+  }
+
+  private boolean hasChildProperties(Long id) {
+    return profilePropertySettingDAO.hasChildProperties(id);
   }
 
   private ProfilePropertyOption fromPropertyOptionEntity(ProfilePropertyOptionEntity profilePropertyOptionEntity) {

--- a/component/core/src/test/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListenerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/listeners/ManagerPropertySettingUpdatedListenerTest.java
@@ -66,6 +66,7 @@ public class ManagerPropertySettingUpdatedListenerTest {
                                                                                true,
                                                                                false,
                                                                                false,
+                                                                               false,
                                                                                new ArrayList<>(),
                                                                                System.currentTimeMillis());
     Event<ProfilePropertyService, ProfilePropertySetting> event = new Event<>("profile-property-setting-updated", profilePropertyService, profilePropertySetting);
@@ -96,6 +97,7 @@ public class ManagerPropertySettingUpdatedListenerTest {
                                                         false,
                                                         false,
                                                         true,
+                                                        false,
                                                         false,
                                                         false,
                                                         new ArrayList<>(),

--- a/component/core/src/test/java/org/exoplatform/social/core/profile/ProfilePropertyServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/profile/ProfilePropertyServiceTest.java
@@ -45,14 +45,13 @@ public class ProfilePropertyServiceTest extends AbstractCoreTest {
     super.setUp();
     profilePropertyService = getContainer().getComponentInstanceOfType(ProfilePropertyService.class);
     profilePropertySettingDAO = getContainer().getComponentInstanceOfType(ProfilePropertySettingDAO.class);
-    getService(CachedProfileSettingStorage.class).clearCaches();
+    cleanData();
   }
 
   @Override
-  public void tearDown() throws Exception {
-    restartTransaction();
-    profilePropertySettingDAO.deleteAll();
-    super.tearDown();
+  protected void afterClass() {
+    cleanData();
+    super.afterClass();
   }
 
   public void testCreateProfilePropertySetting() throws Exception {
@@ -143,18 +142,24 @@ public class ProfilePropertyServiceTest extends AbstractCoreTest {
     assertFalse(profilePropertyService.getExcludedQuickSearchProperties().isEmpty());
   }
 
+  public void testIsSystemPropertySettingNonHiddenable() throws ObjectAlreadyExistsException {
+    ProfilePropertySetting unHiddenableProfilePropertySetting = createProfileSettingInstance("fullName");
+    unHiddenableProfilePropertySetting = profilePropertyService.createPropertySetting(unHiddenableProfilePropertySetting);
+    assertFalse(profilePropertyService.isPropertySettingHiddenable(unHiddenableProfilePropertySetting.getId()));
+  }
+
   public void testIsPropertySettingHiddenable() throws ObjectAlreadyExistsException {
-    ProfilePropertySetting unHiddenableprofilePropertySetting = createProfileSettingInstance("fullName");
-    ProfilePropertySetting hiddenableprofilePropertySetting = createProfileSettingInstance("prop");
-    hiddenableprofilePropertySetting.setHiddenbale(true);
-    ProfilePropertySetting propertySetting = profilePropertyService.createPropertySetting(hiddenableprofilePropertySetting);
+    ProfilePropertySetting propertySetting = createProfileSettingInstance("prop");
+    propertySetting.setHiddenbale(true);
+    propertySetting = profilePropertyService.createPropertySetting(propertySetting);
+
     ProfilePropertySetting childProp = createProfileSettingInstance("childProp");
-    assertFalse(profilePropertyService.isPropertySettingHiddenable(unHiddenableprofilePropertySetting));
-    assertTrue(profilePropertyService.isPropertySettingHiddenable(hiddenableprofilePropertySetting));
+    assertTrue(profilePropertyService.isPropertySettingHiddenable(propertySetting.getId()));
+
     ProfilePropertySetting chilePropertySetting = profilePropertyService.createPropertySetting(childProp);
     chilePropertySetting.setParentId(propertySetting.getId());
     profilePropertyService.updatePropertySetting(chilePropertySetting);
-    assertFalse(profilePropertyService.isPropertySettingHiddenable(propertySetting));
+    assertFalse(profilePropertyService.isPropertySettingHiddenable(propertySetting.getId()));
   }
 
   public void testDropdownListPropertySetting() throws ObjectAlreadyExistsException {
@@ -269,6 +274,12 @@ public class ProfilePropertyServiceTest extends AbstractCoreTest {
     propertySetting.setPropertyOptions(profilePropertyOptions);
 
     return propertySetting;
+  }
+
+  private void cleanData() {
+    restartTransaction();
+    profilePropertySettingDAO.deleteAll();
+    getService(CachedProfileSettingStorage.class).clearCaches();
   }
 
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -2034,8 +2034,8 @@ public class EntityBuilder {
     profilePropertySettingEntity.setOrder(profilePropertySetting.getOrder());
     profilePropertySettingEntity.setUpdated(profilePropertySetting.getUpdated());
     profilePropertySettingEntity.setMultiValued(profilePropertySetting.isMultiValued());
-    profilePropertySettingEntity.setGroupSynchronizationEnabled(profilePropertyService.isGroupSynchronizedEnabledProperty(profilePropertySetting));
-    profilePropertySettingEntity.setHiddenable(profilePropertyService.isPropertySettingHiddenable(profilePropertySetting));
+    profilePropertySettingEntity.setGroupSynchronizationEnabled(profilePropertyService.isGroupSynchronizedEnabledProperty(profilePropertySetting.getId()));
+    profilePropertySettingEntity.setHiddenable(profilePropertyService.isPropertySettingHiddenable(profilePropertySetting.getId()));
     profilePropertySettingEntity.setIndexInAnalytics(profilePropertySetting.isIndexInAnalytics());
     profilePropertySettingEntity.setPropertyType(profilePropertySetting.getPropertyType());
     profilePropertySettingEntity.setLabels(profileLabelService.findLabelByObjectTypeAndObjectId(objectType,
@@ -2462,7 +2462,7 @@ public class EntityBuilder {
     ProfilePropertySetting profilePropertySetting = getProfilePropertyService().getProfileSettingByName(propertyName);
     return profilePropertySetting != null
            && (profilePropertySetting.isVisible()
-               || !getProfilePropertyService().isPropertySettingHiddenable(profilePropertySetting));
+               || !getProfilePropertyService().isPropertySettingHiddenable(profilePropertySetting.getId()));
   }
 
   private static org.exoplatform.services.security.Identity getCurrentUserIdentity() {

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -1729,7 +1729,7 @@ public class UserRest implements ResourceContainer, Startable {
               if (propertySetting == null) {
                 userImportResultEntity.addWarnMessage("ALL", "PROFILE_PROPERTY_DOES_NOT_EXIST:" + field);
                 unauthorizedFields.add(field);
-              } else if (profilePropertyService.hasChildProperties(propertySetting)) {
+              } else if (propertySetting.isHasChildProperties()) {
                 userImportResultEntity.addWarnMessage("ALL", "PARENT_PROPERTY_SHOULD_NOT_HAVE_VALUES:" + field);
                 unauthorizedFields.add(field);
               } else if(propertySetting.isMultiValued() && !systemParentAndMultivaluedFields.contains(field)) {

--- a/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -1,4 +1,6 @@
 <%
+  import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+  import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
   import org.exoplatform.ws.frameworks.cometd.ContinuationService;
   import org.mortbay.cometd.continuation.EXoContinuationBayeux;
   import org.exoplatform.commons.api.settings.ExoFeatureService;
@@ -28,6 +30,8 @@
   Set<String> supportedAttachmentObjectTypes = attachmentService.getSupportedObjectTypes();
   String viewerIdentityId = Utils.getViewerIdentityId();
   String ownerIdentityId = Utils.getOwnerIdentityId();
+  ProfilePropertyService profilePropertyService = uicomponent.getApplicationComponent(ProfilePropertyService.class);
+  ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("manager");
 %>
 <script type="text/javascript" id="socialHeadScripts">
      eXo.env.portal.spaceId = "<%=space == null ? "" : space.getId()%>" ;
@@ -45,6 +49,7 @@
      eXo.env.portal.isExternal = <%=Utils.isExternal(Utils.getViewerIdentity())%>;
      eXo.env.portal.cometdToken = "<%=cometdToken%>";
      eXo.env.portal.cometdContext = "<%=cometdContext%>";
+     eXo.env.portal.isOrganizationalChartEnabled = <%=profilePropertySetting != null && profilePropertySetting.isActive()%>;
      eXo.env.server.sessionId = "<%=rcontext.getRequest().getSession(true).getId()%>";
      eXo.env.portal.vuetifyPreset = {
        dark: true,

--- a/webapp/src/main/webapp/vue-apps/organizational-chart/extensions/main.js
+++ b/webapp/src/main/webapp/vue-apps/organizational-chart/extensions/main.js
@@ -1,27 +1,13 @@
 import {registerExtension} from './extensions.js';
 
 const lang = eXo?.env?.portal?.language || 'en';
-
 const url = `/social/i18n/locale.portlet.Portlets?lang=${lang}`;
+
 export function init() {
-  if (!eXo?.env?.portal?.userIdentityId) {
+  if (!eXo?.env?.portal?.userIdentityId
+    || !eXo.env.portal.isOrganizationalChartEnabled) {
     return;
   }
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/profile/settings/manager`, {
-    method: 'GET',
-    credentials: 'include',
-  }).then(resp => {
-    if (!resp || !resp.ok) {
-      throw new Error('Response code indicates a server error', resp);
-    } else {
-      return resp.json();
-    }
-  }).then(profileSetting => {
-    if (profileSetting.active) {
-      exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-        registerExtension(i18n.t('organizationalChart.header.label'));
-      });
-    }
-  });
+  exoi18n.loadLanguageAsync(lang, url)
+    .then(i18n => registerExtension(i18n.t('organizationalChart.header.label')));
 }
-


### PR DESCRIPTION
Each page rendering, a call to check whether the manager property setting is enabled or not, in order to prepare the popover extension button (of **Organizational Chart**) in case the user displays it by hovering a user name.

This REST call will retrieve from database, using multiple queries, the information whether the property is active or not to know whether to display the button in the Popover or not. This change will rework the API to use 'IDs' in getter methods instead of bypassing the whole object (like an Utils class). Using the id, when retrieving the fresh information from database/cache, the information will be relevant and consistent, in contrary of bypassing an object to the API.

By changing this, the API can rely on cached information rather than retrieved object informations. In addition, the REST call (too much expensive for the information that it brings **true/false**), has to be replaced by a generic flag added in `eXo.env.portal.isOrganizationalChartEnabled` as done for any feature flag.

Resolves Meeds-io/meeds#2904