### PR TITLE
fix: Fix Loading Stream Activity Ids - MEED-9302 - Meeds-io/meeds#3416

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityFilter.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityFilter.java
@@ -33,6 +33,8 @@ public class ActivityFilter implements Serializable {
 
   private String             userId;
 
+  private String             posterId;
+
   private String             spaceId;
 
   private List<Long>         categoryIds;

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -590,6 +590,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       activityFilter.setShowPinned(true);
       break;
     case ALL_STREAM:
+      activityFilter.setPosterId(viewerIdentity.getId());
       streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                      String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                      0,
@@ -670,6 +671,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       activityFilter.setShowPinned(true);
       break;
     case ALL_STREAM:
+      activityFilter.setPosterId(viewerIdentity.getId());
       streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                      String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                      0,
@@ -703,7 +705,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
 
   @Override
   public int getActivitiesCountByFilter(Identity viewerIdentity, ActivityFilter activityFilter) {
-    List<String> spaceIdentityIds = null;
+    List<String> streamIdentityIds = null;
     switch (activityFilter.getStreamType()) {
     case USER_STREAM:
       activityFilter.setUserId(viewerIdentity.getId());
@@ -711,8 +713,8 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
     case USER_FAVORITE_STREAM:
       return getFavoriteActivities(viewerIdentity, activityFilter.getSpaceId()).size();
     case FAVORITE_SPACES_STREAM:
-      spaceIdentityIds = spaceStorage.getFavoriteSpaceIdentityIds(viewerIdentity.getRemoteId(), new SpaceFilter(), 0, -1);
-      if (CollectionUtils.isEmpty(spaceIdentityIds)) {
+      streamIdentityIds = spaceStorage.getFavoriteSpaceIdentityIds(viewerIdentity.getRemoteId(), new SpaceFilter(), 0, -1);
+      if (CollectionUtils.isEmpty(streamIdentityIds)) {
         return 0;
       }
       break;
@@ -731,20 +733,34 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
         }
       }
     case MANAGE_SPACES_STREAM:
-      spaceIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
-                                                                    String.valueOf(SpaceMembershipStatus.MANAGER),
-                                                                    0,
-                                                                    -1);
-      if (CollectionUtils.isEmpty(spaceIdentityIds)) {
+      streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
+                                                                     String.valueOf(SpaceMembershipStatus.MANAGER),
+                                                                     0,
+                                                                     -1);
+      if (CollectionUtils.isEmpty(streamIdentityIds)) {
         return 0;
       }
       break;
-    case ANY_SPACE_ACTIVITY, ALL_STREAM:
+    case ALL_STREAM:
+      activityFilter.setPosterId(viewerIdentity.getId());
+      streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
+                                                                     String.valueOf(SpaceMembershipStatus.MEMBER),
+                                                                     0,
+                                                                     -1);
+      streamIdentityIds = new ArrayList<>(streamIdentityIds);
+      streamIdentityIds.add(viewerIdentity.getId());
+      Set<Long> connectionIds = connectionDAO.getConnectionIds(Long.parseLong(viewerIdentity.getId()),
+                                                               org.exoplatform.social.core.relationship.model.Relationship.Type.CONFIRMED);
+      if (connectionIds != null) {
+        streamIdentityIds.addAll(connectionIds.stream().map(String::valueOf).toList());
+      }
+      break;
+    case ANY_SPACE_ACTIVITY:
       break;
     default:
       throw new UnsupportedOperationException();
     }
-    return activityDAO.getActivitiesCountByFilter(activityFilter, spaceIdentityIds);
+    return activityDAO.getActivitiesCountByFilter(activityFilter, streamIdentityIds);
   }
 
   public List<ExoSocialActivity> getFavoriteActivities(Identity viewerIdentity, String spaceId) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
@@ -55,7 +55,15 @@ import jakarta.persistence.TypedQuery;
  * May 18, 2015  
  */
 public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> implements ActivityDAO {
-  
+
+  private static final String        ACTIVITY_POSTER_ID        = "posterId";
+
+  private static final String        ACTIVITY_PROVIDER_ID        = "providerId";
+
+  private static final String        ACTIVITY_USER_ID          = "userId";
+
+  private static final String        ACTIVITY_OWNER_IDS        = "ownerIds";
+
   private static final String        STREAM_TYPE               = "streamType";
 
   private static final String        QUERY_FILTER_FIND_PREFIX  = "SocActivity.findAllActivities";
@@ -949,22 +957,20 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
     return query;
   }
 
