### PR TITLE
fix: Allow to Mention Space Role in Rich Editor using accent characters - MEED-8129 - Meeds-io/meeds#1557

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/ckeditor/config.js
@@ -126,28 +126,28 @@ CKEDITOR.editorConfig = function(config) {
   const retrieveSpaceRoles = function(query, space) {
     const result = [];
     if (space) {
-      if (space.membersCount && (!query?.length || membersLabel.toLowerCase().includes(query.toLowerCase()))) {
+      if (space.membersCount && (!query?.length || membersLabel.toLowerCase().normalize("NFD").includes(query.normalize("NFD").toLowerCase()))) {
         result.push({
           uid: `member:${space.identityId}`,
           name: membersLabel,
           icon: 'fa-users',
         });
       }
-      if (space.managersCount && (!query?.length || managersLabel.toLowerCase().includes(query.toLowerCase()))) {
+      if (space.managersCount && (!query?.length || managersLabel.toLowerCase().normalize("NFD").includes(query.normalize("NFD").toLowerCase()))) {
         result.push({
           uid: `manager:${space.identityId}`,
           name: managersLabel,
           icon: 'fa-user-cog',
         });
       }
-      if (space.redactorsCount && (!query?.length || redactorsLabel.toLowerCase().includes(query.toLowerCase()))) {
+      if (space.redactorsCount && (!query?.length || redactorsLabel.toLowerCase().normalize("NFD").includes(query.normalize("NFD").toLowerCase()))) {
         result.push({
           uid: `redactor:${space.identityId}`,
           name: redactorsLabel,
           icon: 'fa-user-edit',
         });
       }
-      if (space.publishersCount && (!query?.length || publishersLabel.toLowerCase().includes(query.toLowerCase()))) {
+      if (space.publishersCount && (!query?.length || publishersLabel.toLowerCase().normalize("NFD").includes(query.normalize("NFD").toLowerCase()))) {
         result.push({
           uid: `publisher:${space.identityId}`,
           name: publishersLabel,


### PR DESCRIPTION
Prior to this change, when searching for Space Roles mentioning using accented characters, the search result doesn't return the associated roles. This change will transform the Query and Label to ensure to improve the UX of group mentioning search UX.