### PR TITLE
fix: who's online portlet display js erreur when loaded by external user - MEED-8644

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/whoIsOnline.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/whoIsOnline.jsp
@@ -59,7 +59,11 @@
 <% } else { %>
   <div id="OnlinePortlet">
     <script type="text/javascript">
-      require(['SHARED/vue'], () => Vue.prototype.$updateApplicationVisibility(false, document.querySelector('#OnlinePortlet')));
+      document.onreadystatechange = () => {
+        if (document.readyState === 'complete') {
+          require(['SHARED/vue'], () => Vue.prototype.$updateApplicationVisibility(false, document.querySelector('#OnlinePortlet')));
+        }
+      };
     </script>
   </div>
 <% } %>


### PR DESCRIPTION
Before this fix, when we upgrade from 6.5 to 7.0, the whosonline portlet generates and error for externals only because Vue.prototype.$updateApplicationVisibility is not loaded. On a new create space, this component is loaded when portlet sidebar is mounted, but on a space coming from 6.5, it still use the old layout, and the vue object is not loaded. This commit ensure that the page is loaded before calling updateApplicationVisibility, so that the Vue object exists.

Resolves meeds-io/meeds#3140

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
