### PR TITLE
fix: Prevent disabled space templates from being displayed in the space form drawer - MEED-8707 - Meeds-io/meeds#3193

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -254,7 +254,7 @@ export default {
         || (this.space.description?.length || 0) > this.maxDescriptionLength;
     },
     sortedTemplates() {
-      const spaceTemplates = this.templates?.filter?.(t => t.name) || [];
+      const spaceTemplates = this.templates?.filter?.(t => t.name && t.enabled) || [];
       spaceTemplates.sort((a, b) => this.$root.collator.compare(a.name.toLowerCase(), b.name.toLowerCase()));
       return this.keyword?.length && spaceTemplates.filter(t => {
         const name = this.$te(t.name) ? this.$t(t.name) : t.name;


### PR DESCRIPTION
Prior to this change, disabled space templates were displayed in the space form drawer. This change prevents disabled templates from being displayed in the space form drawer.
Resolves https://github.com/Meeds-io/meeds/issues/3193
