### PR TITLE
fix: Have an accessible name for published articles in stream - MEED-9171 - Meeds-io/meeds#3345

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -4,7 +4,7 @@
     :element="htmlElement"
     :href="link"
     :target="linkTarget"
-    :title="tooltipText"
+    :aria-label="$t('news.activity.clickToAccessArticle',{0: titleText})"
     :class="mainClass">
     <template v-if="useMobileView">
       <div class="border-box-sizing flex">
@@ -109,7 +109,6 @@
         <dynamic-html-element
           v-if="summary"
           :child="summaryElement"
-          :title="summaryTooltip"
           :class="bodyClass"
           class="text-wrap text-break reset-style-box rich-editor-content text-color"
           dir="auto" />
@@ -164,7 +163,6 @@ export default {
     title: null,
     titleTooltip: null,
     summary: null,
-    summaryTooltip: null,
     thumbnail: null,
     sourceLink: null,
     tooltip: null,
@@ -370,7 +368,6 @@ export default {
       }
       this.titleTooltip = this.$utils.htmlToText(this.title);
       this.summary = this.getSummary && this.$utils.trim(this.getSummary(this.activity, this.isActivityDetail));
-      this.summaryTooltip = this.$utils.htmlToText(this.summary);
       this.sourceLink = this.getSourceLink && this.getSourceLink(this.activity, this.isActivityDetail);
       this.tooltip = this.getTooltip && this.getTooltip(this.activity, this.isActivityDetail);
       if (this.supportsThumbnail) {


### PR DESCRIPTION
Before this change, when create an article and access to the stream page, a div containing a title=[the article content]. To fix this problem, add aria-label=Access to article: [Article Name] on the class a and delete title=[the article content] on the div. After this change, no tooltip is displayed in the activity and an aria-label added in the component which opens the activity detail.
Resolves https://github.com/Meeds-io/meeds/issues/3345