### PR TITLE
fix: set default property type to text when editing - MEED-8442 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -505,6 +505,7 @@ export default {
       this.initialSetting = structuredClone(setting);
       this.initialLabels = JSON.parse(JSON.stringify(setting.labels));
       this.setting = { ...setting};
+      this.setting.propertyType = this.propertyTypes[0];
       this.newSetting = false;
       this.labels = JSON.parse(JSON.stringify(this.setting.labels));
       this.changes= false;


### PR DESCRIPTION
when updating a property type, we need to set it to text if the property type field is null