### PR TITLE
fix: after session expiration, redirection on url like /portal/s/xxx is not effective - MEED-8608

### DIFF
--- a/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
@@ -21,10 +21,13 @@ package io.meeds.social.handler;
 import static io.meeds.social.permlink.plugin.SpacePermanentLinkPlugin.APPLICATION_URI;
 import static io.meeds.social.permlink.plugin.SpacePermanentLinkPlugin.OBJECT_TYPE;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.social.core.space.model.Space;
@@ -37,6 +40,7 @@ import org.exoplatform.web.controller.QualifiedName;
 import io.meeds.portal.permlink.model.PermanentLinkObject;
 import io.meeds.portal.permlink.service.PermanentLinkService;
 import jakarta.servlet.ServletConfig;
+import org.exoplatform.web.security.sso.SSOHelper;
 
 public class SpacePermanentLinkHandler extends WebRequestHandler {
 
@@ -80,8 +84,10 @@ public class SpacePermanentLinkHandler extends WebRequestHandler {
       path = path + "?" + queryString;
     }
     Space space = spaceService.getSpaceById(spaceId);
-    if (StringUtils.isBlank(username)
-        || space == null
+    if (StringUtils.isBlank(username)) {
+      String loginPath = getAuthenticationUrl(controllerContext.getRequest().getRequestURI());
+      controllerContext.getResponse().sendRedirect(loginPath);
+    } else if (space == null
         || isHiddenSpace(space, username)) {
       String pageNotFoundUrl = "/portal/" + getPageNotFoundSite(username) + "/page-not-found";
       controllerContext.getResponse().sendRedirect(pageNotFoundUrl);
@@ -105,6 +111,20 @@ public class SpacePermanentLinkHandler extends WebRequestHandler {
     return new PermanentLinkObject(OBJECT_TYPE,
                                    spaceId,
                                    Collections.singletonMap(APPLICATION_URI, path));
+  }
+
+  private String getAuthenticationUrl(String permanentLink) {
+    StringBuilder loginPath = new StringBuilder();
+
+    // . Check SSO Enable
+    SSOHelper ssoHelper = ExoContainerContext.getService(SSOHelper.class);
+    if (ssoHelper != null && ssoHelper.isSSOEnabled() && ssoHelper.skipJSPRedirection()) {
+      loginPath.append("/portal").append(ssoHelper.getSSORedirectURLSuffix());
+    } else {
+      loginPath.append("/portal/login");
+    }
+    loginPath.append("?initialURI=").append(URLEncoder.encode(permanentLink, StandardCharsets.UTF_8));
+    return loginPath.toString();
   }
 
 }


### PR DESCRIPTION
Before this fix, the handler SpacePermanentLinkHandler redirect on page /portal/page-not-found, even if user is not loggued. Then this page redirect user on /portal/login?initialURI=/portal/page-not-found So when user logs in, he is not correctly redirected on the page on which he clicks (/portal/s/xxx)

This fix add a case in the handler : when the user is not connected, we redirect him directly to /portal/login?initialURI=/portal/s/xxxx so that, after login, user can be correctly redirect on the page

Resolves Meeds-io/meeds#3131

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
