### PR TITLE
fix: Fix Retrieving Spaces with Category Filtering - MEED-9071 - Meeds-io/meeds#3303

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/list/SpacesCardList.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/list/SpacesCardList.vue
@@ -151,7 +151,7 @@ export default {
       return this.cardWidth > 280;
     },
     selectedCategoryIds() {
-      return this.$root.selectedCategoryIds;
+      return this.$root.selectedCategoryIds || this.$root.categoryIds;
     },
     displayNoSpaceOptions() {
       return !this.hasSpaces

--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/space-categories/SpacesCategoriesToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/space-categories/SpacesCategoriesToolbar.vue
@@ -137,20 +137,20 @@ export default {
     async init() {
       this.loading = true;
       try {
-        if (this.$root.settings.filterType === 'category' && this.$root.settings.categoryIds?.length) {
-          const subCategories = await Promise.all(this.$root.settings.categoryIds.map(id => this.$categoryService.getCategoryTree({
+        if (this.filterType === 'category' && this.categoryIds?.length) {
+          const subCategories = (await Promise.all(this.categoryIds.map(id => this.$categoryService.getCategoryTree({
             parentId: id,
             objectType: this.objectType,
             depth: this.categoryDepth,
             offset: 0,
             limit: -1,
-            token: this.$root.settingName,
-          })));
+            token: this.settingName,
+          }).catch(() => null)))).filter(c => c);
           this.categoryTree = {
             id: -1,
             parentId: 0,
             ownerId: subCategories?.[0]?.ownerId,
-            categories: subCategories,
+            categories: subCategories || [],
           };
         } else {
           this.categoryTree = await this.$categoryService.getCategoryTree({
@@ -158,8 +158,13 @@ export default {
             depth: this.categoryDepth,
             offset: 0,
             limit: -1,
-            token: this.$root.settingName,
-          });
+            token: this.settingName,
+          }).catch(() => ({
+            id: -1,
+            parentId: 0,
+            ownerId: 0,
+            categories: [],
+          }));
         }
       } finally {
         this.loading = false;


### PR DESCRIPTION
Prior to this change, the category filtering wasn't considered. This change ensures to use the Default Categories retrieved from SpacesList Settings at first display.

(cherry picked from commit b3bd9b0fed584db4c0ee18471e309b6af59f4ab5)