### PR TITLE
fix : setting default platform language to pt-br generates problems in interface - MEED-8665

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingLanguage.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingLanguage.jsp
@@ -18,8 +18,9 @@
 				if (locale.toString().equals("ma")) {
 					continue;
 				} else {
-					object.put("value", locale.toString());
-					object.put("text", locale.getDisplayName(Locale.ENGLISH) + " / " + locale.getDisplayName(locale));
+					object.put("value", locale.toLanguageTag());
+					object.put("text", userLocale.equals(locale) ? locale.getDisplayName(locale) :
+                                                                               locale.getDisplayName(userLocale) + " / " + locale.getDisplayName(locale));
 				}
 				localesJSON.put(object);
 			}

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/language/DefaultLanguageDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/language/DefaultLanguageDrawer.vue
@@ -82,10 +82,12 @@ export default {
   methods: {
     open() {
       this.language = this.branding?.defaultLanguage;
+      this.languages = this.languages.sort((a, b) => a.text.localeCompare(b.text));
+
       this.$refs.drawer.open();
     },
     saveLanguage() {
-      const lang = this.language.replace('-', '_');
+      const lang = this.language;
       this.loading = true;
       this.$languageSettingService.saveDefaultLanguage(lang)
         .then(() => {

--- a/webapp/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-language/components/UserSettingLanguage.vue
@@ -7,7 +7,7 @@
             <v-list-item-title class="text-title">
               {{ $t('UserSettings.language') }}
             </v-list-item-title>
-            <v-list-item-subtitle>
+            <v-list-item-subtitle class="text-capitalize">
               {{ languageLabel }}
             </v-list-item-subtitle>
           </v-list-item-content>


### PR DESCRIPTION
Before this fixn there is an inconsistance between usage and storage of user locale and platform default locale Platform default locale use a _ to separate locale name and country but [rfc](https://datatracker.ietf.org/doc/html/rfc5646) requires to use -.

This lead to some inconsistancy in interface.
This commit ensure to use - everywhere a locale tag is used.

Resolves meeds-io/meeds#3159

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
