### PR TITLE
Accessibility: Set an empty alt to the logo in the top bar - MEED-8917 - Meeds-io/meeds#3250

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-logo/components/CompanyName.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-logo/components/CompanyName.vue
@@ -3,7 +3,7 @@
     <a
       v-if="$root.displayCompanyLogo"
       :href="$root.portalPath"
-      :aria-label="$t('menu.companyNameTooltip',{0: $root.logoTitle})">
+      :aria-label="$t('menu.userHomeLink')">
       <v-list-item-avatar 
         v-if="$root.logoPath"
         id="UserHomePortalLink"
@@ -15,7 +15,7 @@
         tile>
         <img
           :src="$root.logoPath"
-          :alt="$t('menu.companyLogoTooltip')"
+          alt=""
           height="36"
           width="auto"
           class="object-fit-contain">


### PR DESCRIPTION
prior to this fix, The logo in top bar (at the left side) has an alternative text alt ="Platform Logo" while it is integrated in a link containing an aria-label="Platform Name: eXo Tribe" which considered as redundant information
this fix wil set alt= " " for the logo and sets  Aria-label  the real purpose of the link.