### PR TITLE
fix: Organizational chart reinitialized after edit layout - MEED-8759- meeds-io/meeds#2841

### DIFF
--- a/webapp/src/main/java/io/meeds/social/portlet/organizationalChartPortlet.java
+++ b/webapp/src/main/java/io/meeds/social/portlet/organizationalChartPortlet.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package io.meeds.social.portlet;
+
+import org.exoplatform.portal.webui.application.UIPortlet;
+
+import javax.portlet.PortletConfig;
+import javax.portlet.PortletException;
+import javax.portlet.PortletPreferences;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import java.io.IOException;
+
+public class organizationalChartPortlet extends CMSPortlet {
+
+  private static final String OBJECT_TYPE    = "organizationalChart";
+
+  private static final String APPLICATION_ID = "applicationId";
+
+  @Override
+  public void init(PortletConfig config) throws PortletException {
+    this.contentType = OBJECT_TYPE;
+    super.init(config);
+  }
+
+  @Override
+  public void doView(RenderRequest request, RenderResponse response) throws PortletException, IOException {
+    String applicationId = getOrCreateApplicationId(request.getPreferences());
+    request.setAttribute(APPLICATION_ID, applicationId);
+    super.doView(request, response);
+  }
+
+  private String getOrCreateApplicationId(PortletPreferences preferences) {
+    String applicationId = preferences.getValue(APPLICATION_ID, null);
+    if (applicationId == null) {
+      // use the same way as the old application id is generated to avoid lost of of the settings
+      applicationId = OBJECT_TYPE.concat(UIPortlet.getCurrentUIPortlet().getStorageId());
+      savePreference(APPLICATION_ID, applicationId);
+    }
+    return applicationId;
+  }
+
+}

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/organizationalChart.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/organizationalChart.jsp
@@ -25,8 +25,14 @@
     ProfilePropertyService profilePropertyService = CommonsUtils.getService(ProfilePropertyService.class);
     ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName("manager");
     String appObjectType = "organizationalChart";
-    String id = UIPortlet.getCurrentUIPortlet().getStorageId();
-    String applicationId =  appObjectType + id;
+    Object applicationIdParam =  request.getAttribute("applicationId");
+    String applicationId;
+    if (applicationIdParam instanceof String[]) {
+        applicationId = ((String[]) applicationIdParam)[0];
+    } else {
+        applicationId = (String) applicationIdParam;
+    }
+    String id = applicationId.substring(appObjectType.length());
     SettingService settingsService = CommonsUtils.getService(SettingService.class);
     SettingValue<?> centerUserSettingValue = settingsService
             .get(Context.GLOBAL, Scope.APPLICATION.id(applicationId), "organizationalChartCenterUser");

--- a/webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -1028,7 +1028,7 @@
   <portlet>
     <portlet-name>OrganizationalChart</portlet-name>
     <display-name>Organizational Chart portlet</display-name>
-    <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
+    <portlet-class>io.meeds.social.portlet.organizationalChartPortlet</portlet-class>
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/portlet/organizationalChart.jsp</value>

--- a/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChart.vue
+++ b/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChart.vue
@@ -86,7 +86,6 @@
       <v-btn
         :loading="isLoading"
         class="btn"
-        flat
         outlined
         @click="loadMoreMangedUsers">
         {{ $t('Search.button.loadMore') }}

--- a/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChartHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChartHeader.vue
@@ -24,7 +24,6 @@
     class="d-flex">
     <v-btn
       class="btn ma-auto btn-primary"
-      flat
       outlined
       @click="openChartSettingsDrawer">
       <v-icon


### PR DESCRIPTION
Prior to this change, adding and configuring an organizational chart portlet on a page, then editing the page layout, would reinitialize the portlet. This issue was caused by the application ID generated in the portlet’s JSP, which was composed of the object type and the portlet storage ID. Since the portlet storage ID changed when editing the layout, the saved settings and translations filed of the portlet header were lost. This change ensures that the application ID is saved as a portlet preference, preventing it from changing when the layout is edited.
Resolves https://github.com/Meeds-io/meeds/issues/2841