### PR TITLE
fix: Display option ID of the dropdown item in profile admin - EXO-8381 - Meeds-io/meeds#2908.

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -910,6 +910,7 @@ profileSettings.dropdownList.disabled.propertyType.info=You cannot change the at
 profileSettings.dropdownList.close.ariaLabel=Close
 profileSettings.dropdownList.addValue.label=Add a value
 profileSettings.dropdownList.name.label=Name
+profileSettings.dropdownList.name.id=Id
 profileSettings.dropdownList.actions.label=Actions
 profileSettings.dropdownList.input.placeholder=Enter values (comma-separated)
 profileSettings.dropdownList.input.info=Press Enter to confirm. Use commas for multiple values.

--- a/webapp/src/main/webapp/vue-apps/component-translation-field/components/TranslationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/component-translation-field/components/TranslationDrawer.vue
@@ -129,6 +129,7 @@
           {{ $t('translationDrawer.cancel') }}
         </v-btn>
         <v-btn
+          :disabled="!hasChange"
           :loading="loading"
           class="btn btn-primary"
           @click="apply">
@@ -205,6 +206,9 @@ export default {
     translations: null,
     editorIndex: null,
     existingLanguages: [],
+    originalTranslations: [],
+    originalSelectedLanguages: [],
+    hasChange: false,
   }),
   computed: {
     languages() {
@@ -236,6 +240,9 @@ export default {
       this.editorIndex = null;
       this.translations = this.value && JSON.parse(JSON.stringify(this.value)) || {};
       this.refreshExistingLanguages(true);
+      this.hasChange = false;
+      this.originalSelectedLanguages = JSON.parse(JSON.stringify(this.existingLanguages));
+      this.originalTranslations = JSON.parse(JSON.stringify(this.translations));
       this.$refs.drawer.open();
     },
     apply() {
@@ -260,6 +267,8 @@ export default {
     },
     reset() {
       this.translations = null;
+      this.originalTranslations = null;
+      this.originalSelectedLanguages = [];
     },
     refreshExistingLanguages(sort) {
       if (sort) {
@@ -278,6 +287,7 @@ export default {
         this.existingLanguages = Object.keys(this.translations).slice()
           .filter(l => this.supportedLanguages[l]);
       }
+      this.hasChanges();
     },
     addValue() {
       if (this.hasRemainingLanguages) {
@@ -291,6 +301,7 @@ export default {
     },
     changeLanguage(language, event) {
       const newLanguage = event?.target?.value;
+      
       if (newLanguage && this.supportedLanguages[newLanguage]) {
         this.translations[newLanguage] = this.translations[language];
         delete this.translations[language];
@@ -299,6 +310,7 @@ export default {
     },
     updateValue(language, value) {
       this.translations[language] = value;
+      this.hasChanges();
     },
     openOrCloseEditor(index) {
       if (this.editorIndex === index) {
@@ -306,6 +318,10 @@ export default {
       } else {
         this.editorIndex = index;
       }
+    },
+    hasChanges() {
+      this.hasChange = JSON.stringify(this.translations) !== JSON.stringify(this.originalTranslations) 
+        || JSON.stringify(this.existingLanguages) !== JSON.stringify(this.originalSelectedLanguages);
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListOptionItemValue.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListOptionItemValue.vue
@@ -23,12 +23,28 @@
     <v-col
       cols="8"
       class="d-flex py-1 px-0">
-      <span class="my-auto">
-        {{ displayedValue }}
+      <v-tooltip bottom>
+        <template #activator="{ on, attrs }">
+          <span 
+          v-bind="attrs"
+          v-on="on"
+          class="my-auto text-truncate pe-2">
+          {{ displayedValue }}
+          </span>
+        </template>
+        <span class="tooltip-version py-12 text-break"> {{ displayedValue }} </span>
+      </v-tooltip>
+    </v-col>
+    <v-col 
+      cols="1"
+      class="d-flex py-1 px-0">
+      <span 
+      class="my-auto text-truncate">
+      {{ displayedId }}
       </span>
     </v-col>
     <v-col
-      cols="4"
+      cols="3"
       class="text-end py-1 px-0">
       <div class="d-flex ms-auto width-fit-content">
         <translation-text-field
@@ -74,7 +90,10 @@ export default {
     displayedValue() {
       return this.optionObject?.translations?.[this.userLocale] || this.defaultLangValue
                                                                 || this.optionObject.value;
-    }
+    },
+    displayedId() {
+      return this.optionObject.id;
+    },
   },
   created() {
     this.getSavedTranslations();

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListValuesDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListValuesDrawer.vue
@@ -124,7 +124,12 @@
               {{ $t('profileSettings.dropdownList.name.label') }}
             </v-col>
             <v-col
-              cols="4"
+              cols="1"
+              class="font-weight-bold py-4 px-0">
+              {{ $t('profileSettings.dropdownList.name.id') }}
+            </v-col>
+            <v-col
+              cols="3"
               class="text-end font-weight-bold py-4 px-0">
               {{ $t('profileSettings.dropdownList.actions.label') }}
             </v-col>


### PR DESCRIPTION
Before this change, import a user with a CSV file and add them value on a dropdown attribute, no option to know the ID of the item. To fix this problem, add a column displaying id of dropdown value. After this change, the apply button is disabled when no label is set and the column id of dropdown is added.