### PR TITLE
fix: Trigger a listener event after space templates import - EXO-66372 - Meeds-io/meeds#66372

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
@@ -20,36 +20,10 @@
  */
 package io.meeds.social.space.service;
 
-import static org.exoplatform.social.core.space.SpaceUtils.AUTHENTICATED;
-import static org.exoplatform.social.core.space.SpaceUtils.EVERYONE;
-import static org.exoplatform.social.core.space.SpaceUtils.INTERNAL;
-import static org.exoplatform.social.core.space.SpaceUtils.MANAGER;
-import static org.exoplatform.social.core.space.SpaceUtils.MEMBER;
-import static org.exoplatform.social.core.space.SpaceUtils.PLATFORM_PUBLISHER_GROUP;
-import static org.exoplatform.social.core.space.SpaceUtils.PLATFORM_USERS_GROUP;
-import static org.exoplatform.social.core.space.SpaceUtils.PUBLISHER;
-import static org.exoplatform.social.core.space.SpaceUtils.addUserToGroupWithManagerMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.addUserToGroupWithMemberMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.addUserToGroupWithPublisherMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.addUserToGroupWithRedactorMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.createGroup;
-import static org.exoplatform.social.core.space.SpaceUtils.removeGroup;
-import static org.exoplatform.social.core.space.SpaceUtils.removeMembershipFromGroup;
-import static org.exoplatform.social.core.space.SpaceUtils.removeUserFromGroupWithAnyMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.removeUserFromGroupWithManagerMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.removeUserFromGroupWithMemberMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.removeUserFromGroupWithPublisherMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.removeUserFromGroupWithRedactorMembership;
-import static org.exoplatform.social.core.space.SpaceUtils.setPermissionsFromTemplate;
+import static org.exoplatform.social.core.space.SpaceUtils.*;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -80,13 +54,8 @@ import org.exoplatform.social.core.jpa.storage.SpaceStorage;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.model.BannerAttachment;
 import org.exoplatform.social.core.model.SpaceExternalInvitation;
-import org.exoplatform.social.core.space.SpaceException;
+import org.exoplatform.social.core.space.*;
 import org.exoplatform.social.core.space.SpaceException.Code;
-import org.exoplatform.social.core.space.SpaceFilter;
-import org.exoplatform.social.core.space.SpaceLifecycle;
-import org.exoplatform.social.core.space.SpaceListAccess;
-import org.exoplatform.social.core.space.SpaceListAccessType;
-import org.exoplatform.social.core.space.SpaceListenerPlugin;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent.Type;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleListener;
@@ -98,7 +67,6 @@ import org.exoplatform.web.security.security.RemindPasswordTokenService;
 import io.meeds.social.search.SpaceSearchConnector;
 import io.meeds.social.space.template.model.SpaceTemplate;
 import io.meeds.social.space.template.service.SpaceTemplateService;
