### PR TITLE
feat: Set back custom CSS feature from branding page - MEED-8427 - Meeds-io/meeds#2939

### DIFF
--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ar.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ar.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=تحميل صورة خلفية
 generalSettings.deleteBackgroundImageTitle=حذف صورة الخلفية
 generalSettings.errorUploadingPreview=حدث خطأ أثناء تحميل التوضيح. الرجاء الاتصال بالمسؤول أو المحاولة مرة أخرى لاحقاً.
 generalSettings.globalPageFullWindow=صفحات النافذة الكاملة
+generalSettings.editCustomStyle=تحرير نمط مخصص
+generalSettings.customStyle=نمط مخصص
 
 generalSettings.manageDefaultLanguage=اللغة
 generalSettings.subtitle.manageDefaultLanguage=حدد اللغة الافتراضية للمنصة

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_aro.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_aro.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=تحميل صورة خلفية
 generalSettings.deleteBackgroundImageTitle=حذف صورة الخلفية
 generalSettings.errorUploadingPreview=حدث خطأ أثناء تحميل التوضيح. الرجاء الاتصال بالمسؤول أو المحاولة مرة أخرى لاحقاً.
 generalSettings.globalPageFullWindow=صفحات النافذة الكاملة
+generalSettings.editCustomStyle=تحرير نمط مخصص
+generalSettings.customStyle=نمط مخصص
 
 generalSettings.manageDefaultLanguage=اللغة
 generalSettings.subtitle.manageDefaultLanguage=حدد لغة المنصة الافتراضية

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_az.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_az.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ca.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ca.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Carregueu una imatge de fons
 generalSettings.deleteBackgroundImageTitle=Suprimeix la imatge de fons
 generalSettings.errorUploadingPreview=S'ha produït un error en carregar la il·lustració. Poseu-vos en contacte amb l'administrador o torneu-ho a provar més tard.
 generalSettings.globalPageFullWindow=Pàgines de la finestra completa
+generalSettings.editCustomStyle=Edita l'estil personalitzat
+generalSettings.customStyle=Estil personalitzat
 
 generalSettings.manageDefaultLanguage=Idioma
 generalSettings.subtitle.manageDefaultLanguage=Seleccioneu l'idioma predeterminat de la plataforma

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ceb.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ceb.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_co.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_co.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Caricate una imagine di fondo
 generalSettings.deleteBackgroundImageTitle=Sguassà l'imagine di fondo
 generalSettings.errorUploadingPreview=Un errore hè accadutu durante a carica di l'Illustrazione. Per piacè cuntattate l'amministratore o pruvate di novu più tardi.
 generalSettings.globalPageFullWindow=Pagine Full Window
+generalSettings.editCustomStyle=Edite u stile persunalizatu
+generalSettings.customStyle=Stile persunalizatu
 
 generalSettings.manageDefaultLanguage=Lingua
 generalSettings.subtitle.manageDefaultLanguage=Selezziunate a lingua predefinita di a piattaforma

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_cs.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_cs.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Nahrát obrázek pozadí
 generalSettings.deleteBackgroundImageTitle=Odstranit obrázek pozadí
 generalSettings.errorUploadingPreview=Při nahrávání illustrace došlo k chybě. Obraťte se na správce nebo opakujte akci později.
 generalSettings.globalPageFullWindow=Celé stránky okna
+generalSettings.editCustomStyle=Upravit vlastní styl
+generalSettings.customStyle=Vlastní styl
 
 generalSettings.manageDefaultLanguage=Jazyk
 generalSettings.subtitle.manageDefaultLanguage=Vyberte výchozí jazyk platformy

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_de.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_de.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Hintergrundbild hochladen
 generalSettings.deleteBackgroundImageTitle=Hintergrundbild löschen
 generalSettings.errorUploadingPreview=Beim Hochladen der Illustration ist ein Fehler aufgetreten. Bitte kontaktieren Sie den Administrator oder versuchen Sie es später erneut.
 generalSettings.globalPageFullWindow=Volle Fensterseiten
