### PR TITLE
fix: Space avatar not displayed for invited users - MEED-8639 - Meeds-io/meeds#3105

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRest.java
@@ -569,7 +569,7 @@ public class SpaceRest implements ResourceContainer {
       Space space = byId ? spaceService.getSpaceById(id) : spaceService.getSpaceByPrettyName(id);
       if (space == null
           || (Space.HIDDEN.equals(space.getVisibility())
-              && !spaceService.canViewSpace(space, authenticatedUser))) {
+              && !spaceService.canViewSpace(space, authenticatedUser) && !Arrays.asList(space.getInvitedUsers()).contains(authenticatedUser))) {
         return Response.status(Status.NOT_FOUND).build();
       }
       Identity identity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());


### PR DESCRIPTION
Prior to this change, the avatar of a space using the circle template was not displayed in the mail invitation or in the user's pending space card. This issue occurred because the avatar was not visible for non-members if the space is hidden. This change will now allow invited users to see the space avatar of the hidden space they are invited to.