-  private <T> void addQueryFilterParameters(ActivityFilter activityFilter, List<String> spaceIdentityIds, TypedQuery<T> query) {
+  private <T> void addQueryFilterParameters(ActivityFilter activityFilter, List<String> streamIdentityIds, TypedQuery<T> query) {
     if (activityFilter.getUserId() != null) {
-      query.setParameter("posterId", activityFilter.getUserId());
-      query.setParameter("streamTypes", Arrays.asList(StreamType.POSTER, StreamType.SPACE));
+      query.setParameter(ACTIVITY_USER_ID, activityFilter.getUserId());
     }
-    if (activityFilter.getSpaceId() != null) {
-      long ownerId = Long.parseLong(activityFilter.getSpaceId());
-      query.setParameter("ownerIds", Collections.singleton(ownerId));
-      query.setParameter("streamTypes", Arrays.asList(StreamType.SPACE));
-    } else if (CollectionUtils.isNotEmpty(spaceIdentityIds)) {
-      List<Long> owners = new ArrayList<>();
-      for (String id : spaceIdentityIds) {
-        owners.add(Long.parseLong(id));
+    if (CollectionUtils.isNotEmpty(streamIdentityIds) || activityFilter.getSpaceId() != null) {
+      if (activityFilter.getSpaceId() != null) {
+        query.setParameter(ACTIVITY_OWNER_IDS, Collections.singleton(activityFilter.getSpaceId()));
+      } else if (CollectionUtils.isNotEmpty(streamIdentityIds)) {
+        query.setParameter(ACTIVITY_OWNER_IDS, streamIdentityIds);
       }
-      query.setParameter("ownerIds", owners);
-      query.setParameter("streamTypes", Arrays.asList(StreamType.POSTER, StreamType.SPACE));
+      if (activityFilter.getPosterId() != null) {
+        query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getPosterId());
+        query.setParameter(ACTIVITY_PROVIDER_ID, OrganizationIdentityProvider.NAME);
+      }
     }
     if (CollectionUtils.isNotEmpty(activityFilter.getCategoryIds())) {
       query.setParameter("categoryIds", activityFilter.getCategoryIds());
@@ -976,18 +982,21 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
                                List<String> suffixes,
                                List<String> predicates) {
     if (activityFilter.getUserId() != null) {
-      suffixes.add("Poster");
-      predicates.add("item.activity.posterId = :posterId");
-      predicates.add("item.streamType in (:streamTypes)");
+      suffixes.add("UserStream");
+      predicates.add("activity.posterId = :userId");
     }
     if (CollectionUtils.isNotEmpty(streamIdentityIds) || activityFilter.getSpaceId() != null) {
-      suffixes.add("StreamType");
-      predicates.add("item.ownerId in (:ownerIds)");
-      predicates.add("item.streamType in (:streamTypes)");
+      if (activityFilter.getPosterId() == null) {
+        suffixes.add("StreamType");
+        predicates.add("activity.ownerId in (:ownerIds)");
+      } else {
+        suffixes.add("StreamTypeAndPoster");
+        predicates.add("(activity.ownerId in (:ownerIds) OR (activity.posterId = :posterId and activity.providerId = :providerId))");
+      }
     }
     if (activityFilter.isPinned()) {
       suffixes.add("Pinned");
-      predicates.add("item.activity.pinned = true");
+      predicates.add("activity.pinned = true");
     }
     if (CollectionUtils.isNotEmpty(activityFilter.getCategoryIds())) {
       suffixes.add("CategoryIds");
@@ -1005,15 +1014,15 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   }
 
   private String getQueryFilterContent(ActivityFilter activityFilter, List<String> predicates, boolean count) {
-    String querySelect = count ? "SELECT COUNT(item.activity.id)" : "SELECT DISTINCT(item.activity.id), item.activity.pinDate, item.updatedDate";
-    querySelect = querySelect + " FROM SocStreamItem item";
+    String querySelect = count ? "SELECT COUNT(DISTINCT activity.id)" : "SELECT DISTINCT(activity.id), activity.pinDate, activity.updatedDate updatedDate";
+    querySelect = querySelect + " FROM SocActivity activity";
 
-    String orderBy = activityFilter.isShowPinned() ? " ORDER BY item.activity.pinDate DESC NULLS LAST, item.updatedDate DESC NULLS LAST" : " ORDER BY item.updatedDate DESC NULLS LAST";
+    String orderBy = activityFilter.isShowPinned() ? " ORDER BY activity.pinDate DESC NULLS LAST, updatedDate DESC NULLS LAST" : " ORDER BY updatedDate DESC NULLS LAST";
 
     if (CollectionUtils.isNotEmpty(activityFilter.getCategoryIds())) {
-      querySelect += " INNER JOIN item.activity.categories cat ON cat.categoryId in :categoryIds";
+      querySelect += " INNER JOIN activity.categories cat ON cat.categoryId in :categoryIds";
     }
-    querySelect += " WHERE item.activity.hidden = false AND item.activity.parent IS NULL";
+    querySelect += " WHERE activity.hidden = false AND activity.parent IS NULL";
 
     String queryContent;
     if (predicates.isEmpty()) {

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
@@ -48,7 +48,7 @@ import org.exoplatform.social.core.storage.cache.loader.ServiceContext;
 import org.exoplatform.social.core.storage.cache.model.data.ActivityData;
 import org.exoplatform.social.core.storage.cache.model.data.IntegerData;
 import org.exoplatform.social.core.storage.cache.model.data.ListActivitiesData;
-import org.exoplatform.social.core.storage.cache.model.key.ActivityCountKey;
+import org.exoplatform.social.core.storage.cache.model.key.ActivityListKey;
 import org.exoplatform.social.core.storage.cache.model.key.ActivityKey;
 import org.exoplatform.social.core.storage.cache.model.key.ActivityType;
 import org.exoplatform.social.core.storage.cache.model.key.IdentityKey;
@@ -70,13 +70,13 @@ public class CachedActivityStorage implements ActivityStorage {
 
   private final ExoCache<ActivityKey, ActivityData>                                                       exoActivityCache;
 
-  private final ExoCache<ActivityCountKey, IntegerData>                                                   exoActivitiesCountCache;
+  private final ExoCache<ActivityListKey, IntegerData>                                                   exoActivitiesCountCache;
 
   private final ExoCache<ListActivitiesKey, ListActivitiesData>                                           exoActivitiesCache;
 
   private final FutureExoCache<ActivityKey, ActivityData, ServiceContext<ActivityData>>                   activityCache;
 
-  private final FutureExoCache<ActivityCountKey, IntegerData, ServiceContext<IntegerData>>                activitiesCountCache;
+  private final FutureExoCache<ActivityListKey, IntegerData, ServiceContext<IntegerData>>                activitiesCountCache;
 
   private final FutureExoCache<ListActivitiesKey, ListActivitiesData, ServiceContext<ListActivitiesData>> activitiesCache;
 
@@ -270,7 +270,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                                                                               throws ActivityStorageException {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), ActivityType.USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), ActivityType.USER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -294,7 +294,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                            final long limit) throws ActivityStorageException {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), ActivityType.USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), ActivityType.USER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
     //
     ListActivitiesData keys = activitiesCache.get(
@@ -408,7 +408,7 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfUserActivities(final Identity owner) throws ActivityStorageException {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), ActivityType.USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), ActivityType.USER);
 
     //
     return activitiesCountCache.get(
@@ -427,22 +427,21 @@ public class CachedActivityStorage implements ActivityStorage {
    */
   @Override
   public int getActivitiesCountByFilter(Identity viewerIdentity, ActivityFilter activityFilter) {
-
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(viewerIdentity), activityFilter);
-
+    ActivityListKey key = new ActivityListKey(new IdentityKey(viewerIdentity), activityFilter);
     return activitiesCountCache.get(() -> new IntegerData(storage.getActivitiesCountByFilter(viewerIdentity, activityFilter)),
                                     key)
                                .build();
 
   }
+
   /**
    * {@inheritDoc}
    */
   public int getNumberOfNewerOnUserActivities(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_USER);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_USER);
 
     //
     return activitiesCountCache.get(
@@ -465,7 +464,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                           final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.NEWER_USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.NEWER_USER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -492,8 +491,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfOlderOnUserActivities(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_USER);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_USER);
 
     //
     return activitiesCountCache.get(
@@ -516,7 +515,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                           final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_USER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -543,7 +542,7 @@ public class CachedActivityStorage implements ActivityStorage {
   public List<ExoSocialActivity> getActivityFeed(final Identity ownerIdentity, final int offset, final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -565,7 +564,7 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public List<String> getActivityIdsFeed(final Identity ownerIdentity, final int offset, final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
     //
     ListActivitiesData keys = activitiesCache.get(
@@ -596,8 +595,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfActivitesOnActivityFeed(final Identity ownerIdentity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
 
     //
     return activitiesCountCache.get(
@@ -617,8 +616,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfNewerOnActivityFeed(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_FEED);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_FEED);
 
     //
     return activitiesCountCache.get(
@@ -641,7 +640,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                         final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_FEED);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_FEED);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -667,8 +666,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfOlderOnActivityFeed(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_FEED);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_FEED);
 
     //
     return activitiesCountCache.get(
@@ -691,7 +690,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                         final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_FEED);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_FEED);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -717,7 +716,7 @@ public class CachedActivityStorage implements ActivityStorage {
   public List<ExoSocialActivity> getActivitiesOfConnections(final Identity ownerIdentity, final int offset, final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -741,7 +740,7 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public List<String> getActivityIdsOfConnections(final Identity ownerIdentity, final int offset, final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
     //
     ListActivitiesData keys = activitiesCache.get(
@@ -765,8 +764,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfActivitiesOfConnections(final Identity ownerIdentity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
 
     //
     return activitiesCountCache.get(
@@ -794,8 +793,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfNewerOnActivitiesOfConnections(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity),
                                               baseActivity.getId(),
                                               ActivityType.NEWER_CONNECTION);
 
@@ -820,7 +819,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                                    final long limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 baseActivity.getId(),
                                                 ActivityType.NEWER_CONNECTION);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
@@ -849,8 +848,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfOlderOnActivitiesOfConnections(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity),
                                               baseActivity.getId(),
                                               ActivityType.OLDER_CONNECTION);
 
@@ -875,7 +874,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                                    final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 baseActivity.getId(),
                                                 ActivityType.OLDER_CONNECTION);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
@@ -904,7 +903,7 @@ public class CachedActivityStorage implements ActivityStorage {
   public List<ExoSocialActivity> getUserSpacesActivities(final Identity ownerIdentity, final int offset, final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -927,7 +926,7 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public List<String> getUserSpacesActivityIds(final Identity ownerIdentity, final int offset, final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
     //
     ListActivitiesData keys = activitiesCache.get(
@@ -951,8 +950,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfUserSpacesActivities(final Identity ownerIdentity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
 
     //
     return activitiesCountCache.get(
@@ -972,8 +971,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfNewerOnUserSpacesActivities(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACES);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACES);
 
     //
     return activitiesCountCache.get(
@@ -996,7 +995,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                                 final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACES);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACES);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -1023,8 +1022,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfOlderOnUserSpacesActivities(final Identity ownerIdentity, final ExoSocialActivity baseActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACES);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACES);
 
     //
     return activitiesCountCache.get(
@@ -1047,7 +1046,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                                 final int limit) {
 
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACES);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACES);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -1088,7 +1087,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                              final int offset,
                                              final int limit,
                                              boolean sortDescending) {
-    ActivityCountKey key = new ActivityCountKey(existingActivity.getId(),
+    ActivityListKey key = new ActivityListKey(existingActivity.getId(),
                                                 loadSubComments ? ActivityType.COMMENTS_AND_SUB_COMMENTS : ActivityType.COMMENTS);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit, sortDescending);
 
@@ -1116,8 +1115,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfComments(final ExoSocialActivity existingActivity) {
 
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(existingActivity.getId(), ActivityType.COMMENTS);
+    ActivityListKey key =
+                         new ActivityListKey(existingActivity.getId(), ActivityType.COMMENTS);
 
     //
     return activitiesCountCache.get(
@@ -1189,7 +1188,7 @@ public class CachedActivityStorage implements ActivityStorage {
    */
   public int getNumberOfNewerOnActivityFeed(final Identity ownerIdentity, final Long sinceTime) {
 
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.NEWER_FEED);
 
@@ -1205,7 +1204,7 @@ public class CachedActivityStorage implements ActivityStorage {
    */
   public int getNumberOfNewerOnUserActivities(final Identity ownerIdentity, final Long sinceTime) {
 
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.NEWER_USER);
 
@@ -1221,7 +1220,7 @@ public class CachedActivityStorage implements ActivityStorage {
    */
   public int getNumberOfNewerOnActivitiesOfConnections(final Identity ownerIdentity, final Long sinceTime) {
 
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), sinceTime, ActivityType.NEWER_CONNECTION);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), sinceTime, ActivityType.NEWER_CONNECTION);
 
     return activitiesCountCache.get(new ServiceContext<IntegerData>() {
       public IntegerData execute() {
@@ -1234,7 +1233,7 @@ public class CachedActivityStorage implements ActivityStorage {
    * {@inheritDoc}
    */
   public int getNumberOfNewerOnUserSpacesActivities(final Identity ownerIdentity, final Long sinceTime) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.NEWER_SPACE);
 
@@ -1249,8 +1248,8 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public int getNumberOfSpaceActivities(final Identity spaceIdentity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(spaceIdentity), ActivityType.SPACE);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(spaceIdentity), ActivityType.SPACE);
 
     //
     return activitiesCountCache.get(
@@ -1266,8 +1265,8 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public int getNumberOfSpaceActivitiesForUpgrade(final Identity spaceIdentity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(spaceIdentity), ActivityType.SPACE_FOR_UPGRADE);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(spaceIdentity), ActivityType.SPACE_FOR_UPGRADE);
 
     //
     IntegerData countData = activitiesCountCache.get(
@@ -1278,8 +1277,8 @@ public class CachedActivityStorage implements ActivityStorage {
                                                      },
                                                      key);
 
-    ActivityCountKey keySpace =
-                              new ActivityCountKey(new IdentityKey(spaceIdentity), ActivityType.SPACE);
+    ActivityListKey keySpace =
+                              new ActivityListKey(new IdentityKey(spaceIdentity), ActivityType.SPACE);
     exoActivitiesCountCache.putLocal(keySpace, countData);
 
     return countData.build();
@@ -1288,7 +1287,7 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public List<ExoSocialActivity> getSpaceActivities(final Identity ownerIdentity, final int offset, final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACE);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1310,7 +1309,7 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public List<String> getSpaceActivityIds(final Identity spaceIdentity, final int offset, final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(spaceIdentity), ActivityType.SPACE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(spaceIdentity), ActivityType.SPACE);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
     //
     ListActivitiesData keys = activitiesCache.get(
@@ -1330,7 +1329,7 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public List<ExoSocialActivity> getSpaceActivitiesForUpgrade(final Identity ownerIdentity, final int offset, final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACE);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1355,7 +1354,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                        final int offset,
                                                        final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(posterIdentity), ActivityType.POSTER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(posterIdentity), ActivityType.POSTER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1380,7 +1379,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                        final int limit,
                                                        final String... activityTypes) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(posterIdentity), ActivityType.POSTER, activityTypes);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(posterIdentity), ActivityType.POSTER, activityTypes);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1403,8 +1402,8 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public int getNumberOfActivitiesByPoster(final Identity posterIdentity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(posterIdentity), ActivityType.POSTER);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(posterIdentity), ActivityType.POSTER);
 
     //
     return activitiesCountCache.get(
@@ -1420,8 +1419,8 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public int getNumberOfActivitiesByPoster(final Identity ownerIdentity, final Identity viewerIdentity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity),
                                               new IdentityKey(viewerIdentity),
                                               ActivityType.POSTER);
 
@@ -1442,7 +1441,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                            final ExoSocialActivity baseActivity,
                                                            final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACE);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -1466,8 +1465,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfNewerOnSpaceActivities(final Identity ownerIdentity,
                                                final ExoSocialActivity baseActivity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACE);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.NEWER_SPACE);
 
     //
     return activitiesCountCache.get(
@@ -1486,7 +1485,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                            final ExoSocialActivity baseActivity,
                                                            final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACE);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     //
@@ -1510,8 +1509,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public int getNumberOfOlderOnSpaceActivities(final Identity ownerIdentity,
                                                final ExoSocialActivity baseActivity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACE);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), baseActivity.getId(), ActivityType.OLDER_SPACE);
 
     //
     return activitiesCountCache.get(
@@ -1527,7 +1526,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfNewerOnSpaceActivities(final Identity ownerIdentity, final Long sinceTime) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.NEWER_SPACE);
 
@@ -1540,7 +1539,7 @@ public class CachedActivityStorage implements ActivityStorage {
   }
 
   public List<ExoSocialActivity> getNewerFeedActivities(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_FEED);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_FEED);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1554,7 +1553,7 @@ public class CachedActivityStorage implements ActivityStorage {
   }
 
   public List<ExoSocialActivity> getNewerSpaceActivities(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_SPACE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_SPACE);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1569,7 +1568,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public List<ExoSocialActivity> getNewerUserActivities(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_USER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1584,7 +1583,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public List<ExoSocialActivity> getNewerUserSpacesActivities(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_SPACES);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_SPACES);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1599,7 +1598,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public List<ExoSocialActivity> getNewerActivitiesOfConnections(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_CONNECTION);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.NEWER_CONNECTION);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1618,7 +1617,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                final long offset,
                                                final long limit) throws ActivityStorageException {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), new IdentityKey(viewer), ActivityType.VIEWER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), new IdentityKey(viewer), ActivityType.VIEWER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1641,7 +1640,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public List<ExoSocialActivity> getOlderFeedActivities(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.OLDER_FEED);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.OLDER_FEED);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1656,7 +1655,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public List<ExoSocialActivity> getOlderUserActivities(final Identity ownerIdentity, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), sinceTime, ActivityType.OLDER_USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), sinceTime, ActivityType.OLDER_USER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1673,7 +1672,7 @@ public class CachedActivityStorage implements ActivityStorage {
   public List<ExoSocialActivity> getOlderUserSpacesActivities(final Identity ownerIdentity,
                                                               final Long sinceTime,
                                                               final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), sinceTime, ActivityType.OLDER_SPACES);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), sinceTime, ActivityType.OLDER_SPACES);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1688,7 +1687,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public List<ExoSocialActivity> getOlderActivitiesOfConnections(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.OLDER_CONNECTION);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.OLDER_CONNECTION);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1703,7 +1702,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public List<ExoSocialActivity> getOlderSpaceActivities(final Identity owner, final Long sinceTime, final int limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), sinceTime, ActivityType.OLDER_SPACE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), sinceTime, ActivityType.OLDER_SPACE);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1718,7 +1717,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfOlderOnActivityFeed(final Identity ownerIdentity, final Long sinceTime) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.OLDER_FEED);
 
