### PR TITLE
fix: Fix Site Pages Retrieval in Sidebar Navigation Admin UI - MEED-9105 - Meeds-io/meeds#3316

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/js/SiteService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/SiteService.js
@@ -90,7 +90,7 @@ export function getSitesByFilter({
     credentials: 'include',
   }).then(resp => {
     if (resp?.ok) {
-      return resp.json();
+      return resp.json().catch(() => []);
     } else {
       throw new Error('Error while getting sites');
     }
@@ -117,7 +117,7 @@ export function getSite(siteType, siteName, params) {
     credentials: 'include',
   }).then(resp => {
     if (resp?.ok) {
-      return resp.json();
+      return resp.json().catch(() => []);
     } else {
       throw new Error('Error while getting site by type and name');
     }

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/navigation/sidebar/drawer/NavigationSettingsAddSidebarSiteDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/navigation/sidebar/drawer/NavigationSettingsAddSidebarSiteDrawer.vue
@@ -260,9 +260,9 @@ export default {
       this.expandPages = this.item.properties?.expandPages || 'false';
       this.option = this.expandPages === 'true' ? 'PAGE' : this.item.type;
       this.$refs.drawer.open();
-      if (!this.sites) {
-        this.loading = true;
-        try {
+      try {
+        if (!this.sites) {
+          this.loading = true;
           this.sites = await this.$siteService.getSites(
             'PORTAL',
             null,
@@ -275,12 +275,13 @@ export default {
             this.displayed,
             this.filterByPermissions,
             this.excludeGroupNodesWithoutPageChildNodes,
-            this.temporalCheck);
+            this.temporalCheck
+          );
           await this.retrieveSite();
-        } finally {
-          this.loading = false;
-          this.initialized = true;
         }
+      } finally {
+        this.loading = false;
+        this.initialized = true;
       }
     },
     async apply() {


### PR DESCRIPTION
Prior to this change, when opening the Site Navigation Config Drawer the second time, the 'initialized' flag is set as 'false' which doesn't permit to refresh the list of pages. This change will fix the bahavior by setting 'initialized' flag as 'false' all time in a finally block at the end of Drawer opening operation.

Resolves Meeds-io/meeds#3316