### PR TITLE
fix: Fix DOM Id of Topbar Preview Portlet - MEED-8373 - Meeds-io/meeds#2925

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/topbarPreview.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/topbarPreview.jsp
@@ -33,7 +33,7 @@
 <div class="VuetifyApp">
   <div
    class="v-application border-box-sizing theme--light"
-   id="topBarPublishSite">
+   id="topbarPreview">
    <script type="text/javascript">
      require(['PORTLET/social/TopBarPreview'], app => app.init());
    </script>


### PR DESCRIPTION
Prior to this change, the Topbar preview button isn't displayed and mounted due to wrong DOM Id used by Vue to init the app. This change will fix the DOM Id to use the one used in Vue init phase.