### PR TITLE
fix: UI glitch when guest user mentioned - MEED-8775 - Meeds-io/meeds#3070

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -213,7 +213,7 @@ public class LinkProvider {
                .append(">")
                .append(StringEscapeUtils.escapeHtml4(identity.getProfile().getFullName()));
     if(identity.getProfile().getProperty("external") != null && identity.getProfile().getProperty("external").equals("true")){
-      profileLink = profileLink.append("<span \" class=\"externalFlagClass\">").append(" (").append(getResourceBundleLabel(Locale.forLanguageTag(lang), "external.label.tag")).append(")").append("</span>");
+      profileLink = profileLink.append("<span class=\"externalFlagClass\">").append(" (").append(getResourceBundleLabel(Locale.forLanguageTag(lang), "external.label.tag")).append(")").append("</span>");
     }
     return profileLink.append("</a>").toString();
   }


### PR DESCRIPTION
Before this change, when start a new note and mention external user then save and display note, Bad display of external user mention. To fix this problem, eliminate unnecessary characters in profileLink. After this change, the mention of external users is displayed correctly.
