### PR TITLE
fix: Providing an alternative text for project manager avatars - MEED-8968 - Meeds-io/meeds#3259

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -21,9 +21,9 @@
         class="ma-0 flex-shrink-0">
         <img
           :src="userAvatarUrl"
-          class="object-fit-cover ma-auto"
+          class="object-fit-cover ma-auto"  
           loading="lazy"
-          alt="">
+          :alt="alt">
       </v-avatar>
     </component>
     <component
@@ -78,7 +78,7 @@
           :src="userAvatarUrl"
           class="object-fit-cover ma-auto"
           loading="lazy"
-          alt="">
+          :alt="alt">
       </v-avatar>
       <div v-if="userFullname || $slots.subTitle" class="ms-2 my-auto overflow-hidden">
         <p
@@ -132,7 +132,7 @@
           :src="userAvatarUrl"
           class="object-fit-cover ma-auto"
           loading="lazy"
-          alt="">
+          :alt="alt">
       </v-avatar>
     </component>
     <component
@@ -187,7 +187,7 @@
           :src="userAvatarUrl"
           class="object-fit-cover ma-auto"
           loading="lazy"
-          alt="">
+          :alt="alt">
       </v-avatar>
       <div v-if="userFullname || $slots.subTitle" class="ms-2 overflow-hidden">
         <p
@@ -329,6 +329,10 @@ export default {
     displayPosition: {
       type: Boolean,
       default: false
+    },
+    alt: {
+      type: String,
+      default: () => '',
     },
   },
   data() {

--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatarsList.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatarsList.vue
@@ -19,6 +19,7 @@
             :compact="compact"
             :margin-left="index > 0 && marginLeft || ''"
             :class="{ 'mt-n1 z-index-two': hover && compact }"
+            :alt="user?.alt"
             avatar />
         </v-hover>
       </div>
@@ -38,6 +39,7 @@
             :compact="compact"
             :margin-left="index > 0 && marginLeft || ''"
             :class="{ 'mt-n1 z-index-two': hover && compact }"
+            :alt="user?.alt"
             avatar />
         </v-hover>
       </div>


### PR DESCRIPTION
Before this change, when accessing projects board, the Avatar of the project manager contains an empty alt. To fix this problem, add an alt props to the user-avatar component. After this change, avatars provide information about project managers they are contains an alt as alt=Manager of [Project name]: [User name].