### PR TITLE
feat: Hide Overlay When opening Drawer from Sidebar - MEED-8477 - Meeds-io/meeds#3006

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
@@ -66,8 +66,9 @@ export default {
       this.openedDrawers = 1;
       this.hideOverlay();
     },
-    hideOverlay() {
-      if (this.openedDrawers > 0) {
+    hideOverlay(event) {
+      const showOverlay = !event?.detail;
+      if (showOverlay && this.openedDrawers > 0) {
         window.setTimeout(() => {
           this.openedDrawers -= 1;
           if (this.openedDrawers === 0) {

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/Sidebar.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/Sidebar.vue
@@ -221,12 +221,14 @@ export default {
     this.$root.$on('change-spaces-menu', this.changeSpacesMenu);
     this.$root.$on('change-site-menu', this.changeSiteMenu);
     document.addEventListener('closeDisplayedDrawer', this.closeDisplayedDrawer);
+    document.addEventListener('drawerOpened', this.closeDisplayedDrawerIfNotSelf);
   },
   beforeDestroy() {
     this.$root.$off('change-space-menu', this.changeSpaceMenu);
     this.$root.$off('change-spaces-menu', this.changeSpacesMenu);
     this.$root.$off('change-site-menu', this.changeSiteMenu);
     document.removeEventListener('closeDisplayedDrawer', this.closeDisplayedDrawer);
+    document.removeEventListener('drawerOpened', this.closeDisplayedDrawerIfNotSelf);
   },
   methods: {
     async openFirstLevel(mouseEvent) {
@@ -322,6 +324,11 @@ export default {
         this.$root.openedFirstLevelType = 'SITE';
         this.secondLevelDrawer = true;
         this.thirdLevelDrawer = false;
+      }
+    },
+    closeDisplayedDrawerIfNotSelf(event) {
+      if (!event?.detail) {
+        this.closeMenuEffectively(true);
       }
     },
     closeDisplayedDrawer() {


### PR DESCRIPTION
Prior to this change, when opening a drawer from the sidebar, the overlay gets hidden. This change ensures to open the new Overlay when a new drawer is opened from Sidebar.

Resolves Meeds-io/meeds#3006