### PR TITLE
fix: Add missing FontIcon Module Declaration in Portlets JS Modules - MEED-8452 - Meeds-io/meeds#2976

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -381,6 +381,9 @@
       <depends>
         <module>extensionRegistry</module>
       </depends>
+      <depends>
+        <module>fontIcons</module>
+      </depends>
     </module>
   </portlet>
 
@@ -1567,6 +1570,9 @@
         <as>Cropper</as>
       </depends>
       <depends>
+        <module>fontIcons</module>
+      </depends>
+      <depends>
         <module>jquery</module>
         <as>$</as>
       </depends>
@@ -2023,6 +2029,9 @@
       </depends>
       <depends>
         <module>spaceForm</module>
+      </depends>
+      <depends>
+        <module>fontIcons</module>
       </depends>
     </module>
   </portlet>
@@ -3148,6 +3157,9 @@
     </depends>
     <depends>
       <module>vuetify</module>
+    </depends>
+    <depends>
+      <module>fontIcons</module>
     </depends>
   </module>
 


### PR DESCRIPTION
Prior to this change, the `fontIcon` JS module wasn't added explicitly in portlets JS modules, thus the font icon input wasn't displayed in some portlets. This change ensure to explicitly add the dependency declaration between portlets and the `fonIcon` reusable component.