### PR TITLE
fix: Latest commented Activities has to be displayed at first - MEED-9308 - Meeds-io/meeds#3421

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -56,19 +56,23 @@ import jakarta.persistence.TypedQuery;
  */
 public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> implements ActivityDAO {
 
-  private static final String        ACTIVITY_POSTER_ID        = "posterId";
+  private static final List<StreamType> MAIN_STREAM_TYPES         = List.of(StreamType.SPACE, StreamType.POSTER);
 
-  private static final String        ACTIVITY_PROVIDER_ID        = "providerId";
+  private static final String           MAIN_STREAM_TYPES_PARAM   = "mainStreamTypes";
 
-  private static final String        ACTIVITY_USER_ID          = "userId";
+  private static final String           ACTIVITY_POSTER_ID        = "posterId";
 
-  private static final String        ACTIVITY_OWNER_IDS        = "ownerIds";
+  private static final String           ACTIVITY_PROVIDER_ID      = "providerId";
 
-  private static final String        STREAM_TYPE               = "streamType";
+  private static final String           ACTIVITY_USER_ID          = "userId";
 
-  private static final String        QUERY_FILTER_FIND_PREFIX  = "SocActivity.findAllActivities";
+  private static final String           ACTIVITY_OWNER_IDS        = "ownerIds";
 
-  private static final String        QUERY_FILTER_COUNT_PREFIX = "SocActivity.countAllActivities";
+  private static final String           STREAM_TYPE               = "streamType";
+
+  private static final String           QUERY_FILTER_FIND_PREFIX  = "SocActivity.findAllActivities";
+
+  private static final String           QUERY_FILTER_COUNT_PREFIX = "SocActivity.countAllActivities";
 
   private final Map<String, Boolean> filterNamedQueries        = new HashMap<>();
 
@@ -953,11 +957,17 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
       filterNamedQueries.put(queryName, true);
     }
 
-    addQueryFilterParameters(activityFilter, streamIdentityIds, query);
+    addQueryFilterParameters(activityFilter, streamIdentityIds, query, count);
     return query;
   }
 
-  private <T> void addQueryFilterParameters(ActivityFilter activityFilter, List<String> streamIdentityIds, TypedQuery<T> query) {
+  private <T> void addQueryFilterParameters(ActivityFilter activityFilter,
+                                            List<String> streamIdentityIds,
+                                            TypedQuery<T> query,
+                                            boolean count) {
+    if (!count) {
+      query.setParameter(MAIN_STREAM_TYPES_PARAM, MAIN_STREAM_TYPES);
+    }
     if (activityFilter.getUserId() != null) {
       query.setParameter(ACTIVITY_USER_ID, activityFilter.getUserId());
     }
@@ -1014,11 +1024,14 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   }
 
   private String getQueryFilterContent(ActivityFilter activityFilter, List<String> predicates, boolean count) {
-    String querySelect = count ? "SELECT COUNT(DISTINCT activity.id)" : "SELECT DISTINCT(activity.id), activity.pinDate, activity.updatedDate updatedDate";
+    String querySelect = count ? "SELECT COUNT(DISTINCT activity.id)" : "SELECT DISTINCT(activity.id), activity.pinDate, item.updatedDate updatedDate";
     querySelect = querySelect + " FROM SocActivity activity";
 
     String orderBy = activityFilter.isShowPinned() ? " ORDER BY activity.pinDate DESC NULLS LAST, updatedDate DESC NULLS LAST" : " ORDER BY updatedDate DESC NULLS LAST";
 
+    if (!count) {
+      querySelect += " INNER JOIN activity.streamItems item ON item.streamType in (:mainStreamTypes)";
+    }
     if (CollectionUtils.isNotEmpty(activityFilter.getCategoryIds())) {
       querySelect += " INNER JOIN activity.categories cat ON cat.categoryId in :categoryIds";
     }

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -1548,7 +1548,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
                  parentActivity.getUserId());
   }
 
