### PR TITLE
fix: Display Right Space Permissions in Admin UI - MEED-8793 - Meeds-io/meeds#3221

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceAdministrationServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceAdministrationServiceImpl.java
@@ -21,7 +21,10 @@ package io.meeds.social.space.service;
 import static org.exoplatform.social.core.space.SpaceUtils.setPermissionsFromTemplate;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -67,9 +70,24 @@ public class SpaceAdministrationServiceImpl implements SpaceAdministrationServic
     if (space == null) {
       throw new ObjectNotFoundException(String.format(SPACE_NOT_FOUND_MESSAGE, spaceId));
     }
-    return new SpacePermissions(space.getLayoutPermissions(),
-                                space.getPublicSitePermissions(),
-                                space.getDeletePermissions());
+    List<String> layoutPermissions = space.getLayoutPermissions();
+    List<String> publicSitePermissions = space.getPublicSitePermissions();
+    List<String> deletePermissions = space.getDeletePermissions();
+    if (space.getTemplateId() == 0) {
+      List<String> spaceAdminsPermission = Collections.singletonList(String.format("manager:%s", space.getGroupId()));
+      if (CollectionUtils.isEmpty(layoutPermissions)) {
+        layoutPermissions = spaceAdminsPermission;
+      }
+      if (CollectionUtils.isEmpty(publicSitePermissions)) {
+        publicSitePermissions = spaceAdminsPermission;
+      }
+      if (CollectionUtils.isEmpty(deletePermissions)) {
+        deletePermissions = spaceAdminsPermission;
+      }
+    }
+    return new SpacePermissions(layoutPermissions,
+                                publicSitePermissions,
+                                deletePermissions);
   }
 
   @Override


### PR DESCRIPTION
Prior to this change, when upgrading spaces from 6.x to 7.0, then the spaces doesn't have associated templates and thus the old space permission strategy is used, which consists of: Space Managers can manage their created spaces (deleting, layout and space public site). This change will update the display in Space Admin UI in order to mark the '`Space Admins`' checkbox with '`checked`' status rather than displaying it as '`unchecked`'.