### PR TITLE
fix: Set a suitable alt to thumbnail of published article - MEED-9198 - Meeds-io/meeds#3363

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -23,7 +23,7 @@
           <img
             v-if="thumbnail"
             :src="`${thumbnail}`"
-            alt=""
+            :alt="featuredThumbnailAltText"
             :class="thumbnailClass"
             :style="imageMobileStyle"
             class="my-auto"
@@ -66,7 +66,7 @@
         <img
           v-if="thumbnail"
           :src="thumbnail"
-          alt=""
+          :alt="featuredThumbnailAltText"
           :class="thumbnailClass"
           class="my-auto"
           loading="lazy"
@@ -334,7 +334,10 @@ export default {
     },
     activityViewsCount() {
       return this.activityViews?.viewsCount;
-    }
+    },
+    featuredThumbnailAltText() {
+      return this.activity?.news?.properties?.featuredImage?.altText || '';
+    },
   },
   watch: {
     activityTypeExtension(newVal, oldVal) {


### PR DESCRIPTION
Before this change, when create an article with thumbnail and publish it in the stream page, the thumbnail of the published article has alt empty. To fix this problem, add the alt text of activity properties otherwise keep the alt empty. After this change, the thumbnail alt text is displayed correctly.

(cherry picked from commit 311359dae6b233ea4c05650e7dad3ed60d60256e)