### PR TITLE
fix: Ensure Space Banner compatibility with previous version - MEED-8641 - Meeds-io/meeds#3138

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-banner/components/SpaceBanner.vue
+++ b/webapp/src/main/webapp/vue-apps/space-banner/components/SpaceBanner.vue
@@ -9,6 +9,7 @@
           v-if="admin"
           :hover="hover"
           :default-banner="defaultBanner"
+          class="z-index-one"
           @edit="$refs.imageCropDrawer.open()"
           @remove="removeBanner" />
         <div class="d-flex fill-height fill-width">
@@ -16,9 +17,10 @@
             v-if="bannerUrl"
             :src="bannerUrl"
             :alt="spaceDisplayName"
+            style="min-width: 100%;min-height: 100%;"
             width="100%"
             height="100%"
-            class="fill-height fill-width border-box-sizing">
+            class="border-box-sizing absolute-all-center">
         </div>
       </v-responsive>
     </v-hover>


### PR DESCRIPTION
Prior to this change, the Space Banner follows the image ratio. This change will ensure to fix the portlet aspect ratio and display the image in an absolute position with min-width and min-height.

(cherry picked from commit 06c3740237ff18adee9bd8c4ced19860ac94e77c)