+generalSettings.editCustomStyle=Angepassten Stil bearbeiten
+generalSettings.customStyle=Stil anpassen
 
 generalSettings.manageDefaultLanguage=Sprache
 generalSettings.subtitle.manageDefaultLanguage=Wählen Sie die Standard-Plattformsprache

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_el.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_el.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Ανεβάστε μια εικόνα 
 generalSettings.deleteBackgroundImageTitle=Διαγραφή της εικόνας φόντου
 generalSettings.errorUploadingPreview=Παρουσιάστηκε σφάλμα κατά τη μεταφόρτωση της Εικονογράφησης. Παρακαλούμε επικοινωνήστε με το διαχειριστή ή προσπαθήστε ξανά αργότερα.
 generalSettings.globalPageFullWindow=Πλήρες Παράθυρο Σελίδες
+generalSettings.editCustomStyle=Επεξεργασία προσαρμοσμένου στυλ
+generalSettings.customStyle=Προσαρμοσμένο Στυλ
 
 generalSettings.manageDefaultLanguage=Γλώσσα
 generalSettings.subtitle.manageDefaultLanguage=Επιλέξτε την προεπιλεγμένη γλώσσα πλατφόρμας

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_en.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_en.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_es_ES.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_es_ES.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Subir una imagen de fondo
 generalSettings.deleteBackgroundImageTitle=Eliminar la imagen de fondo
 generalSettings.errorUploadingPreview=Se ha producido un error al subir la Illustración. Por favor, contacte con el administrador o inténtelo de nuevo más tarde.
 generalSettings.globalPageFullWindow=Páginas de Ventana completa
+generalSettings.editCustomStyle=Editar estilo personalizado
+generalSettings.customStyle=Estilo personalizado
 
 generalSettings.manageDefaultLanguage=Idioma
 generalSettings.subtitle.manageDefaultLanguage=Seleccione el idioma por defecto de la plataforma

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_eu.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_eu.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_fa.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_fa.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=یک تصویر پس زمینه با�
 generalSettings.deleteBackgroundImageTitle=تصویر پس زمینه را حذف کنید
 generalSettings.errorUploadingPreview=هنگام بارگذاری تصویر خطایی روی داد. لطفاً با سرپرست تماس بگیرید یا بعداً دوباره امتحان کنید.
 generalSettings.globalPageFullWindow=صفحات پنجره کامل
+generalSettings.editCustomStyle=ویرایش سبک سفارشی
+generalSettings.customStyle=سبک سفارشی
 
 generalSettings.manageDefaultLanguage=زبان
 generalSettings.subtitle.manageDefaultLanguage=زبان پلتفرم پیش فرض را انتخاب کنید

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_fi.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_fi.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Lataa taustakuva
 generalSettings.deleteBackgroundImageTitle=Poista taustakuva
 generalSettings.errorUploadingPreview=Virhe ladattaessa Illustration. Ota yhteyttä järjestelmänvalvojaan tai yritä myöhemmin uudelleen.
 generalSettings.globalPageFullWindow=Koko Ikkunasivut
+generalSettings.editCustomStyle=Muokkaa mukautettua tyyliä
+generalSettings.customStyle=Mukautettu Tyyli
 
 generalSettings.manageDefaultLanguage=Kieli
 generalSettings.subtitle.manageDefaultLanguage=Valitse oletusalusta kieli

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_fil.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_fil.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Mag-upload ng larawan sa background
 generalSettings.deleteBackgroundImageTitle=Tanggalin ang larawan sa background
 generalSettings.errorUploadingPreview=Nagkaroon ng error habang ina-upload ang Illustration. Mangyaring makipag-ugnayan sa administrator o subukang muli sa ibang pagkakataon.
 generalSettings.globalPageFullWindow=Mga Full Window Page
+generalSettings.editCustomStyle=I-edit ang custom na istilo
+generalSettings.customStyle=Custom na Estilo
 
 generalSettings.manageDefaultLanguage=Ang Wika
 generalSettings.subtitle.manageDefaultLanguage=Piliin ang default na wika ng platform

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_fr.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Charger une image d'arrière-plan
 generalSettings.deleteBackgroundImageTitle=Supprimer l'image d'arrière-plan
 generalSettings.errorUploadingPreview=Une erreur s'est produite lors de l'opération. Veuillez contacter l'assistance ou réessayer plus tard.
 generalSettings.globalPageFullWindow=Affichage sans marge
