### PR TITLE
fix: Set an empty alt to the space avatar -MEED-8490 - Meeds-io/meeds#2864

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -114,7 +114,7 @@
         tile>
         <img
           :src="item.avatar"
-          :alt="item.name"
+          alt=""
           class="border-radius"
           width="28"
           height="auto">


### PR DESCRIPTION
This change will set an empty alt to the space avatar of the left navigation.

Resolves Meeds-io/meeds#2864