### PR TITLE
fix: Default Space Avatar with letters not generated when using '[' and ']' in name - MEED-8479

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/EntityConverterUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/EntityConverterUtils.java
@@ -172,7 +172,10 @@ public class EntityConverterUtils {
         JSONArray arr = null ;
         try {
           arr = new JSONArray(value);
-          isJsonArray = true;
+          if (value.startsWith("[") && value.endsWith("]")) {
+            // a value like "[john] smith" is not a json array
+            isJsonArray = true;
+          }
         } catch (Exception ex) {
           // Ignore this exception
         }


### PR DESCRIPTION
Before this fix, when creating a space containg "[...]" in named generates and error in log, and make avatar not displayed correctly The problem comes from space profile creation, in which the full name of the space is detected as JSONArray due to [ ... ] in the name. This commit add a new check to ensure that [ and ] are present at the beginning and the end of the property value.

Resolves meeds-io/meeds#3010

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
