### PR TITLE
feat: Display sub categories in Space Directory even when empty - MEED-8545 - Meeds-io/meeds#3077

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/SpacesList.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/SpacesList.vue
@@ -33,8 +33,7 @@
           @loading="loadingSpaces = loadingSpaces || $event" />
         <spaces-categories-toolbar
           v-if="$root.allowFilteringPerCategory"
-          v-show="spacesExists"
-          :spaces-size="spacesSize" />
+          v-show="spacesExists" />
         <spaces-card-list
           ref="spacesList"
           :keyword="keyword"

--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/space-categories/SpacesCategoriesToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/space-categories/SpacesCategoriesToolbar.vue
@@ -52,12 +52,6 @@
 </template>
 <script>
 export default {
-  props: {
-    spacesSize: {
-      type: Number,
-      default: () => 0,
-    }
-  },
   data: () => ({
     categoryTree: null,
     loading: false,
@@ -77,7 +71,7 @@ export default {
       return this.$root.selectedCategoryId;
     },
     displayChipsSelection() {
-      return this.level < 2 && this.spacesSize && this.selectedSubcategories?.length;
+      return this.level < 2 && this.selectedSubcategories?.length;
     },
     displayDivider() {
       return this.displayChipsSelection && this.displayBreadcrumb;

--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/space-categories/SpacesCategoryChipsGroup.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/space-categories/SpacesCategoryChipsGroup.vue
@@ -24,12 +24,12 @@
   <div class="d-flex align-center specific-scrollbar overflow-x-auto position-relative d-inline text-no-wrap">
     <div v-if="initialized" class="flex-grow-0 flex-shrink-1 overflow-hidden">
       <spaces-category-chip
-        v-for="(category, index) in categories"
+        v-for="category in categories"
         :key="category.id"
         :category="category"
-        :breadcrumb="index > 1"
         :parent-width="parentWidth"
         chip-class="flex-shrink-0 me-2"
+        breadcrumb
         @initialized="setVisible(category, $event)"
         @select="openCategory" />
     </div>


### PR DESCRIPTION
Prior to this change:

1. The Space Categories Sub Menu wasn't displayed on the first and second displayed categories. The Sub Menu is displayed starting from the Third category only.

2. When clicking on a Space Category, not having an associated space, from the first level of category tree, then the second level isn't displayed to optimize UX by avoiding displaying Sub categories while no space is displayed.

This change will change the behavior by allowing to display sub menu for the first and second category + will display the sub categories even when not having an associated space.