### PR TITLE
fix: In Like notification the avatar is not the one of mentioned user - EXO-8572 - Meeds-io/meeds#1275.

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/SocialNotificationUtils.java
@@ -501,6 +501,7 @@ public class SocialNotificationUtils {
       previousNotification.setRead(false);
       previousNotification.setResetOnBadge(false);
       previousNotification.setLastModifiedDate(Calendar.getInstance());
+      previousNotification.setFrom(notification.getFrom());
       webNotificationService.update(previousNotification, true);
 
       // Mark new notification as Read as it was grouped


### PR DESCRIPTION
Before this change, when UserA posts something and userB and userC likes it then UserA checks notifications, userC is the one mentioned but the avatar displayed is the userB's. To fix this problem, set the from property of previousNotification to the new value of the from property of the existing notification. After this change, UserC is the one mentioned and the avatar to display in the notif is the userC's one.