### PR TITLE
fix: Task- Providing an explicit label for project managers - MEED-8968 - Meeds-io/meeds#3275

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -11,7 +11,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
-      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
+      :aria-label="ariaLabel ? ariaLabel : $t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -21,9 +21,9 @@
         class="ma-0 flex-shrink-0">
         <img
           :src="userAvatarUrl"
-          class="object-fit-cover ma-auto"  
+          class="object-fit-cover ma-auto"
           loading="lazy"
-          :alt="alt">
+          alt="">
       </v-avatar>
     </component>
     <component
@@ -66,7 +66,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
-      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
+      :aria-label="ariaLabel ? ariaLabel : $t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="d-flex flex-nowrap flex-grow-1 text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -78,7 +78,7 @@
           :src="userAvatarUrl"
           class="object-fit-cover ma-auto"
           loading="lazy"
-          :alt="alt">
+          alt="">
       </v-avatar>
       <div v-if="userFullname || $slots.subTitle" class="ms-2 my-auto overflow-hidden">
         <p
@@ -120,7 +120,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
-      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
+      :aria-label="ariaLabel ? ariaLabel : $t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -132,7 +132,7 @@
           :src="userAvatarUrl"
           class="object-fit-cover ma-auto"
           loading="lazy"
-          :alt="alt">
+          alt="">
       </v-avatar>
     </component>
     <component
@@ -175,7 +175,7 @@
       :fab="clickable"
       :depressed="clickable"
       :href="profileUrl"
-      :aria-label="$t('popover.userAvatar.title',{0:userFullname})"
+      :aria-label="ariaLabel ? ariaLabel : $t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
       class="d-flex flex-nowrap flex-grow-1 text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
@@ -187,7 +187,7 @@
           :src="userAvatarUrl"
           class="object-fit-cover ma-auto"
           loading="lazy"
-          :alt="alt">
+          alt="">
       </v-avatar>
       <div v-if="userFullname || $slots.subTitle" class="ms-2 overflow-hidden">
         <p
@@ -330,7 +330,7 @@ export default {
       type: Boolean,
       default: false
     },
-    alt: {
+    ariaLabel: {
       type: String,
       default: () => '',
     },

--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatarsList.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatarsList.vue
@@ -19,7 +19,7 @@
             :compact="compact"
             :margin-left="index > 0 && marginLeft || ''"
             :class="{ 'mt-n1 z-index-two': hover && compact }"
-            :alt="user?.alt"
+            :aria-label="user?.ariaLabel"
             avatar />
         </v-hover>
       </div>
@@ -39,7 +39,7 @@
             :compact="compact"
             :margin-left="index > 0 && marginLeft || ''"
             :class="{ 'mt-n1 z-index-two': hover && compact }"
-            :alt="user?.alt"
+            :aria-label="user?.ariaLabel"
             avatar />
         </v-hover>
       </div>
@@ -49,6 +49,7 @@
       :height="iconSize"
       :width="iconSize"
       :class="{ 'mt-n1 z-index-two': compact && showAnimation, 'ml-n4': compact }"
+      :aria-label="usersToDisplay[usersToDisplay.length -1]?.ariaLabel"
       fab
       depressed
       @click="$emit('open-detail')"


### PR DESCRIPTION
Before this change, when accessing projects board, the Avatar of the project manager contains that contain aria-label= Open Full name profile. To fix this problem, add an aria-label props to the user-avatar component and pass the requested value. After this change, avatars provide information about project managers they are contains an aria-label equal to Open list of managers if there is more than one project manager. Resolves https://github.com/Meeds-io/meeds/issues/3275