### PR TITLE
fix: Fix post article notification URL to navigate space members to news activity details instead of news details - MEED-8536 - Meeds-io/meeds#3054

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -833,6 +833,10 @@ public class EntityBuilder {
     SpaceService spaceService = getSpaceService();
     setPublicSiteDetails(spaceEntity, space);
     populateGeneralFields(spaceEntity, space);
+    if (StringUtils.isNotBlank(space.getId()) && StringUtils.isBlank(userId)) {
+      Identity currentUserIdentity = RestUtils.getCurrentUserIdentity();
+      spaceEntity.setIsMember(spaceService.isMember(space, currentUserIdentity.getRemoteId()));
+    }
     if (getUserACL().isAnonymousUser(userId)) {
       return spaceEntity;
     }
@@ -946,9 +950,6 @@ public class EntityBuilder {
       spaceEntity.setIsManager(isManager);
       spaceEntity.setIsRedactor(spaceService.isRedactor(space, userId));
       spaceEntity.setIsPublisher(spaceService.isPublisher(space, userId));
-    } else if (StringUtils.isNotBlank(space.getId())) {
-      Identity currentUserIdentity = RestUtils.getCurrentUserIdentity();
-      spaceEntity.setIsMember(spaceService.isMember(space, currentUserIdentity.getRemoteId()));
     }
 
     PortalConfig portalConfig = getLayoutService().getPortalConfig(new SiteKey(PortalConfig.GROUP_TYPE, space.getGroupId()));


### PR DESCRIPTION
Before this change, the post article notification URL redirected space members to the news details page instead of the news activity details page. This issue was due to the WebNotificationRestEntity.space.isMember attribute being null, which is used on the front end to determine the correct redirection URL.

This was a regression introduced during the enhancement of space card visibility for non-logged-in users. That change made the part of the code responsible for setting the isMember attribute reachable when the user ID was blank, which caused the attribute to remain unset.

This pull request fixes the issue by adjusting the execution order to ensure the isMember value is properly set, restoring the correct redirection behavior.