### PR TITLE
fix: Display Card shadow in Links when Hover - MEED-8927 - Meeds-io/meeds#3255

### DIFF
--- a/webapp/src/main/webapp/vue-apps/links/components/LinksApp.vue
+++ b/webapp/src/main/webapp/vue-apps/links/components/LinksApp.vue
@@ -23,9 +23,10 @@
     v-if="canView">
     <v-hover v-slot="{ hover }">
       <v-card
+        :class="$root.isCard ? 'px-5 pt-5' : 'pa-5'"
         min-width="100%"
         max-width="100%"
-        class="d-flex flex-column align-center border-box-sizing pa-5 position-relative application-body"
+        class="d-flex flex-column align-center border-box-sizing position-relative application-body"
         flat>
         <links-header
           v-if="$root.initialized"

--- a/webapp/src/main/webapp/vue-apps/links/components/view/LinksCard.vue
+++ b/webapp/src/main/webapp/vue-apps/links/components/view/LinksCard.vue
@@ -23,6 +23,7 @@
     v-bind="isCard && {
       hover: true,
       outlined: true,
+      class: 'mt-2 mb-5'
     } || {
       text: true,
       class: 'transparent',
@@ -89,9 +90,6 @@ export default {
       default: () => 0,
     },
   },
-  data: () => ({
-    hover: false,
-  }),
   computed: {
     name() {
       return this.$t(this.link?.name?.[this.$root.language] || this.link?.name?.[this.$root.defaultLanguage]);

--- a/webapp/src/main/webapp/vue-apps/links/components/view/LinksHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/links/components/view/LinksHeader.vue
@@ -22,7 +22,9 @@
   <div
     v-if="hasLinks && (showHeader || canEdit)"
     :class="{
-      'position-relative pb-4': showHeader,
+      'position-relative': showHeader,
+      'pb-2': $root.isCard,
+      'pb-4': !$root.isCard,
     }"
     class="d-flex align-center">
     <div v-if="header" class="flex-grow-1 flex-shrink-1 text-truncate widget-text-header text-start">

--- a/webapp/src/main/webapp/vue-apps/links/components/view/LinksList.vue
+++ b/webapp/src/main/webapp/vue-apps/links/components/view/LinksList.vue
@@ -23,9 +23,9 @@
     <component
       v-if="links?.length"
       :is="isColumn && 'v-list' || 'card-carousel'"
-      :class="isColumn && 'pa-0' || 'mt-n2 mb-n4'"
-      v-bind="isColumn && {
-        dense: !largeIcon
+      :class="isColumn && 'pa-0'"
+      v-bind="{
+        dense: !isColumn || !largeIcon
       }">
       <component
         v-for="link in links"

--- a/webapp/src/main/webapp/vue-apps/links/main.js
+++ b/webapp/src/main/webapp/vue-apps/links/main.js
@@ -54,6 +54,9 @@ export function init(appId, name, canEdit) {
           isMobile() {
             return this.$vuetify?.breakpoint?.smAndDown;
           },
+          isCard() {
+            return this.settings?.type === 'CARD' && this.hasLinks;
+          },
         },
         created() {
           this.init().finally(() => this.initialized = true);


### PR DESCRIPTION
Prior to this change, when hovering the link of type 'Card', the show is hidden in top and bottom sides. This change ensures to display shadows.