### PR TITLE
fix: Set an empty alt to the Platform logo - MEED-8752 - Meeds-io/meeds#3075

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListHeader.vue
@@ -38,7 +38,7 @@
         tile>
         <img
           :src="companyLogo"
-          :alt="$t('menu.companyNameTooltip',{0: companyName})"
+          alt=""
           height="36"
           width="auto"
           class="object-fit-contain">


### PR DESCRIPTION
Accessibility- Images C 1.2 : The logo is a decoration image which must have an empty alternative text alt= " "

(cherry picked from commit 3fb089968bf73a071ca207f49921246b51b9df39)