+generalSettings.editCustomStyle=Modifier la feuille de style
+generalSettings.customStyle=Style personnalisé
 
 generalSettings.manageDefaultLanguage=Langue
 generalSettings.subtitle.manageDefaultLanguage=Sélectionnez la langue par défaut de la plateforme

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_hi.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_hi.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_hu.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_hu.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Tölts fel egy háttérképet
 generalSettings.deleteBackgroundImageTitle=Törölje a háttérképet
 generalSettings.errorUploadingPreview=Hiba történt az illusztráció feltöltése közben. Kérjük, forduljon a rendszergazdához, vagy próbálja újra később.
 generalSettings.globalPageFullWindow=Teljes ablakos oldalak
+generalSettings.editCustomStyle=Egyéni stílus szerkesztése
+generalSettings.customStyle=Egyedi stílus
 
 generalSettings.manageDefaultLanguage=Nyelv
 generalSettings.subtitle.manageDefaultLanguage=Válassza ki az alapértelmezett platformnyelvet

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_id.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_id.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Unggah gambar latar belakang
 generalSettings.deleteBackgroundImageTitle=Hapus gambar latar belakang
 generalSettings.errorUploadingPreview=Terjadi kesalahan saat mengunggah Ilustrasi. Silakan hubungi administrator atau coba lagi nanti.
 generalSettings.globalPageFullWindow=Halaman Jendela Penuh
+generalSettings.editCustomStyle=Edit gaya khusus
+generalSettings.customStyle=Gaya Kustom
 
 generalSettings.manageDefaultLanguage=Bahasa
 generalSettings.subtitle.manageDefaultLanguage=Pilih bahasa platform default

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_it.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_it.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Carica un'immagine di sfondo
 generalSettings.deleteBackgroundImageTitle=Elimina l'immagine di sfondo
 generalSettings.errorUploadingPreview=Si è verificato un errore durante il caricamento di Illustrazione. Si prega di contattare l'amministratore o riprovare più tardi.
 generalSettings.globalPageFullWindow=Pagine A Finestra Completa
+generalSettings.editCustomStyle=Modifica stile personalizzato
+generalSettings.customStyle=Stile Personalizzato
 
 generalSettings.manageDefaultLanguage=Linguaggio
 generalSettings.subtitle.manageDefaultLanguage=Seleziona la lingua predefinita della piattaforma

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ja.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ja.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=背景画像をアップロード
 generalSettings.deleteBackgroundImageTitle=背景画像を削除
 generalSettings.errorUploadingPreview=Illustrationのアップロード中にエラーが発生しました。管理者に連絡するか、後でもう一度お試しください。
 generalSettings.globalPageFullWindow=全画面表示ページ
+generalSettings.editCustomStyle=カスタムスタイルを編集
+generalSettings.customStyle=カスタムスタイル
 
 generalSettings.manageDefaultLanguage=言語
 generalSettings.subtitle.manageDefaultLanguage=デフォルトのプラットフォーム言語を選択してください

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ko.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ko.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=배경 이미지 업로드
 generalSettings.deleteBackgroundImageTitle=배경 이미지 삭제
 generalSettings.errorUploadingPreview=일러스트레이션을 업로드하는 동안 오류가 발생했습니다. 관리자에게 문의하거나 나중에 다시 시도하세요.
 generalSettings.globalPageFullWindow=전체 창 페이지
+generalSettings.editCustomStyle=맞춤 스타일 수정
+generalSettings.customStyle=맞춤 스타일
 
 generalSettings.manageDefaultLanguage=언어
 generalSettings.subtitle.manageDefaultLanguage=기본 플랫폼 언어 선택

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_lt.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_lt.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Įkelkite fono paveikslėlį
 generalSettings.deleteBackgroundImageTitle=Ištrinkite fono paveikslėlį
 generalSettings.errorUploadingPreview=Įkeliant iliustraciją įvyko klaida. Susisiekite su administratoriumi arba bandykite dar kartą vėliau.
 generalSettings.globalPageFullWindow=Viso lango puslapiai
