### PR TITLE
feat: Add a check if the user is connected or not when creating space - MEED-8809 - Meeds-io/MIPs#187 

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
@@ -61,6 +61,7 @@ spacesList.warning.lastManager=You are the last space admin. Please, promote ano
 spacesList.error.spaceWithSameNameExists=A space with the same name already exists
 spacesList.error.InvalidSpaceName=The length of the text in field "name" must be between 3 and 200 characters, and must contain only letters, digits, '&' character and space characters.
 spacesList.error.unknownErrorWhenSavingSpace=An unkown error happened when saving space. Please contact the support services.
+spacesList.error.creation.space.anonymousUser=An error has occurred while creating space, try to connect
 spacesList.button.confirm=Confirm
 spacesList.button.createSpace=Create
 spacesList.button.updateSpace=Update

--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -458,13 +458,19 @@ export default {
       }
       this.savingSpace = true;
       this.space.templateId = this.templateId;
-      return this.$spaceService.createSpace(this.space)
-        .then(space => {
-          this.spaceSaved = true;
-          window.location.href = `${eXo.env.portal.context}/s/${space.id}`;
-        })
-        .catch(() => this.$root.$emit(this.$t('spacesList.error.unknownErrorWhenSavingSpace'), 'error'))
-        .finally(() => this.savingSpace = false);
+      if (eXo.env.portal.userName) {
+        return this.$spaceService.createSpace(this.space)
+          .then(space => {
+            this.spaceSaved = true;
+            window.location.href = `${eXo.env.portal.context}/s/${space.id}`;
+          })
+          .catch(() => this.$root.$emit(this.$t('spacesList.error.unknownErrorWhenSavingSpace'), 'error'))
+          .finally(() => this.savingSpace = false);
+      } else {
+        this.$root.$emit('alert-message', this.$t('spacesList.error.creation.space.anonymousUser'), 'error');
+        this.savingSpace = false;
+      }
+
     },
   },
 };


### PR DESCRIPTION
This modification will add a check if the user is logged in or not when creating a space. If the user is anonymous, an alert will be displayed temporarily when creating space; else, if the user is logged in, he will be redirected to the space created.