### PR TITLE
fix: Status messages not rendered by assistive technologies - MEED-9172 - Meeds-io/meeds#3346

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/Notifications.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/Notifications.vue
@@ -49,6 +49,8 @@
         left: `${left}px`,
       }"
       :role="alertType"
+      aria-live="assertive"
+      :aria-atomic="true"
       v-touch="{
         start: moveStart,
         end: moveEnd,

--- a/webapp/src/main/webapp/vue-apps/common/components/Notifications.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/Notifications.vue
@@ -48,7 +48,7 @@
       :style="absolute && {
         left: `${left}px`,
       }"
-      :role="alertType"
+      role="alert"
       aria-live="assertive"
       :aria-atomic="true"
       v-touch="{


### PR DESCRIPTION
Before this change, when an alert is triggered, the status message is not rendered by assistive technologies, the rendering is done only by hovering over the status message, but not at the time of the action. To fix this problem, add an aria-atomic with an aria-live equal to assertive and change role to alert. After this change, status message is rendered by assistive technology.
Resolves https://github.com/Meeds-io/meeds/issues/3346