### PR TITLE
fix: Display option ID of the dropdown item in profile admin - EXO-8381 - Meeds-io/meeds#2908.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListOptionItemValue.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListOptionItemValue.vue
@@ -39,7 +39,7 @@
       cols="1"
       class="d-flex py-1 px-0">
       <span 
-      class="my-auto text-truncate">
+      class="my-auto">
       {{ displayedId }}
       </span>
     </v-col>


### PR DESCRIPTION
Before this change, import a user with a CSV file and add them value on a dropdown attribute, no option to know the ID of the item. To fix this problem, add a column displaying id of dropdown value. After this change, the apply button is disabled when no label is set and the column id of dropdown is added.