### PR TITLE
fix: Fix Display of Dynamic HTML Element Reusable Component - MEED-9219 - Meeds-io/meeds#3370

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -287,7 +287,7 @@ export default {
     },
     summaryElement() {
       return {
-        template: ExtendedDomPurify.purify(this.summary?.startsWith?.('<') ? this.summary : `<div>${this.summary}</div>`) || '',
+        template: ExtendedDomPurify.purify(`<div>${this.summary}</div>`) || '',
       };
     },
     titleElement() {


### PR DESCRIPTION
Prior to this change, when displaying a Kudos with html not embedded inside a single parent dom, the resulted element doesn't include all DOM children elements. To avoid this, a systematic Parent Element DOM is added to summary Vue template in Dynamic HTML Element Reusable Component.