-  public void testGetActivitiesByUser() throws ActivityStorageException {
+  public void testGetActivitiesByUser() {
     String activityTitle = "title";
     String userId = rootIdentity.getId();
     ExoSocialActivity activity = new ExoSocialActivityImpl();
@@ -1583,7 +1583,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(21, activityList.size());
   }
 
-  public void testGetActivitiesByUserAndConnectionsAndSpaces() throws ActivityStorageException {
+  public void testGetActivitiesByUserAndConnectionsAndSpaces() {
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("Post activity to 'john' user stream by 'john'");
     activity.setUserId(johnIdentity.getId());
@@ -1597,14 +1597,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     Space space = this.getSpaceInstance(0);
     restartTransaction();
 
-    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
-    RealtimeListAccess<ExoSocialActivity> spaceActivitiesListAccess = activityManager.getActivitiesOfSpaceWithListAccess(spaceIdentity);
-    if (spaceActivitiesListAccess.getSize() > 0) {
-      // Ensure that automatic Space Activity is removed
-      assertEquals(1, spaceActivitiesListAccess.getSize());
-      activityManager.deleteActivity(spaceActivitiesListAccess.loadIdsAsList(0, 1).get(0));
-      restartTransaction();
-    }
+    deleteSpaceAutomaticActivities(space);
 
     ActivityFilter activityFilter = new ActivityFilter();
     activityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
@@ -1618,21 +1611,14 @@ public class ActivityManagerTest extends AbstractCoreTest {
     relationshipManager.confirm(demoIdentity, johnIdentity);
     restartTransaction();
 
+    deleteRelationshipAutomaticActivities(demoIdentity);
     activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
-    if (activities.getSize() > 1) {
-      // Ensure that automatic Relationship Activity is removed
-      List<ExoSocialActivity> activityList = activities.loadAsList(0, 100);
-      activityList.stream()
-                  .filter(a -> StringUtils.equals(a.getType(), RelationshipPublisher.USER_ACTIVITIES_FOR_RELATIONSHIP))
-                  .forEach(activityManager::deleteActivity);
-      restartTransaction();
-      activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
-    }
     assertEquals("Demo activity posted to mary stream and john's stream activity must be the only activities to return", 2, activities.getSize());
     assertEquals(2, activities.loadAsList(0, 100).size());
     assertEquals(2, activities.loadIdsAsList(0, 100).size());
 
     // demo posts activities to space
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
     for (int i = 0; i < 10; i++) {
       activity = new ExoSocialActivityImpl();
       activity.setTitle("Activity Title: " + i);
@@ -1671,6 +1657,92 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(11, activities.getSize());
     assertEquals(11, activities.loadAsList(0, 100).size());
     assertEquals(11, activities.loadIdsAsList(0, 100).size());
+  }
+
+  public void testGetActivitiesWithLastCommentedFirst() {
+    ExoSocialActivity johnActivity = new ExoSocialActivityImpl();
+    johnActivity.setTitle("Post activity to 'john' user stream by 'john'");
+    johnActivity.setUserId(johnIdentity.getId());
+    activityManager.saveActivityNoReturn(johnIdentity, johnActivity);
+
+    ExoSocialActivity maryActivity = new ExoSocialActivityImpl();
+    maryActivity.setTitle("Post activity to 'mary' user stream by 'demo'");
+    maryActivity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(maryIdentity, maryActivity);
+
+    Space space = this.getSpaceInstance(0);
+    restartTransaction();
+
+    relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
+    relationshipManager.confirm(demoIdentity, johnIdentity);
+    restartTransaction();
+
+    deleteSpaceAutomaticActivities(space);
+    deleteRelationshipAutomaticActivities(demoIdentity);
+    restartTransaction();
+
+    // demo posts activities to space
+    List<ExoSocialActivity> spaceActivities = new ArrayList<>();
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    for (int i = 0; i < 10; i++) {
+      ExoSocialActivity activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title: " + i);
+      activity.setUserId(johnIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+      spaceActivities.add(0, activity);
+    }
+    restartTransaction();
+
+    ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
+    RealtimeListAccess<ExoSocialActivity> activitiesListAccess = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(12, activitiesListAccess.getSize());
+
+    List<ExoSocialActivity> activities = activitiesListAccess.loadAsList(0, 100);
+    assertEquals(12, activities.size());
+
+    List<String> activityIds = activitiesListAccess.loadIdsAsList(0, 100);
+    assertEquals(12, activityIds.size());
+
+    for (int i = 0; i < activities.size(); i++) {
+      assertEquals(activityIds.get(i), activities.get(i).getId());
+    }
+
+    for (int i = 0; i < spaceActivities.size(); i++) {
+      assertEquals(String.format("Activity n°%s doesn't match", i),
+                   activityIds.get(i),
+                   spaceActivities.get(i).getId());
+    }
+    assertEquals(activityIds.get(10), maryActivity.getId());
+    assertEquals(activityIds.get(11), johnActivity.getId());
+
+    ExoSocialActivity johnActivityComment = new ExoSocialActivityImpl();
+    johnActivityComment.setTitle("John's activity comment");
+    johnActivityComment.setUserId(rootIdentity.getId());
+    activityManager.saveComment(johnActivity, johnActivityComment);
+
+    activitiesListAccess = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(12, activitiesListAccess.getSize());
+
+    activities = activitiesListAccess.loadAsList(0, 100);
+    assertEquals(johnActivity.getId(), activities.get(0).getId());
+
+    activityIds = activitiesListAccess.loadIdsAsList(0, 100);
+    assertEquals(johnActivity.getId(), activityIds.get(0));
+
+    ExoSocialActivity maryActivityComment = new ExoSocialActivityImpl();
+    maryActivityComment.setTitle("Mary's activity comment");
+    maryActivityComment.setUserId(rootIdentity.getId());
+    activityManager.saveComment(maryActivity, maryActivityComment);
+
+    activitiesListAccess = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(12, activitiesListAccess.getSize());
+
+    activities = activitiesListAccess.loadAsList(0, 100);
+    assertEquals(maryActivity.getId(), activities.get(0).getId());
+
+    activityIds = activitiesListAccess.loadIdsAsList(0, 100);
+    assertEquals(maryActivity.getId(), activityIds.get(0));
   }
 
   public void testGetActivitiesByCategoryIds() throws ActivityStorageException {
@@ -2954,6 +3026,31 @@ public class ActivityManagerTest extends AbstractCoreTest {
       identityManager.updateIdentity(identity);
     }
     return identityManager.getOrCreateUserIdentity(username);
+  }
+
+  private void deleteSpaceAutomaticActivities(Space space) {
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    RealtimeListAccess<ExoSocialActivity> spaceActivitiesListAccess = activityManager.getActivitiesOfSpaceWithListAccess(spaceIdentity);
+    if (spaceActivitiesListAccess.getSize() > 0) {
+      // Ensure that automatic Space Activity is removed
+      assertEquals(1, spaceActivitiesListAccess.getSize());
+      activityManager.deleteActivity(spaceActivitiesListAccess.loadIdsAsList(0, 1).get(0));
+      restartTransaction();
+    }
+  }
+
+  private void deleteRelationshipAutomaticActivities(Identity identity) {
+    ActivityFilter userActivityFilter = new ActivityFilter();
+    userActivityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
+    RealtimeListAccess<ExoSocialActivity> userActivities = activityManager.getActivitiesByFilterWithListAccess(identity, userActivityFilter);
+    if (userActivities.getSize() > 1) {
+      // Ensure that automatic Relationship Activity is removed
+      List<ExoSocialActivity> activityList = userActivities.loadAsList(0, 100);
+      activityList.stream()
+                  .filter(a -> StringUtils.equals(a.getType(), RelationshipPublisher.USER_ACTIVITIES_FOR_RELATIONSHIP))
+                  .forEach(activityManager::deleteActivity);
+      restartTransaction();
+    }
   }
 
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.social.rest.impl.activity;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -133,34 +132,18 @@ public class ActivityRest implements ResourceContainer {
   )
   public Response getActivities( // NOSONAR
                                 @Context UriInfo uriInfo,
-                                @Parameter(
-                                    description = "Space technical identifier",
-                                    required = false
-                                )
+                                @Parameter(description = "Space technical identifier", required = false)
                                 @QueryParam("spaceId") String spaceId,
                                 @Parameter(description = "Category id used to search associated activities", required = false)
                                 @QueryParam("categoryId")
                                 List<Long> categoryIds,
-                                @Parameter(
-                                    description = "offset time to use for searching newer activities until a time identified using format yyyy-MM-dd HH:mm:ss",
-                                    required = false
-                                ) @Schema(defaultValue = "0")
-                                @QueryParam("beforeTime") String beforeTime,
-                                @Parameter(
-                                    description = "offset time to use for searching newer activities since a time identified using format yyyy-MM-dd HH:mm:ss",
-                                    required = false
-                                ) @Schema(defaultValue = "0")
-                                @QueryParam("afterTime") String afterTime,
                                 @Parameter(description = "Offset", required = false)
                                 @QueryParam("offset") int offset,
                                 @Parameter(description = "Limit", required = false) @Schema(defaultValue = "20")
                                 @QueryParam("limit") int limit,
                                 @Parameter(description = "Returning the number of activities or not") @Schema(defaultValue = "false")
                                 @QueryParam("returnSize") boolean returnSize,
-                                @Parameter(
-                                    description = "Asking for a full representation of a specific subresource, ex: <em>comments</em> or <em>likes</em>",
-                                    required = false
-                                )
+                                @Parameter(description = "Asking for a full representation of a specific subresource, ex: <em>comments</em> or <em>likes</em>", required = false)
                                 @QueryParam("expand") String expand,
                                 @Parameter(description = "Activity stream type. Possible values: ALL_STREAM, USER_STREAM, USER_FAVORITE_STREAM, MANAGE_SPACES_STREAM, FAVORITE_SPACES_STREAM.", required = false)
                                 @QueryParam("streamType") ActivityStreamType streamType) {
@@ -177,7 +160,6 @@ public class ActivityRest implements ResourceContainer {
     }
 
     boolean canPost;
-    RealtimeListAccess<ExoSocialActivity> listAccess;
     ActivityFilter activityFilter = new ActivityFilter();
     activityFilter.setCategoryIds(categoryIds);
     if (!StringUtils.isBlank(spaceId)) {
@@ -196,16 +178,10 @@ public class ActivityRest implements ResourceContainer {
       activityFilter.setStreamType(streamType);
     } else if (StringUtils.isNotBlank(spaceId)) {
       activityFilter.setStreamType(ActivityStreamType.ANY_SPACE_ACTIVITY);
-    } else if (CollectionUtils.isNotEmpty(categoryIds)) {
+    } else {
       activityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
     }
-    if (!StringUtils.isEmpty(activityFilter.getSpaceId())
-        || activityFilter.getStreamType() != null
-        || CollectionUtils.isNotEmpty(categoryIds)) {
-      listAccess = activityManager.getActivitiesByFilterWithListAccess(currentUserIdentity, activityFilter);
-    } else {
-      listAccess = activityManager.getActivityFeedWithListAccess(currentUserIdentity);
-    }
+    RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getActivitiesByFilterWithListAccess(currentUserIdentity, activityFilter);
 
     String entitiesName = null;
     List<DataEntity> activityEntities = null;
@@ -220,22 +196,7 @@ public class ActivityRest implements ResourceContainer {
       }).toList();
       entitiesName = EntityBuilder.ACTIVITY_IDS_TYPE;
     } else {
-      List<ExoSocialActivity> activities = null;
-      if (StringUtils.isNotBlank(afterTime)) {
-        try {
-          activities = listAccess.loadNewer(RestUtils.getBaseTime(afterTime), limit);
-        } catch (ParseException e) {
-          return Response.status(Status.BAD_REQUEST).entity("afterTime Date has to be of format yyyy-MM-dd HH:mm:ss").build();
-        }
-      } else if (StringUtils.isNotBlank(beforeTime)) {
-        try {
-          activities = listAccess.loadOlder(RestUtils.getBaseTime(beforeTime), limit);
-        } catch (ParseException e) {
-          return Response.status(Status.BAD_REQUEST).entity("afterTime Date has to be of format yyyy-MM-dd HH:mm:ss").build();
-        }
-      } else {
-        activities = listAccess.loadAsList(offset, limit);
-      }
+      List<ExoSocialActivity> activities = listAccess.loadAsList(offset, limit);
       activityEntities = convertToEntities(activities, currentUserIdentity, uriInfo, expand);
       entitiesName = EntityBuilder.ACTIVITIES_TYPE;
     }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -48,7 +48,6 @@ import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
-import org.exoplatform.deprecation.DeprecatedAPI;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.rest.UserFieldValidator;
 import org.exoplatform.services.log.ExoLogger;
@@ -1485,45 +1484,6 @@ public class UserRest implements ResourceContainer, Startable {
       collectionSpace.setSize(commonSpacesAccessList.getSize());
     }
     return EntityBuilder.getResponse(collectionSpace, uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);
-  }
-
-  @POST
-  @Path("{id}/activities")
-  @RolesAllowed("users")
-  @Operation(
-      summary = "Creates an activity by a specific user",
-      method = "POST",
-      description = "This creates the activity if the given user is the authenticated user.")
-  @Deprecated
-  @DeprecatedAPI(value = "Use ActivityRestResourcesV1.postActivity instead", insist = true)
-  public Response addActivityByUser(@Context UriInfo uriInfo,
-                                    @Parameter(description = "User name", required = true) @PathParam("id") String id,
-                                    @Parameter(description = "Asking for a full representation of a specific subresource, ex: <em>comments</em> or <em>likes</em>") @QueryParam("expand") String expand,
-                                    @RequestBody(description = "Activity object to be created, in which the title of activity is required, ex: <br/>{\"title\": \"act4 posted\"}", required = true) ActivityEntity model) throws Exception {
-    return activityRestResourcesV1.postActivity(uriInfo, null, expand, model);
-  }
-
-  @GET
-  @Path("{id}/activities")
-  @RolesAllowed("users")
-  @Operation(
-      summary = "Gets activities of a specific user",
-      method = "GET",
-      description = "This returns an activity in the list in the following cases: " +
-          "<br/><ul><li>this is a user activity and the owner of the activity is the authenticated user or one of his connections</li>" +
-          "<li>this is a space activity and the authenticated user is a member of the space</li></ul>")
-  @Deprecated
-  @DeprecatedAPI(value = "Use ActivityRestResourcesV1.getActivities instead", insist = true)
-  public Response getActivitiesOfUser(@Context UriInfo uriInfo,
-                                      @Parameter(description = "User name", required = true) @PathParam("id") String id,
-                                      @Parameter(description = "Activity stream type, ex: <em>owner, connections, spaces</em> or <em>all</em>") @Schema(defaultValue = "all") @QueryParam("type") String type,
-                                      @Parameter(description = "Offset") @Schema(defaultValue = "0") @QueryParam("offset") int offset,
-                                      @Parameter(description = "Limit") @Schema(defaultValue = "20") @QueryParam("limit") int limit,
-                                      @Parameter(description = "Base time to load older activities (yyyy-MM-dd HH:mm:ss)") @QueryParam("before") String before,
-                                      @Parameter(description = "Base time to load newer activities (yyyy-MM-dd HH:mm:ss)") @QueryParam("after") String after,
-                                      @Parameter(description = "Returning the number of activities or not") @Schema(defaultValue = "false") @QueryParam("returnSize") boolean returnSize,
-                                      @Parameter(description = "Asking for a full representation of a specific subresource, ex: <em>comments</em> or <em>likes</em>") @QueryParam("expand") String expand) throws Exception {
-    return activityRestResourcesV1.getActivities(uriInfo, null, null, before, after, offset, limit, returnSize, expand, null);
   }
 
   @POST


### PR DESCRIPTION
Prior to this change, when commenting an activity, it's not displayed at first position in the stream. This is due to the fact that the activities retrieval by filter is using activity update date rather than Associated Stream Item (of Type POSTER or SPACE only) Update Date. This change will change the used sort field in order to sort activities using the associated Stream Items update date which is updated when commenting an activity rather than the activity update date field.
In addition, this change will drop previously deprecated endpoint which retrieves User Activities (which is replaced by another centralized Endpoint)