### PR TITLE
fix: Fix Spaces Cache when using category filter - MEED-8852 - Meeds-io/meeds#3228

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/selector/LastAccessedSpacesCacheSelector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/selector/LastAccessedSpacesCacheSelector.java
@@ -75,21 +75,6 @@ public class LastAccessedSpacesCacheSelector extends CacheSelector<ListSpacesKey
             ((ExoCache<ListSpacesKey, ListSpacesData>) exoCache).put(listSpacesKey, listSpacesData);
             // Cache enry updated, so no need to clear it
             return;
-          } else if (ids.size() == listSpacesKey.getLimit()) {
-            ids.remove(ids.size() - 1);
-            ids.add(0, spaceKey);
-            listSpacesData.setIds(ids);
-            cacheService.getSpacesCountCache().remove(listSpacesKey);
-            ((ExoCache<ListSpacesKey, ListSpacesData>) exoCache).put(listSpacesKey, listSpacesData);
-            // Cache enry updated, so no need to clear it
-            return;
-          } else {
-            ids.add(0, spaceKey);
-            listSpacesData.setIds(ids);
-            cacheService.getSpacesCountCache().remove(listSpacesKey);
-            ((ExoCache<ListSpacesKey, ListSpacesData>) exoCache).put(listSpacesKey, listSpacesData);
-            // Cache enry updated, so no need to clear it
-            return;
           }
         }
       }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
@@ -18,6 +18,7 @@
 package org.exoplatform.social.core.jpa.storage;
 
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -34,7 +35,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
 import org.exoplatform.social.core.storage.cache.SocialStorageCacheService;
 
-public abstract class SpaceStorageTest extends AbstractCoreTest {
+public class SpaceStorageTest extends AbstractCoreTest {
 
   private SpaceStorage              spaceStorage;
 
@@ -1597,6 +1598,33 @@ public abstract class SpaceStorageTest extends AbstractCoreTest {
     assertEquals(5, spaceFromCache.getMembers().length);
     assertNotNull(spaceFromCache.getManagers());
     assertEquals(2, spaceFromCache.getManagers().length);
+  }
+
+  public void testGetLastAccessedSpaceWithCategoryIds() {
+    Space space1 = getSpaceInstance(1);
+    space1.setCategoryIds(Collections.singletonList(2l));
+    spaceStorage.saveSpace(space1, true);
+    spaceStorage.updateSpaceAccessed("raul", space1);
+
+    Space space2 = getSpaceInstance(2);
+    spaceStorage.saveSpace(space2, true);
+    spaceStorage.updateSpaceAccessed("raul", space2);
+
+    SpaceFilter filter = new SpaceFilter();
+    filter.setRemoteId("raul");
+    List<Space> spaces = spaceStorage.getLastAccessedSpace(filter, 0, 10);
+    assertNotNull(spaces);
+    assertEquals(2, spaces.size());
+
+    filter.setCategoryIds(Collections.singletonList(3l));
+    spaces = spaceStorage.getLastAccessedSpace(filter, 0, 10);
+    assertNotNull(spaces);
+    assertEquals(0, spaces.size());
+
+    filter.setCategoryIds(Collections.singletonList(2l));
+    spaces = spaceStorage.getLastAccessedSpace(filter, 0, 10);
+    assertNotNull(spaces);
+    assertEquals(1, spaces.size());
   }
 
   public void testGetLastAccessedPagination() throws Exception {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
@@ -37,6 +37,7 @@ import org.exoplatform.social.core.jpa.storage.IdentityStorageTest;
 import org.exoplatform.social.core.jpa.storage.ProfileLabelStorageTest;
 import org.exoplatform.social.core.jpa.storage.ProfileSettingStorageTest;
 import org.exoplatform.social.core.jpa.storage.RelationshipStorageTest;
+import org.exoplatform.social.core.jpa.storage.SpaceStorageTest;
 import org.exoplatform.social.core.jpa.storage.dao.ActivityDAOTest;
 import org.exoplatform.social.core.jpa.storage.dao.IdentityDAOTest;
 import org.exoplatform.social.core.jpa.storage.dao.ProfileLabelDAOTest;
@@ -84,6 +85,7 @@ import io.meeds.social.translation.service.TranslationServiceTest;
   IdentityDAOTest.class,
   StreamItemDAOTest.class,
   RelationshipStorageTest.class,
+  SpaceStorageTest.class,
   IdentityStorageTest.class,
   ProfileSettingStorageTest.class,
   ProfileLabelStorageTest.class,


### PR DESCRIPTION

Prior to this change, when accessing to a space, all cached Spaces List sorted by Last Accessed are updated by adding the last accessed space. This change ensures to make this tricky update only on lists holding the accessed space and then clear all other lists.

(cherry picked from commit 902db78c073a8793de0ea1ca937f1e0dbc759843)