### PR TITLE
fix: Allow direct access to allowed sub-pages - MEED-8472 - Meeds-io/meeds#2999

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -2338,7 +2338,7 @@ public class EntityBuilder {
     UserNavigation navigation = userPortal.getNavigation(siteKey);
     if (navigation != null) {
       UserNodeFilterConfig.Builder builder = UserNodeFilterConfig.builder();
-      builder.withReadWriteCheck().withVisibility(convertVisibilities(visibilityNames));
+      builder.withReadCheckNoPage().withVisibility(convertVisibilities(visibilityNames));
       if (temporalCheck) {
         builder.withTemporalCheck();
       }

--- a/webapp/src/main/webapp/vue-apps/common/js/SiteService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/SiteService.js
@@ -133,9 +133,6 @@ export function getSiteById(siteId, params) {
   if (params?.expandNavigations) {
     formData.append('expandNavigations', params?.expandNavigations);
   }
-  if (params?.excludeEmptyNavigationSites) {
-    formData.append('excludeEmptyNavigationSites', params?.excludeEmptyNavigationSites);
-  }
   if (params?.excludeGroupNodesWithoutPageChildNodes) {
     formData.append('excludeGroupNodesWithoutPageChildNodes', params?.excludeGroupNodesWithoutPageChildNodes);
   }

--- a/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuContent.vue
+++ b/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuContent.vue
@@ -47,19 +47,16 @@ export default {
     this.retrieveCurrentSite();
   },
   methods: {
-    retrieveCurrentSite(){
+    retrieveCurrentSite() {
       this.loading = true;
       return this.$siteService.getSiteById(this.siteId, {
         expandNavigations: true,
-        excludeEmptyNavigationSites: true,
         lang: eXo.env.portal.language,
         visibility: ['displayed', 'temporal'],
         excludeGroupNodesWithoutPageChildNodes: true,
         temporalCheck: true,
       })
-        .then(site => {
-          this.site = site;
-        })
+        .then(site => this.site = site)
         .finally(() => this.loading = false);
     },
   }


### PR DESCRIPTION
This change will update the used nodes filter in order to check on page read access instead of write access when filtering nodes list to retrieve in site navigation.

Resolves Meeds-io/meeds#2999