### PR TITLE
fix: Remove caption and text-bold classes from user and space popover content - MEED-8595 - Meeds-io/Meeds#309

### DIFF
--- a/webapp/src/main/webapp/vue-apps/popover/components/SpacePopoverContent.vue
+++ b/webapp/src/main/webapp/vue-apps/popover/components/SpacePopoverContent.vue
@@ -37,7 +37,7 @@
             link-style
             subtitle-new-line>
             <template slot="subTitle">
-              <span v-if="spaceMembersCount" class="caption text-bold">
+              <span v-if="spaceMembersCount">
                 {{ spaceMembersCount }} {{ $t('UIActivity.label.Members') }}
               </span>
             </template>

--- a/webapp/src/main/webapp/vue-apps/popover/components/UserPopoverContent.vue
+++ b/webapp/src/main/webapp/vue-apps/popover/components/UserPopoverContent.vue
@@ -37,7 +37,7 @@
             bold-title
             link-style>
             <template v-if="primaryProperty" slot="subTitle">
-              <span class="caption text-bold">
+              <span>
                 {{ primaryProperty }}
               </span>
             </template>


### PR DESCRIPTION
This change is going to remove the caption and text-bold classes from the space and user popover content
