### PR TITLE
fix: Avoid Displaying Spaces Directory Warning when Platform Access is Open - MEED-8529 - Meeds-io/meeds#3066

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-list/main.js
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/main.js
@@ -88,6 +88,7 @@ export function init(
         settingName,
         isAdministrator,
         isPublicPage,
+        registrationType,
         invitationsCount: 0,
         pendingCount: 0,
         requestsCount: 0,


### PR DESCRIPTION
Prior to this change, when the Platform Access is Open, a warning is displayed in Space Directory of Public pages. This change ensures to hide such a warning when the Platform is Open to be displayed only when the Platform is Restricted.