### PR TITLE
fix: Fix display of item id instead of item name for profile properties using dropdown option - MEED-9072 - Meeds-io/meeds#3299

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -250,7 +250,11 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     fields.put("name", profile.getFullName());
     fields.put("firstName", (String) profile.getProperty(Profile.FIRST_NAME));
     fields.put("lastName", (String) profile.getProperty(Profile.LAST_NAME));
-    fields.put("position", removeAccents(profile.getPosition()));
+    ProfilePropertySetting positionPropertySetting = profilePropertyService.getProfileSettingByName("position");
+    fields.put("position",
+               StringUtils.isNotEmpty(profile.getPosition()) ? removeAccents(parseValue(positionPropertySetting,
+                                                                                        profile.getPosition()))
+                                                             : profile.getPosition());
     fields.put("aboutMe", removeAccents(profile.getAboutMe()));
     fields.put("skills", removeAccents((String) profile.getProperty(Profile.EXPERIENCES_SKILLS)));
     fields.put("avatarUrl", profile.getAvatarUrl());

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -61,6 +61,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import org.exoplatform.commons.api.notification.model.UserSetting;
 import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
@@ -326,7 +327,7 @@ public class EntityBuilder {
       userEntity.setFullname(profile.getFullName());
     }
     if (canViewProperties || isProfilePropertyVisible(Profile.POSITION)) {
-      userEntity.setPosition(profile.getPosition());
+      userEntity.setPosition(getProfilePropertyValue(profile, "position"));
     }
     if (canViewProperties || isProfilePropertyVisible(Profile.EMAIL)) {
       userEntity.setEmail(profile.getEmail());
@@ -487,12 +488,14 @@ public class EntityBuilder {
       if (propertySetting != null && propertySetting.isVisible()
           && !getProfilePropertyService().getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId()))
                                          .contains(propertySetting.getId())) {
-        userEntity.setPrimaryProperty((String) profile.getProperty(propertyName));
+        String primaryPropertyValue = getProfilePropertyValue(profile, propertyName);
+        userEntity.setPrimaryProperty(primaryPropertyValue);
       } else {
         userEntity.setPrimaryProperty("");
       }
     } else if (StringUtils.isNotBlank(userEntity.getPosition())) {
-      userEntity.setPrimaryProperty(userEntity.getPosition());
+      String positionValue = getProfilePropertyValue(profile, "position");
+      userEntity.setPrimaryProperty(positionValue);
     } else {
       userEntity.setPrimaryProperty("");
     }
@@ -502,12 +505,14 @@ public class EntityBuilder {
       if (propertySetting != null && propertySetting.isVisible()
           && !getProfilePropertyService().getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId()))
                                          .contains(propertySetting.getId())) {
-        userEntity.setSecondaryProperty((String) profile.getProperty(propertyName));
+        String secondaryPropertyValue = getProfilePropertyValue(profile, propertyName);
+        userEntity.setSecondaryProperty(secondaryPropertyValue);
       } else {
         userEntity.setSecondaryProperty("");
       }
     } else if (StringUtils.isNotBlank(userEntity.getTeam())) {
-      userEntity.setSecondaryProperty(userEntity.getTeam());
+      String teamValue = getProfilePropertyValue(profile, "team");
+      userEntity.setSecondaryProperty(teamValue);
     } else {
       userEntity.setSecondaryProperty("");
     }
@@ -518,17 +523,26 @@ public class EntityBuilder {
       if (propertySetting != null && propertySetting.isVisible()
           && !getProfilePropertyService().getHiddenProfilePropertyIds(Long.parseLong(userEntity.getId()))
                                          .contains(propertySetting.getId())) {
-        userEntity.setTertiaryProperty((String) profile.getProperty(propertyName));
+        String tertiaryPropertyValue = getProfilePropertyValue(profile, propertyName);
+        userEntity.setTertiaryProperty(tertiaryPropertyValue);
       } else {
         userEntity.setTertiaryProperty("");
       }
     } else if (StringUtils.isNotBlank(userEntity.getCity())) {
-      userEntity.setTertiaryProperty(userEntity.getCity());
+      String cityValue = getProfilePropertyValue(profile, "city");
+      userEntity.setTertiaryProperty(cityValue);
     } else {
       userEntity.setTertiaryProperty("");
     }
 
     return userEntity;
