### PR TITLE
fix: Providing an alternative text for the image near the form - MEED-9008 - Meeds-io/meeds#3279.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/LoginBackgroundSelector.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/LoginBackgroundSelector.vue
@@ -143,7 +143,7 @@ export default {
         });
       } else {
         Object.assign(branding, {
-          loginBackgroundTextColor: null,
+          loginBackgroundAltText: null,
         });
       }
     },


### PR DESCRIPTION

Before this change, when access to login page, the image near the form can provide information but it has an empty alt. To fix this problem, add the textrea to create the value of alt and adapt it in the code to retrieve it from the login page and insert it into the image near. After this change, the alternative text field is displayed correctly in the drawer Change background in the administration page and the alt has the value added by this text field.