### PR TITLE
fix: add missing expand parameter in JS identityservice - MEED-9161 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/js/IdentityService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/IdentityService.js
@@ -11,10 +11,10 @@ export function getIdentityById(identityId, expand) {
   });
 }
 
-export function getIdentityByProviderIdAndRemoteId(providerId, remoteId) {
+export function getIdentityByProviderIdAndRemoteId(providerId, remoteId, expand) {
   const url = remoteId.includes('/') ?
-    `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/identities/byParams?providerId=${providerId}&remoteId=${remoteId}`
-    : `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/identities/${providerId}/${remoteId}`;
+    `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/identities/byParams?providerId=${providerId}&remoteId=${remoteId}&expand=${expand || ''}`
+    : `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/identities/${providerId}/${remoteId}?expand=${expand || ''}`;
   return fetch(url, {
     method: 'GET',
     credentials: 'include',


### PR DESCRIPTION
The expand parameter was missing from the JS function _getIdentityByProviderIdAndRemoteId_ of identity service
This fix adds it to support calls with various values of the expand parameter.