### PR TITLE
fix: Adjust the text of the card link when using small icons - MEED-8388 - Meeds-io/meeds#2877 

### DIFF
--- a/webapp/src/main/webapp/vue-apps/links/components/view/LinksCard.vue
+++ b/webapp/src/main/webapp/vue-apps/links/components/view/LinksCard.vue
@@ -120,7 +120,7 @@ export default {
       return this.link?.icon;
     },
     itemSize() {
-      return this.iconSize * 5;
+      return this.iconSize >= 20 ? this.iconSize * 5 : (this.iconSize < 20 && this.iconSize > 15 ? this.iconSize * 7 : this.iconSize * 8);
     },
     itemWidth() {
       return this.showName && this.itemSize || parseInt(this.itemSize / 2);


### PR DESCRIPTION
This fix will adjsut the text of the card link when using different sizes.

Resolves Meeds-io/meeds#2877 