+generalSettings.editCustomStyle=Redaguoti pasirinktinį stilių
+generalSettings.customStyle=Pasirinktinis stilius
 
 generalSettings.manageDefaultLanguage=Kalba
 generalSettings.subtitle.manageDefaultLanguage=Pasirinkite numatytąją platformos kalbą

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ms.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ms.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_nl.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_nl.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload een achtergrondafbeelding
 generalSettings.deleteBackgroundImageTitle=Verwijder de achtergrondafbeelding
 generalSettings.errorUploadingPreview=Er is een fout opgetreden tijdens het uploaden van Illustratie. Neem contact op met de beheerder of probeer het later opnieuw.
 generalSettings.globalPageFullWindow=Volledige vensterpagina's
+generalSettings.editCustomStyle=Aangepaste stijl bewerken
+generalSettings.customStyle=Aangepaste stijl
 
 generalSettings.manageDefaultLanguage=Taal
 generalSettings.subtitle.manageDefaultLanguage=Selecteer de standaard platformtaal

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_no.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_no.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Last opp et bakgrunnsbilde
 generalSettings.deleteBackgroundImageTitle=Slett bakgrunnsbildet
 generalSettings.errorUploadingPreview=En feil oppsto under opplasting av Illustrasjon. Vennligst kontakt administratoren eller prøv igjen senere.
 generalSettings.globalPageFullWindow=Fullskjerm sider
+generalSettings.editCustomStyle=Rediger egendefinert stil
+generalSettings.customStyle=Egendefinert stil
 
 generalSettings.manageDefaultLanguage=Språk
 generalSettings.subtitle.manageDefaultLanguage=Velg standard plattformspråk

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_pcm.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_pcm.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_pl.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_pl.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Prześlij obraz tła
 generalSettings.deleteBackgroundImageTitle=Usuń obraz tła
 generalSettings.errorUploadingPreview=Wystąpił błąd podczas przesyłania ilustracji. Skontaktuj się z administratorem lub spróbuj ponownie później.
 generalSettings.globalPageFullWindow=Strony pełnego okna
+generalSettings.editCustomStyle=Edytuj niestandardowy styl
+generalSettings.customStyle=Własny styl
 
 generalSettings.manageDefaultLanguage=Język
 generalSettings.subtitle.manageDefaultLanguage=Wybierz domyślny język platformy

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_pt_BR.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_pt_BR.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Enviar uma imagem de fundo
 generalSettings.deleteBackgroundImageTitle=Excluir a imagem de fundo
 generalSettings.errorUploadingPreview=Ocorreu um erro ao carregar o Ilustração. Entre em contato com o administrador ou tente novamente mais tarde.
 generalSettings.globalPageFullWindow=Páginas completas de janela
+generalSettings.editCustomStyle=Editar estilo personalizado
+generalSettings.customStyle=Estilo personalizado
 
 generalSettings.manageDefaultLanguage=Sobrenome
 generalSettings.subtitle.manageDefaultLanguage=Selecione o idioma padrão da plataforma

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_pt_PT.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_pt_PT.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Enviar uma imagem de fundo
 generalSettings.deleteBackgroundImageTitle=Excluir a imagem de fundo
 generalSettings.errorUploadingPreview=Ocorreu um erro ao carregar o Ilustração. Entre em contato com o administrador ou tente novamente mais tarde.
 generalSettings.globalPageFullWindow=Páginas completas de janela
+generalSettings.editCustomStyle=Editar estilo personalizado
+generalSettings.customStyle=Estilo personalizado
 
 generalSettings.manageDefaultLanguage=Sobrenome
 generalSettings.subtitle.manageDefaultLanguage=Selecione o idioma padrão da plataforma

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ro.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ro.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Încarcă o imagine de fundal
 generalSettings.deleteBackgroundImageTitle=Șterge imaginea de fundal
 generalSettings.errorUploadingPreview=A apărut o eroare la încărcarea Ilustrației. Vă rugăm să contactați administratorul sau să încercați din nou mai târziu.
 generalSettings.globalPageFullWindow=Pagini Ferestre complete
