### PR TITLE
fix: Hide Overlay displayed when reducing Window size - MEED-8881 - Meeds-io/meeds#3214

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/parent/SidebarParentDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/parent/SidebarParentDrawer.vue
@@ -53,6 +53,7 @@ export default {
   },
   data: () => ({
     drawer: false,
+    hideOverlay: true,
   }),
   computed: {
     width() {
@@ -61,8 +62,12 @@ export default {
     stickyAllowed() {
       return this.$root.stickyAllowed;
     },
+    isMobile() {
+      return this.$root.isMobile;
+    },
     showOverlay() {
-      return !this.$root.icon || this.$root.expand;
+      const isMobile = this.$root.isMobile || window.innerWidth < this.$vuetify.breakpoint.thresholds.md;
+      return (!isMobile || !this.hideOverlay) && (!this.$root.icon || this.$root.expand);
     },
     permanent() {
       return this.$root.icon;
@@ -75,6 +80,23 @@ export default {
       } else if (this.$root.icon && !this.drawer) {
         this.drawer = true;
       }
+    },
+    isMobile: {
+      immediate: true,
+      handler(newVal, oldVal) {
+        if (newVal !== oldVal) {
+          this.hideOverlay = true;
+          if (this.timeout) {
+            window.clearTimeout(this.timeout);
+          }
+          if (this.isMobile) {
+            this.timeout = window.setTimeout(() => {
+              this.timeout = null;
+              this.hideOverlay = false;
+            }, 500);
+          }
+        }
+      },
     },
     drawer() {
       if (!this.drawer && this.$root.icon) {

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
@@ -20,7 +20,7 @@
 -->
 <template>
   <v-list-item
-    v-if="isMobile"
+    v-if="$root.isMobile"
     :class="homeIcon && (homeLink === spaceLink && 'UserPageLinkHome' || 'UserPageLink')"
     class="px-2 spaceItem text-truncate"
     role="button"
@@ -156,9 +156,6 @@ export default {
     },
     toggleArrow() {
       return this.showItemActions || this.drawerOpened;
-    },
-    isMobile() {
-      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
     drawerOpened() {
       return this.openedSpace?.id === this.space?.id;

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpacePanelHamburgerNavigation.vue
@@ -195,9 +195,6 @@ export default {
     enabledExtensionComponents() {
       return this.externalExtensions.filter(extension => extension.enabled);
     },
-    isMobile() {
-      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
-    },
     spaceGroupId() {
       return this.space?.groupId;
     },
@@ -212,10 +209,10 @@ export default {
       }
     },
     avatarWidth() {
-      return this.isMobile && '45' || '60';
+      return this.$root.isMobile && '45' || '60';
     },
     avatarHeight() {
-      return this.isMobile && '45' || '60';
+      return this.$root.isMobile && '45' || '60';
     },
     hasUnreadItems() {
       return this.$root?.unreadPerSpace?.[this.space?.id];

--- a/webapp/src/main/webapp/vue-apps/sidebar/main.js
+++ b/webapp/src/main/webapp/vue-apps/sidebar/main.js
@@ -80,6 +80,9 @@ export function init(
           hoverDeferred: false,
         },
         computed: {
+          isMobile() {
+            return this.$vuetify.breakpoint.width < this.$vuetify.breakpoint.thresholds.md;
+          },
           autoSwitchToIcon() {
             return this.mode === 'STICKY'
               && this.allowIcon


### PR DESCRIPTION
Prior to this change, when reducing the size of Window, an overlay is displayed on Top of Page body. This change, ensures to not show the overlay right after switching from Mobile to Desktop dimensions.

(cherry picked from commit 9f1d78e8c3959877c0c7b5b3f5e50fbf92bea01f)