### PR TITLE
fix: Remove the outlined property from the 'Add Profile Property Value' button - MEED-8891 - Meeds-io/meeds#3142

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfileContactEditMultiField.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfileContactEditMultiField.vue
@@ -13,7 +13,6 @@
         <v-btn
           color="primary"
           class="px-0"
-          outlined
           link
           text
           @click="addNewItem">


### PR DESCRIPTION


this change is going to remove the outlined property from the 'Add Profile Property Value' button .
Resolves https://github.com/Meeds-io/meeds/issues/3142
