### PR TITLE
fix: Modification of the background color of the link/activity in the stream - MEED-9097 - Meeds-io/meeds#3310

### DIFF
--- a/webapp/src/main/webapp/skin/less/portlet/ActivityStream/Style.less
+++ b/webapp/src/main/webapp/skin/less/portlet/ActivityStream/Style.less
@@ -143,7 +143,7 @@
 }
 
 .activity-comment-background {
-  background: @commentBackgroundColor;
+  background: @commentBackgroundColor !important;
 }
 
 .linear-gradient-comment-background {

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -319,7 +319,7 @@ export default {
       return !!this.activityTypeExtension?.addMargin;
     },
     mainClass() {
-      return `${!this.useEmbeddedLinkView && 'd-flex flex-no-wrap' || 'activity-thumbnail-box light-grey-background-color overflow-hidden hover-elevation border-radius border-color mb-4 d-block d-sm-flex flex-sm-nowrap'} ${this.addMargin && 'my-4' || ''}`;
+      return `${!this.useEmbeddedLinkView && 'd-flex flex-no-wrap' || 'activity-thumbnail-box overflow-hidden hover-elevation border-radius border-color mb-4 d-block d-sm-flex flex-sm-nowrap activity-comment-background'} ${this.addMargin && 'my-4' || ''}`;
     },
     imageMobileStyle() {
       return {


### PR DESCRIPTION
Before this change, when check background color of link/news, this color is different to the background color of the comment. To fix this problem, change the light-grey-background-color class to the activity-comment-background class. After this change, modify the background color of link/news in the stream as comments from #F2F2F2 to #F2F5F8. 
Resolves https://github.com/Meeds-io/meeds/issues/3310