### PR TITLE
fix: Delete Parent Category ACL from indexed permissions - MEED-8895 - Meeds-io/meeds#3247

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -633,6 +633,14 @@ public interface MetadataService {
   List<Metadata> getMetadatas(String metadataTypeName, long limit);
 
   /**
+   * @param metadataTypeName metadata name {@link Metadata} name
+   * @param offset offset of results to retrieve
+   * @param limit limit of results to retrieve
+   * @return {@link List} of Managed {@link Metadata}
+   */
+  List<Long> getMetadataIds(String metadataTypeName, int offset, int limit);
+
+  /**
    * Deletes Metadata items for a given {@link MetadataItem} parentObjectId and
    * objectType. This is generally called when the associated parent object has
    * been removed (activity removed bu example, its comments metadata items has

--- a/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
@@ -196,6 +196,20 @@ public class CategoryStorage {
     }
   }
 
+  public MetadataItem getMetadataItem(long categoryId, CategoryObject object) {
+    Metadata metadata = metadataService.getMetadataById(categoryId);
+    if (metadata == null) {
+      return null;
+    } else {
+      List<MetadataItem> items = metadataService.getMetadataItemsByMetadataAndObject(metadata.key(), object);
+      return CollectionUtils.isNotEmpty(items) ? items.get(0) : null;
+    }
+  }
+
+  public List<Long> getAllCategoryIds(int offset, int limit) {
+    return metadataService.getMetadataIds(METADATA_TYPE.getName(), offset, limit);
+  }
+
   private Category toCategory(Metadata metadata) {
     if (metadata == null) {
       return null;
@@ -227,16 +241,6 @@ public class CategoryStorage {
                         category.getCreatorId(),
                         System.currentTimeMillis(),
                         properties);
-  }
-
-  public MetadataItem getMetadataItem(long categoryId, CategoryObject object) {
-    Metadata metadata = metadataService.getMetadataById(categoryId);
-    if (metadata == null) {
-      return null;
-    } else {
-      List<MetadataItem> items = metadataService.getMetadataItemsByMetadataAndObject(metadata.key(), object);
-      return CollectionUtils.isNotEmpty(items) ? items.get(0) : null;
-    }
   }
 
   private String toString(List<Long> ids) {

--- a/component/core/src/main/java/io/meeds/social/category/storage/elasticsearch/CategoryIndexingConnector.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/elasticsearch/CategoryIndexingConnector.java
@@ -140,7 +140,7 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
 
   @Override
   public List<String> getAllIds(int offset, int limit) {
-    throw new UnsupportedOperationException();
+    return getCategoryStorage().getAllCategoryIds(offset, limit).stream().map(String::valueOf).toList();
   }
 
   @Override
@@ -218,6 +218,9 @@ public class CategoryIndexingConnector extends ElasticIndexingServiceConnector {
       return;
     }
     Category parentCategory = getCategoryStorage().getCategory(parentId);
+    if (parentCategory.getParentId() == 0) {
+      return;
+    }
     accessPermissionIds.retainAll(parentCategory.getAccessPermissionIds());
     deleteNonParentPermissions(parentCategory.getParentId(), accessPermissionIds);
   }

--- a/component/core/src/main/java/io/meeds/social/permlink/plugin/SpacePermanentLinkPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/permlink/plugin/SpacePermanentLinkPlugin.java
@@ -83,9 +83,11 @@ public class SpacePermanentLinkPlugin implements PermanentLinkPlugin {
     spaceUrl.append(Arrays.stream(space.getGroupId().split("/"))
                           .map(s -> URLEncoder.encode(s, StandardCharsets.UTF_8))
                           .collect(Collectors.joining(":")))
-            .append("/")
-            .append(URLEncoder.encode(space.getUrl(), StandardCharsets.UTF_8))
             .append("/");
+    if (space.getUrl() != null) {
+      spaceUrl.append(URLEncoder.encode(space.getUrl(), StandardCharsets.UTF_8))
+              .append("/");
+    }
     if (object.getParameters() != null) {
       if (object.getParameters().containsKey(APPLICATION_URI)) {
         spaceUrl.append(object.getParameters().get(APPLICATION_URI));

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataDAO.java
@@ -190,6 +190,22 @@ public class MetadataDAO extends GenericDAOJPAImpl<MetadataEntity, Long> {
     }
   }
 
+  public List<Long> getMetadataIds(long type, int offset, int limit) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("SocMetadataEntity.getMetadataIds", Long.class);
+    if (limit > 0) {
+      query.setMaxResults(limit);
+    }
+    if (offset > 0) {
+      query.setFirstResult(offset);
+    }
+    query.setParameter("type", type);
+    try {
+      return query.getResultList();
+    } catch (NoResultException e) {
+      return Collections.emptyList();
+    }
+  }
+
   public List<Long> getMetadataIdsByProperty(String propertyKey,
                                              String propertyValue,
                                              long offset,

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataEntity.java
@@ -97,6 +97,12 @@ import jakarta.persistence.Table;
       + " ORDER BY sm.name ASC"
 )
 @NamedQuery(
+  name = "SocMetadataEntity.getMetadataIds",
+  query = "SELECT sm.id FROM SocMetadataEntity sm WHERE"
+      + " sm.type = :type"
+      + " ORDER BY sm.id ASC"
+)
+@NamedQuery(
   name = "SocMetadataEntity.getMetadatasByPropertyOrderByName",
   query = """
     SELECT sm.id FROM SocMetadataEntity sm

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -590,6 +590,11 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   }
 
   @Override
+  public List<Long> getMetadataIds(String metadataTypeName, int offset, int limit) {
+    return metadataStorage.getMetadataIds(metadataTypeName, offset, limit);
+  }
+
+  @Override
   public List<Metadata> getMetadatasByProperty(String propertyKey, String propertyValue, long limit) {
     List<Long> ids = metadataStorage.getMetadataIdsByProperty(propertyKey, propertyValue, 0l, limit, true);
     return ids.stream().map(this::getMetadataById).toList();

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
@@ -469,6 +469,11 @@ public class MetadataStorage {
     return metadatasEntities.stream().map(this::fromEntity).toList();
   }
 
+  public List<Long> getMetadataIds(String metadataTypeName, int offset, int limit) {
+    MetadataType metadataType = getMetadataTypeWithCheck(metadataTypeName);
+    return metadataDAO.getMetadataIds(metadataType.getId(), offset, limit);
+  }
+
   public List<Long> getMetadataIdsByProperty(String propertyKey,
                                              String propertyValue,
                                              long offset,

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/indexing-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/indexing-configuration.xml
@@ -130,9 +130,9 @@
         <properties-param>
           <name>constructor.params</name>
           <property name="index_alias" value="category_alias" />
-          <property name="index_previous" value="${meeds.social.index.category.previous:}" />
-          <property name="index_current" value="${meeds.social.index.category.current:category_v1}" />
-          <property name="reindexOnUpgrade" value="${meeds.social.index.category.reindexOnUpgrade:false}" />
+          <property name="index_previous" value="${meeds.social.index.category.previous:category_v1}" />
+          <property name="index_current" value="${meeds.social.index.category.current:category_v2}" />
+          <property name="reindexOnUpgrade" value="${meeds.social.index.category.reindexOnUpgrade:true}" />
         </properties-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
Prior to this change, the parent category ACL was included in transitive restrictions inherited by child categories. Knowing that parent category ACL is empty, all subcategories will be restricted to be accessed by administrators only. This change ensures to not include the Root Category ACL in Sub Categories ACL check, knowing that it's invisible and not configurable through UI. To ensure existing data consistency, a reindexation will be made by creating a new ES index.

(cherry picked from commit 5f0007ba3774a401d01cdce1116693aa1079b6e4)