### PR TITLE
Accessibility: Set an empty alt to user card's avatar and banner - MEED-8955 - Meeds-io/meeds#3265

### DIFF
--- a/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -36,7 +36,7 @@
         flat>
         <img
           :src="bannerUrl"
-          :alt="$t('peopleList.userBanner.alt')"
+          alt=""
           style="max-width: 1000%; min-width: 100%; max-height: 100%; min-height: 100%;"
           class="position-absolute"
           height="100%"
@@ -58,7 +58,7 @@
           flat>
           <img
             :src="`${avatarUrl}&size=65x65`"
-            :alt="$t('peopleList.userAvatar.alt')"
+            alt=""
             style="max-width: 1000%; max-height: 100%;"
             height="100%"
             width="auto"


### PR DESCRIPTION
In people directory, need to set an empty alt to user's profile & banner.

(cherry picked from commit a268d0a7185f5bbc4e903b9c459caf837bab4da7)