+generalSettings.editCustomStyle=Editare stil personalizat
+generalSettings.customStyle=Stil personalizat
 
 generalSettings.manageDefaultLanguage=Limba
 generalSettings.subtitle.manageDefaultLanguage=Selectaţi limba implicită a platformei

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ru.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ru.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Загрузить фоновое и�
 generalSettings.deleteBackgroundImageTitle=Удалить фоновое изображение
 generalSettings.errorUploadingPreview=Произошла ошибка при загрузке иллюстрации. Пожалуйста, свяжитесь с администратором или повторите попытку позже.
 generalSettings.globalPageFullWindow=Полное окно
+generalSettings.editCustomStyle=Изменить стиль
+generalSettings.customStyle=Пользовательский стиль
 
 generalSettings.manageDefaultLanguage=Язык
 generalSettings.subtitle.manageDefaultLanguage=Выберите язык платформы по умолчанию

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_sk.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_sk.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Nahrajte obrázok na pozadí
 generalSettings.deleteBackgroundImageTitle=Odstráňte obrázok na pozadí
 generalSettings.errorUploadingPreview=Pri odovzdávaní obrázka sa vyskytla chyba. Kontaktujte správcu alebo to skúste znova neskôr.
 generalSettings.globalPageFullWindow=Stránky celého okna
+generalSettings.editCustomStyle=Upraviť vlastný štýl
+generalSettings.customStyle=Vlastný štýl
 
 generalSettings.manageDefaultLanguage=Jazyk
 generalSettings.subtitle.manageDefaultLanguage=Vyberte predvolený jazyk platformy

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_sl.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_sl.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Naložite sliko ozadja
 generalSettings.deleteBackgroundImageTitle=Izbrišite sliko ozadja
 generalSettings.errorUploadingPreview=Med nalaganjem ilustracije je prišlo do napake. Obrnite se na skrbnika ali poskusite znova pozneje.
 generalSettings.globalPageFullWindow=Strani s polnim oknom
+generalSettings.editCustomStyle=Uredite slog po meri
+generalSettings.customStyle=Slog po meri
 
 generalSettings.manageDefaultLanguage=Jezik
 generalSettings.subtitle.manageDefaultLanguage=Izberite privzeti jezik platforme

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_sq.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_sq.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=crwdns43802:0crwdne43802:0
 generalSettings.deleteBackgroundImageTitle=crwdns43804:0crwdne43804:0
 generalSettings.errorUploadingPreview=crwdns43806:0crwdne43806:0
 generalSettings.globalPageFullWindow=crwdns43808:0crwdne43808:0
+generalSettings.editCustomStyle=crwdns43810:0crwdne43810:0
+generalSettings.customStyle=crwdns43812:0crwdne43812:0
 
 generalSettings.manageDefaultLanguage=crwdns43814:0crwdne43814:0
 generalSettings.subtitle.manageDefaultLanguage=crwdns43816:0crwdne43816:0

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_sv_SE.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_sv_SE.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Ladda upp en bakgrundsbild
 generalSettings.deleteBackgroundImageTitle=Ta bort bakgrundsbilden
 generalSettings.errorUploadingPreview=Ett fel inträffade vid uppladdning av Illustration. Kontakta administratören eller försök igen senare.
 generalSettings.globalPageFullWindow=Hela fönstersidor
+generalSettings.editCustomStyle=Redigera anpassad stil
+generalSettings.customStyle=Anpassad stil
 
 generalSettings.manageDefaultLanguage=Språk
 generalSettings.subtitle.manageDefaultLanguage=Välj standardspråk för plattformen

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_th.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_th.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=อัพโหลดรูปภา�
 generalSettings.deleteBackgroundImageTitle=ลบภาพพื้นหลัง
 generalSettings.errorUploadingPreview=เกิดข้อผิดพลาดขณะอัปโหลดภาพประกอบ โปรดติดต่อผู้ดูแลระบบหรือลองอีกครั้งในภายหลัง
 generalSettings.globalPageFullWindow=หน้าต่างเต็มหน้า
