### PR TITLE
feat: Make meeds attachment preview extensible - EXO-77966

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -2089,6 +2089,9 @@
         <module>attachImage</module>
       </depends>
       <depends>
+        <module>attachmentsPreview</module>
+      </depends>
+      <depends>
         <module>eXoVueI18n</module>
       </depends>
       <depends>
@@ -2544,6 +2547,9 @@
       <module>attachImage</module>
     </depends>
     <depends>
+      <module>attachmentsPreview</module>
+    </depends>
+    <depends>
       <module>commons-cometd3</module>
       <as>cCometd</as>
     </depends>
@@ -2598,6 +2604,31 @@
     </depends>
     <depends>
       <module>imageCropper</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+    <depends>
+      <module>jquery</module>
+      <as>jQuery</as>
+    </depends>
+  </module>
+  <module>
+    <name>attachmentsPreview</name>
+    <script>
+      <path>/js/attachmentsPreview.bundle.js</path>
+    </script>
+    <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>commonVueComponents</module>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
     </depends>
     <depends>
       <module>vuetify</module>

--- a/webapp/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -423,7 +423,7 @@ extensionRegistry.registerComponent('ActivityCommentFooter', 'activity-comment-f
 
 extensionRegistry.registerComponent('ActivityStream', 'activity-stream-drawers', {
   id: 'attachment-dialog',
-  vueComponent: Vue.options.components['attachments-image-preview-dialog'],
+  vueComponent: Vue.options.components['attachments-preview-dialog'],
   rank: 50,
 });
 

--- a/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsImagePreview.vue
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsImagePreview.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
 
- Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -42,7 +42,7 @@ export default {
   },
   computed: {
     thumbnailUrl() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/attachments/${this.objectType}/${this.objectId}/${this.attachment.id}`;
+      return this.attachment.downloadUrl?`${eXo.env.portal.context}${this.attachment.downloadUrl}`:`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/attachments/${this.objectType}/${this.objectId}/${this.attachment.id}`;
     },
     isMobile() {
       return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'md';

--- a/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsPreviewDialog.vue
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsPreviewDialog.vue
@@ -65,10 +65,10 @@
             :value="attachment.id"
             reverse-transition="fade-transition"
             transition="fade-transition">
-            <attachments-image-preview-item
-              :attachment="attachment"
-              :object-type="objectType"
-              :object-id="objectId" />
+            <extension-registry-component
+              :component="getExtension(attachment)"
+              :params="getParams(attachment)"
+              :element="div" />
           </v-carousel-item>
         </v-carousel>
       </v-card>
@@ -83,10 +83,13 @@ export default {
     filename: '',
     objectType: '',
     attachments: null,
+    previewExtensionApp: 'Preview',
+    previewExtensionType: 'previewExtensions',
+    previewExtensions: [],
   }),
   computed: {
     downloadURL() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/attachments/${this.objectType}/${this.objectId}/${this.currentAttachmentId}?size=0x0&download=true`;
+      return this.currentAttachmentUrl?`${eXo.env.portal.context}${this.currentAttachmentUrl}`:`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/attachments/${this.objectType}/${this.objectId}/${this.currentAttachmentId}?size=0x0&download=true`;
     },
     attachmentFilename() {
       return  this.attachments?.length && this.attachments.filter(attachment => attachment.id === this.currentAttachmentId).finename || this.filename;
@@ -112,7 +115,10 @@ export default {
     }
   },
   created() {
+    this.refreshPreviewExtensions();
     this.$root.$on('open-attachments-preview', this.open);
+    document.addEventListener(`extension-${this.previewExtensionApp}-${this.previewExtensionType}-updated`, this.refreshPreviewExtensions);
+    document.addEventListener('open-attachments-preview', this.openPreview);
     document.addEventListener('keydown', (event) => {
       if (this.$refs.attachmentsCarousel) {
         if (event.key === 'Escape') {
@@ -126,6 +132,24 @@ export default {
     });
   },
   methods: {
+    refreshPreviewExtensions() {
+      this.previewExtensions = extensionRegistry.loadExtensions(this.previewExtensionApp, this.previewExtensionType);
+    },
+    getParams(attachment) {
+      return {
+        attachment: attachment,
+        objectType: this.objectType,
+        objectId: this.objectId,
+      };
+    },
+    getExtension(attachment) {
+      return this.previewExtensions.find((element) => attachment.mimetype.includes(element.fileType));
+    },
+    openPreview(event) {
+      const attachment = event?.detail;
+      this.currentAttachmentUrl = attachment.downloadUrl;
+      this.open(attachment.objectType, attachment.objectId, attachment.attachments, attachment.id);
+    },
     open(objectType, objectId, attachments, id) {
       this.objectType = objectType;
       this.objectId = objectId;

--- a/webapp/src/main/webapp/vue-apps/attachments-preview/extensions.js
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/extensions.js
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+extensionRegistry.registerExtension('Preview', 'previewExtensions', {
+  id: 'image-preview',
+  fileType: 'image',
+  rank: 10,
+  componentOptions: {
+    vueComponent: Vue.options.components['attachments-image-preview'],
+  },
+});

--- a/webapp/src/main/webapp/vue-apps/attachments-preview/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,24 +16,13 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import ImageInput from './components/form/ImageInput.vue';
-import ImageInputMultiUpload from './components/form/ImageInputMultiUpload.vue';
-import ImageInputItems from './components/form/ImageInputItems.vue';
-import ImageInputItem from './components/form/ImageInputItem.vue';
-import ImageAttachmentCropDrawer from './components/form/ImageAttachmentCropDrawer.vue';
 
-import ImageItems from './components/view/ImageItems.vue';
-import ImageItem from './components/view/ImageItem.vue';
-
+import AttachmentsPreviewDialog from './components/preview/AttachmentsPreviewDialog.vue';
+import AttachmentsImagePreview from './components/preview/AttachmentsImagePreview.vue';
 
 const components = {
-  'attachments-image-input': ImageInput,
-  'attachments-image-input-multi-upload': ImageInputMultiUpload,
-  'attachments-image-input-items': ImageInputItems,
-  'attachments-image-input-item': ImageInputItem,
-  'attachments-image-crop-drawer': ImageAttachmentCropDrawer,
-  'attachments-image-items': ImageItems,
-  'attachments-image-item': ImageItem
+  'attachments-preview-dialog': AttachmentsPreviewDialog,
+  'attachments-image-preview': AttachmentsImagePreview,
 };
 
 for (const key in components) {

--- a/webapp/src/main/webapp/vue-apps/attachments-preview/main.js
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/main.js
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import './initComponents.js';
+import './extensions.js';

--- a/webapp/src/main/webapp/vue-apps/simple-storage/components/SimpleStorageApp.vue
+++ b/webapp/src/main/webapp/vue-apps/simple-storage/components/SimpleStorageApp.vue
@@ -45,7 +45,7 @@
         </v-btn>
       </v-card-actions>
     </v-card>
-    <attachments-image-preview-dialog
+    <attachments-preview-dialog
       ref="previewDialog" />
     <confirm-dialog
       ref="dialog"

--- a/webapp/webpack.common.js
+++ b/webapp/webpack.common.js
@@ -89,6 +89,7 @@ let config = {
     notificationAdministration: './src/main/webapp/vue-apps/notification-administration/main.js',
     notificationExtensions: './src/main/webapp/vue-apps/notification-extensions/main.js',
     attachImage: './src/main/webapp/vue-apps/attach-image/main.js',
+    attachmentsPreview: './src/main/webapp/vue-apps/attachments-preview/main.js',
     links: './src/main/webapp/vue-apps/links/main.js',
     image: './src/main/webapp/vue-apps/image/main.js',
     verticalMenu: './src/main/webapp/vue-apps/vertical-menu/main.js',


### PR DESCRIPTION
Meeds attachment preview only supports images. this change will make it extensible to support other content types and create a default extension for images.