### PR TITLE
fix: Providing an alternative text for the image near the form - MEED-9008 - Meeds-io/meeds#3279

### DIFF
--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/LoginBackgroundSelector.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/LoginBackgroundSelector.vue
@@ -24,7 +24,7 @@
       <v-btn
         class="btn btn-primary"
         outlined
-        @click="$refs.imageCropDrawer.open()">
+        @click="$refs.imageCropDrawer.open(loginBackgroundItem)">
         {{ hasImage && $t('generalSettings.changeLoginBackground.button') || $t('generalSettings.addLoginBackground.button') }}
       </v-btn>
       <portal-general-settings-color-picker
@@ -38,8 +38,10 @@
       :crop-options="cropOptions"
       :max-file-size="maxFileSize"
       :src="loginBackgroundPreviewSrc"
+      alt
       drawer-title="generalSettings.changeLoginBackground.drawerTitle"
-      @data="loginBackgroundData = $event" />
+      @data="loginBackgroundData = $event"
+      @alt-text="loginBackgroundAltText = $event" />
   </div>
 </template>
 <script>
@@ -57,15 +59,21 @@ export default {
       type: String,
       default: null,
     },
+    altText: {
+      type: String,
+      default: null,
+    },
   },
   data: () => ({
     loginBackgroundData: null,
     loginBackgroundUploadId: null,
     loginBackgroundTextColor: '#FFFFFF',
+    loginBackgroundAltText: '',
     uploadInProgress: false,
     uploadProgress: 0,
     maxFileSize: 2097152,
     resetInput: false,
+    loginBackgroundItem: {},
   }),
   computed: {
     cropOptions() {
@@ -91,10 +99,14 @@ export default {
       this.$emit('input', this.loginBackgroundUploadId || '');
     },
     loginBackgroundData() {
+      this.$emit('text-alt-updated', this.loginBackgroundAltText);
       this.$emit('data-updated', this.loginBackgroundData);
     },
     loginBackgroundTextColor() {
       this.$emit('text-color-updated', this.loginBackgroundTextColor);
+    },
+    altText() {
+      this.loginBackgroundItem.altText = this.altText;
     },
   },
   methods: {
@@ -102,6 +114,8 @@ export default {
       this.loginBackgroundUploadId = defaultUploadId || null;
       this.loginBackgroundData = defaultData;
       this.loginBackgroundTextColor = defaultTextColor || '#FFFFFF';
+      this.loginBackgroundAltText = this.altText;
+      this.loginBackgroundItem.altText = this.loginBackgroundAltText;
       if (this.$refs.imageCropDrawer) {
         this.$refs.imageCropDrawer.init();
       }
@@ -121,6 +135,15 @@ export default {
       } else {
         Object.assign(branding, {
           loginBackgroundTextColor: null,
+        });
+      }
+      if (this.altText || this.loginBackgroundAltText) {
+        Object.assign(branding, {
+          loginBackgroundAltText: this.loginBackgroundAltText,
+        });
+      } else {
+        Object.assign(branding, {
+          loginBackgroundAltText: null,
         });
       }
     },

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/login-page/LoginBranding.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/login-page/LoginBranding.vue
@@ -126,8 +126,10 @@
             v-model="loginBackgroundUploadId"
             :default-data="defaultLoginBackgroundSrc"
             :aspect-ratio="aspectRatio"
+            :alt-text="defaultLoginBackgroundAltText"
             @data-updated="updateLoginBackgroundData"
-            @text-color-updated="loginBackgroundTextColor = $event" />
+            @text-color-updated="loginBackgroundTextColor = $event" 
+            @text-alt-updated="loginBackgroundAltText = $event"/>
         </v-card>
       </div>
     </v-col>
@@ -172,6 +174,7 @@ export default {
   data: () => ({
     loginTitle: {},
     loginSubtitle: {},
+    loginBackgroundAltText: {},
     loginBackgroundUploadId: null,
     loginBackgroundData: null,
     loginBackgroundTextColor: null,
@@ -208,6 +211,9 @@ export default {
     },
     defaultLoginSubtitle() {
       return this.branding?.loginSubtitle || {};
+    },
+    defaultLoginBackgroundAltText() {
+      return this.branding?.loginBackgroundAltText || '';
     },
     defaultLoginBackgroundSrc() {
       return this.hasDefaultBackground && `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/platform/branding/loginBackground?v=${this.refreshImageIndex}` || null;
@@ -247,6 +253,7 @@ export default {
       const newBranding = Object.assign(JSON.parse(JSON.stringify(this.branding)), {
         loginTitle: this.loginTitle,
         loginSubtitle: this.loginSubtitle,
+        loginBackgroundAltText: this.loginBackgroundAltText,
       });
       return JSON.stringify(oldBranding) !== JSON.stringify(newBranding);
     },
@@ -262,6 +269,9 @@ export default {
     changed() {
       this.$emit('changed', this.changed);
     },
+    loginBackgroundAltText() {
+      this.branding.loginBackgroundAltText = this.loginBackgroundAltText;
+    }
   },  
   mounted() {
     this.init();
@@ -272,6 +282,7 @@ export default {
       this.refreshImageIndex = Date.now();
       this.loginTitle = this.defaultLoginTitle && JSON.parse(JSON.stringify(this.defaultLoginTitle)) || {};
       this.loginSubtitle = this.defaultLoginSubtitle && JSON.parse(JSON.stringify(this.defaultLoginSubtitle)) || {};
+      this.loginBackgroundAltText = this.branding.loginBackgroundAltText;
       this.loginBackgroundTextColor = this.branding?.loginBackgroundTextColor;
       this.loginBackgroundData = this.defaultLoginBackgroundSrc;
       this.$refs.loginBackground.init(this.loginBackgroundData, this.loginBackgroundTextColor);
@@ -283,6 +294,7 @@ export default {
       this.$refs.loginBackground.preSave(branding);
       branding.loginTitle = this.loginTitle;
       branding.loginSubtitle = this.loginSubtitle;
+      branding.loginBackgroundAltText = this.loginBackgroundAltText;
 
       this.$root.loading = true;
       return this.$brandingService.updateBrandingInformation(branding)

--- a/webapp/src/main/webapp/vue-apps/login-common/components/PageTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/login-common/components/PageTemplate.vue
@@ -45,7 +45,7 @@
           class
           :src="background"
           style="height: 100%;"
-          alt="">
+          :alt="params.loginBackgroundAltText">
         <v-card
           :class="background && 'position-absolute t-0'"
           min-width="100%"


### PR DESCRIPTION
Before this change, when access to login page, the image near the form can provide information but it has an empty alt. To fix this problem, add the textrea to create the value of alt and adapt it in the code to retrieve it from the login page and insert it into the image near. After this change, the alternative text field is displayed correctly in the drawer Change background in the administration page and the alt has the value added by this text field.
Resolves https://github.com/Meeds-io/meeds/issues/3279