### PR TITLE
fix: The notification setting link must have an accessible name - MEED-9201 - Meeds-io/meeds#3366

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -47,12 +47,17 @@
         <span>{{ markingAsReadDisabled && $t('Notification.label.NoMarkAllAsRead') || $t('Notification.label.MarkAsRead', {0: $t(`Notification.label.types.${groupName}`)}) }}</span>
       </v-tooltip>
       <v-tooltip bottom>
-        <template #activator="{on, bind}">
+        <template #activator="{on, attrs}">
           <v-btn
             :href="settingsLink"
             icon
             v-on="on"
-            v-bind="bind"
+            v-bind="{
+            ...attrs,
+            'aria-label': $t('UIIntranetNotificationsPortlet.title.NotificationsSetting'),
+            role: null,
+            'aria-haspopup': null,
+            'aria-expanded': null}"
             @click="openSettings">
             <v-icon size="18" class="notifDrawerSettings">fa-sliders-h</v-icon>
           </v-btn>


### PR DESCRIPTION
Before this change, when accessing the notification settings link, The notification settings link doesn't have an accessible name. To fix this problem, add an aria-label to the button. After this change, add an aria-label attributes to the NotificationSettings with a text Notification settings.