### PR TITLE
fix: Avoid Flickering when clicking on Notification in Mobile - MEED-8542 - Meeds-io/meeds#2836

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
@@ -177,6 +177,7 @@ export default {
     minWidth: 0,
     movingLeft: false,
     moving: false,
+    movingMouseDown: false,
     markedAsRead: false,
     markedAsReadMuted: false,
     showMenu: false,
@@ -307,12 +308,18 @@ export default {
         return;
       }
       await this.reset();
+      this.movingMouseDown = true;
       this.minHeight = Math.max(this.minHeight, this.$refs?.content?.$el?.offsetHeight);
       this.minWidth = Math.max(this.minWidth, this.$refs?.content?.$el?.offsetWidth);
       await this.$nextTick();
-      window.setTimeout(() => this.absolute = true, 50);
+      window.setTimeout(() => {
+        if (this.movingMouseDown) {
+          this.absolute = true;
+        }
+      }, 50);
     },
     moveEnd() {
+      this.movingMouseDown = false;
       const deleteNotification = this.left > 0;
       const confirm = Math.abs(this.left) > (this.minWidth / 2);
       if (confirm) {


### PR DESCRIPTION
Prior to this change, sometimes, when clicking on a notification to open it, then the notification disappears just before switching the page to display the target link of the notification. This change ensures to not enable Absolute position of the notification (used to swipe notification left & right) when the user clicks on the notification to open it instead of swiping it.