### PR TITLE
feat: Use Space Members First Name in Circle Space Name instead of Full Name - MEED-9136 - Meeds-io/meeds#2798

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
@@ -1117,11 +1117,14 @@ public class SpaceServiceImpl implements SpaceService {
                                          CollectionUtils.isEmpty(invitees) ? new String[0] :
                                                                            invitees.toArray(new String[invitees.size()]));
       List<String> userFullNames = Arrays.stream(users)
+                                         .limit(2)
                                          .map(u -> {
                                            Profile profile = identityManager.getOrCreateUserIdentity(u).getProfile();
-                                           return StringUtils.firstNonBlank(profile.getFullName());
+                                           String firstName = (String) profile.getProperty(Profile.FIRST_NAME);
+                                           String lastName = (String) profile.getProperty(Profile.LAST_NAME);
+                                           String fullName = profile.getFullName();
+                                           return StringUtils.firstNonBlank(firstName, lastName, fullName);
                                          })
-                                         .limit(2)
                                          .toList();
       String displayName = StringUtils.join(userFullNames, ", ");
       if (users.length > 2) {

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -1216,7 +1216,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
     space.setRegistration(Space.VALIDATION);
     Space createdSpace = spaceService.createSpace(space, DRAGON_NAME);
     assertNotNull(createdSpace);
-    assertEquals("Dragon Ball", createdSpace.getDisplayName());
+    assertEquals("Dragon", createdSpace.getDisplayName());
   }
 
   public void testCreateSpaceWithExistingName() {
@@ -1277,7 +1277,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
     try {
       Space createdSpace = spaceService.createSpace(new Space(), RAUL_NAME, Arrays.asList(dragon, john));
       assertNotNull(createdSpace);
-      assertTrue(createdSpace.getDisplayName().contains("Dragon Ball"));
+      assertTrue(createdSpace.getDisplayName().contains("Dragon"));
       assertTrue(createdSpace.getDisplayName().contains("and 1 more"));
       assertTrue(createdSpace.getDisplayName().contains(", "));
       assertEquals(spaceTemplate.getSpaceDefaultVisibility().name().toLowerCase(), createdSpace.getVisibility());


### PR DESCRIPTION
This change will allow creating Spaces using Members and Invitees First Name rather than Full Names in order to avoid having a long display name of spaces.

Resolves Meeds-io/meeds#2798