### PR TITLE
Fix: Space-directory - Set an empty alt to aspace avatars - MEED-9063 - Meeds-io/meeds#3296

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
@@ -96,6 +96,7 @@ spaceList.advanced.filter.button.title=Filter
 spaceList.advanced.filter.drawer.title=Filter Spaces
 spaceList.advanced.filter.spaceType.label=Space Type
 spaceList.spaceAvatar.alt=Space Picture
+spaceList.spaceCard.ariaLabel=Open space: {0}
 spaceList.spaceMembers={0} Members
 spaceList.publicSite=Website
 spacesList.button.options=Space Options

--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/space-card/SpaceCard.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/space-card/SpaceCard.vue
@@ -30,6 +30,7 @@
       :elevation="hoverCard && 3 || 0"
       :min-width="minWidth"
       :max-width="maxWidth"
+      :aria-label="$t('spaceList.spaceCard.ariaLabel', {0: spaceDisplayName})"
       width="auto"
       class="d-flex flex-column application-border-radius border-color">
       <space-card-unread-badge :space="space" />
@@ -49,7 +50,7 @@
           flat>
           <img
             :src="space.avatarUrl"
-            :alt="$t('spaceList.spaceAvatar.alt')"
+            alt=""
             style="max-width: 1000%; max-height: 100%;"
             height="100%"
             width="auto"


### PR DESCRIPTION
Before this change, when accessing Discover Spaces, the space's avatar contains an alt equal to Space Picture. To fix this problem, change the alt to empty and add an aria label with the value Open space: spaceDisplayName. After this change, the alt and aria-label display correctly.
Resolves https://github.com/Meeds-io/meeds/issues/3296