### PR TITLE
fix: Compute Real Space Home on Renaming - MEED-9026 - Meeds-io/meeds#3286

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceLayoutService.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceLayoutService.java
@@ -94,7 +94,7 @@ public class SpaceLayoutService {
     // Set URL of root node of the space
     String url = getFirstSpacePageUri(space.getGroupId());
     space = spaceService.getSpaceById(space.getId());
-    space.setUrl(url);
+    space.setUrl(StringUtils.defaultIfBlank(url, Space.HOME_URL));
     spaceService.updateSpace(space);
   }
 

--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
@@ -377,6 +377,7 @@ public class SpaceServiceImpl implements SpaceService {
     spaceToCreate.setEditor(username);
     spaceToCreate.setMembers(new String[] { username });
     spaceToCreate.setManagers(new String[] { username });
+    spaceToCreate.setUrl(Space.HOME_URL);
 
     SpaceTemplate spaceTemplate = getSpaceTemplateService().getSpaceTemplate(spaceToCreate.getTemplateId());
     if (spaceTemplate == null || !spaceTemplate.isEnabled() || spaceTemplate.isDeleted()) {
@@ -452,20 +453,8 @@ public class SpaceServiceImpl implements SpaceService {
   public void renameSpace(Space space, String newDisplayName) {
     spaceLifeCycle.setCurrentEvent(Type.SPACE_RENAMED);
     try {
-      String oldPrettyName = space.getPrettyName();
-      // Ensure unicity of new pretty name
-      String newPrettyName = buildPrettyName(newDisplayName);
-
       space.setDisplayName(newDisplayName);
-      space.setPrettyName(newPrettyName);
-      if (oldPrettyName.equals(space.getUrl())) {
-        // Update URL only if legacy
-        // navigation tree which uses pretty name
-        space.setUrl(newPrettyName);
-      } else if (StringUtils.isBlank(space.getUrl())) {
-        space.setUrl(Space.HOME_URL);
-      }
-
+      space.setPrettyName(buildPrettyName(newDisplayName));
       spaceStorage.renameSpace(space);
       spaceLifeCycle.spaceRenamed(space, space.getEditor());
     } finally {

--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceRenamedListenerImpl.java
@@ -1,10 +1,10 @@
 package org.exoplatform.social.core.space.impl;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.file.services.FileService;
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
@@ -17,36 +17,47 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.SpaceListenerPlugin;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.common.ContainerTransactional;
+import io.meeds.social.space.service.SpaceLayoutService;
 
 public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
 
-  private static final Log LOG = ExoLogger.getLogger(SpaceRenamedListenerImpl.class);
+  private static final Log    LOG = ExoLogger.getLogger(SpaceRenamedListenerImpl.class);
+
+  private SpaceLayoutService  spaceLayoutService;
+
+  private SpaceService        spaceService;
+
+  private OrganizationService organizationService;
+
+  private IdentityManager     identityManager;
+
+  private FileService         fileService;
 
   @Override
   public void spaceRenamed(SpaceLifeCycleEvent event) {
     Space space = event.getSpace();
     renameGroupLabel(space);
     updateDefaultSpaceAvatar(space);
+    updateSpaceUrl(space);
   }
 
+  @ContainerTransactional
   private void renameGroupLabel(Space space) {
     try {
-      RequestLifeCycle.begin(PortalContainer.getInstance());
-      OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
-      GroupHandler groupHandler = organizationService.getGroupHandler();
+      GroupHandler groupHandler = getOrganizationService().getGroupHandler();
       Group group = groupHandler.findGroupById(space.getGroupId());
       group.setLabel(space.getDisplayName());
       groupHandler.saveGroup(group, true);
     } catch (Exception e) {
       LOG.error("Error while renaming, space group Label, ignore minor change and keep the old Group Label", e);
-    } finally {
-      RequestLifeCycle.end();
     }
   }
 
   private void updateDefaultSpaceAvatar(Space space) {
-    IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    Identity spaceIdentity = getIdentityManager().getOrCreateSpaceIdentity(space.getPrettyName());
     FileItem spaceAvatar = identityManager.getAvatarFile(spaceIdentity);
     if (spaceAvatar != null && spaceAvatar.getFileInfo().getId() != null
         && EntityConverterUtils.DEFAULT_AVATAR.equals(spaceAvatar.getFileInfo().getName())) {
@@ -58,9 +69,50 @@ public class SpaceRenamedListenerImpl extends SpaceListenerPlugin {
       space.setAvatarAttachment(null);
       space.setAvatarLastUpdated(System.currentTimeMillis());
       identityManager.updateProfile(profile);
-      FileService fileService = CommonsUtils.getService(FileService.class);
-      fileService.deleteFile(spaceAvatar.getFileInfo().getId());
+      getFileService().deleteFile(spaceAvatar.getFileInfo().getId());
     }
   }
 
+  private void updateSpaceUrl(Space space) {
+    String spaceUri = getSpaceLayoutService().getFirstSpacePageUri(space.getGroupId());
+    if (!StringUtils.equals(spaceUri, space.getUrl())) {
+      space.setUrl(StringUtils.firstNonBlank(spaceUri, space.getUrl(), Space.HOME_URL));
+      getSpaceService().updateSpace(space);
+    }
+  }
+
+  public SpaceLayoutService getSpaceLayoutService() {
+    if (spaceLayoutService == null) {
+      spaceLayoutService = ExoContainerContext.getService(SpaceLayoutService.class);
+    }
+    return spaceLayoutService;
+  }
+
+  public SpaceService getSpaceService() {
+    if (spaceService == null) {
+      spaceService = ExoContainerContext.getService(SpaceService.class);
+    }
+    return spaceService;
+  }
+
+  public FileService getFileService() {
+    if (fileService == null) {
+      fileService = ExoContainerContext.getService(FileService.class);
+    }
+    return fileService;
+  }
+
+  public IdentityManager getIdentityManager() {
+    if (identityManager == null) {
+      identityManager = ExoContainerContext.getService(IdentityManager.class);
+    }
+    return identityManager;
+  }
+
+  public OrganizationService getOrganizationService() {
+    if (organizationService == null) {
+      organizationService = ExoContainerContext.getService(OrganizationService.class);
+    }
+    return organizationService;
+  }
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -1370,6 +1370,10 @@ public class SpaceServiceTest extends AbstractCoreTest {
 
   public void testRenameSpace() throws SpaceException {
     Space space = this.getSpaceInstance(0);
+    assertEquals(Space.HOME_URL, space.getUrl());
+    String newUrl = "fakeUrl";
+    space.setUrl(newUrl);
+    spaceService.updateSpace(space);
 
     Identity identity = new Identity(SpaceIdentityProvider.NAME, space.getPrettyName());
     identityStorage.saveIdentity(identity);
@@ -1380,6 +1384,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
 
     Space got = spaceService.getSpaceById(space.getId());
     assertEquals(newDisplayName, got.getDisplayName());
+    assertEquals(Space.HOME_URL, space.getUrl());
 
     newDisplayName = "new display name with super admin";
 


### PR DESCRIPTION
Prior to this change, when renaming a space, the space URL isn't computing switch space Navigation Nodes. This change ensures to compute the real Space Home Page Uri when renaming in order to ensure Model consistency. In addition, the Improvement made in https://github.com/Meeds-io/gatein-portal/pull/1116 will ensure a retro compatibility with previous renamed Space Home paths which was using the space pretty name.