### PR TITLE
Fix: Display of item id instead of item name in job title when using dropdown option - MEED-9072 - Meeds-io/meeds#3299

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileDropdownProperty.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileDropdownProperty.vue
@@ -102,7 +102,7 @@ export default {
       this.clonePropertyObject();
     },
     selectedOption() {
-      this.propertyObject.value = this.selectedOption?.id;
+      this.propertyObject.value = this.selectedOption?.value;
       this.$emit('property-updated', this.propertyObject);
     }
   },
@@ -119,7 +119,7 @@ export default {
     clonePropertyObject() {
       this.propertyObject = this.parentProperty && this.property || structuredClone(this.property);
       this.selectedOption = this.mappedOptions?.find(
-        option => `${option.id}` === `${this.propertyObject.value}`
+        option => `${option.id}` === `${this.propertyObject.id}`
       );
     }
   }


### PR DESCRIPTION
Prior to this change, the job title (position), in user's profile, displays the id of the chosen value from combobox instead of the text.
After this change, the name related of the chosen option is well displayed.

Resolves https://github.com/Meeds-io/meeds/issues/3299