@@ -1731,7 +1730,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfOlderOnUserActivities(final Identity ownerIdentity, final Long sinceTime) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.OLDER_USER);
 
@@ -1744,7 +1743,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfOlderOnActivitiesOfConnections(final Identity ownerIdentity, final Long sinceTime) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.OLDER_CONNECTION);
 
@@ -1757,7 +1756,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfOlderOnUserSpacesActivities(final Identity ownerIdentity, final Long sinceTime) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.OLDER_SPACES);
 
@@ -1770,7 +1769,7 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfOlderOnSpaceActivities(final Identity ownerIdentity, final Long sinceTime) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity),
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity),
                                                 sinceTime,
                                                 ActivityType.OLDER_SPACE);
 
@@ -1785,8 +1784,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public List<ExoSocialActivity> getNewerComments(final ExoSocialActivity existingActivity,
                                                   final Long sinceTime,
                                                   final int limit) {
-    ActivityCountKey key =
-                         new ActivityCountKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.NEWER_COMMENTS);
+    ActivityListKey key =
+                         new ActivityListKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.NEWER_COMMENTS);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1803,8 +1802,8 @@ public class CachedActivityStorage implements ActivityStorage {
   public List<ExoSocialActivity> getOlderComments(final ExoSocialActivity existingActivity,
                                                   final Long sinceTime,
                                                   final int limit) {
-    ActivityCountKey key =
-                         new ActivityCountKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.OLDER_COMMENTS);
+    ActivityListKey key =
+                         new ActivityListKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.OLDER_COMMENTS);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, limit);
 
     ListActivitiesData keys = activitiesCache.get(new ServiceContext<ListActivitiesData>() {
@@ -1819,8 +1818,8 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfNewerComments(final ExoSocialActivity existingActivity, final Long sinceTime) {
-    ActivityCountKey key =
-                         new ActivityCountKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.NEWER_COMMENTS);
+    ActivityListKey key =
+                         new ActivityListKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.NEWER_COMMENTS);
 
     return activitiesCountCache.get(new ServiceContext<IntegerData>() {
       public IntegerData execute() {
@@ -1831,8 +1830,8 @@ public class CachedActivityStorage implements ActivityStorage {
 
   @Override
   public int getNumberOfOlderComments(final ExoSocialActivity existingActivity, final Long sinceTime) {
-    ActivityCountKey key =
-                         new ActivityCountKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.OLDER_COMMENTS);
+    ActivityListKey key =
+                         new ActivityListKey(new ActivityKey(existingActivity.getId()), sinceTime, ActivityType.OLDER_COMMENTS);
 
     return activitiesCountCache.get(new ServiceContext<IntegerData>() {
       public IntegerData execute() {
@@ -1846,7 +1845,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                              final long offset,
                                                              final long limit) throws ActivityStorageException {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), ActivityType.USER);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), ActivityType.USER);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1870,26 +1869,30 @@ public class CachedActivityStorage implements ActivityStorage {
                                                        ActivityFilter activityFilter,
                                                        long offset,
                                                        long limit) {
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(viewerIdentity), activityFilter);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(viewerIdentity), activityFilter);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
-
     ListActivitiesData keys = activitiesCache.get(() -> {
-      List<ExoSocialActivity> got = storage.getActivitiesByFilter(viewerIdentity, activityFilter, offset, limit);
-      return buildIds(got);
+      List<String> got = storage.getActivityIdsByFilter(viewerIdentity, activityFilter, offset, limit);
+      return buildActivityIds(got);
     }, listKey);
-
     return buildActivities(keys);
   }
 
   @Override
   public List<String> getActivityIdsByFilter(Identity viewerIdentity, ActivityFilter activityFilter, long offset, long limit) {
-    return storage.getActivityIdsByFilter(viewerIdentity, activityFilter, offset, limit);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(viewerIdentity), activityFilter);
+    ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
+    ListActivitiesData keys = activitiesCache.get(() -> {
+      List<String> got = storage.getActivityIdsByFilter(viewerIdentity, activityFilter, offset, limit);
+      return buildActivityIds(got);
+    }, listKey);
+    return buildActivityIds(keys);
   }
 
   @Override
   public int getNumberOfUserActivitiesForUpgrade(final Identity owner) throws ActivityStorageException {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(owner), ActivityType.USER_FOR_UPGRADE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(owner), ActivityType.USER_FOR_UPGRADE);
 
     //
     IntegerData countData = activitiesCountCache.get(
@@ -1901,8 +1904,8 @@ public class CachedActivityStorage implements ActivityStorage {
                                                      key);
 
     //
-    ActivityCountKey keyUser =
-                             new ActivityCountKey(new IdentityKey(owner), ActivityType.USER);
+    ActivityListKey keyUser =
+                             new ActivityListKey(new IdentityKey(owner), ActivityType.USER);
     exoActivitiesCountCache.putLocal(keyUser, countData);
 
     //
@@ -1915,7 +1918,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                            final int offset,
                                                            final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1938,7 +1941,7 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public int getNumberOfActivitesOnActivityFeedForUpgrade(final Identity ownerIdentity) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.FEED_FOR_UPGRADE);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.FEED_FOR_UPGRADE);
 
     //
     IntegerData countData = activitiesCountCache.get(
@@ -1950,8 +1953,8 @@ public class CachedActivityStorage implements ActivityStorage {
                                                      key);
 
     //
-    ActivityCountKey keyFeed =
-                             new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
+    ActivityListKey keyFeed =
+                             new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.FEED);
     exoActivitiesCountCache.putLocal(keyFeed, countData);
 
     //
