### PR TITLE
fix: Make the tag controllable by the keyboard and by any pointing device - MEED-9010 - Meeds-io/meeds#2930

### DIFF
--- a/webapp/src/main/webapp/js/tag.suggester.js
+++ b/webapp/src/main/webapp/js/tag.suggester.js
@@ -153,7 +153,7 @@
       if (phase === "onDisplay") {
         return $(`<li class="option"><span>#${item.name}<span></li>`);
       } else if (phase == "onInsert") {
-        return $(`<a class="metadata-tag">#${item.name}</a>`);
+        return $(`<a class="metadata-tag" href="#">#${item.name}</a>`);
       } else {
         return atWhoCallback.tplEval(tpl, item);
       }


### PR DESCRIPTION
Before this change, when shouting a text in a ckeditor component with a tag and posting it then type tab on a page containing a hashtag, the focus never go on the hashtag. To fix this problem, add an href attribute to the create by tag element. After this change, the hashtag is focusable when using tabulation. 
Resolves https://github.com/Meeds-io/meeds/issues/2930