### PR TITLE
Fix: Allow submenus control with the keyboard - MEED-9030 - Meeds-io/meeds#2900

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -250,7 +250,8 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     fields.put("name", profile.getFullName());
     fields.put("firstName", (String) profile.getProperty(Profile.FIRST_NAME));
     fields.put("lastName", (String) profile.getProperty(Profile.LAST_NAME));
-    fields.put("position", removeAccents(profile.getPosition()));
+    ProfilePropertySetting positionPropertySetting = profilePropertyService.getProfileSettingByName("position");
+    fields.put("position", removeAccents(parseValue(positionPropertySetting, profile.getPosition())));
     fields.put("aboutMe", removeAccents(profile.getAboutMe()));
     fields.put("skills", removeAccents((String) profile.getProperty(Profile.EXPERIENCES_SKILLS)));
     fields.put("avatarUrl", profile.getAvatarUrl());

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -61,6 +61,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import org.exoplatform.commons.api.notification.model.UserSetting;
 import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
@@ -326,7 +327,7 @@ public class EntityBuilder {
       userEntity.setFullname(profile.getFullName());
     }
     if (canViewProperties || isProfilePropertyVisible(Profile.POSITION)) {
-      userEntity.setPosition(profile.getPosition());
+      userEntity.setPosition(getProfilePropertyValue(profile, "position"));
     }
     if (canViewProperties || isProfilePropertyVisible(Profile.EMAIL)) {
       userEntity.setEmail(profile.getEmail());
@@ -487,12 +488,14 @@ public class EntityBuilder {
       if (propertySetting != null && propertySetting.isVisible()
           && !getProfilePropertyService().getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId()))
                                          .contains(propertySetting.getId())) {
-        userEntity.setPrimaryProperty((String) profile.getProperty(propertyName));
+        String primaryPropertyValue = getProfilePropertyValue(profile, propertyName);
+        userEntity.setPrimaryProperty(primaryPropertyValue);
       } else {
         userEntity.setPrimaryProperty("");
       }
     } else if (StringUtils.isNotBlank(userEntity.getPosition())) {
-      userEntity.setPrimaryProperty(userEntity.getPosition());
+      String positionValue = getProfilePropertyValue(profile, "position");
+      userEntity.setPrimaryProperty(positionValue);
     } else {
       userEntity.setPrimaryProperty("");
     }
@@ -502,12 +505,14 @@ public class EntityBuilder {
       if (propertySetting != null && propertySetting.isVisible()
           && !getProfilePropertyService().getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId()))
                                          .contains(propertySetting.getId())) {
-        userEntity.setSecondaryProperty((String) profile.getProperty(propertyName));
+        String secondaryPropertyValue = getProfilePropertyValue(profile, propertyName);
+        userEntity.setSecondaryProperty(secondaryPropertyValue);
       } else {
         userEntity.setSecondaryProperty("");
       }
     } else if (StringUtils.isNotBlank(userEntity.getTeam())) {
-      userEntity.setSecondaryProperty(userEntity.getTeam());
+      String teamValue = getProfilePropertyValue(profile, "team");
+      userEntity.setSecondaryProperty(teamValue);
     } else {
       userEntity.setSecondaryProperty("");
     }
@@ -518,17 +523,26 @@ public class EntityBuilder {
       if (propertySetting != null && propertySetting.isVisible()
           && !getProfilePropertyService().getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId()))
                                          .contains(propertySetting.getId())) {
-        userEntity.setTertiaryProperty((String) profile.getProperty(propertyName));
+        String tertiaryPropertyValue = getProfilePropertyValue(profile, propertyName);
+        userEntity.setTertiaryProperty(tertiaryPropertyValue);
       } else {
         userEntity.setTertiaryProperty("");
       }
     } else if (StringUtils.isNotBlank(userEntity.getCity())) {
-      userEntity.setTertiaryProperty(userEntity.getCity());
+      String cityValue = getProfilePropertyValue(profile, "city");
+      userEntity.setTertiaryProperty(cityValue);
     } else {
       userEntity.setTertiaryProperty("");
     }
 
     return userEntity;
