### PR TITLE
fix: Upgrade Hibernate to version 6.6 - Meeds-io/meeds#3365

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
@@ -28,6 +28,8 @@ import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
 import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
 import org.exoplatform.social.core.binding.spi.GroupSpaceBindingService;
 
+import io.meeds.common.ContainerTransactional;
+
 @DisallowConcurrentExecution
 public class QueueGroupSpaceBindingJob implements Job {
   private static final Log         LOG = ExoLogger.getLogger(QueueGroupSpaceBindingJob.class);
@@ -35,6 +37,7 @@ public class QueueGroupSpaceBindingJob implements Job {
   private GroupSpaceBindingService groupSpaceBindingService;
 
   @Override
+  @ContainerTransactional
   public void execute(JobExecutionContext context) throws JobExecutionException {
     groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
     LOG.info("Start treating GroupSpaceBinding queue");

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSGroupSpaceBindingStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSGroupSpaceBindingStorageImpl.java
@@ -217,7 +217,6 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
                                          .collect(Collectors.toList());
   }
 
-  @ExoTransactional
   public void deleteGroupBinding(long id) throws GroupSpaceBindingStorageException {
     GroupSpaceBindingEntity bindingEntity = groupSpaceBindingDAO.find(id);
     if (bindingEntity != null) {

--- a/component/core/src/test/java/io/meeds/social/category/AbstractCategoryConfigurationTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/AbstractCategoryConfigurationTest.java
@@ -68,6 +68,7 @@ public abstract class AbstractCategoryConfigurationTest extends AbstractSpringCo
   @After
   @SneakyThrows
   public void afterEach() {
+    restartTransaction();
     Category rootCategory = categoryService.getRootCategory(getAdminGroupIdentityId());
     categoryService.deleteCategory(rootCategory.getId(), ROOT_USER);
     end();

--- a/component/core/src/test/java/org/exoplatform/social/core/binding/spi/RDBMSGroupSpaceBindingStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/binding/spi/RDBMSGroupSpaceBindingStorageTest.java
@@ -20,6 +20,7 @@ package org.exoplatform.social.core.binding.spi;
 import java.util.Date;
 import java.util.List;
 
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
 import org.exoplatform.social.core.binding.model.GroupSpaceBindingOperationReport;
 import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
@@ -110,7 +111,10 @@ public class RDBMSGroupSpaceBindingStorageTest extends AbstractCoreTest {
                             .forEach(binding -> groupSpaceBindingStorage.deleteGroupBindingQueue(binding.getId()));
     groupSpaceBindingStorage.findAllGroupSpaceBinding()
                             .stream()
-                            .forEach(binding -> groupSpaceBindingStorage.deleteGroupBinding(binding.getId()));
+                            .forEach(binding -> {
+                              RequestLifeCycle.restartTransaction();
+                              groupSpaceBindingStorage.deleteGroupBinding(binding.getId());
+                            });
     
   }
 

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -954,8 +954,8 @@ public class ActivityManagerTest extends AbstractCoreTest {
 
     List<ExoSocialActivity> comments = activityManager.getCommentsWithListAccess(activity).loadAsList(0, 1);
     assertEquals(1, comments.size());
-    assertEquals(htmlRemovedString, comments.get(0).getBody());
-    assertEquals(htmlRemovedString, comments.get(0).getTitle());
+    assertEquals(htmlRemovedString.trim(), comments.get(0).getBody().trim());
+    assertEquals(htmlRemovedString.trim(), comments.get(0).getTitle().trim());
   }
 
   public void testGetCommentList() {

--- a/component/core/src/test/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessorTest.java
@@ -16,11 +16,7 @@
  */
 package org.exoplatform.social.core.processor;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.exoplatform.container.PortalContainer;
-import org.exoplatform.social.core.BaseActivityProcessorPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.test.AbstractCoreTest;
@@ -51,47 +47,50 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
 
   public void testProcessActivity() throws Exception {
     System.setProperty("gatein.email.domain.url", "test.com");
-    ExoSocialActivity activity = new ExoSocialActivityImpl();
-    String sample = "this is a <strong> tag to keep</strong>";
-    activity.setTitle(sample);
-    activity.setBody(sample);
-    processor.processActivity(activity);
-
-    assertEquals(sample, activity.getTitle());
-    assertEquals(sample, activity.getBody());
-
-    // tags with attributes
-    sample = "text <a href='test.com'>bar</a> zed";
-
-    activity.setTitle(sample);
-    processor.processActivity(activity);
-
-    assertEquals("text <a href=\"test.com\" rel=\"nofollow\" target=\"_self\">bar</a> zed", activity.getTitle());
-
-    // only with open tag
-    sample = "<strong> only open!!!";
-    activity.setTitle(sample);
-    processor.processActivity(activity);
-    assertEquals("<strong> only open!!!</strong>", activity.getTitle());
-
-    // self closing tags
-    sample = "<script href='#' />bar</a>";
-    activity.setTitle(sample);
-    processor.processActivity(activity);
-    assertEquals("bar", activity.getTitle());
-
-    // forbidden tag
-    sample = "<script>foo</script>";
-    activity.setTitle(sample);
-    processor.processActivity(activity);
-    assertEquals("", activity.getTitle());
-
-    // embedded
-    sample = "<span><strong>foo</strong>bar<script>zed</script></span>";
-    activity.setTitle(sample);
-    processor.processActivity(activity);
-    assertEquals("<strong>foo</strong>bar", activity.getTitle());
-    System.clearProperty("gatein.email.domain.url");
+    try {
+      ExoSocialActivity activity = new ExoSocialActivityImpl();
+      String sample = "this is a <strong> tag to keep</strong>";
+      activity.setTitle(sample);
+      activity.setBody(sample);
+      processor.processActivity(activity);
+  
+      assertEquals(sample, activity.getTitle());
+      assertEquals(sample, activity.getBody());
+  
+      // tags with attributes
+      sample = "text <a href='test.com'>bar</a> zed";
+  
+      activity.setTitle(sample);
+      processor.processActivity(activity);
+  
+      assertEquals("text <a href=\"test.com\" rel=\"nofollow\" target=\"_self\">bar</a> zed", activity.getTitle());
+  
+      // only with open tag
+      sample = "<strong> only open!!!";
+      activity.setTitle(sample);
+      processor.processActivity(activity);
+      assertEquals("<strong> only open!!!</strong>", activity.getTitle());
+  
+      // self closing tags
+      sample = "<script href='#' />bar</a>";
+      activity.setTitle(sample);
+      processor.processActivity(activity);
+      assertEquals("", activity.getTitle());
+  
+      // forbidden tag
+      sample = "<script>foo</script>";
+      activity.setTitle(sample);
+      processor.processActivity(activity);
+      assertEquals("", activity.getTitle());
+  
+      // embedded
+      sample = "<span><strong>foo</strong>bar<script>zed</script></span>";
+      activity.setTitle(sample);
+      processor.processActivity(activity);
+      assertEquals("<strong>foo</strong>bar", activity.getTitle().trim());
+    } finally {
+      System.clearProperty("gatein.email.domain.url");
+    }
   }
 
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/service/LinkProviderTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/service/LinkProviderTest.java
@@ -18,7 +18,6 @@ package org.exoplatform.social.core.service;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;


### PR DESCRIPTION
This change will upgrade Hibernate to version 6.6 which introduced a bug fix (as explained in https://discourse.hibernate.org/t/instance-save-transient-before/10293/2) which makes some operations buggy when made in the same transaction. This change ensures to split operations to not hit such a problem.