### PR TITLE
fix: Hide Space Display Setting Option when Hub is Opened Access - MEED-8529 - Meeds-io/meeds#3066

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/drawer/SpacesListSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/drawer/SpacesListSettingsDrawer.vue
@@ -33,7 +33,7 @@
       <div class="pa-5" flat>
         <div class="mb-2 text-header">{{ $t('spacesList.settings.displayOptions') }}</div>
         <v-tooltip
-          v-if="$root.isPublicPage"
+          v-if="$root.isPublicPage && $root.registrationType !== 'OPEN'"
           :disabled="$root.isAdministrator"
           bottom>
           <template #activator="{on, attrs}">


### PR DESCRIPTION
Prior to this change, when the Platform Access is Open, a 'Display' Option is displayed in Settings Drawer. This change will avoid this display only when the Hub is restricted.