### PR TITLE
fix : Add validators when using Social Rest Endpoint to create users - MEED-9303

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -538,6 +538,7 @@ public class UserRest implements ResourceContainer, Startable {
       @ApiResponse (responseCode = "200", description = "Request fulfilled"),
       @ApiResponse (responseCode = "400", description = "Invalid query input") })
   public Response addUser(@Context UriInfo uriInfo,
+                          @Context HttpServletRequest request,
                           @Parameter(description = "Asking for a full representation of a specific subresource if any") @QueryParam("expand") String expand,
                           @RequestBody(description = "User object to be created, ex:<br />" +
                               "{<br />\"username\": \"john\"," +
@@ -564,13 +565,40 @@ public class UserRest implements ResourceContainer, Startable {
       throw new WebApplicationException(Response.Status.FORBIDDEN);
     }
 
+    Locale locale = request == null ? Locale.ENGLISH : request.getLocale();
+
+    String errorMessage = USERNAME_VALIDATOR.validate(locale, model.getUsername());
+    if (StringUtils.isNotBlank(errorMessage)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("USERNAME:" + errorMessage).build();
+    }
+
+    errorMessage = PASSWORD_VALIDATOR.validate(locale, model.getPassword());
+    if (StringUtils.isNotBlank(errorMessage)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("PASSWORD:" + errorMessage).build();
+    }
+
+    errorMessage = LASTNAME_VALIDATOR.validate(locale, model.getLastname());
+    if (StringUtils.isNotBlank(errorMessage)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("LASTNAME:" + errorMessage).build();
+    }
+
+    errorMessage = FIRSTNAME_VALIDATOR.validate(locale, model.getFirstname());
+    if (StringUtils.isNotBlank(errorMessage)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("FIRSTNAME:" + errorMessage).build();
+    }
+
+    errorMessage = EMAIL_VALIDATOR.validate(locale, model.getEmail());
+    if (StringUtils.isNotBlank(errorMessage)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("EMAIL:" + errorMessage).build();
+    }
+
     //Create new user
     UserHandler userHandler = organizationService.getUserHandler();
     User user = userHandler.createUserInstance(model.getUsername());
     user.setFirstName(model.getFirstname());
     user.setLastName(model.getLastname());
     user.setEmail(model.getEmail());
-    user.setPassword(model.getPassword() == null || model.getPassword().isEmpty() ? "exo" : model.getPassword());
+    user.setPassword(model.getPassword());
     userHandler.createUser(user, true);
     //
     return EntityBuilder.getResponse(EntityBuilder.buildEntityProfile(model.getUsername(), uriInfo.getPath(), expand), uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);


### PR DESCRIPTION
Before this fix, when calling Social endpoint to create users, there was any validators like for Portal Endpoint This commit add the validators on username, password, email, firstname and lastname

Resolves meeds-io/meeds#3417

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
