### PR TITLE
fix: Stream & News-details- User reactions Information are given only by color - MEED-8932 - Meeds-io/meeds#2985

### DIFF
--- a/component/service/src/main/resources/locale/social/Webui_en.properties
+++ b/component/service/src/main/resources/locale/social/Webui_en.properties
@@ -102,6 +102,9 @@ BaseUIActivity.msg.info.Activity_No_Longer_Exist=This activity no longer exists.
 #####################################################################################
 #                                  UIActivity                                       #
 #####################################################################################
+UIActivity.aria.Comment=You commented
+UIActivity.aria.Like=You liked
+UIActivity.aria.Share=You shared
 UIActivity.label.Source=Source
 UIActivity.label.Activity_Can_Be_Deleted=This activity was not found.
 UIActivity.label.Comment=Comment

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
@@ -7,6 +7,7 @@
           :id="`CommentLink${activityId}`"
           :class="commentTextColorClass"
           class="pa-0 mt-0"
+          :aria-label="$t('UIActivity.aria.Comment')"
           text
           link
           small

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
@@ -7,11 +7,15 @@
           :id="`CommentLink${activityId}`"
           :class="commentTextColorClass"
           class="pa-0 mt-0"
-          :aria-label="$t('UIActivity.aria.Comment')"
+          :aria-label="hasCommented ? $t('UIActivity.aria.Comment') : $t('UIActivity.label.Comment')"
           text
           link
           small
-          v-bind="attrs"
+          v-bind="{
+              ...attrs,
+              role: null,
+              'aria-haspopup': null,
+              'aria-expanded': null}"
           v-on="on"
           @click="openCommentsDrawer">
           <div class="d-flex flex-lg-row flex-column">

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
@@ -7,6 +7,7 @@
           :id="`LikeLink${activityId}`"
           :loading="changingLike"
           :class="likeTextColorClass"
+          :aria-label="$t('UIActivity.aria.Like')"
           class="pa-0 mt-0"
           text
           link

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
@@ -7,12 +7,17 @@
           :id="`LikeLink${activityId}`"
           :loading="changingLike"
           :class="likeTextColorClass"
-          :aria-label="$t('UIActivity.aria.Like')"
+          :aria-label="hasLiked ? $t('UIActivity.aria.Like') : $t('UIActivity.msg.LikeActivity')"
           class="pa-0 mt-0"
           text
           link
           small
-          v-bind="attrs"
+          v-bind="{
+              ...attrs,
+              role: null,
+              'aria-haspopup': null,
+              'aria-expanded': null,
+              'aria-pressed': hasLiked}"
           v-on="on"
           @click="changeLike">
           <div class="d-flex flex-lg-row flex-column">

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -7,12 +7,16 @@
           v-if="isShareable"
           :id="`ShareActivity${activityId}`"
           :class="shareTextColorClass"
-          :aria-label="$t('UIActivity.aria.Share')"
+          :aria-label="hasShared ? $t('UIActivity.aria.Share') : $t('UIActivity.share')"
           class="pa-0 mt-0"
           text
           link
           small
-          v-bind="attrs"
+          v-bind="{
+              ...attrs,
+              role: null,
+              'aria-haspopup': null,
+              'aria-expanded': null}"
           v-on="on"
           @click="openShareDrawer()">
           <div class="d-flex flex-lg-row flex-column">

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -7,6 +7,7 @@
           v-if="isShareable"
           :id="`ShareActivity${activityId}`"
           :class="shareTextColorClass"
+          :aria-label="$t('UIActivity.aria.Share')"
           class="pa-0 mt-0"
           text
           link


### PR DESCRIPTION
Before this change, when Access to Stream (or an article), User reactions on a post (or articles) and post's comments (or articles' comments) are indicated only by a change in color of the reaction icons (Like, Comment, Kudos and Share). To fix this problem, add an aria-label to these buttons. After this change, add an aria-label attributes to the likeButton with a text You liked, the commentButton with a text You commented, the kudosButton with a text You sent a kudos and the shareButton with a text You sent a kudos.
Resolves https://github.com/Meeds-io/meeds/issues/2985