### PR TITLE
fix: Enable Branding Apply Button - MEED-9280 - Meeds-io/meeds#3397

### DIFF
--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
@@ -218,6 +218,7 @@ export default {
     changed() {
       return this.branding
           && (this.logoUploadId
+          || this.companyName !== this.defaultCompanyName
           || this.faviconUploadId
           || this.isTopBarStylingPropertiesChanged
           || this.isSideBarStylingPropertiesChanged


### PR DESCRIPTION
Prior to this change, when changing the company name, the button 'Apply' isn't enabled. This change ensures to enable the 'Apply' button when the company name is changed.

Resolves Meeds-io/meeds#3397