### PR TITLE
feat: Allow to use Language Edit Drawer in any page - MEED-8728 - Meeds-io/MIPs#185

### DIFF
--- a/webapp/src/main/webapp/vue-apps/user-setting-language/components/UserLanguageDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-language/components/UserLanguageDrawer.vue
@@ -53,7 +53,10 @@ export default {
     },
     saveLanguage() {
       const lang = this.value.replace('_', '-');
-      window.location.replace(`${eXo.env.portal.context}/${lang}/${eXo.env.portal.metaPortalName}/settings`);
+      const url = window.location.href
+        .replace(`${eXo.env.portal.context}/${eXo.env.portal.language}`, eXo.env.portal.context)
+        .replace(eXo.env.portal.context, `${eXo.env.portal.context}/${lang}`);
+      window.location.replace(url);
     },
     cancel() {
       this.$refs.userLanguageDrawer.close();


### PR DESCRIPTION
This change will allow to use the 'Edit Language' drawer in any page instead of making it used in settings page only.