### PR TITLE
fix: Fix people profile search when searched fields contain white spaces - MEED-9163_MEED-9174 - Meeds-io/meeds#3336_ Meeds-io/meeds#3338

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -529,7 +529,7 @@ public class ProfileSearchConnector {
                 } else {
                   searchedText = removeAccents(splittedValues[i]);
                 }
-                expression.append(" ").append(key).append(":").append(searchedText);
+                expression.append(" ").append(key.replace(" ", "\\\\ ")).append(":").append(searchedText);
               }
             }
             query.append("""
@@ -552,7 +552,7 @@ public class ProfileSearchConnector {
                         "query": "%s:%s"
                       }
                    }
-                  """.formatted(property.getPropertyName(), searchedText));
+                  """.formatted(property.getPropertyName().replace(" ", "\\\\ "), searchedText));
           }
           index++;
         }


### PR DESCRIPTION

Prior to this change, when searching people profile based on a field whose name contains white spaces, the result is not correct since the field name with spaces is not well considered by ES query. After this commit, to fix this problem, we will escape the white space for the field name used on the ES query.
Resolves https://github.com/Meeds-io/meeds/issues/3336 https://github.com/Meeds-io/meeds/issues/3338