### PR TITLE
fix: Make the login background image focusable - MEED-9051 - Meeds-io/meeds#3291

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Login_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Login_en.properties
@@ -41,7 +41,6 @@ UILoginForm.label.provider.linkedin=LinkedIn
 UILoginForm.label.provider.twitter=Twitter
 UILoginForm.label.provider.google=Google
 UILoginForm.label.moreProviders=More authentication providers
-UILoginForm.tooltip.backgroundImage=Login background image
 
 forgotpassword.pagetitle=Forgot Password
 forgotpassword.summary=Can't access your account?

--- a/webapp/src/main/resources/locale/portlet/Login_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Login_en.properties
@@ -41,6 +41,7 @@ UILoginForm.label.provider.linkedin=LinkedIn
 UILoginForm.label.provider.twitter=Twitter
 UILoginForm.label.provider.google=Google
 UILoginForm.label.moreProviders=More authentication providers
+UILoginForm.tooltip.backgroundImage=Login background image
 
 forgotpassword.pagetitle=Forgot Password
 forgotpassword.summary=Can't access your account?

--- a/webapp/src/main/webapp/vue-apps/login-common/components/PageTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/login-common/components/PageTemplate.vue
@@ -29,11 +29,17 @@
         class="d-none d-sm-flex flex-shrink-0 full-height position-relative"
         flat
         tile>
-        <img
-          v-if="background"
-          :src="background"
-          style="height: 100%;"
-          alt="">
+        <v-tooltip bottom>
+          <template v-slot:activator="{ on }">
+            <img
+              v-on="on"
+              :src="background"
+              style="height: 100%;"
+              tabindex="0"
+              :alt="params.loginBackgroundAltText">
+          </template>
+          <span>{{ params.loginBackgroundAltText || $t('UILoginForm.tooltip.backgroundImage')}}</span>
+        </v-tooltip>
         <v-card
           :class="background && 'position-absolute t-0'"
           min-width="100%"

--- a/webapp/src/main/webapp/vue-apps/login-common/components/PageTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/login-common/components/PageTemplate.vue
@@ -29,17 +29,23 @@
         class="d-none d-sm-flex flex-shrink-0 full-height position-relative"
         flat
         tile>
-        <v-tooltip bottom>
+        <v-tooltip bottom v-if="tooltipMessage">
           <template v-slot:activator="{ on }">
             <img
               v-on="on"
               :src="background"
               style="height: 100%;"
               tabindex="0"
-              :alt="params.loginBackgroundAltText">
+              :alt="tooltipMessage">
           </template>
-          <span>{{ params.loginBackgroundAltText || $t('UILoginForm.tooltip.backgroundImage')}}</span>
+          <span>{{ tooltipMessage }}</span>
         </v-tooltip>
+        <img
+          v-else
+          class
+          :src="background"
+          style="height: 100%;"
+          alt="">
         <v-card
           :class="background && 'position-absolute t-0'"
           min-width="100%"
@@ -121,6 +127,9 @@ export default {
     },
   },
   computed: {
+    tooltipMessage() {
+      return this.params?.loginBackgroundAltText;
+    },
     companyName() {
       return this.params?.companyName;
     },


### PR DESCRIPTION
Before this change, when access to the login page, the login background image isn't focusable so its alternative text can't be rendered by screen reader. To fix this problem, add a tabindex and tootltip props to the image. After this change, the login background image is focusable by adding tooltip.
Resolves https://github.com/Meeds-io/meeds/issues/3291