### PR TITLE
fix: Set an empty alt to images of published and pinned article and to the avatar of whom pinned it - MEED-9151 - Meeds-io/meeds#3337

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -23,7 +23,7 @@
           <img
             v-if="thumbnail"
             :src="`${thumbnail}`"
-            :alt="title"
+            alt=""
             :class="thumbnailClass"
             :style="imageMobileStyle"
             class="my-auto"
@@ -66,7 +66,7 @@
         <img
           v-if="thumbnail"
           :src="thumbnail"
-          :alt="title"
+          alt=""
           :class="thumbnailClass"
           class="my-auto"
           loading="lazy"


### PR DESCRIPTION
Before this change, when creating an article with image and access to the stream page, the image of the article has alt=[article name]. 
To fix this problem, we will change the alt to empty. After this change, the alt is displayed correctly. 

Resolves https://github.com/Meeds-io/meeds/issues/3337
