### PR TITLE
fix: Set an empty alt to the profile picture - MEED-8753 - Meeds-io/meeds#3076

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
@@ -67,7 +67,7 @@
                 size="24">
                 <img
                   :src="avatarUrl"
-                  :alt="userName"
+                  alt=" "
                   height="24"
                   width="24"
                   contain>

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
@@ -67,7 +67,7 @@
                 size="24">
                 <img
                   :src="avatarUrl"
-                  alt=" "
+                  alt=""
                   height="24"
                   width="24"
                   contain>


### PR DESCRIPTION
Accessibility- Images C 1.2 : The Profile picture is a decoration image which must have an empty alternative text