### PR TITLE
fix:Display the number of users by role in space role settings - MEED-8646 - Meeds-io/meeds#3144 (#4572)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
@@ -184,7 +184,7 @@ public class SpaceMembershipRest implements ResourceContainer {
                                                              uriInfo,
                                                              expand);
       if (returnSize) {
-        size = spaceMemberships.size();
+        size = listAccess.getSize();
       }
     } else {
       SpaceFilter spaceFilter = new SpaceFilter();


### PR DESCRIPTION
Before this change, the space role settings section displayed only 3 users with no indication of the total user count. The issue was due to an incorrect return size. This change corrects the return size and resolves the problem.
