### PR TITLE
Fix: Technical label displayed in text the profile property tooltip - MEED-8892 - Meeds-io/meeds#3143

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -119,6 +119,7 @@ export default {
       return this.disabledSynchronizedField(property) && this.$t('profileContactInformation.synchronizedUser.tooltip')
                                                       || this.disabledField(property)
                                                       && this.$t('profileContactInformation.nonEditable.field')
+                                                      || property?.labels?.find(label => label.language === this.lang)?.label
                                                       || this.$t(`profileContactInformation.${property.propertyName}`);
     },
     save() {


### PR DESCRIPTION
Prior to this change, the technical label was displayed in the profile property tooltip. This change ensures that the user-friendly property label is displayed instead.
Resolves https://github.com/Meeds-io/meeds/issues/3143