### PR TITLE
fix : NotificationUpgradePlugin falsly detects error on execution - MEED-8688

### DIFF
--- a/component/notification/src/main/java/io/meeds/social/notification/upgrade/NotificationUpgradePlugin.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/upgrade/NotificationUpgradePlugin.java
@@ -48,12 +48,8 @@ public class NotificationUpgradePlugin extends UpgradeProductPlugin {
 
   private static final String  NOTIFICATION_CHANNEL_IDS_PARAM      = "channelIds";
 
-  private static final String  COUNT_UPGRADED_USERS_QUERY          =
-                                                          "SELECT COUNT(DISTINCT s.context.id) FROM SettingsEntity s WHERE s.value LIKE :"
-                                                              + NOTIFICATION_PLUGIN_ID_LIKE_PARAM;
-
   private static final String  COUNT_NOT_UPGRADED_USERS_QUERY      =
-                                                              "SELECT COUNT(DISTINCT s.context.id) FROM SettingsEntity s WHERE s.name LIKE 'exo:%Channel' AND s.value NOT LIKE :"
+                                                              "SELECT COUNT(DISTINCT s.context.id) FROM SettingsEntity s WHERE s.name IN (:" + NOTIFICATION_CHANNEL_IDS_PARAM +") AND s.value NOT LIKE :"
                                                                   + NOTIFICATION_PLUGIN_ID_LIKE_PARAM;
 
   private static final String  UPGRADE_USERS_NOTIFICATIONS_QUERY   =
@@ -106,6 +102,7 @@ public class NotificationUpgradePlugin extends UpgradeProductPlugin {
 
   @Override
   public void processUpgrade(String oldVersion, String newVersion) {
+
     int usersToUpgradeCount = countUsersToUpgrade();
     if (usersToUpgradeCount == 0) {
       LOG.debug("Notification Plugin '{}' Setting upgrade will not proceed since no user has specific Notifications settings.",
@@ -113,20 +110,20 @@ public class NotificationUpgradePlugin extends UpgradeProductPlugin {
     } else {
       LOG.info("Start:: Upgrade Notification Plugin Setting '{}' for {} users.", notificationPluginId, usersToUpgradeCount);
       Set<String> activeChannels =
-                                 StringUtils.isBlank(notificationChannelId) ? userSettingService.getDefaultSettings()
-                                                                                                .getChannelActives()
-                                                                            : Collections.singleton(notificationChannelId);
+          StringUtils.isBlank(notificationChannelId) ? userSettingService.getDefaultSettings()
+                                                                         .getChannelActives()
+                                                     : Collections.singleton(notificationChannelId);
       upgradeUsersNotifications(activeChannels);
-      int upgradedUsers = countUpgradedUsers();
-      if (upgradedUsers < usersToUpgradeCount) {
+      int usersToUpgradeCountAfterUpdate = countUsersToUpgrade();
+      if (usersToUpgradeCountAfterUpdate > 0) {
         throw new IllegalStateException(String.format("End:: Upgrade Notification Plugin Setting '%s' didn't upgraded all users settings: %s/%s",
                                                       notificationPluginId,
-                                                      upgradedUsers,
+                                                      (usersToUpgradeCount - usersToUpgradeCountAfterUpdate),
                                                       usersToUpgradeCount));
       }
       LOG.info("End:: Upgrade Notification Plugin Setting '{}' for {}/{} users.",
                notificationPluginId,
-               upgradedUsers,
+               (usersToUpgradeCount - usersToUpgradeCountAfterUpdate),
                usersToUpgradeCount);
     }
   }
@@ -143,23 +140,18 @@ public class NotificationUpgradePlugin extends UpgradeProductPlugin {
   }
 
   @ExoTransactional
-  public int countUpgradedUsers() {
-    EntityManager entityManager = entityManagerService.getEntityManager();
-    TypedQuery<Long> query = entityManager.createQuery(COUNT_UPGRADED_USERS_QUERY, Long.class);
-    query.setParameter(NOTIFICATION_PLUGIN_ID_LIKE_PARAM, "%" + notificationPluginId + "%");
-    try {
-      Long queryResult = query.getSingleResult();
-      return queryResult == null ? 0 : queryResult.intValue();
-    } catch (NoResultException e) {
-      return 0;
-    }
-  }
-
-  @ExoTransactional
   public int countUsersToUpgrade() {
+    Set<String> channelIds =
+        StringUtils.isBlank(notificationChannelId) ? userSettingService.getDefaultSettings()
+                                                                       .getChannelActives()
+                                                   : Collections.singleton(notificationChannelId);
+    List<String> channelValues = channelIds.stream().map(channelId -> "exo:" + channelId + "Channel").toList();
+
     EntityManager entityManager = entityManagerService.getEntityManager();
     TypedQuery<Long> query = entityManager.createQuery(COUNT_NOT_UPGRADED_USERS_QUERY, Long.class);
     query.setParameter(NOTIFICATION_PLUGIN_ID_LIKE_PARAM, "%" + notificationPluginId + "%");
+    query.setParameter(NOTIFICATION_CHANNEL_IDS_PARAM, channelValues);
+
     try {
       Long queryResult = query.getSingleResult();
       return queryResult == null ? 0 : queryResult.intValue();

--- a/component/notification/src/test/java/io/meeds/social/notification/upgrade/NotificationUpgradePluginTest.java
+++ b/component/notification/src/test/java/io/meeds/social/notification/upgrade/NotificationUpgradePluginTest.java
@@ -18,7 +18,9 @@
 package io.meeds.social.notification.upgrade;
 
 import java.util.Arrays;
+import java.util.Iterator;
 
+import org.exoplatform.commons.api.notification.channel.ChannelManager;
 import org.exoplatform.commons.api.notification.model.UserSetting;
 import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
 import org.exoplatform.commons.api.settings.SettingService;
@@ -27,13 +29,17 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.social.notification.AbstractNotificationCoreTest;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class NotificationUpgradePluginTest extends AbstractNotificationCoreTest {// NOSONAR
 
   private static final String DEFAULT_NOTIFICATION_PLUGIN_ID = "DefaultNotificationPluginId";
 
   private static final String UPGRADE_NOTIFICATION_PLUGIN    = "UpgradeNotificationPlugin";
 
-  private UserSettingService  userSettingService;
+  private UserSettingService userSettingService;
 
   @Override
   protected void setUp() throws Exception {
@@ -80,6 +86,82 @@ public class NotificationUpgradePluginTest extends AbstractNotificationCoreTest 
 
     rootUserSettings = userSettingService.get(userSettings.getUserId());
     assertTrue(rootUserSettings.getPlugins(channelId).contains(UPGRADE_NOTIFICATION_PLUGIN));
+  }
+
+  public void testNotificationUpgradeWithOneChannel() {
+
+    //john have default notification plugin id for first channel (MAIL_CHANNEL)
+    //he does not have the default notification plugin id for the second channel (WEB_CHANNEL)
+
+    UserSetting userSettings = userSettingService.get("john");
+    String channelId = userSettings.getChannelActives().iterator().next();
+    userSettings.setChannelPlugins(channelId, Arrays.asList(DEFAULT_NOTIFICATION_PLUGIN_ID));
+    userSettingService.save(userSettings);
+    UserSetting johnUserSettings = userSettingService.get(userSettings.getUserId());
+    Iterator channels = userSettings.getChannelActives().iterator();
+    boolean firstChannel = true;
+    while (channels.hasNext()) {
+      String channel = (String) channels.next();
+      if (firstChannel) {
+        assertTrue(johnUserSettings.getPlugins(channel).contains(DEFAULT_NOTIFICATION_PLUGIN_ID));
+      } else {
+        assertFalse(johnUserSettings.getPlugins(channel).contains(DEFAULT_NOTIFICATION_PLUGIN_ID));
+      }
+      firstChannel=false;
+    }
+
+
+    //The plugin upgrade only ONE CHANNEL : SPACE_WEB_CHANNEL for which john have no configuration
+    //because of old data for example
+
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.social");
+    initParams.addParam(valueParam);
+
+    valueParam = new ValueParam();
+    valueParam.setName("plugin.execution.order");
+    valueParam.setValue("5");
+    initParams.addParam(valueParam);
+
+    valueParam = new ValueParam();
+    valueParam.setName("notificationPluginId");
+    valueParam.setValue(UPGRADE_NOTIFICATION_PLUGIN);
+    initParams.addParam(valueParam);
+
+    valueParam = new ValueParam();
+    valueParam.setName("notificationChannelId");
+    valueParam.setValue("SPACE_WEB_CHANNEL");
+    initParams.addParam(valueParam);
+
+    EntityManagerService entityManagerService = getContainer().getComponentInstanceOfType(EntityManagerService.class);
+    SettingService settingService = getContainer().getComponentInstanceOfType(SettingService.class);
+    NotificationUpgradePlugin upgradePlugin = new NotificationUpgradePlugin(entityManagerService,
+                                                                            userSettingService,
+                                                                            settingService,
+                                                                            initParams);
+    upgradePlugin.setName(UPGRADE_NOTIFICATION_PLUGIN);
+    assertTrue(upgradePlugin.isEnabled());
+
+    try {
+      //the upgrade should not generate an exception
+      upgradePlugin.processUpgrade(null, null);
+    } catch (RuntimeException e) {
+      fail("Upgrade plugin should not throw an exception");
+      throw e;
+    }
+    restartTransaction();
+
+    //both channel for john should not have the new upgrade plugin
+    johnUserSettings = userSettingService.get(userSettings.getUserId());
+    channels = userSettings.getChannelActives().iterator();
+    while (channels.hasNext()) {
+      String channel = (String) channels.next();
+      assertFalse(johnUserSettings.getPlugins(channel).contains(UPGRADE_NOTIFICATION_PLUGIN));
+    }
+
   }
 
 }


### PR DESCRIPTION
Before this fix, when the UP is configured with not all channel (for example only SPACE_WEB_CHANNEL) and some users have any configuration for this channel, the UP think that the execution is not finished, even if all users are migrated. This comes to the way users are count
This commit update the users count to
1) take care of channel
2) execute the same query before and after the update query. After the query, the count must be 0.

Resolves meeds-io/meeds#3175

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
