### PR TITLE
fix: When using OIDC, redirection to initialURI is not working in some case - MEED-8609

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
@@ -112,6 +112,7 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
       for (Cookie cookie : cookies) {
         if (cookie.getName().equals("OPENID_ACCESS_TOKEN")) {
           try {
+            saveInitialURI(request);
             openIdProcessor.processOAuthInteraction(request, response);
           } catch (OAuthException | ExecutionException | InterruptedException | IOException ex) {
             log.error("Error during OAuth flow with: " + ex.getMessage(), ex);
@@ -121,4 +122,11 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
       }
     }
   }
+  private void saveInitialURI(HttpServletRequest request) {
+    String initialURI = request.getParameter("initialURI");
+    if (initialURI != null) {
+      request.getSession().setAttribute(OAuthConstants.ATTRIBUTE_URL_TO_REDIRECT_AFTER_LINK_SOCIAL_ACCOUNT, initialURI);
+    }
+  }
+
 }


### PR DESCRIPTION
Before this fix, when the OIDC authentication is done with the cookie OPENID_ACCESS_TOKEN, the initialUri is not correctly used This commit ensure to store and reuse initialUri in this case

Resolves meeds-io/meeds#3132

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