+  }
+  
+  private static String getProfilePropertyValue(Profile profile, String propertyName) {
+    ProfilePropertySetting propertySetting = getProfilePropertyService().getProfileSettingByName(propertyName);
+    String profilePropertyValue = (String) profile.getProperty(propertyName);
+    return propertySetting != null && propertySetting.isDropdownList()
+        && NumberUtils.isCreatable(profilePropertyValue) ? getTranslationService().getTranslationLabelOrDefault(PROFILE_PROPERTY_OBJECT_TYPE, Long.parseLong(profilePropertyValue), PROFILE_PROPERTY_FIELD_NAME, LocaleContextInfoUtils.getUserLocale(getCurrentUserName())) : profilePropertyValue;
   }
 
   private static void buildManagedUsersCount(ProfileEntity userEntity) {

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
@@ -97,8 +97,6 @@ public class ProfileEntity extends BaseEntity {
   public static final String MANAGED_USERS_COUNT     = "managedUsersCount";
 
   public static final String PRIMARY_PROPERTY   = "primaryProperty";
-  
-  public static final String IS_PRIMARY_PROPERTY_DROPDWOWN_LIST   = "isPrimaryPropertyDropdownList";
 
   public static final String SECONDARY_PROPERTY = "secondaryProperty";
 
@@ -563,21 +561,11 @@ public class ProfileEntity extends BaseEntity {
   public String getPrimaryProperty() {
     return getString(PRIMARY_PROPERTY);
   }
-  
+
   public ProfileEntity setPrimaryProperty(String primaryProperty) {
     setProperty(PRIMARY_PROPERTY, primaryProperty);
     return this;
   }
-  
-  public Boolean getIsPrimaryPropertyDropdownList() {
-    return (Boolean) getProperty(IS_PRIMARY_PROPERTY_DROPDWOWN_LIST);
-  }
-
-  public ProfileEntity setIsPrimaryPropertyDropdownList(boolean isPrimaryPropertyDropdownList) {
-    setProperty(IS_PRIMARY_PROPERTY_DROPDWOWN_LIST, isPrimaryPropertyDropdownList);
-    return this;
-  }
-  
   public String getSecondaryProperty() {
     return getString(SECONDARY_PROPERTY);
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfileEntity.java
@@ -97,6 +97,8 @@ public class ProfileEntity extends BaseEntity {
   public static final String MANAGED_USERS_COUNT     = "managedUsersCount";
 
   public static final String PRIMARY_PROPERTY   = "primaryProperty";
+  
+  public static final String IS_PRIMARY_PROPERTY_DROPDWOWN_LIST   = "isPrimaryPropertyDropdownList";
 
   public static final String SECONDARY_PROPERTY = "secondaryProperty";
 
@@ -561,11 +563,21 @@ public class ProfileEntity extends BaseEntity {
   public String getPrimaryProperty() {
     return getString(PRIMARY_PROPERTY);
   }
-
+  
   public ProfileEntity setPrimaryProperty(String primaryProperty) {
     setProperty(PRIMARY_PROPERTY, primaryProperty);
     return this;
   }
+  
+  public Boolean getIsPrimaryPropertyDropdownList() {
+    return (Boolean) getProperty(IS_PRIMARY_PROPERTY_DROPDWOWN_LIST);
+  }
+
+  public ProfileEntity setIsPrimaryPropertyDropdownList(boolean isPrimaryPropertyDropdownList) {
+    setProperty(IS_PRIMARY_PROPERTY_DROPDWOWN_LIST, isPrimaryPropertyDropdownList);
+    return this;
+  }
+  
   public String getSecondaryProperty() {
     return getString(SECONDARY_PROPERTY);
   }

--- a/webapp/src/main/webapp/vue-apps/common/components/RippleHoverButton.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/RippleHoverButton.vue
@@ -24,6 +24,9 @@
     :ripple="!ripple"
     :text="text"
     :icon="icon"
+    tabindex="0"
+    @focus="handleFocus()"
+    @blur="handleBlur()"
     @mousedown.stop.prevent="0"
     @touchstart.stop.prevent="0"
     @touchend.stop.prevent="emitAction($event, false)"
@@ -61,6 +64,12 @@ export default {
     },
   },
   methods: {
+    handleFocus() {
+      this.$emit('event-change', true);
+    },
+    handleBlur() {
+      this.$emit('event-change', false);
+    },
     emitAction(event, mouseover) {
       if (!this.active && mouseover) {
         return;
@@ -116,6 +125,9 @@ export default {
           }));
       }
     },
+  },
+  mounted() {
+    this.$emit('blur-change', true);
   }
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -55,8 +55,8 @@
       <span v-if="$slots.subTitle" class="text-subtitle text-truncate my-auto text-left">
         <slot name="subTitle"></slot>
       </span>
-      <span v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate my-auto text-left">
-        {{ userPosition }}
+      <span v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate my-auto text-left">
+        {{ primaryProperty }}
       </span>
     </component>
     <component
@@ -100,8 +100,8 @@
         <p v-if="$slots.subTitle" class="text-subtitle text-truncate text-left mb-0">
           <slot name="subTitle"></slot>
         </p>
-        <p v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate text-left mb-0">
-          {{ userPosition }}
+        <p v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate text-left mb-0">
+          {{ primaryProperty }}
         </p>
       </div>
       <template v-if="$slots.actions">
@@ -164,8 +164,8 @@
       <span v-if="$slots.subTitle" class="text-subtitle text-truncate my-auto text-left">
         <slot name="subTitle"></slot>
       </span>
-      <span v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate my-auto text-left">
-        {{ userPosition }}
+      <span v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate my-auto text-left">
+        {{ primaryProperty }}
       </span>
     </component>
     <component
@@ -209,8 +209,8 @@
         <p v-if="$slots.subTitle" class="text-subtitle text-truncate text-left mb-0">
           <slot name="subTitle"></slot>
         </p>
-        <p v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate text-left mb-0">
-          {{ userPosition }}
+        <p v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate text-left mb-0">
+          {{ primaryProperty }}
         </p>
       </div>
       <template v-if="$slots.actions">
@@ -326,7 +326,7 @@ export default {
       type: Boolean,
       default: () => true
     },
-    displayPosition: {
+    displayPrimaryProperty: {
       type: Boolean,
       default: false
     },
@@ -371,9 +371,6 @@ export default {
     },
     userAvatarUrl() {
       return this.userIdentity?.enabled ? (this.userIdentity.avatar || this.avatarUrl || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.username || this.profileId}/avatar`) : (this.avatarUrl  || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/default-image/avatar`);
-    },
-    userPosition() {
-      return this.userIdentity?.position;
     },
     profileUrl() {
       if (this.url && !this.clickable && this.username) {
@@ -439,7 +436,7 @@ export default {
   },
   created() {
     if (this.username && this.mustRetrieveIdentity) {
-      this.$userService.getUser(this.username)
+      this.$userService.getUser(this.username, 'settings')
         .then(user => this.retrievedIdentity = user && JSON.parse(JSON.stringify(user)));
     }
   },

--- a/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCompactCard.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCompactCard.vue
@@ -84,7 +84,7 @@
             <a
               :href="url"
               class="grey--text text--darken-1">
-              {{ userPosition }}
+              {{ primaryProperty }}
             </a>
           </v-card-subtitle>
         </div>
@@ -142,8 +142,8 @@ export default {
     usernameClass() {
       return `${(!this.user.enabled || this.user.deleted) && 'text-subtitle' || 'primary--text text-truncate-2 mt-0'}`;
     },
-    userPosition() {
-      return this.user?.position || '';
+    primaryProperty() {
+      return this.user?.primaryProperty || '';
     },
     externalUser() {
       return this.user?.external === 'true';

--- a/webapp/src/main/webapp/vue-apps/platformAdminsWidget/components/AdminCard.vue
+++ b/webapp/src/main/webapp/vue-apps/platformAdminsWidget/components/AdminCard.vue
@@ -35,7 +35,7 @@
         </v-list-item-avatar>
         <v-list-item-content>
           <v-list-item-title>{{ fullName }}</v-list-item-title>
-          <v-list-item-subtitle>{{ position }}</v-list-item-subtitle>
+          <v-list-item-subtitle>{{ primaryProperty }}</v-list-item-subtitle>
         </v-list-item-content>
         <v-list-item-action @click="deleteAdminMembership()">
           <v-btn
@@ -68,8 +68,8 @@ export default {
     fullName() {
       return this.user?.fullname;
     },
-    position() {
-      return this.user?.position;
+    primaryProperty() {
+      return this.user?.primaryProperty;
     },
     userName() {
       return this.membership?.userName || this.membership?.remoteId;

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/Sidebar.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/Sidebar.vue
@@ -21,6 +21,7 @@
 -->
 <template>
   <v-app
+    ref="appHamburgerNavigationMenu"
     color="transaprent"
     class="HamburgerNavigationMenu"
     flat>
@@ -54,6 +55,7 @@
           :opened-site="site"
           :opened-space="space"
           :drawer-width="drawerWidth"
+          @focusedDrawer="isFocusedDrawer($event)"
           @firstLevelDrawer="updateFirstLevelDrawer($event)" />
         <v-overlay
           v-if="showInnerOverlay"
@@ -68,6 +70,7 @@
           :opened-site="site"
           :opened-space="space"
           :drawer-width="drawerWidth"
+          @focusedDrawer="isFocusedDrawer($event)"
           @firstLevelDrawer="updateFirstLevelDrawer($event)" />
         <sidebar-second-level
           v-if="allowDisplayLevels"
@@ -105,7 +108,9 @@ export default {
     interval: null,
     mouseEvent: false,
     closeTimeout: null,
-    visibility: ['displayed', 'temporal']
+    visibility: ['displayed', 'temporal'],
+    isFocused: false,
+    isSecondLevelDrawerOpen: false,
   }),
   computed: {
     allowDisplayLevels() {
@@ -161,10 +166,17 @@ export default {
         }
       }
       if (!this.secondLevelDrawer) {
+        if (this.$root.mode === 'ICON') {
+          this.isSecondLevelDrawerOpen = true;
+        }
         this.thirdLevelDrawer = false;
         this.space = null;
         this.site = null;
         this.secondLevel = null;
+      } else {
+        if (this.$root.mode === 'ICON') {
+          this.isSecondLevelDrawerOpen = false;
+        }
       }
     },
     firstLevelDrawer() {
@@ -174,10 +186,10 @@ export default {
         this.space = null;
         this.site = null;
         this.secondLevel = null;
-      } else if (this.firstLevelDrawer && this.$root.displaySequentially && this.mouseEvent) {
+      } else if (this.firstLevelDrawer && this.$root.displaySequentially && this.mouseEvent || this.isFocused) {
         // Close if mouse is not entered to menu
         this.closeTimeout = window.setTimeout(() => {
-          if (!this.hover) {
+          if (!this.hover && !this.isFocused) {
             this.closeMenu();
           }
         }, 500);
@@ -192,13 +204,16 @@ export default {
       }
     },
     hover() {
-      if (this.hover) {
+      if (this.hover || this.isFocused) {
         if (this.interval) {
           window.clearInterval(this.interval);
           this.interval = null;
         }
       } else if (!this.interval && this.$root.displaySequentially && !this.$root.hidden) {
         this.interval = window.setTimeout(() => this.closeMenu(), 500);
+      } else if (!this.hover) {
+        this.isFocused = false;
+        this.isSecondLevelDrawerOpen = false;
       }
     },
     site() {
@@ -219,6 +234,10 @@ export default {
     this.$root.$on('change-site-menu', this.changeSiteMenu);
     document.addEventListener('closeDisplayedDrawer', this.closeDisplayedDrawer);
     document.addEventListener('drawerOpened', this.closeDisplayedDrawerIfNotSelf);
+    document.addEventListener('keydown', this.closeDisplayedDrawerWithEsc);
+  },
+  mounted() {
+    this.$refs.appHamburgerNavigationMenu.$el.addEventListener('keydown', this.openDisplayedDrawer);
   },
   beforeDestroy() {
     this.$root.$off('change-space-menu', this.changeSpaceMenu);
@@ -226,8 +245,18 @@ export default {
     this.$root.$off('change-site-menu', this.changeSiteMenu);
     document.removeEventListener('closeDisplayedDrawer', this.closeDisplayedDrawer);
     document.removeEventListener('drawerOpened', this.closeDisplayedDrawerIfNotSelf);
+    this.$ref.appHamburgerNavigationMenu.$el.addEventListener('keydown', this.openDisplayedDrawer);
+    document.addEventListener('keydown', this.closeDisplayedDrawerWithEsc);
   },
   methods: {
+    isFocusedDrawer(event) {
+      if (!this.stickyDisplay && !this.hover) {
+        this.isFocused = false;
+        this.closeMenu();
+      } else {
+        this.isFocused = event;
+      }
+    },
     async openFirstLevel(mouseEvent) {
       this.mouseEvent = mouseEvent;
       this.firstLevelDrawer = false;
@@ -328,6 +357,23 @@ export default {
         this.closeMenuEffectively(true);
       }
     },
+    closeDisplayedDrawerWithEsc(event) {
+      if (event.key === 'Escape' && this.$root.mode === 'ICON' && this.isFocused && !this.isSecondLevelDrawerOpen) {
+        this.$root.hoverFirstLevel = false;
+        this.$root.hover = false;
+        this.isFocused = false;
+        this.closeMenuEffectively();
+      } else if (event.key === 'Escape') {
+        this.isSecondLevelDrawerOpen = false;
+      }
+    },
+    openDisplayedDrawer(event) {
+      if (event.key === 'Tab' && this.$root.icon && !this.isFocused) {
+        this.$root.hoverFirstLevel = true;
+        this.$root.hover = true;
+        this.isFocused = true;
+      }
+    },
     closeDisplayedDrawer() {
       if (this.firstLevelDrawer || this.secondLevelDrawer) {
         this.closeMenu();
@@ -356,6 +402,7 @@ export default {
         this.$root.hoverSecondLevel = false;
         this.$root.hoverFirstLevel = false;
         this.$root.hoverDeferred = false;
+        this.isFocused = false;
       } else {
         this.updateFirstLevelDrawer(false);
       }

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarFirstLevel.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarFirstLevel.vue
@@ -21,6 +21,7 @@
 <template>
   <component
     :is="stickyDisplay && 'sidebar-parent-menu' || 'sidebar-parent-drawer'"
+    ref="HamburgerMenuNavigation"
     id="HamburgerMenuNavigation"
     :value="firstLevelDrawer"
     :drawer-width="drawerWidth"
@@ -82,6 +83,16 @@ export default {
   },
   data: () => ({
     drawerStyle: null,
+    listFocusableElement: [],
+    lastFocusedElement: null,
+    firstElementFocusable: null,
+    lastElementFocusable: null,
+    lastElementDisabled: null,
+    secondLastElementFocusable: null,
+    firstListener: null,
+    lastListener: null,
+    secondLastListener: null,
+    lastDisabledListener: null,
   }),
   computed: {
     levelsOpened() {
@@ -111,6 +122,130 @@ export default {
         }
       },
     },
+    firstLevelDrawer(newVal) {
+      this.$nextTick().then(()  => {
+        if (newVal) {
+          this.lastFocusedElement = document.activeElement;
+          this.focusNavigationDrawer().then(() => {
+            this.firstElementFocusable?.focus();
+            if (this.$root.mode === 'ICON') {
+              this.$emit('focusedDrawer', true);
+            }
+          });
+        } else {
+          this.$emit('focusedDrawer', false); 
+        }
+      });
+    },
   },
+  beforeDestroy() {
+    if (this.$refs.HamburgerMenuNavigation) {
+      this.removeEventListenerKeydown(this.$refs?.HamburgerMenuNavigation?.$el, this.keydownListener);
+      this.removeEventListenerKeydown(this.firstElementFocusable, this.firstListener);
+      this.removeEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+      this.removeEventListenerKeydown(this.secondLastElementFocusable, this.lastListener);
+      this.removeEventListenerKeydown(this.lastElementDisabled, this.lastDisabledListener);
+    }
+  },
+  methods: {
+    async focusNavigationDrawer() {
+      await this.$nextTick();
+      await new Promise(resolve => setTimeout(resolve, 200));
+      this.listFocusableElement = this.getVisibleFocusableElements();
+      this.firstElementFocusable = this.listFocusableElement[0];
+      this.lastElementFocusable = this.listFocusableElement[this.listFocusableElement.length-1];
+      if (this.listFocusableElement.length > 0) {
+        this.firstListener = (e) => this.handleFocusableKeydown('firstElementFocusable', e);
+        this.lastListener = (e) => this.handleFocusableKeydown('lastElementFocusable', e);
+        this.addEventListenerKeydown(this.firstElementFocusable, this.firstListener);
+        this.addEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+        this.addEventListenerKeydown(this.$refs?.HamburgerMenuNavigation?.$el, this.keydownListener);
+      }
+    },
+    keydownListener(event) {
+      if (event.key === 'Escape') {
+        this.$nextTick(() => {
+          this.$emit('input', false);
+          if (this.lastFocusedElement) {
+            this.lastFocusedElement?.focus();
+          }
+        });
+      } else if (event.key === 'Enter') {
+        setTimeout(() => {
+          const listFocusableElement = this.getVisibleFocusableElements();
+          if (!listFocusableElement.includes(this.lastElementFocusable)) {
+            this.removeEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+            this.lastElementFocusable = listFocusableElement[listFocusableElement.length-1];
+            this.addEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+          }
+        }, 500);
+      } else if (event.key === 'Tab' && this.$root.mode === 'ICON' && !this.$root.icon) {
+        this.$emit('focusedDrawer', true);
+      }
+    },
+    handleFocusableKeydown(elemntFocusable, event) {
+      if (event && event.key !== 'Tab') {
+        return;
+      }
+      const listFocusableElement = this.getVisibleFocusableElements();
+      const secondLastElementFocusable = listFocusableElement[listFocusableElement.length-1];
+      if (secondLastElementFocusable !== this.lastElementFocusable && !this.secondLastElementFocusable && secondLastElementFocusable !== this.secondLastElementFocusable) {
+        this.secondLastElementFocusable = secondLastElementFocusable;
+        this.secondLastListener = (e) => this.handleFocusableKeydown('secondLastElementFocusable', e);
+        this.addEventListenerKeydown(this.secondLastElementFocusable, this.secondLastListener);
+        return;
+      } else if (secondLastElementFocusable === this.lastElementFocusable && this.secondLastElementFocusable) {
+        this.removeEventListenerKeydown(this.secondLastElementFocusable, this.secondLastListener);
+        this.secondLastElementFocusable = null;
+      } else if (secondLastElementFocusable !== this.lastElementFocusable && !this.lastElementDisabled && secondLastElementFocusable !== this.secondLastElementFocusable) {
+        this.lastElementDisabled = secondLastElementFocusable;
+        this.lastDisabledListener = (e) => this.handleFocusableKeydown('lastElementDisabled', e);
+        this.addEventListenerKeydown(this.lastElementDisabled, this.lastDisabledListener);
+      } else if (secondLastElementFocusable !== this.lastElementFocusable && elemntFocusable === 'lastElementFocusable') {
+        return;
+      }
+      
+      if (event.key === 'Tab') {
+        if (!event.shiftKey && elemntFocusable !== 'firstElementFocusable') {
+          if (this.lastElementDisabled && elemntFocusable === 'secondLastElementFocusable') {
+            this.lastElementDisabled?.focus();
+          } else {
+            this.firstElementFocusable?.focus();
+          }
+        } else if (event.shiftKey && elemntFocusable === 'firstElementFocusable') {
+          if (this.secondLastElementFocusable) {
+            //event.preventDefault();
+            this.secondLastElementFocusable?.focus();
+          } else {
+            //event.preventDefault();
+            this.lastElementFocusable?.focus();
+          }
+        }
+      }
+    },
+    getVisibleFocusableElements() {
+      const listFocusableElement = this.$refs?.HamburgerMenuNavigation?.$el.querySelectorAll('button, [href], input, [tabindex]:not([tabindex="-1"])');
+      return Array.from(listFocusableElement).filter(el  => { return this.checkVisibleElement(el);});
+    },
+    checkVisibleElement(element) {
+      return element?.offsetParent !== null && element instanceof HTMLElement && window?.getComputedStyle(element)?.visibility !== 'hidden' && window?.getComputedStyle(element)?.display !== 'none';
+    },
+    isSameElement(element1, element2) {
+      if (!element1 || !element2) {
+        return false;
+      }
+      return element1.isSameNode(element2);
+    },
+    addEventListenerKeydown(element, event) {
+      if (element && typeof element.addEventListener === 'function') {
+        element.addEventListener('keydown', event);
+      }
+    },
+    removeEventListenerKeydown(element, event) {
+      if (element && typeof element.addEventListener === 'function') {
+        element.removeEventListener('keydown', event);
+      }
+    },
+  }
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarSecondLevel.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarSecondLevel.vue
@@ -84,6 +84,16 @@ export default {
   },
   data: () => ({
     drawer: false,
+    listFocusableElement: [],
+    lastFocusedElement: null,
+    firstElementFocusable: null,
+    lastElementFocusable: null,
+    lastElementDisabled: null,
+    secondLastElementFocusable: null,
+    firstListener: null,
+    lastListener: null,
+    secondLastListener: null,
+    lastDisabledListener: null,
   }),
   computed: {
     drawerOffset() {
@@ -107,14 +117,129 @@ export default {
       }
     },
     drawer() {
-      this.$emit('input', this.drawer);
+      this.$nextTick().then(() => {
+        this.focusNavigationDrawer().then(() => {
+          this.firstElementFocusable?.focus();
+          this.$emit('input', this.drawer);
+        });
+      });
     },
-    value() {
-      this.drawer = this.value;
+    value(newVal) {
+      if (newVal) {
+        this.lastFocusedElement = document.activeElement;
+      }
+      this.drawer = newVal;
     },
   },
   created() {
     this.drawer = this.value;
   },
+  beforeDestroy() {
+    this.removeEventListenerKeydown(this.$refs?.secondLevelDrawer?.$el, this.keydownListener);
+    this.removeEventListenerKeydown(this.firstElementFocusable, this.firstListener);
+    this.removeEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+    this.removeEventListenerKeydown(this.secondLastElementFocusable, this.lastListener);
+    this.removeEventListenerKeydown(this.lastElementDisabled, this.lastDisabledListener);
+  },
+  methods: {
+    async focusNavigationDrawer() {
+      await this.$nextTick();
+      await new Promise(resolve => setTimeout(resolve, 200));
+      this.listFocusableElement = this.getVisibleFocusableElements();
+      this.firstElementFocusable = this.listFocusableElement[0];
+      this.lastElementFocusable = this.listFocusableElement[this.listFocusableElement.length-1];
+      if (this.listFocusableElement.length > 0) {
+        this.firstListener = (e) => this.handleFocusableKeydown('firstElementFocusable', e);
+        this.lastListener = (e) => this.handleFocusableKeydown('lastElementFocusable', e);
+        this.addEventListenerKeydown(this.firstElementFocusable, this.firstListener);
+        this.addEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+        this.addEventListenerKeydown(this.$refs?.secondLevelDrawer?.$el, this.keydownListener);
+      }
+    },
+    keydownListener(event) {
+      if (event.key === 'Escape') {
+        this.$emit('input', false);
+        this.$nextTick(() => {
+          if (this.lastFocusedElement) {
+            this.lastFocusedElement?.focus();
+          }
+        });
+      } else if (event.key === 'Enter') {
+        setTimeout(() => {
+          const listFocusableElement = this.getVisibleFocusableElements();
+          if (!listFocusableElement.includes(this.lastElementFocusable)) {
+            this.removeEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+            this.lastElementFocusable = listFocusableElement[listFocusableElement.length-1];
+            this.addEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+          }
+        }, 500);
+      }
+    },
+    handleFocusableKeydown(elemntFocusable, event) {
+      if (event && event.key !== 'Tab') {
+        return;
+      }
+      const listFocusableElement = this.getVisibleFocusableElements();
+      const secondLastElementFocusable = listFocusableElement[listFocusableElement.length-1];
+      if (secondLastElementFocusable !== this.lastElementFocusable && !this.secondLastElementFocusable && secondLastElementFocusable !== this.secondLastElementFocusable) {
+        this.secondLastElementFocusable = secondLastElementFocusable;
+        this.secondLastListener = (e) => this.handleFocusableKeydown('secondLastElementFocusable', e);
+        this.addEventListenerKeydown(this.secondLastElementFocusable, this.secondLastListener);
+        return;
+      } else if (secondLastElementFocusable === this.lastElementFocusable && this.secondLastElementFocusable) {
+        this.removeEventListenerKeydown(this.secondLastElementFocusable, this.secondLastListener);
+        this.secondLastElementFocusable = null;
+      } else if (secondLastElementFocusable !== this.lastElementFocusable && !this.lastElementDisabled && secondLastElementFocusable !== this.secondLastElementFocusable) {
+        this.lastElementDisabled = secondLastElementFocusable;
+        this.lastDisabledListener = (e) => this.handleFocusableKeydown('lastElementDisabled', e);
+        this.addEventListenerKeydown(this.lastElementDisabled, this.lastDisabledListener);
+      } else if (secondLastElementFocusable !== this.lastElementFocusable && elemntFocusable === 'lastElementFocusable') {
+        return;
+      }
+      
+      if (event.key === 'Tab') {
+        if (!event.shiftKey && elemntFocusable !== 'firstElementFocusable') {
+          if (this.lastElementDisabled && elemntFocusable === 'secondLastElementFocusable') {
+            event.preventDefault();
+            this.lastElementDisabled?.focus();
+          } else {
+            event.preventDefault();
+            this.firstElementFocusable?.focus();
+          }
+        } else if (event.shiftKey && elemntFocusable === 'firstElementFocusable') {
+          if (this.secondLastElementFocusable) {
+            event.preventDefault();
+            this.secondLastElementFocusable?.focus();
+          } else {
+            event.preventDefault();
+            this.lastElementFocusable?.focus();
+          }
+        }
+      }
+    },
+    getVisibleFocusableElements() {
+      const listFocusableElement = this.$refs?.secondLevelDrawer?.$el.querySelectorAll('button, [href], input, [tabindex]:not([tabindex="-1"])');
+      return Array.from(listFocusableElement).filter(el  => { return this.checkVisibleElement(el);});
+    },
+    checkVisibleElement(element) {
+      return element?.offsetParent !== null && element instanceof HTMLElement && window?.getComputedStyle(element)?.visibility !== 'hidden' && window?.getComputedStyle(element)?.display !== 'none';
+    },
+    isSameElement(element1, element2) {
+      if (!element1 || !element2) {
+        return false;
+      }
+      return element1.isSameNode(element2);
+    },
+    addEventListenerKeydown(element, event) {
+      if (element && typeof element.addEventListener === 'function') {
+        element.addEventListener('keydown', event);
+      }
+    },
+    removeEventListenerKeydown(element, event) {
+      if (element && typeof element.addEventListener === 'function') {
+        element.removeEventListener('keydown', event);
+      }
+    },
+  }
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarThirdLevel.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarThirdLevel.vue
@@ -27,6 +27,7 @@
     :right="$vuetify.rtl"
     class="HamburgerMenuThirdLevelParent layout-side-bar border-box-sizing z-index-drawer"
     max-width="100%"
+    @keydown="closeDrawer"
     hide-overlay>
     <v-hover v-if="drawer" v-model="$root.hoverThirdLevel">
       <div class="full-width fill-height overflow-x-hidden overflow-x-auto specific-scrollbar">
@@ -61,6 +62,16 @@ export default {
   },
   data: () => ({
     drawer: false,
+    listFocusableElement: [],
+    lastFocusedElement: null,
+    firstElementFocusable: null,
+    lastElementFocusable: null,
+    lastElementDisabled: null,
+    secondLastElementFocusable: null,
+    firstListener: null,
+    lastListener: null,
+    secondLastListener: null,
+    lastDisabledListener: null,
   }),
   computed: {
     drawerOffset() {
@@ -85,13 +96,128 @@ export default {
     },
     drawer() {
       this.$emit('input', this.drawer);
+      this.$nextTick().then(() => {
+        this.focusNavigationDrawer().then(() => {
+          this.firstElementFocusable?.focus();
+        });
+      });
     },
-    value() {
-      this.drawer = this.value;
+    value(newVal) {
+      if (newVal) {
+        this.lastFocusedElement = document.activeElement;
+      }
+      this.drawer = newVal;
     },
   },
   created() {
     this.drawer = this.value;
   },
+  beforeDestroy() {
+    this.removeEventListenerKeydown(this.$refs?.thirdLevelDrawer?.$el, this.keydownListener);
+    this.removeEventListenerKeydown(this.firstElementFocusable, this.firstListener);
+    this.removeEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+    this.removeEventListenerKeydown(this.secondLastElementFocusable, this.lastListener);
+    this.removeEventListenerKeydown(this.lastElementDisabled, this.lastDisabledListener);
+  },
+  methods: {
+    async focusNavigationDrawer() {
+      await this.$nextTick();
+      await new Promise(resolve => setTimeout(resolve, 200));
+      this.listFocusableElement = this.getVisibleFocusableElements();
+      this.firstElementFocusable = this.listFocusableElement[0];
+      this.lastElementFocusable = this.listFocusableElement[this.listFocusableElement.length-1];
+      if (this.listFocusableElement.length > 0) {
+        this.firstListener = (e) => this.handleFocusableKeydown('firstElementFocusable', e);
+        this.lastListener = (e) => this.handleFocusableKeydown('lastElementFocusable', e);
+        this.addEventListenerKeydown(this.firstElementFocusable, this.firstListener);
+        this.addEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+        this.addEventListenerKeydown(this.$refs?.thirdLevelDrawer?.$el, this.keydownListener);
+      }
+    },
+    keydownListener(event) {
+      if (event.key === 'Escape') {
+        this.$emit('input', false);
+        this.$nextTick(() => {
+          if (this.lastFocusedElement) {
+            this.lastFocusedElement?.focus();
+          }
+        });
+      } else if (event.key === 'Enter') {
+        setTimeout(() => {
+          const listFocusableElement = this.getVisibleFocusableElements();
+          if (!listFocusableElement.includes(this.lastElementFocusable)) {
+            this.removeEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+            this.lastElementFocusable = listFocusableElement[listFocusableElement.length-1];
+            this.addEventListenerKeydown(this.lastElementFocusable, this.lastListener);
+          }
+        }, 500);
+      }
+    },
+    handleFocusableKeydown(elemntFocusable, event) {
+      if (event && event.key !== 'Tab') {
+        return;
+      }
+      const listFocusableElement = this.getVisibleFocusableElements();
+      const secondLastElementFocusable = listFocusableElement[listFocusableElement.length-1];
+      if (secondLastElementFocusable !== this.lastElementFocusable && !this.secondLastElementFocusable && secondLastElementFocusable !== this.secondLastElementFocusable) {
+        this.secondLastElementFocusable = secondLastElementFocusable;
+        this.secondLastListener = (e) => this.handleFocusableKeydown('secondLastElementFocusable', e);
+        this.addEventListenerKeydown(this.secondLastElementFocusable, this.secondLastListener);
+        return;
+      } else if (secondLastElementFocusable === this.lastElementFocusable && this.secondLastElementFocusable) {
+        this.removeEventListenerKeydown(this.secondLastElementFocusable, this.secondLastListener);
+        this.secondLastElementFocusable = null;
+      } else if (secondLastElementFocusable !== this.lastElementFocusable && !this.lastElementDisabled && secondLastElementFocusable !== this.secondLastElementFocusable) {
+        this.lastElementDisabled = secondLastElementFocusable;
+        this.lastDisabledListener = (e) => this.handleFocusableKeydown('lastElementDisabled', e);
+        this.addEventListenerKeydown(this.lastElementDisabled, this.lastDisabledListener);
+      } else if (secondLastElementFocusable !== this.lastElementFocusable && elemntFocusable === 'lastElementFocusable') {
+        return;
+      }
+      
+      if (event.key === 'Tab') {
+        if (!event.shiftKey && elemntFocusable !== 'firstElementFocusable') {
+          if (this.lastElementDisabled && elemntFocusable === 'secondLastElementFocusable') {
+            event.preventDefault();
+            this.lastElementDisabled?.focus();
+          } else {
+            event.preventDefault();
+            this.firstElementFocusable?.focus();
+          }
+        } else if (event.shiftKey && elemntFocusable === 'firstElementFocusable') {
+          if (this.secondLastElementFocusable) {
+            event.preventDefault();
+            this.secondLastElementFocusable?.focus();
+          } else {
+            event.preventDefault();
+            this.lastElementFocusable?.focus();
+          }
+        }
+      }
+    },
+    getVisibleFocusableElements() {
+      const listFocusableElement = this.$refs?.thirdLevelDrawer?.$el.querySelectorAll('button, [href], input, [tabindex]:not([tabindex="-1"])');
+      return Array.from(listFocusableElement).filter(el  => { return this.checkVisibleElement(el);});
+    },
+    checkVisibleElement(element) {
+      return element?.offsetParent !== null && element instanceof HTMLElement && window?.getComputedStyle(element)?.visibility !== 'hidden' && window?.getComputedStyle(element)?.display !== 'none';
+    },
+    isSameElement(element1, element2) {
+      if (!element1 || !element2) {
+        return false;
+      }
+      return element1.isSameNode(element2);
+    },
+    addEventListenerKeydown(element, event) {
+      if (element && typeof element.addEventListener === 'function') {
+        element.addEventListener('keydown', event);
+      }
+    },
+    removeEventListenerKeydown(element, event) {
+      if (element && typeof element.addEventListener === 'function') {
+        element.removeEventListener('keydown', event);
+      }
+    },
+  }
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -30,50 +30,62 @@
       v-model="hover"
       v-if="displaySpacesList"
       :disabled="!$root.displaySequentially">
-      <v-list-item
-        :title="spacesTooltip"
-        :class="$root.iconCollapse && 'mx-0'"
-        class="d-flex ps-3"
-        dense
-        @click="handleSpacesClick">
-        <v-list-item-avatar class="me-2 my-auto" min-width="40">
-          <v-btn
-            v-if="displaySpacesExpandButton"
+      <v-card
+        class="d-flex flex-row transparent"
+        flat>
+        <v-card-content class="pa-0 flex-grow-1">
+          <v-list-item
             :title="spacesTooltip"
-            height="36"
-            width="36"
-            icon
-            @mousedown.prevent.stop="0"
-            @mouseup.prevent.stop="0"
-            @click.prevent.stop="collapsedSpaces = !collapsedSpaces">
-            <v-icon size="18">{{ spacesIcon }}</v-icon>
-          </v-btn>
-          <v-icon v-else size="18">{{ spacesIcon }}</v-icon>
-        </v-list-item-avatar>
-        <v-list-item-content v-if="$root.expand">
-          <v-list-item-title class="menu-text-color text-truncate">
-            {{ $t(item.name) }}
-          </v-list-item-title>
-        </v-list-item-content>
-        <v-list-item-action
-          v-if="toggleArrow && $root.expand"
-          class="my-auto align-center"
-          @mousedown.stop.prevent
-          @mouseup.stop.prevent>
-          <ripple-hover-button
-            :active="!drawerOpened"
-            :title="$t('menu.accessToSpacesList')"
-            class="ms-2"
-            icon
-            @ripple-hover="openSpacesList">
-            <v-icon
-              class="me-0 pa-2 icon-default-color"
-              small>
-              {{ arrowIcon }}
-            </v-icon>
-          </ripple-hover-button>
-        </v-list-item-action>
-      </v-list-item>
+            :class="$root.iconCollapse && 'mx-0'"
+            class="d-flex ps-3"
+            dense
+            @keydown="handleKeyDown"
+            @blur="handleListItemBlur"
+            @focus="changeHover"
+            @click="handleSpacesClick">
+            <v-list-item-avatar class="me-2 my-auto" min-width="40">
+              <v-btn
+                v-if="displaySpacesExpandButton"
+                :title="spacesTooltip"
+                height="36"
+                width="36"
+                icon
+                @mousedown.prevent.stop="0"
+                @mouseup.prevent.stop="0"
+                @click.prevent.stop="collapsedSpaces = !collapsedSpaces">
+                <v-icon size="18">{{ spacesIcon }}</v-icon>
+              </v-btn>
+              <v-icon v-else size="18">{{ spacesIcon }}</v-icon>
+            </v-list-item-avatar>
+            <v-list-item-content v-if="$root.expand">
+              <v-list-item-title class="menu-text-color text-truncate" max-width="50">
+                {{ $t(item.name) }}
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-card-content>
+        <v-card-actions class="pa-0 align-center">
+          <div
+            v-show="toggleArrow && $root.expand && (localExpand || drawerOpened)"
+            class="my-auto align-center me-4"
+            @mousedown.stop.prevent
+            @mouseup.stop.prevent>
+            <ripple-hover-button
+              :active="!drawerOpened"
+              :title="$t('menu.accessToSpacesList')"
+              class="ms-2"
+              icon
+              @event-change="changeEvent"
+              @ripple-hover="openSpacesList">
+              <v-icon
+                class="me-0 pa-2 icon-default-color"
+                small>
+                {{ arrowIcon }}
+              </v-icon>
+            </ripple-hover-button>
+          </div>
+        </v-card-actions>
+      </v-card>
     </v-hover>
     <v-expand-transition v-if="displayItemsInMobile">
       <sidebar-list-sub-list
@@ -84,98 +96,111 @@
   <v-hover
     v-else-if="item.url"
     v-model="hover">
-    <v-list-item
-      v-bind="itemAttributes"
-      v-on="itemActions"
-      :title="tooltip"
-      :value="item.url"
-      :disabled="!item.url"
-      :class="!$root.expand && item.avatar && 'ms-n2px'"
-      class="d-flex ps-3"
-      dense>
-      <v-list-item-avatar
-        v-if="$root.expand || !item.avatar"
-        class="my-auto me-2"
-        min-width="40">
-        <v-icon
-          v-if="!item.avatar"
-          class="icon-default-color"
-          size="18">
-          {{ item.icon || 'fa-folder' }}
-        </v-icon>
-      </v-list-item-avatar>
-      <v-list-item-avatar
-        v-if="item.avatar"
-        :class="$root.expand && 'me-2' || 'ms-2'"
-        class="my-auto"
-        min-width="28"
-        width="28"
-        height="28"
-        tile>
-        <img
-          :src="item.avatar"
-          alt=""
-          class="border-radius"
-          width="28"
-          height="auto">
-      </v-list-item-avatar>
-      <v-card
-        v-if="spaceUnreadCount && $root.icon && !$root.expand"
-        :class="$vuetify.rtl && 'l-0' || 'r-0'"
-        class="hamburger-unread-badge border-radius-circle error-color-background position-absolute t-0 me-4 mt-0"
-        width="12"
-        height="12"
-        flat />
-      <v-list-item-content v-if="$root.expand">
-        <v-list-item-title class="menu-text-color text-truncate">
-          {{ item.name }}
-        </v-list-item-title>
-      </v-list-item-content>
-      <v-list-item-action
-        v-if="toggleArrow && $root.expand"
-        class="my-auto align-center z-index-one position-relative"
-        @mousedown.stop.prevent
-        @mouseup.stop.prevent>
-        <ripple-hover-button
-          :active="!drawerOpened"
-          :title="$t('menu.accessToPagesList')"
-          class="ms-2"
-          icon
-          @ripple-hover="openOrCloseDrawer()">
-          <v-icon
-            class="me-0 pa-2 icon-default-color"
-            small>
-            {{ arrowIcon }}
-          </v-icon>
-        </ripple-hover-button>
-      </v-list-item-action>
-      <v-list-item-action
-        v-else-if="isPage"
-        class="my-auto align-center"
-        @mousedown.stop.prevent
-        @mouseup.stop.prevent>
-        <v-btn
-          v-if="$root.expand && $root.allowUserHome"
-          v-show="hover || isHome"
-          :title="$t('menu.spaces.makeAsHomePage')"
-          class="ms-2"
-          icon
-          @click.stop.prevent="$root.$emit('update-home-link-page', item)">
-          <v-icon
-            :class="isHome && 'primary--text' || 'icon-default-color'"
-            class="me-0 pa-2"
-            small>
-            fa-house-user
-          </v-icon>
-        </v-btn>
-      </v-list-item-action>
+    <v-card
+      class="d-flex flex-row transparent"
+      flat>
+      <v-card-content class="pa-0 flex-grow-1">
+        <v-list-item
+          v-bind="itemAttributes"
+          v-on="itemActions"
+          :title="tooltip"
+          :value="item.url"
+          :disabled="!item.url"
+          :class="!$root.expand && item.avatar && 'ms-n2px'"
+          @keydown="handleKeyDown"
+          @focus="changeHover"
+          @blur="handleListItemBlur"
+          class="d-flex ps-3"
+          dense>
+          <v-list-item-avatar
+            v-if="$root.expand || !item.avatar"
+            class="my-auto me-2"
+            min-width="40">
+            <v-icon
+              v-if="!item.avatar"
+              class="icon-default-color"
+              size="18">
+              {{ item.icon || 'fa-folder' }}
+            </v-icon>
+          </v-list-item-avatar>
+          <v-list-item-avatar
+            v-if="item.avatar"
+            :class="$root.expand && 'me-2' || 'ms-2'"
+            class="my-auto"
+            min-width="28"
+            width="28"
+            height="28"
+            tile>
+            <img
+              :src="item.avatar"
+              alt=""
+              class="border-radius"
+              width="28"
+              height="auto">
+          </v-list-item-avatar>
+          <v-card
+            v-if="spaceUnreadCount && $root.icon && !$root.expand"
+            :class="$vuetify.rtl && 'l-0' || 'r-0'"
+            class="hamburger-unread-badge border-radius-circle error-color-background position-absolute t-0 me-4 mt-0"
+            width="12"
+            height="12"
+            flat />
+          <v-list-item-content v-if="$root.expand">
+            <v-list-item-title class="menu-text-color text-truncate">
+              {{ item.name }}
+            </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-card-content>
+      <v-card-actions class="pa-0 align-center">
+        <div
+          v-show="toggleArrow && $root.expand && (localExpand || drawerOpened)"
+          class="my-auto align-center me-4 z-index-one position-relative"
+          @mousedown.stop.prevent
+          @mouseup.stop.prevent>
+          <ripple-hover-button
+            :active="!drawerOpened"
+            :title="$t('menu.accessToPagesList')"
+            class="ms-2"
+            icon
+            @event-change="changeEvent"
+            @ripple-hover="openOrCloseDrawer()">
+            <v-icon
+              class="me-0 pa-2 icon-default-color"
+              small>
+              {{ arrowIcon }}
+            </v-icon>
+          </ripple-hover-button>
+        </div>
+        <div
+          v-show="isPage"
+          class="my-auto align-center me-4"
+          @mousedown.stop.prevent
+          @mouseup.stop.prevent>
+          <v-btn
+            v-if="$root.expand && $root.allowUserHome && localExpand"
+            v-show="hover || isHome"
+            :title="$t('menu.spaces.makeAsHomePage')"
+            class="ms-2"
+            icon
+            @blur="hover=false"
+            @click.stop.prevent="$root.$emit('update-home-link-page', item)">
+            <v-icon
+              :class="isHome && 'primary--text' || 'icon-default-color'"
+              class="me-0 pa-2"
+              small>
+              fa-house-user
+            </v-icon>
+          </v-btn>
+        </div>
+      </v-card-actions>
       <space-unread-badge
         v-if="isSpace"
         v-show="!toggleArrow"
         :space-id="spaceId"
         :unread-badge="spaceUnreadCount"
         @refresh="retrieveSpace(true)" />
-    </v-list-item>
+    </v-card>
   </v-hover>
 </template>
 <script>
@@ -190,6 +215,8 @@ export default {
     hover: false,
     collapsedSpaces: false,
     space: null,
+    localExpand: false,
+    isShiftTabPressed: false,
   }),
   computed: {
     menuItems() {
@@ -350,7 +377,10 @@ export default {
   watch: {
     hover() {
       if (this.hover) {
+        this.localExpand = true;
         this.initHover();
+      } else {
+        this.localExpand = false;
       }
     },
     collapsedSpaces() {
@@ -358,6 +388,11 @@ export default {
         window.localStorage.setItem(this.displaySpacesExpandKey, 'true');
       } else {
         window.localStorage.removeItem(this.displaySpacesExpandKey);
+      }
+    },
+    drawerOpened(newVal) {
+      if (!newVal){
+        this.localExpand = true;
       }
     },
   },
@@ -369,11 +404,21 @@ export default {
     document.removeEventListener('space-settings-updated', this.handleSpaceUpdated);
   },
   methods: {
-    handleSpaceUpdated(event) {
-      const space = event?.detail;
-      if (space && this.space?.id === space?.id) {
-        this.retrieveSpace(true);
+    handleKeyDown(event) {
+      this.isShiftTabPressed = event.key === 'Tab' && event.shiftKey;
+    },
+    handleListItemBlur() {
+      if (this.isShiftTabPressed) {
+        this.localExpand = false;
+        this.isShiftTabPressed = false;
       }
+    },
+    changeHover() {
+      this.hover = true;
+      this.localExpand = true;
+    },
+    changeEvent(localExpand) {
+      this.localExpand = localExpand;
     },
     handleSpacesClick() {
       if (this.$root.displaySequentially && (this.isSpaceTemplate || this.isSpaceCategory)) {

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
@@ -51,58 +51,68 @@
       </v-chip>
     </v-list-item-action>
   </v-list-item>
-  <v-hover v-else v-model="showItemActions">
-    <v-list-item
-      :href="spaceLink"
-      :class="homeIcon && (homeLink === spaceLink && 'UserPageLinkHome' || 'UserPageLink')"
-      :arial-label="$t('space.avatar.href.title',{0:space.prettyName})"
-      :title="spaceDisplayName"
-      class="px-2 spaceItem"
-      role="link">
-      <v-list-item-avatar 
-        size="28"
-        class="me-3 ms-2 tile my-0 spaceAvatar"
-        tile>
-        <img
-          :src="spaceAvatar"
-          alt=""
-          class="rounded"
-          width="28"
-          height="28">
-      </v-list-item-avatar>
-      <v-list-item-content>
-        <v-list-item-title v-text="spaceDisplayName" class="menu-text-color" />
-      </v-list-item-content>
-      <v-list-item-action
-        v-if="toggleArrow"
-        :disabled="loading"
-        :loading="loading"
-        class="me-2 my-auto align-center">
-        <ripple-hover-button
-          :active="!drawerOpened"
-          icon
-          @ripple-hover="openOrCloseDrawer()">
-          <v-icon
-            :id="space.id"
-            class="me-0 pa-2 icon-default-color"
-            small>
-            {{ arrowIcon }} 
-          </v-icon>
-        </ripple-hover-button>
-      </v-list-item-action>
-      <v-list-item-action
-        v-if="!toggleArrow && spaceUnreadCount"
-        class="me-2 my-auto align-center">
-        <v-chip
-          v-if="spaceUnreadCount"
-          color="error-color-background"
-          min-width="22"
-          height="22"
-          dark>
-          {{ spaceUnreadCount }}
-        </v-chip>
-      </v-list-item-action>
-    </v-list-item>
+  <v-hover v-else v-model="hover">
+    <v-card class="d-flex flex-row transparent" flat>
+      <v-card-content class="pa-0 flex-grow-1">
+        <v-list-item
+          :href="spaceLink"
+          :class="homeIcon && (homeLink === spaceLink && 'UserPageLinkHome' || 'UserPageLink')"
+          :arial-label="$t('space.avatar.href.title',{0:space.prettyName})"
+          :title="spaceDisplayName"
+          class="px-2 spaceItem"
+          role="link"
+          @keydown="handleKeyDown"
+          @focus="changeHover"
+          @blur="handleListItemBlur">
+          <v-list-item-avatar 
+            size="28"
+            class="me-3 ms-2 tile my-0 spaceAvatar"
+            tile>
+            <img
+              :src="spaceAvatar"
+              alt=""
+              class="rounded"
+              width="28"
+              height="28">
+          </v-list-item-avatar>
+          <v-list-item-content>
+            <v-list-item-title v-text="spaceDisplayName" class="menu-text-color" />
+          </v-list-item-content>
+        </v-list-item>
+      </v-card-content>
+      <v-card-actions class="pa-0 align-center">
+        <div
+          v-show="toggleArrow && (localExpand || drawerOpened)"
+          :disabled="loading"
+          :loading="loading"
+          class="me-2 my-auto align-center">
+          <ripple-hover-button
+            :active="!drawerOpened"
+            icon
+            @event-change="changeEvent"
+            @ripple-hover="openOrCloseDrawer()">
+            <v-icon
+              :id="space.id"
+              class="me-0 pa-2 icon-default-color"
+              small>
+              {{ arrowIcon }} 
+            </v-icon>
+          </ripple-hover-button>
+        </div>
+        <div
+          v-show="!toggleArrow && spaceUnreadCount"
+          class="me-2 my-auto align-center">
+          <v-chip
+            v-if="spaceUnreadCount"
+            color="error-color-background"
+            min-width="22"
+            height="22"
+            dark>
+            {{ spaceUnreadCount }}
+          </v-chip>
+        </div>
+      </v-card-actions>
+    </v-card>
   </v-hover>
 </template>
 <script>
@@ -135,8 +145,10 @@ export default {
     },
   },
   data: () => ({
-    showItemActions: false,
+    hover: false,
     spaceUnreadItems: null,
+    localExpand: false,
+    isShiftTabPressed: false,
   }),
   computed: {
     spaceId() {
@@ -155,7 +167,7 @@ export default {
       return this.$root?.unreadPerSpace?.[this.space?.id];
     },
     toggleArrow() {
-      return this.showItemActions || this.drawerOpened;
+      return this.hover || this.drawerOpened;
     },
     drawerOpened() {
       return this.openedSpace?.id === this.space?.id;
@@ -180,6 +192,21 @@ export default {
         }
       },
     },
+    toggleArrow(newVal) {
+      this.localExpand = newVal;
+    },
+    drawerOpened(newVal) {
+      if (!newVal){
+        this.localExpand = true;
+      }
+    },
+    hover() {
+      if (this.hover) {
+        this.localExpand = true;
+      } else {
+        this.localExpand = false;
+      }
+    },
   },
   methods: {
     openOrCloseDrawer(event) {
@@ -188,6 +215,23 @@ export default {
         event.stopPropagation();
       }
       this.$root.$emit('change-space-menu', this.space, this.thirdLevel);
+    },
+    changeEvent(localExpand) {
+      this.localExpand = localExpand;
+    },
+    handleKeyDown(event) {
+      this.isShiftTabPressed = event.key === 'Tab' && event.shiftKey;
+    },
+    changeHover() {
+      this.hover = true;
+      this.localExpand = true;
+    },
+    handleListItemBlur() {
+      if (this.isShiftTabPressed) {
+        this.localExpand = false;
+        this.hover = false;
+      }
+      this.isShiftTabPressed = false;
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationItem.vue
+++ b/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationItem.vue
@@ -16,49 +16,61 @@
 -->
 
 <template>
-  <a
-    :href="uri"
-    :target="target"
-    :rel="rel"
-    :ripple="false"
-    class="d-flex px-0"
-    @mouseover="showAction = true"
-    @mouseleave="showAction = false">
-    <v-list-item-icon size="20" class="d-flex align-center justify-center my-auto ms-0 me-3">
-      <v-icon size="20" class="icon-default-color">
-        {{ icon }}
-      </v-icon>
-    </v-list-item-icon>
-    <v-list-item-title class="menu-text-color">
-      <div class="d-flex align-center justify-space-between my-auto">
-        <span class="text-truncate" :style="navigationLabelStyle">{{ navigationLabel }}</span>
-        <v-chip
-          v-if="unreadBadge && enableUnread"
-          color="error-color-background"
-          min-width="22"
-          height="22"
-          dark>
-          {{ unreadBadge }}
-        </v-chip>
+  <v-card
+    class="d-flex flex-row transparent"
+    transparent
+    flat>
+    <v-card-content class="pa-0 flex-grow-1 my-auto">
+      <a
+        :href="uri"
+        :target="target"
+        :rel="rel"
+        :ripple="false"
+        class="d-flex px-0"
+        @mouseover="showAction = true"
+        @mouseleave="showAction = false"
+        @keydown="handleKeyDown"
+        @focus="changeHover"
+        @blur="handleListItemBlur">
+        <v-list-item-icon size="20" class="d-flex align-center justify-center my-auto ms-0 me-3">
+          <v-icon size="20" class="icon-default-color">
+            {{ icon }}
+          </v-icon>
+        </v-list-item-icon>
+        <v-list-item-title class="menu-text-color">
+          <div class="d-flex align-center justify-space-between my-auto width-fit-content">
+            <span class="text-truncate" :style="navigationLabelStyle">{{ navigationLabel }}</span>
+            <v-chip
+              v-if="unreadBadge && enableUnread"
+              color="error-color-background"
+              min-width="22"
+              height="22"
+              dark>
+              {{ unreadBadge }}
+            </v-chip>
+          </div>
+        </v-list-item-title>
+      </a>
+    </v-card-content>
+    <v-card-actions class="pa-0 align-center">
+      <div
+        v-show="!unreadBadge && enableChangeHome && !isNodeGroup && (isHomeLink || showAction || localExpand)"
+        class="ms-auto my-auto flex-shrink-0">
+        <v-btn
+          :title="$t('menu.spaces.makeAsHomePage')"
+          icon
+          class="pa-0 ms-2"
+          @blur="showAction=false"
+          @click="selectHome($event)">
+          <v-icon
+            :class="isHomeLink && 'primary--text' || 'icon-default-color'"
+            small>
+            fa-house-user
+          </v-icon>
+        </v-btn>
       </div>
-    </v-list-item-title>
-    <v-list-item-action
-      v-if="!unreadBadge && enableChangeHome && !isNodeGroup && (isHomeLink || showAction)"
-      class="ms-auto my-auto flex-shrink-0">
-      <v-btn
-        :title="$t('menu.spaces.makeAsHomePage')"
-        height="36"
-        min-width="36"
-        icon
-        @click="selectHome($event)">
-        <v-icon
-          :class="isHomeLink && 'primary--text' || 'icon-default-color'"
-          small>
-          fa-house-user
-        </v-icon>
-      </v-btn>
-    </v-list-item-action>
-  </a>
+    </v-card-actions>
+  </v-card>
 </template>
 
 <script>
@@ -80,6 +92,8 @@ export default {
   data: () => ({
     homeLink: eXo.env.portal.homeLink,
     showAction: false,
+    localExpand: false,
+    isShiftTabPressed: false,
   }),
   computed: {
     baseSiteUri() {
@@ -117,6 +131,20 @@ export default {
       return this.unreadBadge > 0 ? { 'max-width': '140px' } : { 'max-width': '200px'};
     },
   },
+  watch: {
+    showAction() {
+      if (this.showAction) {
+        this.localExpand = true;
+      } else {
+        this.localExpand = false;
+      }
+    },
+    drawerOpened(newVal) {
+      if (!newVal){
+        this.localExpand = true;
+      }
+    },
+  },
   created() {
     document.addEventListener('homeLinkUpdated', this.updateHome);
   },
@@ -133,6 +161,20 @@ export default {
     },
     updateHome() {
       this.homeLink = eXo.env.portal.homeLink;
+    },
+    handleKeyDown(event) {
+      this.isShiftTabPressed = event.key === 'Tab' && event.shiftKey;
+    },
+    handleListItemBlur() {
+      if (this.isShiftTabPressed) {
+        this.localExpand = false;
+        this.showAction = false;
+        this.isShiftTabPressed = false;
+      }
+    },
+    changeHover() {
+      this.showAction = true;
+      this.localExpand = true;
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormInviteUserListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormInviteUserListItem.vue
@@ -80,14 +80,14 @@ export default {
     fullName() {
       return this.user.fullname || this.user.profile?.fullName;
     },
-    position() {
-      return this.user.position || this.user.profile?.position;
+    primaryProperty() {
+      return this.user.primaryProperty;
     },
     email() {
       return this.user.email || this.user.profile?.email;
     },
     subtitle() {
-      return this.emailSubtitle ? this.email : this.position;
+      return this.emailSubtitle ? this.email : this.primaryProperty;
     },
     isSpace() {
       return this.user.providerId === 'space';

--- a/webapp/src/main/webapp/vue-apps/space-invitation/components/list/SpaceSettingRoleListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/space-invitation/components/list/SpaceSettingRoleListItem.vue
@@ -110,14 +110,14 @@ export default {
     fullName() {
       return this.user.fullname || this.user.profile?.fullName;
     },
-    position() {
-      return this.user.position || this.user.profile?.position;
+    primaryProperty() {
+      return this.user.primaryProperty;
     },
     email() {
       return this.user.email || this.user.profile?.email;
     },
     subtitle() {
-      return this.emailSubtitle ? this.email : this.position;
+      return this.emailSubtitle ? this.email : this.primaryProperty;
     },
     isSpace() {
       return this.user.providerId === 'space';

--- a/webapp/src/main/webapp/vue-apps/space-widget-managers/components/SpaceManagersApplication.vue
+++ b/webapp/src/main/webapp/vue-apps/space-widget-managers/components/SpaceManagersApplication.vue
@@ -55,7 +55,7 @@
               avatar-class="me-2"
               extra-class="mt-3"
               size="36"
-              display-position
+              display-primary-property
               bold-title />
           </div>
         </template>

--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/space-card/menu/SpaceRoleListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/space-card/menu/SpaceRoleListItem.vue
@@ -100,10 +100,7 @@ export default {
     },
     fullName() {
       return this.user.fullname || this.user.profile?.fullName;
-    },
-    position() {
-      return this.user.position || this.user.profile?.position;
-    },
+    }
   }
 };
 </script>


### PR DESCRIPTION
Before this change, when Access to the left menu then to any element (page or space) by the keyboard, the functionalities associated with them are unusable with the keyboard too. To fix this problem, add to the left menu in drawer mode, icon and stickly the focus for the three menu levels of each mode and separate the buttons from the element of each level. After this changes, the sidebar menu is accessible via the keyboard.
Resolves https://github.com/Meeds-io/meeds/issues/2900