+generalSettings.editCustomStyle=แก้ไขรูปแบบที่กำหนดเอง
+generalSettings.customStyle=สไตล์ที่กำหนดเอง
 
 generalSettings.manageDefaultLanguage=ภาษา
 generalSettings.subtitle.manageDefaultLanguage=เลือกภาษาแพลตฟอร์มเริ่มต้น

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_tl.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_tl.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_tr.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_tr.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Bir arka plan resmi yükleyin
 generalSettings.deleteBackgroundImageTitle=Arka plan resmini sil
 generalSettings.errorUploadingPreview=İllüstrasyon yüklenirken bir hata oluştu. Lütfen yöneticiyle iletişime geçin veya daha sonra tekrar deneyin.
 generalSettings.globalPageFullWindow=Tam Pencere Sayfaları
+generalSettings.editCustomStyle=Özel stili düzenle
+generalSettings.customStyle=Özel Stil
 
 generalSettings.manageDefaultLanguage=Dil
 generalSettings.subtitle.manageDefaultLanguage=Varsayılan platform dilini seçin

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_uk.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_uk.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Завантажити фонове �
 generalSettings.deleteBackgroundImageTitle=Видалити фонове зображення
 generalSettings.errorUploadingPreview=Сталася помилка під час завантаження Illustration. Будь ласка, зверніться до адміністратора або спробуйте ще раз пізніше.
 generalSettings.globalPageFullWindow=Повні віконні сторінки
+generalSettings.editCustomStyle=Редагувати користувацький стиль
+generalSettings.customStyle=Користувацький стиль
 
 generalSettings.manageDefaultLanguage=Мова
 generalSettings.subtitle.manageDefaultLanguage=Виберіть мову для платформи за замовчуванням

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_ur_IN.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_ur_IN.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Upload a background image
 generalSettings.deleteBackgroundImageTitle=Delete the background image
 generalSettings.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the support services or try again later.
 generalSettings.globalPageFullWindow=Full Window Pages
+generalSettings.editCustomStyle=Edit custom style
+generalSettings.customStyle=Custom Style
 
 generalSettings.manageDefaultLanguage=Language
 generalSettings.subtitle.manageDefaultLanguage=Select the default platform language

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_vi.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_vi.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=Tải lên hình nền
 generalSettings.deleteBackgroundImageTitle=Xóa hình nền
 generalSettings.errorUploadingPreview=Đã xảy ra lỗi khi tải lên Minh họa. Vui lòng liên hệ với quản trị viên hoặc thử lại sau.
 generalSettings.globalPageFullWindow=Trang cửa sổ đầy đủ
+generalSettings.editCustomStyle=Chỉnh sửa phong cách tùy chỉnh
+generalSettings.customStyle=Phong cách tùy chỉnh
 
 generalSettings.manageDefaultLanguage=Ngôn ngữ
 generalSettings.subtitle.manageDefaultLanguage=Chọn ngôn ngữ nền tảng mặc định

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_zh_CN.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_zh_CN.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=上传背景图像
 generalSettings.deleteBackgroundImageTitle=删除背景图像
 generalSettings.errorUploadingPreview=上传插图时出错。请联系管理员或稍后再试。
 generalSettings.globalPageFullWindow=完整窗口页面
+generalSettings.editCustomStyle=编辑自定义样式
+generalSettings.customStyle=自定义样式
 
 generalSettings.manageDefaultLanguage=语言
 generalSettings.subtitle.manageDefaultLanguage=选择默认平台语言

--- a/webapp/src/main/resources/locale/portlet/GeneralSettings_zh_TW.properties
+++ b/webapp/src/main/resources/locale/portlet/GeneralSettings_zh_TW.properties
@@ -201,6 +201,8 @@ generalSettings.uploadBackgroundImageTitle=上傳背景圖片
 generalSettings.deleteBackgroundImageTitle=刪除背景圖片
 generalSettings.errorUploadingPreview=上傳插圖時發生錯誤。請聯絡管理員或稍後重試。
 generalSettings.globalPageFullWindow=全視窗頁面
