### PR TITLE
fix: Enable visitors to obtain ckeditor configuration to use it - MEED-9036 - Meeds-io/MIPs#187  

### DIFF
--- a/component/service/src/main/java/io/meeds/social/rest/impl/richeditor/RichEditorConfigurationRest.java
+++ b/component/service/src/main/java/io/meeds/social/rest/impl/richeditor/RichEditorConfigurationRest.java
@@ -68,7 +68,6 @@ public class RichEditorConfigurationRest implements ResourceContainer {
   }
 
   @GET
-  @RolesAllowed("users")
   @Operation(summary = "Retrieves rich editor configuration Javascript file", method = "GET", description = "Returns list of tags")
   @Produces("text/javascript")
   @ApiResponses(value = {


### PR DESCRIPTION
This change will enable visitors to obtain CKeditor configuration to use it.