### PR TITLE
fix: Fix Retrieving attachments when no offset and no limit params - MEED-8370 - Meeds-io/meeds#2922

### DIFF
--- a/webapp/src/main/webapp/vue-apps/attach-image/js/FileAttachmentService.js
+++ b/webapp/src/main/webapp/vue-apps/attach-image/js/FileAttachmentService.js
@@ -35,7 +35,14 @@ export function saveAttachments(attachmentResource) {
 }
 
 export function getAttachments(objectType, objectId, offset, limit) {
-  const params = new URLSearchParams({ offset, limit }).toString();
+  const formData = new FormData();
+  if (offset || offset === 0) {
+    formData.append('offset', offset);
+  }
+  if (limit || limit === 0) {
+    formData.append('limit', limit);
+  }
+  const params = new URLSearchParams(formData).toString();
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/attachments/${objectType}/${objectId}?${params}`, {
     method: 'GET',
     credentials: 'include',


### PR DESCRIPTION
Prior to this change, the offset and limit params of Attachments retrieval operation has become mandatory. In order to not break the existing API usage, those new parameters should be optional with the default values as parameters instead, which is '0' for both, or even better, no value to let REST API decide the default values to use 0, 10 or -1. This change will let REST API decide which default values was passed to avoid Breaking change of API.