### PR TITLE
fix: Enable Navigation Drawer in Space Templates - MEED-8432 - Meeds-io/meeds#2950

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-templates-management/main.js
+++ b/webapp/src/main/webapp/vue-apps/space-templates-management/main.js
@@ -78,5 +78,6 @@ export function init(isExternalFeatureEnabled) {
         vuetify: Vue.prototype.vuetifyOptions,
         i18n,
       }, `#${appId}`, 'Space Templates')
-    );
+    )
+    .finally(() => Vue.prototype.$utils.includeExtensions('SpaceTemplateManagementExtension'));
 }


### PR DESCRIPTION
Prior to this change, the 'edit navigation' button isn't displayed in Space Template Menu. This change will enable including Extensions loaded in the same Group Module of Space Template Management UI.

Resolves Meeds-io/meeds#2950