### PR TITLE
fix: suggest only active templates when applying a template to a space - MEED-8864 - Meeds-io/meeds#3231

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-administration/components/drawer/SpacesAdministrationApplyTemplateDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-administration/components/drawer/SpacesAdministrationApplyTemplateDrawer.vue
@@ -66,7 +66,7 @@
             v-for="item in spaceTemplateItems"
             :key="item.value"
             :value="item.value">
-            {{ item.text }}{{ item.deleted && ` ${$t('social.spaces.administration.manageSpaces.deletedSpaceTemplate')}` || (!item.enabled && ` ${$t('social.spaces.administration.manageSpaces.disabledSpaceTemplate')}`) || '' }}
+            {{ item.text }}
           </option>
         </select>
         <template v-if="spaceTemplate">
@@ -254,7 +254,7 @@ export default {
           value: t.id,
           enabled: t.enabled,
           deleted: t.deleted,
-        })));
+        })).filter(item => item.enabled && !item.deleted));
       }
       return spaceTemplateItems;
     },


### PR DESCRIPTION
Prior to this change, all space templates were suggested when applying a template to a space. This change ensures that only active templates are suggested.
Resolves https://github.com/Meeds-io/meeds/issues/3231
