### PR TITLE
fix: The icon of each site must have an accessible name - MEED-8958 - Meeds-io/meeds#3269

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-logo/components/SiteName.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-logo/components/SiteName.vue
@@ -4,7 +4,7 @@
     <a
       v-if="$root.displaySiteLogo"
       :href="$root.siteHomePath"
-      :arial-label="tooltip">
+      :aria-label="tooltip">
       <v-tooltip :disabled="$root.displaySiteTitle" bottom>
         <template #activator="{on, attrs}">
           <v-list-item-avatar


### PR DESCRIPTION
Before this change, when accessing the Site's icon in the top bar, there is a confusing and unnecessary use of role=button and title. To fix 	this problem, delete the role and change the title to aria-label. After this change, in the a class, the title=Access Site [Site name] is changed to Aria-label= Access Site [Site name] and in the div class, the role=button is deleted.