+generalSettings.editCustomStyle=編輯自訂樣式
+generalSettings.customStyle=客製化風格
 
 generalSettings.manageDefaultLanguage=語言
 generalSettings.subtitle.manageDefaultLanguage=選擇預設平台語言

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -655,6 +655,18 @@
         </init-params>
     </component>
 
+    <component>
+        <key>CustomStylesheetFeatureProperties</key>
+        <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+        <init-params>
+            <properties-param>
+                <name>CustomStylesheetFeatureProperties</name>
+                <description>Custom Stylesheet Button in Theme Admin UI</description>
+                <property name="exo.feature.customStylesheet.enabled" value="false" />
+            </properties-param>
+        </init-params>
+    </component>
+
     <external-component-plugins>
         <target-component>org.exoplatform.services.resources.ResourceBundleService</target-component>
         <component-plugin>

--- a/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -72,4 +72,5 @@
      eXo.env.portal.postToNetworkEnabled = <%=featureService.isFeatureActiveForUser("PostToNetwork", userName)%>;
      eXo.env.portal.editorAttachImageEnabled = <%=featureService.isFeatureActiveForUser("EditorAttachImage", userName)%>;
      eXo.env.portal.attachmentObjectTypes = ['<%=StringUtils.join(supportedAttachmentObjectTypes, "', '")%>'];
+     eXo.env.portal.customStylesheetEnabled = <%=featureService.isFeatureActiveForUser("customStylesheet", userName)%>;
 </script>

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
@@ -99,6 +99,14 @@
       <portal-general-settings-branding-options />
     </v-col>
     <v-col
+      v-if="customStylesheetEnabled"
+      cols="12"
+      class="pa-0">
+      <portal-general-settings-custom-style-input
+        v-model="customCss"
+        class="mt-8" />
+    </v-col>
+    <v-col
       cols="12"
       class="pa-0">
       <div class="d-flex justify-end mt-4 pb-2">
@@ -156,6 +164,8 @@ export default {
     faviconUploadId: null,
     defaultCustomPageWidth: '1320px',
     defaultPageBackground: '#F0F0F0',
+    customStylesheetEnabled: eXo.env.portal.customStylesheetEnabled,
+    customCss: null,
     topBarStylingProperties: null,
     isTopBarStylingPropertiesChanged: false,
     sideBarStylingProperties: null,
@@ -190,6 +200,12 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'md';
     },
+    oldCustomStyle() {
+      return this.branding?.customCss;
+    },
+    isCustomStyleChanged() {
+      return this.oldCustomStyle !== this.customCss;
+    },
     validForm() {
       return this.changed && this.isValidForm;
     },
