### PR TITLE
fix: Allow creating multiple spaces with same name - MEED-8504 - Meeds-io/meeds#3041

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
@@ -46,6 +46,7 @@ import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.common.Utils;
 import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
@@ -357,7 +358,12 @@ public class SpaceServiceImpl implements SpaceService {
 
     // Copy only settable properties from provided DTO
     Space spaceToCreate = new Space();
-    setSpaceProperties(space, spaceToCreate);
+    spaceToCreate.setDisplayName(space.getDisplayName());
+    spaceToCreate.setPrettyName(space.getPrettyName());
+    spaceToCreate.setDescription(space.getDescription());
+    spaceToCreate.setRegistration(space.getRegistration());
+    spaceToCreate.setVisibility(space.getVisibility());
+    spaceToCreate.setTemplateId(space.getTemplateId());
     spaceToCreate.setEditor(username);
     spaceToCreate.setMembers(new String[] { username });
     spaceToCreate.setManagers(new String[] { username });
@@ -436,7 +442,21 @@ public class SpaceServiceImpl implements SpaceService {
   public void renameSpace(Space space, String newDisplayName) {
     spaceLifeCycle.setCurrentEvent(Type.SPACE_RENAMED);
     try {
-      spaceStorage.renameSpace(space, newDisplayName);
+      String oldPrettyName = space.getPrettyName();
+      // Ensure unicity of new pretty name
+      String newPrettyName = buildPrettyName(newDisplayName);
+
+      space.setDisplayName(newDisplayName);
+      space.setPrettyName(newPrettyName);
+      if (oldPrettyName.equals(space.getUrl())) {
+        // Update URL only if legacy
+        // navigation tree which uses pretty name
+        space.setUrl(newPrettyName);
+      } else if (StringUtils.isBlank(space.getUrl())) {
+        space.setUrl(Space.HOME_URL);
+      }
+
+      spaceStorage.renameSpace(space);
       spaceLifeCycle.spaceRenamed(space, space.getEditor());
     } finally {
       spaceLifeCycle.resetCurrentEvent(Type.SPACE_RENAMED);
@@ -1046,21 +1066,14 @@ public class SpaceServiceImpl implements SpaceService {
     registerSpaceLifeCycleListener(plugin);
   }
 
-  private void setSpaceProperties(Space space, Space spaceToSave) {
-    spaceToSave.setDisplayName(space.getDisplayName());
-    spaceToSave.setPrettyName(space.getPrettyName());
-    spaceToSave.setDescription(space.getDescription());
-    spaceToSave.setRegistration(space.getRegistration());
-    spaceToSave.setVisibility(space.getVisibility());
-    spaceToSave.setTemplateId(space.getTemplateId());
-  }
-
   private void copySpaceTemplateProperties(Space space,
                                            SpaceTemplate spaceTemplate,
                                            String username,
                                            List<String> invitees) throws SpaceException {
     setSpaceAccess(space, spaceTemplate);
     setSpaceDisplayName(space, invitees);
+    setSpacePrettyName(space);
+
     // Creates the associated group to the space
     String groupId = createSpaceGroup(space, username);
     setDeletePermissions(space, spaceTemplate, groupId);
@@ -1121,6 +1134,10 @@ public class SpaceServiceImpl implements SpaceService {
                || space.getDisplayName().length() > MAX_SPACE_NAME_LENGTH) {
       throw new SpaceException(Code.INVALID_SPACE_NAME);
     }
+  }
+
+  private void setSpacePrettyName(Space space) {
+    space.setPrettyName(buildPrettyName(space.getPrettyName(), space.getDisplayName()));
   }
 
   private String createSpaceGroup(Space space, String username) throws SpaceException {
@@ -1314,6 +1331,24 @@ public class SpaceServiceImpl implements SpaceService {
       spaceTemplateService = ExoContainerContext.getService(SpaceTemplateService.class);
     }
     return spaceTemplateService;
+  }
+
+  private String buildPrettyName(String... names) {
+    return Arrays.stream(names)
+            .filter(StringUtils::isNotBlank)
+            .map(displayName -> {
+              String name = Utils.cleanString(displayName);
+              int index = 0;
+              while (getSpaceByPrettyName(name) != null) {
+                // Use the same algorithm to compute new pretty name as for
+                // creation
+                // used in SpaceUtils.buildGroupId
+                name = Utils.cleanString(displayName + " " + ++index);
+              }
+              return name;
+            })
+            .findFirst()
+            .orElseThrow();
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
@@ -37,7 +37,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.social.common.Utils;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -393,24 +392,10 @@ public class SpaceStorage {
     return spaceMemberDAO.getSpaceMembershipDate(spaceId, username);
   }
 
-  public void renameSpace(Space space, String newDisplayName) throws SpaceStorageException {
-    String oldPrettyName = space.getPrettyName();
-    // Ensure unicity of new pretty name
-    String newPrettyName = buildPrettyName(newDisplayName);
-
-    space.setDisplayName(newDisplayName);
-    space.setPrettyName(newPrettyName);
-    if (oldPrettyName.equals(space.getUrl())) {
-      // Update URL only if legacy
-      // navigation tree which uses pretty name
-      space.setUrl(newPrettyName);
-    } else if (StringUtils.isBlank(space.getUrl())) {
-      space.setUrl(Space.HOME_URL);
-    }
-
+  public void renameSpace(Space space) throws SpaceStorageException {
     SpaceEntity entity = spaceDAO.find(Long.parseLong(space.getId()));
     // Retrieve identity before saving
-    Identity identitySpace = identityStorage.findIdentity(SpaceIdentityProvider.NAME, oldPrettyName);
+    Identity identitySpace = identityStorage.findIdentity(SpaceIdentityProvider.NAME, entity.getPrettyName());
 
     EntityConverterUtils.buildFrom(space, entity);
     entity.setUpdatedDate(new Date());
@@ -425,7 +410,6 @@ public class SpaceStorage {
       profileSpace.setProperty(Profile.URL, space.getUrl());
       identityStorage.saveProfile(profileSpace);
     }
-    LOG.debug("Space {} ({}) saved", space.getPrettyName(), space.getId());
   }
 
   public void ignoreSpace(String spaceId, String userId) {
@@ -454,7 +438,6 @@ public class SpaceStorage {
     if (isNew) {
       entity = new SpaceEntity();
       // Ensure unicity of pretty name
-      space.setPrettyName(buildPrettyName(space.getPrettyName(), space.getDisplayName()));
       EntityConverterUtils.buildFrom(space, entity);
 
       //
@@ -786,24 +769,6 @@ public class SpaceStorage {
     return token == null ? null :
                          Instant.ofEpochMilli(token.getExpirationTimeMillis())
                                 .minusSeconds(remindPasswordTokenService.getValidityTime());
-  }
-
-  private String buildPrettyName(String... names) {
-    return Arrays.stream(names)
-            .filter(StringUtils::isNotBlank)
-            .map(displayName -> {
-              String name = Utils.cleanString(displayName);
-              int index = 0;
-              while (spaceDAO.getSpaceByPrettyName(name) != null) {
-                // Use the same algorithm to compute new pretty name as for
-                // creation
-                // used in SpaceUtils.buildGroupId
-                name = Utils.cleanString(displayName + " " + ++index);
-              }
-              return name;
-            })
-            .findFirst()
-            .orElseThrow();
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
@@ -218,11 +218,12 @@ public class CachedSpaceStorage extends SpaceStorage {
   }
 
   @Override
-  public void renameSpace(Space space, String newDisplayName) throws SpaceStorageException {
-    String oldPrettyName = space.getPrettyName();
+  public void renameSpace(Space space) throws SpaceStorageException {
+    Space existingSpace = getSpaceById(space.getSpaceId());
+    String oldPrettyName = existingSpace.getPrettyName();
 
     //
-    super.renameSpace(space, newDisplayName);
+    super.renameSpace(space);
 
     // remove identity and profile from cache
     cachedIdentityStorage = this.getCachedIdentityStorage();

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
@@ -1133,7 +1133,8 @@ public abstract class SpaceStorageTest extends AbstractCoreTest {
     identityStorage.saveIdentity(spaceIdentity);
 
     String newDisplayName = "new display name";
-    spaceStorage.renameSpace(space, newDisplayName);
+    space.setDisplayName(newDisplayName);
+    spaceStorage.renameSpace(space);
 
     got = spaceStorage.getSpaceById(space.getSpaceId());
     assertEquals(newDisplayName, got.getDisplayName());

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -1219,6 +1219,54 @@ public class SpaceServiceTest extends AbstractCoreTest {
     assertEquals("Dragon Ball", createdSpace.getDisplayName());
   }
 
+  public void testCreateSpaceWithExistingName() {
+    Space space = new Space();
+    space.setDisplayName(SPACE1_DISPLAY_NAME);
+    space.setRegistration(Space.OPEN);
+    space.setDescription(SPACE_DESCRIPTION);
+    space.setVisibility(Space.PUBLIC);
+    space.setRegistration(Space.VALIDATION);
+    Space space1 = spaceService.createSpace(space, DRAGON_NAME);
+    assertNotNull(space1);
+
+    space = new Space();
+    space.setDisplayName(SPACE1_DISPLAY_NAME);
+    space.setRegistration(Space.OPEN);
+    space.setDescription(SPACE_DESCRIPTION);
+    space.setVisibility(Space.PUBLIC);
+    space.setRegistration(Space.VALIDATION);
+    Space space2 = spaceService.createSpace(space, DRAGON_NAME);
+    assertNotNull(space2);
+
+    assertNotEquals(space1.getId(), space2.getId());
+    assertNotEquals(space1.getPrettyName(), space2.getPrettyName());
+    assertNotEquals(space1.getGroupId(), space2.getGroupId());
+  }
+
+  public void testCreateSpaceWithExistingPrettyName() {
+    Space space = new Space();
+    space.setPrettyName(SPACE1_NAME);
+    space.setRegistration(Space.OPEN);
+    space.setDescription(SPACE_DESCRIPTION);
+    space.setVisibility(Space.PUBLIC);
+    space.setRegistration(Space.VALIDATION);
+    Space space1 = spaceService.createSpace(space, DRAGON_NAME);
+    assertNotNull(space1);
+
+    space = new Space();
+    space.setPrettyName(SPACE1_NAME);
+    space.setRegistration(Space.OPEN);
+    space.setDescription(SPACE_DESCRIPTION);
+    space.setVisibility(Space.PUBLIC);
+    space.setRegistration(Space.VALIDATION);
+    Space space2 = spaceService.createSpace(space, DRAGON_NAME);
+    assertNotNull(space2);
+
+    assertNotEquals(space1.getId(), space2.getId());
+    assertNotEquals(space1.getPrettyName(), space2.getPrettyName());
+    assertNotEquals(space1.getGroupId(), space2.getGroupId());
+  }
+
   public void testCreateSpaceWithTemplateCharacteristics() throws ObjectNotFoundException, SpaceException {
     SpaceTemplateService spaceTemplateService = getService(SpaceTemplateService.class);
     SpaceTemplate spaceTemplate = spaceTemplateService.getSpaceTemplates().getFirst();


### PR DESCRIPTION
Prior to this change, when creating a space with a same existing space name (Circle, Community, Announcement ...), the an `HTTP 400` error is raised. This is due to a recent change which intend to allow setting space's `prettyName` by API. This change will ensure to allow setting the pretty name by API but to not make it exclusive, which means it will allow to generate a new pretty name if it already exists.