+  }
+  
+  private static String getProfilePropertyValue(Profile profile, String propertyName) {
+    ProfilePropertySetting propertySetting = getProfilePropertyService().getProfileSettingByName(propertyName);
+    String profilePropertyValue = (String) profile.getProperty(propertyName);
+    return propertySetting != null && propertySetting.isDropdownList()
+        && NumberUtils.isCreatable(profilePropertyValue) ? getTranslationService().getTranslationLabelOrDefault(PROFILE_PROPERTY_OBJECT_TYPE, Long.parseLong(profilePropertyValue), PROFILE_PROPERTY_FIELD_NAME, LocaleContextInfoUtils.getUserLocale(getCurrentUserName())) : profilePropertyValue;
   }
 
   private static void buildManagedUsersCount(ProfileEntity userEntity) {

--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -55,8 +55,8 @@
       <span v-if="$slots.subTitle" class="text-subtitle text-truncate my-auto text-left">
         <slot name="subTitle"></slot>
       </span>
-      <span v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate my-auto text-left">
-        {{ userPosition }}
+      <span v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate my-auto text-left">
+        {{ primaryProperty }}
       </span>
     </component>
     <component
@@ -100,8 +100,8 @@
         <p v-if="$slots.subTitle" class="text-subtitle text-truncate text-left mb-0">
           <slot name="subTitle"></slot>
         </p>
-        <p v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate text-left mb-0">
-          {{ userPosition }}
+        <p v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate text-left mb-0">
+          {{ primaryProperty }}
         </p>
       </div>
       <template v-if="$slots.actions">
@@ -164,8 +164,8 @@
       <span v-if="$slots.subTitle" class="text-subtitle text-truncate my-auto text-left">
         <slot name="subTitle"></slot>
       </span>
-      <span v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate my-auto text-left">
-        {{ userPosition }}
+      <span v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate my-auto text-left">
+        {{ primaryProperty }}
       </span>
     </component>
     <component
@@ -209,8 +209,8 @@
         <p v-if="$slots.subTitle" class="text-subtitle text-truncate text-left mb-0">
           <slot name="subTitle"></slot>
         </p>
-        <p v-else-if="displayPosition && userPosition" class="text-subtitle text-truncate text-left mb-0">
-          {{ userPosition }}
+        <p v-else-if="displayPrimaryProperty" class="text-subtitle text-truncate text-left mb-0">
+          {{ primaryProperty }}
         </p>
       </div>
       <template v-if="$slots.actions">
@@ -326,7 +326,7 @@ export default {
       type: Boolean,
       default: () => true
     },
-    displayPosition: {
+    displayPrimaryProperty: {
       type: Boolean,
       default: false
     },
@@ -367,9 +367,6 @@ export default {
     },
     userAvatarUrl() {
       return this.userIdentity?.enabled ? (this.userIdentity.avatar || this.avatarUrl || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.username || this.profileId}/avatar`) : (this.avatarUrl  || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/default-image/avatar`);
-    },
-    userPosition() {
-      return this.userIdentity?.position;
     },
     profileUrl() {
       if (this.url && !this.clickable && this.username) {
@@ -435,7 +432,7 @@ export default {
   },
   created() {
     if (this.username && this.mustRetrieveIdentity) {
-      this.$userService.getUser(this.username)
+      this.$userService.getUser(this.username, 'settings')
         .then(user => this.retrievedIdentity = user && JSON.parse(JSON.stringify(user)));
     }
   },

--- a/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCompactCard.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCompactCard.vue
@@ -84,7 +84,7 @@
             <a
               :href="url"
               class="grey--text text--darken-1">
-              {{ userPosition }}
+              {{ primaryProperty }}
             </a>
           </v-card-subtitle>
         </div>
@@ -142,8 +142,8 @@ export default {
     usernameClass() {
       return `${(!this.user.enabled || this.user.deleted) && 'text-subtitle' || 'primary--text text-truncate-2 mt-0'}`;
     },
-    userPosition() {
-      return this.user?.position || '';
+    primaryProperty() {
+      return this.user?.primaryProperty || '';
     },
     externalUser() {
       return this.user?.external === 'true';

--- a/webapp/src/main/webapp/vue-apps/platformAdminsWidget/components/AdminCard.vue
+++ b/webapp/src/main/webapp/vue-apps/platformAdminsWidget/components/AdminCard.vue
@@ -35,7 +35,7 @@
         </v-list-item-avatar>
         <v-list-item-content>
           <v-list-item-title>{{ fullName }}</v-list-item-title>
-          <v-list-item-subtitle>{{ position }}</v-list-item-subtitle>
+          <v-list-item-subtitle>{{ primaryProperty }}</v-list-item-subtitle>
         </v-list-item-content>
         <v-list-item-action @click="deleteAdminMembership()">
           <v-btn
@@ -68,8 +68,8 @@ export default {
     fullName() {
       return this.user?.fullname;
     },
-    position() {
-      return this.user?.position;
+    primaryProperty() {
+      return this.user?.primaryProperty;
     },
     userName() {
       return this.membership?.userName || this.membership?.remoteId;

--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormInviteUserListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormInviteUserListItem.vue
@@ -80,14 +80,14 @@ export default {
     fullName() {
       return this.user.fullname || this.user.profile?.fullName;
     },
-    position() {
-      return this.user.position || this.user.profile?.position;
+    primaryProperty() {
+      return this.user.primaryProperty;
     },
     email() {
       return this.user.email || this.user.profile?.email;
     },
     subtitle() {
-      return this.emailSubtitle ? this.email : this.position;
+      return this.emailSubtitle ? this.email : this.primaryProperty;
     },
     isSpace() {
       return this.user.providerId === 'space';

--- a/webapp/src/main/webapp/vue-apps/space-invitation/components/list/SpaceSettingRoleListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/space-invitation/components/list/SpaceSettingRoleListItem.vue
@@ -110,14 +110,14 @@ export default {
     fullName() {
       return this.user.fullname || this.user.profile?.fullName;
     },
-    position() {
-      return this.user.position || this.user.profile?.position;
+    primaryProperty() {
+      return this.user.primaryProperty;
     },
     email() {
       return this.user.email || this.user.profile?.email;
     },
     subtitle() {
-      return this.emailSubtitle ? this.email : this.position;
+      return this.emailSubtitle ? this.email : this.primaryProperty;
     },
     isSpace() {
       return this.user.providerId === 'space';

--- a/webapp/src/main/webapp/vue-apps/space-widget-managers/components/SpaceManagersApplication.vue
+++ b/webapp/src/main/webapp/vue-apps/space-widget-managers/components/SpaceManagersApplication.vue
@@ -55,7 +55,7 @@
               avatar-class="me-2"
               extra-class="mt-3"
               size="36"
-              display-position
+              display-primary-property
               bold-title />
           </div>
         </template>

--- a/webapp/src/main/webapp/vue-apps/spaces-list/components/space-card/menu/SpaceRoleListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list/components/space-card/menu/SpaceRoleListItem.vue
@@ -100,10 +100,7 @@ export default {
     },
     fullName() {
       return this.user.fullname || this.user.profile?.fullName;
-    },
-    position() {
-      return this.user.position || this.user.profile?.position;
-    },
+    }
   }
 };
 </script>


### PR DESCRIPTION


Prior to this change, wehen a profile property is using dropdown options, the displayed value is the property option id instead of the property value, this is due to a wrong computing of this kind of use profile properties from the backend.
After this change, we will ensure to calculate and send the needed use profile property value with the current user translation language.

Resolves https://github.com/Meeds-io/meeds/issues/3299