### PR TITLE
fix: Allow saving Links Header - MEED-8596 - Meeds-io/meeds#3118

### DIFF
--- a/webapp/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/links/components/settings/LinkSettingsDrawer.vue
@@ -424,8 +424,17 @@ export default {
     showIcon() {
       return this.settings?.showIcon || false;
     },
-    header() {
-      return this.settings?.header || '';
+    header: {
+      get () {
+        return this.settings?.header || '';
+      },
+      set (value) {
+        if (value) {
+          this.$set(this.settings, 'header', value);
+        } else {
+          this.settings.header = null;
+        }
+      },
     }
   },
   watch: {
@@ -471,15 +480,6 @@ export default {
         this.stepper = 1;
       }
     },
-    header() {
-      if (this.header) {
-        if (this.$root.language) {
-          this.header[this.$root.language] = this.$t(this.settings?.header?.[this.$root.language]);
-        } else {
-          this.header[this.$root.defaultLanguage] = this.$t(this.settings?.header?.[this.$root.defaultLanguage]);
-        }
-      }
-    }
   },
   created() {
     this.$root.$on('links-settings-drawer', this.open);
@@ -514,6 +514,12 @@ export default {
             }
           });
           this.showHeader = !!this.settings?.header?.[this.$root.defaultLanguage]?.length;
+          if (this.showHeader) {
+            const defaultHeaderValue = this.settings.header[this.$root.defaultLanguage];
+            if (defaultHeaderValue.includes('.') && this.$te(defaultHeaderValue)) {
+              this.settings.header[this.$root.defaultLanguage] = this.$t(defaultHeaderValue);
+            }
+          }
           this.seeMore = !!this.settings?.seeMore?.length;
           if (!this.showHeader) {
             this.settings.header = null;

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListOptionItemValue.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/DropdownListOptionItemValue.vue
@@ -26,10 +26,10 @@
       <v-tooltip bottom>
         <template #activator="{ on, attrs }">
           <span 
-          v-bind="attrs"
-          v-on="on"
-          class="my-auto text-truncate pe-2">
-          {{ displayedValue }}
+            v-bind="attrs"
+            v-on="on"
+            class="my-auto text-truncate pe-2">
+            {{ displayedValue }}
           </span>
         </template>
         <span class="tooltip-version py-12 text-break"> {{ displayedValue }} </span>
@@ -39,8 +39,8 @@
       cols="1"
       class="d-flex py-1 px-0">
       <span 
-      class="my-auto">
-      {{ displayedId }}
+        class="my-auto">
+        {{ displayedId }}
       </span>
     </v-col>
     <v-col


### PR DESCRIPTION
Prior to this change, when changing the Links Header, then the field input isn't considered and is reset each time the drawer is opened. This change will ensure to consider changes made on input form.

(cherry picked from commit d565d5684dd6e72a03bdd3659410e3380d51098f)