### PR TITLE
fix: Any user can access org chart settings - MEED-8333 - Meeds-io/meeds#2863

### DIFF
--- a/webapp/src/main/webapp/vue-apps/organizational-chart/components/OrganizationalChartApp.vue
+++ b/webapp/src/main/webapp/vue-apps/organizational-chart/components/OrganizationalChartApp.vue
@@ -136,7 +136,7 @@ export default {
       return this.hasSettings || (!this.hasSettings && this.isAdmin) || this.preview;
     },
     isAdmin() {
-      return this.user?.isAdmin || this.isSpaceManager;
+      return this.user?.isAdmin === 'true' || this.isSpaceManager;
     },
     savedHeaderTranslations() {
       return this.$root.settings?.headerTranslations;


### PR DESCRIPTION
Before this change, as a non admin user, when go to the page listing the chart My Team for example and hover the chart app, settings button is displayed. To resolve this problem, at OrganizationalChartApp, change the type of isAdmin from String to boolean. After this change, regular user (non-admin) cannot see the setting option when hovering the chart app.

(cherry picked from commit fa0d1efc523b88372d503c4bcca3ae00c3142844)