### PR TITLE
fix: superuser property not taken in account - meeds-io/meeds#2953

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/portal/social-portal-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/portal/social-portal-configuration.xml
@@ -29,7 +29,7 @@
       <value-param>
         <name>super.user</name>
         <description>administrator</description>
-        <value>root</value>
+        <value>${exo.super.user:root}</value>
       </value-param>
 
       <value-param>


### PR DESCRIPTION
Before this fix, the property exo.super.user is not taken in account. This commit ensure to use the property in UserACL if exists, and set a default value if not

Resolves meeds-io/meeds#2953

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
