### PR TITLE
fix: Not all group members are added to bounded space - Meeds-io/meeds#8218

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
@@ -345,7 +345,6 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
     long count, toBind;
     int limit, offset = 0;
     long startTime = System.currentTimeMillis();
-
     try {
       ListAccess<User> groupMembersAccess = organizationService.getUserHandler().findUsersByGroupId(groupSpaceBinding.getGroup());
       List<User> users;
@@ -360,8 +359,12 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
                                                                                  GroupSpaceBindingReportAction.ADD_ACTION);
         bindingReportAddAction=groupSpaceBindingStorage.saveGroupSpaceBindingReport(report);
       }
-     
       do {
+        if(getGroupSpaceBindingsFromQueueByAction(GroupSpaceBindingQueue.ACTION_REMOVE).stream().anyMatch(gSBinding -> groupSpaceBinding.getGroup().equals(gSBinding.getGroup()) && groupSpaceBinding.getId()==gSBinding.getId())){
+          LOG.info("Binding process: Stopped since binding was removed");
+          offset = totalGroupMembersSize;
+          break;
+        }
         long startBunchTime = System.currentTimeMillis();
         toBind = totalGroupMembersSize - offset;
         limit = toBind < USERS_TO_BIND_PAGE_SIZE ? (int) toBind : USERS_TO_BIND_PAGE_SIZE;

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/listener/SpaceBindingMembershipGroupEventListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/listener/SpaceBindingMembershipGroupEventListener.java
@@ -31,6 +31,7 @@ import org.exoplatform.services.organization.MembershipEventListener;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
+import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
 import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
 import org.exoplatform.social.core.binding.model.UserSpaceBinding;
 import org.exoplatform.social.core.binding.spi.GroupSpaceBindingService;
@@ -56,9 +57,18 @@ public class SpaceBindingMembershipGroupEventListener extends MembershipEventLis
         if (isActive(userName) && isUserNewMemberToGroup(userName, groupId)) {
           groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
           spaceService = CommonsUtils.getService(SpaceService.class);
-
+          // Retrieve all removed bindings ids.
+          List<Long> removedSpaceBindingsIds =
+                  groupSpaceBindingService.getGroupSpaceBindingsFromQueueByAction(GroupSpaceBindingQueue.ACTION_REMOVE)
+                          .stream()
+                          .map(groupSpaceBinding -> groupSpaceBinding.getId())
+                          .toList();
           // Retrieve all bindings of the group.
           List<GroupSpaceBinding> groupSpaceBindings = groupSpaceBindingService.findGroupSpaceBindingsByGroup(m.getGroupId());
+          // Get rid of removed bindings.
+          if (removedSpaceBindingsIds.size() > 0 && groupSpaceBindings.size() > 0) {
+            groupSpaceBindings.removeIf(spaceBinding -> removedSpaceBindingsIds.contains(Long.valueOf(spaceBinding.getId())));
+          }
           // For each bound space of the group add a user binding to it.
           for (GroupSpaceBinding groupSpaceBinding : groupSpaceBindings) {
             Space space = spaceService.getSpaceById(groupSpaceBinding.getSpaceId());


### PR DESCRIPTION
Prior to this fix, In some cases when users add binding to spaces then import a big number of users then delete mapping then re-add it, it may cause conflics and concurrent changes and not all users are added. 
This commit avoid useless parallel adding and removing paddings by checking the list of bindings and only add imported user if there is no removed binding after.