-
 import lombok.SneakyThrows;
 
 public class SpaceServiceImpl implements SpaceService {
@@ -1080,6 +1048,7 @@ public class SpaceServiceImpl implements SpaceService {
 
   private void setSpaceProperties(Space space, Space spaceToSave) {
     spaceToSave.setDisplayName(space.getDisplayName());
+    spaceToSave.setPrettyName(space.getPrettyName());
     spaceToSave.setDescription(space.getDescription());
     spaceToSave.setRegistration(space.getRegistration());
     spaceToSave.setVisibility(space.getVisibility());

--- a/component/core/src/main/java/io/meeds/social/space/template/service/injection/SpaceTemplateImportService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/injection/SpaceTemplateImportService.java
@@ -39,11 +39,13 @@ import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.configuration.ConfigurationManager;
 import org.exoplatform.portal.config.model.Container;
 import org.exoplatform.portal.config.model.ModelUnmarshaller;
 import org.exoplatform.portal.config.model.UnmarshalledObject;
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.attachment.AttachmentService;
@@ -61,7 +63,6 @@ import io.meeds.social.space.template.service.injection.model.SpaceTemplateDescr
 import io.meeds.social.space.template.service.injection.model.SpaceTemplateDescriptorList;
 import io.meeds.social.space.template.storage.SpaceTemplateStorage;
 import io.meeds.social.util.JsonUtils;
-
 import lombok.SneakyThrows;
 
 @Component
@@ -73,10 +74,14 @@ public class SpaceTemplateImportService implements ContainerStartableService {
 
   private static final String                   SPACE_TEMPLATE_VERSION      = "version";
 
+  public static final String SPACE_TEMPLATES_INTIALIZED_EVENT = "space.templates.initialized";
+
   private static final Log                      LOG                         =
                                                     ExoLogger.getLogger(SpaceTemplateImportService.class);
 
   private static final Random                   RANDOM                      = new Random();
+
+  private ListenerService listenerService;
 
   @Autowired
   private SpaceTemplateTranslationImportService layoutTranslationService;
@@ -123,6 +128,10 @@ public class SpaceTemplateImportService implements ContainerStartableService {
                  .flatMap(List::stream)
                  .forEach(this::importDescriptor);
       LOG.info("Importing Space Templates finished successfully");
+
+      if (getSettingValue(SPACE_TEMPLATE_VERSION) == 0l) {
+        getListenerService().broadcast(SPACE_TEMPLATES_INTIALIZED_EVENT, null, null);
+      }
 
       LOG.info("Processing Post Space Templates import");
       layoutTranslationService.postImport(SpaceTemplateTranslationPlugin.OBJECT_TYPE);
@@ -279,6 +288,13 @@ public class SpaceTemplateImportService implements ContainerStartableService {
       FileUtils.copyInputStreamToFile(inputStream, tempFile);
       return tempFile;
     }
+  }
+
+  private ListenerService getListenerService() {
+    if (listenerService == null) {
+      listenerService = ExoContainerContext.getService(ListenerService.class);
+    }
+    return listenerService;
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
@@ -795,7 +795,7 @@ public class SpaceStorage {
               String name = Utils.cleanString(displayName);
               int index = 0;
               while (spaceDAO.getSpaceByPrettyName(name) != null) {
-                // Use sapme algorithm to compte new pretty name as for
+                // Use the same algorithm to compute new pretty name as for
                 // creation
                 // used in SpaceUtils.buildGroupId
                 name = Utils.cleanString(displayName + " " + ++index);

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
@@ -454,7 +454,7 @@ public class SpaceStorage {
     if (isNew) {
       entity = new SpaceEntity();
       // Ensure unicity of pretty name
-      space.setPrettyName(buildPrettyName(space.getDisplayName()));
+      space.setPrettyName(buildPrettyName(space.getPrettyName(), space.getDisplayName()));
       EntityConverterUtils.buildFrom(space, entity);
 
       //
@@ -788,15 +788,22 @@ public class SpaceStorage {
                                 .minusSeconds(remindPasswordTokenService.getValidityTime());
   }
 
-  private String buildPrettyName(String displayName) {
-    String prettyName = Utils.cleanString(displayName);
-    int index = 0;
-    while (spaceDAO.getSpaceByPrettyName(prettyName) != null) {
-      // Use sapme algorithm to compte new pretty name as for creation
-      // used in SpaceUtils.buildGroupId
-      prettyName = Utils.cleanString(displayName + " " + ++index);
-    }
-    return prettyName;
+  private String buildPrettyName(String... names) {
+    return Arrays.stream(names)
+            .filter(StringUtils::isNotBlank)
+            .map(displayName -> {
+              String name = Utils.cleanString(displayName);
+              int index = 0;
+              while (spaceDAO.getSpaceByPrettyName(name) != null) {
+                // Use sapme algorithm to compte new pretty name as for
+                // creation
+                // used in SpaceUtils.buildGroupId
+                name = Utils.cleanString(displayName + " " + ++index);
+              }
+              return name;
+            })
+            .findFirst()
+            .orElseThrow();
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -16,11 +16,7 @@
  */
 package org.exoplatform.social.core.space;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -38,15 +34,7 @@ import org.exoplatform.portal.mop.service.NavigationService;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.Group;
-import org.exoplatform.services.organization.GroupHandler;
-import org.exoplatform.services.organization.Membership;
-import org.exoplatform.services.organization.MembershipHandler;
-import org.exoplatform.services.organization.MembershipType;
-import org.exoplatform.services.organization.MembershipTypeHandler;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.User;
-import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.services.organization.*;
 import org.exoplatform.social.common.Utils;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -217,7 +205,7 @@ public class SpaceUtils {
       parentGroup = groupHandler.findGroupById(SPACE_GROUP);
       // Creates new group
       newGroup = groupHandler.createGroupInstance();
-      shortName = Utils.cleanString(StringUtils.firstNonBlank(groupLabel, spaceName));
+      shortName = Utils.cleanString(StringUtils.firstNonBlank(spaceName, groupLabel));
       groupId = parentGroup.getId() + "/" + shortName;
 
       if (getSpaceService().getSpaceByGroupId(groupId) != null) {


### PR DESCRIPTION
Prior to this fix, default spaces cannot be created on first server start since space templates are not yet initialized. 
This commit adds a listener event when the default space templates are created so other services can run the spaces creations