### PR TITLE
fix: Modify the color of summary/description and the number of views of activity in the stream - MEED-9099 - Meeds-io/meeds#3311

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -111,7 +111,7 @@
           :child="summaryElement"
           :title="summaryTooltip"
           :class="bodyClass"
-          class="text-wrap text-break reset-style-box rich-editor-content"
+          class="text-wrap text-break reset-style-box rich-editor-content text-color"
           dir="auto" />
         <v-btn
           v-if="showReadMore"
@@ -131,7 +131,7 @@
             class="icon-default-color">
             fas fa-eye
           </v-icon>
-          <span class="ms-1 text-subtitle">
+          <span class="ms-1 text-subtitle text-color">
             {{ activityViewsCount }}
           </span>
         </div>
@@ -298,7 +298,7 @@ export default {
       };
     },
     bodyClass() {
-      return `${this.textTruncate || ''} ${this.useEllipsisOnSummary && 'text-light-color' || 'text-color'} ${!this.useEllipsisOnSummary && this.collapsed && !this.fullContent && 'text-truncate-4' || ''} ${this.regularFontSizeOnSummary && 'text-font-size' || 'caption'}`;
+      return `${this.textTruncate || ''} ${!this.useEllipsisOnSummary && this.collapsed && !this.fullContent && 'text-truncate-4' || ''} ${this.regularFontSizeOnSummary && 'text-font-size' || 'caption'}`;
     },
     textTruncate() {
       return this.useEllipsisOnSummary && `text-truncate-${this.summaryLinesToDisplay}`;


### PR DESCRIPTION
Before this change, when Create an article/notes and publish it then view it by some users, The Color of the summary/description and the number of views in the stream is #707070. To fix this problem, change the class text-light-color if it is displayed and add a class text-color. After this change, the color of summary/description and the number of views is changed from #707070 to #20282C.
Resolves https://github.com/Meeds-io/meeds/issues/3311