### PR TITLE
fix: Login page - Indication of mandatory fields - MEED-9181 - Meeds-io/meeds#3353.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login/components/LoginMain.vue
+++ b/webapp/src/main/webapp/vue-apps/login/components/LoginMain.vue
@@ -86,6 +86,7 @@
             prepend-inner-icon="fas fa-lock ms-n2 grey--text text--lighten-1"
             class="login-password border-box-sizing"
             name="password"
+            aria-required="true"
             required="required"
             outlined
             dense


### PR DESCRIPTION
Before this change, when access to login page, the field Password are mandatory but it is missing an aria-required attribute equal to true. To fix this problem, add the attribute. After this change, the two fields Login and Password have two attributes aria-required and required.
Resolves https://github.com/Meeds-io/meeds/issues/3353