### PR TITLE
fix: Space banner portlet display - MEED-8508 Meeds-io/meeds#1986.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-banner/components/SpaceBanner.vue
+++ b/webapp/src/main/webapp/vue-apps/space-banner/components/SpaceBanner.vue
@@ -15,6 +15,7 @@
           height="auto"
           min-width="100%"
           class="d-flex application-border-radius"
+          contain
           eager>
           <div
             v-if="admin"


### PR DESCRIPTION
Before this change, when adding a space banner portlet in a page of a space and display is different with the image portle. To fix this problem, add a contain property to v-img of space banner. After this change, the sapce banner image is displayed correctly.