@@ -1963,7 +1966,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                                       final int offset,
                                                                       final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -1986,8 +1989,8 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public int getNumberOfActivitiesOfConnectionsForUpgrade(final Identity ownerIdentity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION_FOR_UPGRADE);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION_FOR_UPGRADE);
 
     //
     IntegerData countData = activitiesCountCache.get(
@@ -1999,8 +2002,8 @@ public class CachedActivityStorage implements ActivityStorage {
                                                      key);
 
     //
-    ActivityCountKey keyConnection =
-                                   new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
+    ActivityListKey keyConnection =
+                                   new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.CONNECTION);
     exoActivitiesCountCache.putLocal(keyConnection, countData);
 
     //
@@ -2012,7 +2015,7 @@ public class CachedActivityStorage implements ActivityStorage {
                                                                    final int offset,
                                                                    final int limit) {
     //
-    ActivityCountKey key = new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
+    ActivityListKey key = new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
     ListActivitiesKey listKey = new ListActivitiesKey(key, offset, limit);
 
     //
@@ -2035,8 +2038,8 @@ public class CachedActivityStorage implements ActivityStorage {
   @Override
   public int getNumberOfUserSpacesActivitiesForUpgrade(final Identity ownerIdentity) {
     //
-    ActivityCountKey key =
-                         new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACES_FOR_UPGRADE);
+    ActivityListKey key =
+                         new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACES_FOR_UPGRADE);
 
     //
     IntegerData countData = activitiesCountCache.get(
@@ -2047,8 +2050,8 @@ public class CachedActivityStorage implements ActivityStorage {
                                                      },
                                                      key);
 
-    ActivityCountKey keySpaces =
-                               new ActivityCountKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
+    ActivityListKey keySpaces =
+                               new ActivityListKey(new IdentityKey(ownerIdentity), ActivityType.SPACES);
     exoActivitiesCountCache.putLocal(keySpaces, countData);
 
     return countData.build();
@@ -2100,7 +2103,7 @@ public class CachedActivityStorage implements ActivityStorage {
    * {@inheritDoc}
    */
   public List<ExoSocialActivity> getSubComments(ExoSocialActivity comment) {
-    ActivityCountKey key = new ActivityCountKey(comment.getId(), ActivityType.SUB_COMMENTS);
+    ActivityListKey key = new ActivityListKey(comment.getId(), ActivityType.SUB_COMMENTS);
     ListActivitiesKey listKey = new ListActivitiesKey(key, 0, Integer.MAX_VALUE);
 
     //

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedRelationshipStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedRelationshipStorage.java
@@ -44,7 +44,7 @@ import org.exoplatform.social.core.storage.cache.model.data.ListActivitiesData;
 import org.exoplatform.social.core.storage.cache.model.data.ListIdentitiesData;
 import org.exoplatform.social.core.storage.cache.model.data.RelationshipData;
 import org.exoplatform.social.core.storage.cache.model.data.SuggestionsData;
-import org.exoplatform.social.core.storage.cache.model.key.ActivityCountKey;
+import org.exoplatform.social.core.storage.cache.model.key.ActivityListKey;
 import org.exoplatform.social.core.storage.cache.model.key.IdentityFilterKey;
 import org.exoplatform.social.core.storage.cache.model.key.IdentityKey;
 import org.exoplatform.social.core.storage.cache.model.key.ListActivitiesKey;
@@ -80,7 +80,7 @@ public class CachedRelationshipStorage implements RelationshipStorage {
 
   private final ExoCache<SuggestionKey, SuggestionsData>                                                     exoSuggestionCache;
 
-  private final ExoCache<ActivityCountKey, IntegerData>                                                      exoActivitiesCountCache;
+  private final ExoCache<ActivityListKey, IntegerData>                                                      exoActivitiesCountCache;
 
   private final ExoCache<ListActivitiesKey, ListActivitiesData>                                              exoActivitiesCache;
 

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/SocialStorageCacheService.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/SocialStorageCacheService.java
@@ -31,7 +31,7 @@ import org.exoplatform.social.core.storage.cache.model.data.ProfileData;
 import org.exoplatform.social.core.storage.cache.model.data.RelationshipData;
 import org.exoplatform.social.core.storage.cache.model.data.SpaceData;
 import org.exoplatform.social.core.storage.cache.model.data.SuggestionsData;
-import org.exoplatform.social.core.storage.cache.model.key.ActivityCountKey;
+import org.exoplatform.social.core.storage.cache.model.key.ActivityListKey;
 import org.exoplatform.social.core.storage.cache.model.key.ActivityKey;
 import org.exoplatform.social.core.storage.cache.model.key.IdentityCompositeKey;
 import org.exoplatform.social.core.storage.cache.model.key.IdentityFilterKey;
@@ -73,7 +73,7 @@ public class SocialStorageCacheService {
 
   // ActivityStorage
   private final ExoCache<ActivityKey, ActivityData> activityCache;
-  private final ExoCache<ActivityCountKey, IntegerData> activitiesCountCache;
+  private final ExoCache<ActivityListKey, IntegerData> activitiesCountCache;
   private final ExoCache<ListActivitiesKey, ListActivitiesData> activitiesCache;
 
   // SpaceStorage
@@ -161,7 +161,7 @@ public class SocialStorageCacheService {
     return activityCache;
   }
 
-  public ExoCache<ActivityCountKey, IntegerData> getActivitiesCountCache() {
+  public ExoCache<ActivityListKey, IntegerData> getActivitiesCountCache() {
     return activitiesCountCache;
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/ActivityListKey.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/ActivityListKey.java
@@ -26,7 +26,7 @@ import org.exoplatform.social.core.activity.ActivityFilter;
  * @author <a href="mailto:alain.defrance@exoplatform.com">Alain Defrance</a>
  * @version $Revision$
  */
-public class ActivityCountKey implements CacheKey {
+public class ActivityListKey implements CacheKey {
   private static final long serialVersionUID = -2153747306033203041L;
 
   private IdentityKey key;
@@ -45,47 +45,47 @@ public class ActivityCountKey implements CacheKey {
   
   private String[] activityTypes;
 
-  public ActivityCountKey(final IdentityKey key, final ActivityType type) {
+  public ActivityListKey(final IdentityKey key, final ActivityType type) {
     this.key = key;
     this.type = type;
   }
   
-  public ActivityCountKey(final IdentityKey key, final ActivityType type, final String...activityTypes) {
+  public ActivityListKey(final IdentityKey key, final ActivityType type, final String...activityTypes) {
     this.key = key;
     this.type = type;
     this.activityTypes = activityTypes;
   }
   
-  public ActivityCountKey(final IdentityKey key, final IdentityKey viewerKey, final ActivityType type) {
+  public ActivityListKey(final IdentityKey key, final IdentityKey viewerKey, final ActivityType type) {
     this.key = key;
     this.type = type;
     this.viewerKey = viewerKey;
   }
 
-  public ActivityCountKey(final IdentityKey key, final String baseId, final ActivityType type) {
+  public ActivityListKey(final IdentityKey key, final String baseId, final ActivityType type) {
     this.key = key;
     this.baseId = baseId;
     this.type = type;
   }
 
-  public ActivityCountKey(final IdentityKey key, final Long time, final ActivityType type) {
+  public ActivityListKey(final IdentityKey key, final Long time, final ActivityType type) {
     this.key = key;
     this.time = time;
     this.type = type;
   }
   
-  public ActivityCountKey(final ActivityKey activityKey, final Long time, final ActivityType type) {
+  public ActivityListKey(final ActivityKey activityKey, final Long time, final ActivityType type) {
     this.activityKey = activityKey;
     this.time = time;
     this.type = type;
   }
   
-  public ActivityCountKey(final String baseId, final ActivityType type) {
+  public ActivityListKey(final String baseId, final ActivityType type) {
     this.baseId = baseId;
     this.type = type;
   }
 
-  public ActivityCountKey(IdentityKey key, ActivityFilter activityFilter) {
+  public ActivityListKey(IdentityKey key, ActivityFilter activityFilter) {
     this.key = key;
     this.activityFilter = activityFilter;
   }
@@ -103,11 +103,11 @@ public class ActivityCountKey implements CacheKey {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ActivityCountKey)) {
+    if (!(o instanceof ActivityListKey)) {
       return false;
     }
 
-    ActivityCountKey that = (ActivityCountKey) o;
+    ActivityListKey that = (ActivityListKey) o;
 
     if (baseId != null ? !baseId.equals(that.baseId) : that.baseId != null) {
       return false;

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/ListActivitiesKey.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/ListActivitiesKey.java
@@ -28,13 +28,13 @@ import org.exoplatform.social.core.storage.cache.model.data.ListIdentitiesData;
  */
 public class ListActivitiesKey extends ListCacheKey {
 
-  private final ActivityCountKey   key;
+  private final ActivityListKey   key;
 
   private final ListIdentitiesData identities;
 
   private final boolean            sortDescending;
 
-  public ListActivitiesKey(final ActivityCountKey key, final long offset, final long limit) {
+  public ListActivitiesKey(final ActivityListKey key, final long offset, final long limit) {
     this(key, offset, limit, false);
   }
 
@@ -42,7 +42,7 @@ public class ListActivitiesKey extends ListCacheKey {
     this(identities, offset, limit, false);
   }
 
-  public ListActivitiesKey(final ActivityCountKey key, final long offset, final long limit, boolean sortDescending) {
+  public ListActivitiesKey(final ActivityListKey key, final long offset, final long limit, boolean sortDescending) {
     super(offset, limit);
     this.key = key;
     this.identities = null;
@@ -56,7 +56,7 @@ public class ListActivitiesKey extends ListCacheKey {
     this.sortDescending = sortDescending;
   }
 
-  public ActivityCountKey getKey() {
+  public ActivityListKey getKey() {
     return key;
   }
 

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -61,6 +61,7 @@ import org.exoplatform.social.core.activity.model.ActivityStream;
 import org.exoplatform.social.core.activity.model.ActivityStreamImpl;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
+import org.exoplatform.social.core.application.RelationshipPublisher;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -76,6 +77,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.ActivityStorageException;
 import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
 import org.exoplatform.social.core.storage.cache.CachedIdentityStorage;
 import org.exoplatform.social.core.test.AbstractCoreTest;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
@@ -1546,7 +1548,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
                  parentActivity.getUserId());
   }
 
-  public void testGetActivitiiesByUser() throws ActivityStorageException {
+  public void testGetActivitiesByUser() throws ActivityStorageException {
     String activityTitle = "title";
     String userId = rootIdentity.getId();
     ExoSocialActivity activity = new ExoSocialActivityImpl();
@@ -1581,7 +1583,97 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(21, activityList.size());
   }
 
-  public void testGetActivitiiesByCategoryIds() throws ActivityStorageException {
+  public void testGetActivitiesByUserAndConnectionsAndSpaces() throws ActivityStorageException {
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'john' user stream by 'john'");
+    activity.setUserId(johnIdentity.getId());
+    activityManager.saveActivityNoReturn(johnIdentity, activity);
+
+    activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'mary' user stream by 'demo'");
+    activity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(maryIdentity, activity);
+
+    Space space = this.getSpaceInstance(0);
+    restartTransaction();
+
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    RealtimeListAccess<ExoSocialActivity> spaceActivitiesListAccess = activityManager.getActivitiesOfSpaceWithListAccess(spaceIdentity);
+    if (spaceActivitiesListAccess.getSize() > 0) {
+      // Ensure that automatic Space Activity is removed
+      assertEquals(1, spaceActivitiesListAccess.getSize());
+      activityManager.deleteActivity(spaceActivitiesListAccess.loadIdsAsList(0, 1).get(0));
+      restartTransaction();
+    }
+
+    ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
+
+    RealtimeListAccess<ExoSocialActivity> activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals("Demo activity posted to mary stream must be the only activity to return", 1, activities.getSize());
+    assertEquals(1, activities.loadAsList(0, 100).size());
+    assertEquals(1, activities.loadIdsAsList(0, 100).size());
+
+    relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
+    relationshipManager.confirm(demoIdentity, johnIdentity);
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    if (activities.getSize() > 1) {
+      // Ensure that automatic Relationship Activity is removed
+      List<ExoSocialActivity> activityList = activities.loadAsList(0, 100);
+      activityList.stream()
+                  .filter(a -> StringUtils.equals(a.getType(), RelationshipPublisher.USER_ACTIVITIES_FOR_RELATIONSHIP))
+                  .forEach(activityManager::deleteActivity);
+      restartTransaction();
+      activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    }
+    assertEquals("Demo activity posted to mary stream and john's stream activity must be the only activities to return", 2, activities.getSize());
+    assertEquals(2, activities.loadAsList(0, 100).size());
+    assertEquals(2, activities.loadIdsAsList(0, 100).size());
+
+    // demo posts activities to space
+    for (int i = 0; i < 10; i++) {
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title: " + i);
+      activity.setUserId(johnIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+    }
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(12, activities.getSize());
+    assertEquals(12, activities.loadAsList(0, 100).size());
+    assertEquals(12, activities.loadIdsAsList(0, 100).size());
+
+    spaceService.removeMember(space, demoIdentity.getRemoteId());
+    ((CachedActivityStorage) activityStorage).clearCache();
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(2, activities.getSize());
+    assertEquals(2, activities.loadAsList(0, 100).size());
+    assertEquals(2, activities.loadIdsAsList(0, 100).size());
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(johnIdentity, activityFilter);
+    assertEquals(11, activities.getSize());
+    assertEquals(11, activities.loadAsList(0, 100).size());
+    assertEquals(11, activities.loadIdsAsList(0, 100).size());
+
+    relationshipManager.deny(demoIdentity, johnIdentity);
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(1, activities.getSize());
+    assertEquals(1, activities.loadAsList(0, 100).size());
+    assertEquals(1, activities.loadIdsAsList(0, 100).size());
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(johnIdentity, activityFilter);
+    assertEquals(11, activities.getSize());
+    assertEquals(11, activities.loadAsList(0, 100).size());
+    assertEquals(11, activities.loadIdsAsList(0, 100).size());
+  }
+
+  public void testGetActivitiesByCategoryIds() throws ActivityStorageException {
     String activityTitle = "title";
     String userId = rootIdentity.getId();
     ExoSocialActivity activity = new ExoSocialActivityImpl();

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -48,7 +48,6 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.portal.application.localization.LocalizationFilter;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -70,7 +69,6 @@ import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.exoplatform.social.core.storage.api.ActivityStorage;
 import org.exoplatform.social.rest.api.EntityBuilder;
 import org.exoplatform.social.rest.api.RestUtils;
 import org.exoplatform.social.rest.entity.ActivityEntity;


### PR DESCRIPTION
Prior to this change, when loading General Activity Stream and having users confirmed relationships, then the list of retrieved activities includes the relationships posted activities even in spaces the current user is not member of. Due to this, the list of retrieved ids are less than the really displayed activities to the end user since the user doesn't have access to all activities (unless, it's a platform administrator). This change will ensure to include only activities posted in designated streams rather than testing on Stream Items (which is created to each space member). Thus, the returned activities will include only:
- Activities from spaces where the user is member of
- Activities from user connections personal stream
- Activities posted by current user, even those posted on users stream who aren't a con firmed connection (case of Kudos Activity by example).