### PR TITLE
fix: Fix the display of recent spaces of a category - MEED-8664 - Meeds-io/meeds#3155

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacesHamburgerNavigation.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacesHamburgerNavigation.vue
@@ -181,13 +181,6 @@ export default {
   created() {
     this.init();
   },
-  beforeDestroy() {
-    this.$root.openedSpaceTemplateId = null;
-    this.$root.openedSpaceCategoryId = null;
-    this.$root.openedItem = null;
-    this.$root.openedSpaces = false;
-    this.$root.spacesSortBy = null;
-  },
   methods: {
     async init() {
       if (!this.$root.spaceTemplates) {


### PR DESCRIPTION
This change will  Fix the display of recent spaces of a category.

Resolves: Meeds-io/meeds#3155
(cherry picked from commit fdea07b5dc54d7dc9df671cf7edc63d2555b11ae)