### PR TITLE
fix: User Global Stream doesn't list all activities - MEED-9287 - Meeds-io/meeds#3407

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -591,7 +591,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       break;
     case ALL_STREAM:
       streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
-                                                                     String.valueOf(SpaceMembershipStatus.MANAGER),
+                                                                     String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                      0,
                                                                      -1);
       streamIdentityIds = new ArrayList<>(streamIdentityIds);
@@ -671,7 +671,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       break;
     case ALL_STREAM:
       streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
-                                                                     String.valueOf(SpaceMembershipStatus.MANAGER),
+                                                                     String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                      0,
                                                                      -1);
       streamIdentityIds = new ArrayList<>(streamIdentityIds);

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mockito.Mockito;
 
+import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.commons.utils.PropertyManager;
@@ -50,7 +51,6 @@ import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.social.common.ObjectAlreadyExistsException;
 import org.exoplatform.social.common.RealtimeListAccess;
 import org.exoplatform.social.core.ActivityTypePlugin;
 import org.exoplatform.social.core.activity.ActivityFilter;
@@ -740,6 +740,32 @@ public class ActivityManagerTest extends AbstractCoreTest {
     activities = activitiesListAccess.loadAsList(0, activitiesListAccess.getSize());
     // then
     assertEquals(0, activities.size());
+  }
+
+  public void testLoadSpaceActivities() {
+    String activityTitle = "activity title";
+    String userId = johnIdentity.getId();
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    activity.setTitle(activityTitle);
+    activity.setUserId(userId);
+    Space space = createSpace("spaceTestActivity", "john", "demo");
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    activityManager.saveActivityNoReturn(spaceIdentity, activity);
+
+    ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
+
+    RealtimeListAccess<ExoSocialActivity> activitiesListAccess = activityManager.getActivitiesByFilterWithListAccess(johnIdentity, activityFilter);
+    assertTrue(activitiesListAccess.getSize() > 0);
+
+    List<ExoSocialActivity> activities = activitiesListAccess.loadAsList(0, activitiesListAccess.getSize());
+    assertFalse(activities.isEmpty());
+
+    List<String> activityIds = activitiesListAccess.loadIdsAsList(0, activitiesListAccess.getSize());
+    assertFalse(activityIds.isEmpty());
+
+    assertEquals(activity.getId(), activityIds.get(0));
+    assertEquals(activity.getId(), activities.get(0).getId());
   }
 
   /**


### PR DESCRIPTION
Prior to this change, when no filter is applied on global stream, the listed activities for a user includes only managed spaces. This change fix the list of spaces to include in general stream to apply space ids where the user is member of in addition to the spaces it's designated as manager.

Resolves Meeds-io/meeds#3407