@@ -200,12 +216,15 @@ export default {
           && this.tertiaryColor?.length;
     },
     changed() {
-      if (!this.branding) {
-        return false;
-      }
-      return this.logoUploadId || this.faviconUploadId || this.isTopBarStylingPropertiesChanged
-          || this.isSideBarStylingPropertiesChanged || this.isDrawerStylingPropertiesChanged
-          || this.isPageStylingPropertiesChanged || this.isThemeColorsChanged;
+      return this.branding
+          && (this.logoUploadId
+          || this.faviconUploadId
+          || this.isTopBarStylingPropertiesChanged
+          || this.isSideBarStylingPropertiesChanged
+          || this.isDrawerStylingPropertiesChanged
+          || this.isPageStylingPropertiesChanged
+          || this.isThemeColorsChanged
+          || this.isCustomStyleChanged);
     },
   },
   watch: {
@@ -285,6 +304,7 @@ export default {
       this.primaryColor = this.defaultPrimaryColor;
       this.secondaryColor = this.defaultSecondaryColor;
       this.tertiaryColor = this.defaultTertiaryColor;
+      this.customCss = this.branding?.customCss;
       this.pageStylingProperties = {
         pageBackground: this.branding?.pageBackground || null,
         pageBackgroundSize: this.branding?.pageBackgroundSize || null,
@@ -341,6 +361,7 @@ export default {
         pageBackgroundColor: this.pageStylingProperties.pageBackgroundColor || null,
         pageBackgroundEffect: this.pageStylingProperties.pageBackgroundEffect || null,
         pageWidth: this.pageStylingProperties.pageWidth,
+        customCss: this.customCss,
       });
       this.$root.loading = true;
       return this.$brandingService.updateBrandingInformation(branding)

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBrandingWindow.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBrandingWindow.vue
@@ -26,6 +26,7 @@
       class="pa-0">
       <portal-general-settings-branding-site 
         :branding="branding"
+        :custom-css="customStylesheet"
         @changed="$emit('changed')"
         @saved="$emit('saved')"
         @close="$emit('close')" />

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/CustomStyleInput.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/CustomStyleInput.vue
@@ -1,0 +1,94 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <div>
+    <v-btn class="btn" @click="open">
+      <v-icon class="icon-default-color me-2" size="18">fa-edit</v-icon>
+      {{ $t('generalSettings.editCustomStyle') }}
+    </v-btn>
+    <exo-drawer
+      ref="drawer"
+      allow-expand
+      right>
+      <template #title>
+        {{ $t('generalSettings.editCustomStyle') }}
+      </template>
+      <template #content>
+        <div class="full-height pa-5">
+          <textarea
+            v-model="customStyle"
+            :aria-label="$t('generalSettings.customStyle')"
+            class="full-width full-height"></textarea>
+        </div>
+      </template>
+      <template #footer>
+        <div class="d-flex justify-end">
+          <v-btn
+            :aria-label="$t('generalSettings.cancel')"
+            :disabled="loading"
+            class="btn cancel-button me-4"
+            elevation="0"
+            @click="close">
+            {{ $t('generalSettings.cancel') }}
+          </v-btn>
+          <v-btn
+            :aria-label="$t('generalSettings.apply')"
+            color="primary"
+            class="btn btn-primary"
+            elevation="0"
+            @click="apply">
+            {{ $t('generalSettings.apply') }}
+          </v-btn>
+        </div>
+      </template>
+    </exo-drawer>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      default: null,
+    },
+  },
+  data: () => ({
+    customStyle: null,
+  }),
+  created() {
+    this.customStyle = this.value;
+  },
+  methods: {
+    open() {
+      this.customStyle = this.value;
+      this.$refs.drawer.open();
+    },
+    close() {
+      this.$refs.drawer.close();
+    },
+    apply() {
+      this.$emit('input', this.customStyle);
+      this.$refs.drawer.close();
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/general-settings/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/general-settings/initComponents.js
@@ -27,6 +27,7 @@ import LoginBackgroundSelector from './components/branding/form/LoginBackgroundS
 import BorderRadiusSelector from './components/branding/form/BorderRadiusSelector.vue';
 import BackgroundImageAttachment from './components/branding/form/BackgroundImageAttachment.vue';
 import BackgroundInput from './components/branding/form/BackgroundInput.vue';
+import CustomStyleInput from './components/branding/form/CustomStyleInput.vue';
 import StickyPositionElement from './components/common/StickyPositionElement.vue';
 
 import SiteBranding from './components/branding/SiteBranding.vue';
@@ -78,6 +79,7 @@ const components = {
   'portal-general-settings-branding-text-input': TextInput,
   'portal-general-settings-background-image-attachment': BackgroundImageAttachment,
   'portal-general-settings-background-input': BackgroundInput,
+  'portal-general-settings-custom-style-input': CustomStyleInput,
   'portal-general-settings-login-background-selector': LoginBackgroundSelector,
   'portal-general-settings-public-site-drawer': PublicSiteEditDrawer,
   'portal-general-settings-default-language-drawer': DefaultLanguageDrawer,


### PR DESCRIPTION
This change will set back a removed feature due to existing styling customization in already live productions. This behavior will be disabled by default for new platforms but can be enabled through a feature flag.

Resolves Meeds-io/meeds#2939