### PR TITLE
fix: Displaying a Space Stream displays User Activities as well - MEED-9314 - Meeds-io/meeds#3428

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityFilter.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityFilter.java
@@ -35,7 +35,7 @@ public class ActivityFilter implements Serializable {
 
   private String             posterId;
 
-  private String             spaceId;
+  private String             spaceIdentityId;
 
   private List<Long>         categoryIds;
 

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -541,13 +541,30 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
                                                        ActivityFilter activityFilter,
                                                        long offset,
                                                        long limit) {
+    if (activityFilter.getSpaceIdentityId() != null) {
+      Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
+      if (spaceIdentity == null || spaceIdentity.isDeleted() || !spaceIdentity.isEnable()) {
+        return Collections.emptyList();
+      } else {
+        Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
+        if (space == null || !ArrayUtils.contains(space.getMembers(), viewerIdentity.getRemoteId())) {
+          return Collections.emptyList();
+        }
+      }
+    }
     List<String> streamIdentityIds = null;
     switch (activityFilter.getStreamType()) {
     case USER_STREAM:
       activityFilter.setUserId(viewerIdentity.getId());
+      if (activityFilter.getSpaceIdentityId() == null) {
+        streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
+                                                                       String.valueOf(SpaceMembershipStatus.MEMBER),
+                                                                       0,
+                                                                       -1);
+      }
       break;
     case USER_FAVORITE_STREAM:
-      List<ExoSocialActivity> activities = getFavoriteActivities(viewerIdentity, activityFilter.getSpaceId());
+      List<ExoSocialActivity> activities = getFavoriteActivities(viewerIdentity, activityFilter.getSpaceIdentityId());
       return StorageUtils.subList(activities, (int) offset, (int) limit);
     case FAVORITE_SPACES_STREAM:
       streamIdentityIds = spaceStorage.getFavoriteSpaceIdentityIds(viewerIdentity.getRemoteId(), new SpaceFilter(), 0, -1);
@@ -557,18 +574,18 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       break;
     case UNREAD_SPACES_STREAM:
       List<Long> activityIds;
-      if (StringUtils.isBlank(activityFilter.getSpaceId())) {
+      if (StringUtils.isBlank(activityFilter.getSpaceIdentityId())) {
         activityIds = spaceWebNotificationService.getUnreadActivityIds(viewerIdentity.getRemoteId(), offset, limit);
       } else {
         try {
           activityIds = spaceWebNotificationService.getUnreadActivityIdsBySpace(viewerIdentity.getRemoteId(),
-                                                                                Long.parseLong(activityFilter.getSpaceId()),
+                                                                                Long.parseLong(activityFilter.getSpaceIdentityId()),
                                                                                 offset,
                                                                                 limit);
         } catch (Exception e) {
           throw new IllegalStateException(String.format("Unable to retrieve activities for user %s with filtered space %s",
                                                         viewerIdentity.getRemoteId(),
-                                                        activityFilter.getSpaceId()),
+                                                        activityFilter.getSpaceIdentityId()),
                                           e);
         }
       }
@@ -587,6 +604,9 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case ANY_SPACE_ACTIVITY:
+      if (activityFilter.getSpaceIdentityId() == null) {
+        return Collections.emptyList();
+      }
       activityFilter.setShowPinned(true);
       break;
     case ALL_STREAM:
@@ -615,13 +635,30 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
 
   @Override
   public List<String> getActivityIdsByFilter(Identity viewerIdentity, ActivityFilter activityFilter, long offset, long limit) {
+    if (activityFilter.getSpaceIdentityId() != null) {
+      Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
+      if (spaceIdentity == null || spaceIdentity.isDeleted() || !spaceIdentity.isEnable()) {
+        return Collections.emptyList();
+      } else {
+        Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
+        if (space == null || !ArrayUtils.contains(space.getMembers(), viewerIdentity.getRemoteId())) {
+          return Collections.emptyList();
+        }
+      }
+    }
     List<String> streamIdentityIds = null;
     switch (activityFilter.getStreamType()) {
     case USER_STREAM:
       activityFilter.setUserId(viewerIdentity.getId());
+      if (activityFilter.getSpaceIdentityId() == null) {
+        streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
+                                                                       String.valueOf(SpaceMembershipStatus.MEMBER),
+                                                                       0,
+                                                                       -1);
+      }
       break;
     case USER_FAVORITE_STREAM:
-      List<String> activityIds = getFavoriteActivities(viewerIdentity, activityFilter.getSpaceId()).stream()
+      List<String> activityIds = getFavoriteActivities(viewerIdentity, activityFilter.getSpaceIdentityId()).stream()
                                                                                                    .map(ExoSocialActivity::getId)
                                                                                                    .collect(Collectors.toList());
       return StorageUtils.subList(activityIds, (int) offset, (int) limit);
@@ -633,11 +670,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       break;
     case UNREAD_SPACES_STREAM:
       List<Long> unreadActivityIds;
-      if (StringUtils.isBlank(activityFilter.getSpaceId())) {
+      if (StringUtils.isBlank(activityFilter.getSpaceIdentityId())) {
         unreadActivityIds = spaceWebNotificationService.getUnreadActivityIds(viewerIdentity.getRemoteId(), offset, limit);
       } else {
         try {
-          Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceId());
+          Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
           if (spaceIdentity == null || !spaceIdentity.isEnable() || spaceIdentity.isDeleted() || !spaceIdentity.isSpace()) {
             return Collections.emptyList();
           }
@@ -649,7 +686,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
         } catch (Exception e) {
           throw new IllegalStateException(String.format("Unable to retrieve activities for user %s with filtered space %s",
                                                         viewerIdentity.getRemoteId(),
-                                                        activityFilter.getSpaceId()),
+                                                        activityFilter.getSpaceIdentityId()),
                                           e);
         }
       }
@@ -668,6 +705,9 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case ANY_SPACE_ACTIVITY:
+      if (activityFilter.getSpaceIdentityId() == null) {
+        return Collections.emptyList();
+      }
       activityFilter.setShowPinned(true);
       break;
     case ALL_STREAM:
@@ -705,13 +745,30 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
 
   @Override
   public int getActivitiesCountByFilter(Identity viewerIdentity, ActivityFilter activityFilter) {
+    if (activityFilter.getSpaceIdentityId() != null) {
+      Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
+      if (spaceIdentity == null || spaceIdentity.isDeleted() || !spaceIdentity.isEnable()) {
+        return 0;
+      } else {
+        Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
+        if (space == null || !ArrayUtils.contains(space.getMembers(), viewerIdentity.getRemoteId())) {
+          return 0;
+        }
+      }
+    }
     List<String> streamIdentityIds = null;
     switch (activityFilter.getStreamType()) {
     case USER_STREAM:
       activityFilter.setUserId(viewerIdentity.getId());
+      if (activityFilter.getSpaceIdentityId() == null) {
+        streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
+                                                                       String.valueOf(SpaceMembershipStatus.MEMBER),
+                                                                       0,
+                                                                       -1);
+      }
       break;
     case USER_FAVORITE_STREAM:
-      return getFavoriteActivities(viewerIdentity, activityFilter.getSpaceId()).size();
+      return getFavoriteActivities(viewerIdentity, activityFilter.getSpaceIdentityId()).size();
     case FAVORITE_SPACES_STREAM:
       streamIdentityIds = spaceStorage.getFavoriteSpaceIdentityIds(viewerIdentity.getRemoteId(), new SpaceFilter(), 0, -1);
       if (CollectionUtils.isEmpty(streamIdentityIds)) {
@@ -719,16 +776,16 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case UNREAD_SPACES_STREAM:
-      if (StringUtils.isBlank(activityFilter.getSpaceId())) {
+      if (StringUtils.isBlank(activityFilter.getSpaceIdentityId())) {
         return (int) spaceWebNotificationService.countUnreadActivities(viewerIdentity.getRemoteId());
       } else {
         try {
           return (int) spaceWebNotificationService.countUnreadActivitiesBySpace(viewerIdentity.getRemoteId(),
-                                                                                Long.parseLong(activityFilter.getSpaceId()));
+                                                                                Long.parseLong(activityFilter.getSpaceIdentityId()));
         } catch (Exception e) {
           throw new IllegalStateException(String.format("Unable to retrieve activities for user %s with filtered space %s",
                                                         viewerIdentity.getRemoteId(),
-                                                        activityFilter.getSpaceId()),
+                                                        activityFilter.getSpaceIdentityId()),
                                           e);
         }
       }
@@ -756,6 +813,9 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case ANY_SPACE_ACTIVITY:
+      if (activityFilter.getSpaceIdentityId() == null) {
+        return 0;
+      }
       break;
     default:
       throw new UnsupportedOperationException();

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -36,6 +36,7 @@ import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.social.core.activity.ActivityFilter;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.jpa.storage.dao.ActivityDAO;
 import org.exoplatform.social.core.jpa.storage.dao.ConnectionDAO;
 import org.exoplatform.social.core.jpa.storage.entity.ActivityEntity;
@@ -62,9 +63,13 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
 
   private static final String           ACTIVITY_POSTER_ID        = "posterId";
 
+  private static final String           ACTIVITY_ID_PARAM         = "activityId";
+
   private static final String           ACTIVITY_PROVIDER_ID      = "providerId";
 
-  private static final String           ACTIVITY_USER_ID          = "userId";
+  private static final String           USER_PROVIDER_ID          = "userProviderId";
+
+  private static final String           SPACE_PROVIDER_ID         = "spaceProviderId";
 
   private static final String           ACTIVITY_OWNER_IDS        = "ownerIds";
 
@@ -74,9 +79,9 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
 
   private static final String           QUERY_FILTER_COUNT_PREFIX = "SocActivity.countAllActivities";
 
-  private final Map<String, Boolean> filterNamedQueries        = new HashMap<>();
+  private final Map<String, Boolean>    filterNamedQueries        = new HashMap<>();
 
-  private final ConnectionDAO        connectionDAO;
+  private final ConnectionDAO           connectionDAO;
 
   public ActivityDAOImpl(ConnectionDAO connectionDAO) {
     this.connectionDAO = connectionDAO;
@@ -101,14 +106,14 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
     }
     query.setParameter("owners", Collections.singleton(ownerId));
     if (limit > 0) {
-      query.setFirstResult(offset > 0 ? (int)offset : 0);
-      query.setMaxResults((int)limit);
+      query.setFirstResult(offset > 0 ? (int) offset : 0);
+      query.setMaxResults((int) limit);
     }
 
     List<Tuple> resultList = query.getResultList();
     return convertActivityEntitiesToIds(resultList);
   }
-  
+
   @Override
   public List<String> getUserIdsActivities(Identity owner, long offset, long limit) throws ActivityStorageException {
     long ownerId = Long.parseLong(owner.getId());
@@ -810,7 +815,7 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   @Override
   public long getNumberOfComments(long activityId) {
     TypedQuery<Long> query = getEntityManager().createNamedQuery("SocActivity.numberCommentsOfActivity", Long.class);
-    query.setParameter("activityId", activityId);
+    query.setParameter(ACTIVITY_ID_PARAM, activityId);
     return query.getSingleResult();
   }
 
@@ -825,7 +830,7 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   public List<ActivityEntity> findCommentsAndSubCommentsOfActivity(Long activityId) {
     TypedQuery<ActivityEntity> query = getEntityManager().createNamedQuery("SocActivity.findCommentsAndSubCommentsOfActivity",
                                                                            ActivityEntity.class);
-    query.setParameter("activityId", activityId);
+    query.setParameter(ACTIVITY_ID_PARAM, activityId);
     return query.getResultList();
   }
 
@@ -833,7 +838,7 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   public List<ActivityEntity> getComments(long activityId, int offset, int limit, boolean sortDescending) {
     String queryString = sortDescending ? "SocActivity.findLastCommentsOfActivity" : "SocActivity.findCommentsOfActivity";
     TypedQuery<ActivityEntity> query = getEntityManager().createNamedQuery(queryString, ActivityEntity.class);
-    query.setParameter("activityId", activityId);
+    query.setParameter(ACTIVITY_ID_PARAM, activityId);
     if (limit > 0) {
       query.setFirstResult(offset >= 0 ? offset : 0);
       query.setMaxResults(limit);
@@ -844,7 +849,7 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   @Override
   public List<ActivityEntity> getNewerComments(long activityId, Date sinceTime, int offset, int limit) {
     TypedQuery<ActivityEntity> query = getEntityManager().createNamedQuery("SocActivity.findNewerCommentsOfActivity", ActivityEntity.class);
-    query.setParameter("activityId", activityId);
+    query.setParameter(ACTIVITY_ID_PARAM, activityId);
     query.setParameter("sinceTime", sinceTime != null ? sinceTime.getTime() : 0);
     if (limit > 0) {
       query.setFirstResult(offset >= 0 ? offset : 0);
@@ -856,7 +861,7 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   @Override
   public List<ActivityEntity> getOlderComments(long activityId, Date sinceTime, int offset, int limit) {
     TypedQuery<ActivityEntity> query = getEntityManager().createNamedQuery("SocActivity.findOlderCommentsOfActivity", ActivityEntity.class);
-    query.setParameter("activityId", activityId);
+    query.setParameter(ACTIVITY_ID_PARAM, activityId);
     query.setParameter("sinceTime", sinceTime != null ? sinceTime.getTime() : 0);
     if (limit > 0) {
       query.setFirstResult(offset >= 0 ? offset : 0);
@@ -941,7 +946,10 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
     }
   }
 
-  private <T> TypedQuery<T> buildQueryFromFilter(ActivityFilter activityFilter, List<String> streamIdentityIds, Class<T> clazz, boolean count) {
+  private <T> TypedQuery<T> buildQueryFromFilter(ActivityFilter activityFilter,
+                                                 List<String> streamIdentityIds,
+                                                 Class<T> clazz,
+                                                 boolean count) {
     List<String> suffixes = new ArrayList<>();
     List<String> predicates = new ArrayList<>();
     buildPredicates(activityFilter, streamIdentityIds, suffixes, predicates);
@@ -968,19 +976,27 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
     if (!count) {
       query.setParameter(MAIN_STREAM_TYPES_PARAM, MAIN_STREAM_TYPES);
     }
-    if (activityFilter.getUserId() != null) {
-      query.setParameter(ACTIVITY_USER_ID, activityFilter.getUserId());
-    }
-    if (CollectionUtils.isNotEmpty(streamIdentityIds) || activityFilter.getSpaceId() != null) {
-      if (activityFilter.getSpaceId() != null) {
-        query.setParameter(ACTIVITY_OWNER_IDS, Collections.singleton(activityFilter.getSpaceId()));
-      } else if (CollectionUtils.isNotEmpty(streamIdentityIds)) {
+    if (activityFilter.getSpaceIdentityId() != null) {
+      query.setParameter(ACTIVITY_OWNER_IDS, Collections.singleton(activityFilter.getSpaceIdentityId()));
+      if (activityFilter.getUserId() != null) {
+        query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getUserId());
+      }
+    } else if (activityFilter.getUserId() != null) {
+      query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getUserId());
+      query.setParameter(USER_PROVIDER_ID, OrganizationIdentityProvider.NAME);
+      if (CollectionUtils.isNotEmpty(streamIdentityIds)) {
+        query.setParameter(SPACE_PROVIDER_ID, SpaceIdentityProvider.NAME);
         query.setParameter(ACTIVITY_OWNER_IDS, streamIdentityIds);
       }
-      if (activityFilter.getPosterId() != null) {
-        query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getPosterId());
-        query.setParameter(ACTIVITY_PROVIDER_ID, OrganizationIdentityProvider.NAME);
-      }
+    } else if (activityFilter.getPosterId() == null) {
+      query.setParameter(ACTIVITY_OWNER_IDS, streamIdentityIds == null ? Collections.emptyList() : streamIdentityIds);
+    } else if (CollectionUtils.isEmpty(streamIdentityIds)) {
+      query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getPosterId());
+      query.setParameter(USER_PROVIDER_ID, OrganizationIdentityProvider.NAME);
+    } else {
+      query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getPosterId());
+      query.setParameter(USER_PROVIDER_ID, OrganizationIdentityProvider.NAME);
+      query.setParameter(ACTIVITY_OWNER_IDS, streamIdentityIds);
     }
     if (CollectionUtils.isNotEmpty(activityFilter.getCategoryIds())) {
       query.setParameter("categoryIds", activityFilter.getCategoryIds());
@@ -991,18 +1007,33 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
                                List<String> streamIdentityIds,
                                List<String> suffixes,
                                List<String> predicates) {
-    if (activityFilter.getUserId() != null) {
-      suffixes.add("UserStream");
-      predicates.add("activity.posterId = :userId");
-    }
-    if (CollectionUtils.isNotEmpty(streamIdentityIds) || activityFilter.getSpaceId() != null) {
-      if (activityFilter.getPosterId() == null) {
-        suffixes.add("StreamType");
-        predicates.add("activity.ownerId in (:ownerIds)");
+    if (activityFilter.getSpaceIdentityId() != null) {
+      if (activityFilter.getUserId() != null) {
+        suffixes.add("PostedSpaceStream");
+        predicates.add("activity.posterId = :posterId");
       } else {
-        suffixes.add("StreamTypeAndPoster");
-        predicates.add("(activity.ownerId in (:ownerIds) OR (activity.posterId = :posterId and activity.providerId = :providerId))");
+        suffixes.add("SpaceStream");
       }
+      predicates.add("activity.ownerId in (:ownerIds)");
+    } else if (activityFilter.getUserId() != null) {
+      predicates.add("activity.posterId = :posterId");
+      if (CollectionUtils.isEmpty(streamIdentityIds)) {
+        suffixes.add("PostedActivitiesInUserStreams");
+        predicates.add("activity.providerId = :userProviderId");
+      } else {
+        suffixes.add("PostedActivitiesInAllStreams");
+        predicates.add("(activity.providerId = :userProviderId OR (activity.providerId = :spaceProviderId AND activity.ownerId in (:ownerIds)))");
+      }
+    } else if (activityFilter.getPosterId() == null) {
+      suffixes.add("SpacesAndConnectionsStream");
+      predicates.add("activity.ownerId in (:ownerIds)");
+    } else if (CollectionUtils.isEmpty(streamIdentityIds)) {
+      suffixes.add("UserStream");
+      predicates.add("activity.posterId = :posterId");
+      predicates.add("activity.providerId = :userProviderId");
+    } else {
+      suffixes.add("AllStream");
+      predicates.add("(activity.ownerId in (:ownerIds) OR (activity.posterId = :posterId and activity.providerId = :userProviderId))");
     }
     if (activityFilter.isPinned()) {
       suffixes.add("Pinned");
@@ -1039,7 +1070,7 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
 
     String queryContent;
     if (predicates.isEmpty()) {
-      queryContent = querySelect ;
+      queryContent = querySelect;
     } else {
       queryContent = querySelect + " AND " + StringUtils.join(predicates, " AND ");
     }
@@ -1048,4 +1079,5 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
     }
     return queryContent;
   }
+
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -1659,6 +1659,247 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(11, activities.loadIdsAsList(0, 100).size());
   }
 
+  public void testGetActivitiesPostedByUser() {
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'john' user stream by 'john'");
+    activity.setUserId(johnIdentity.getId());
+    activityManager.saveActivityNoReturn(johnIdentity, activity);
+
+    activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'mary' user stream by 'demo'");
+    activity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(maryIdentity, activity);
+
+    activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to own stream");
+    activity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(demoIdentity, activity);
+
+    Space space = this.getSpaceInstance(0);
+    restartTransaction();
+
+    deleteSpaceAutomaticActivities(space);
+
+    ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setStreamType(ActivityStreamType.USER_STREAM);
+
+    RealtimeListAccess<ExoSocialActivity> activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(2, activities.getSize());
+    assertEquals(2, activities.loadAsList(0, 100).size());
+    assertEquals(2, activities.loadIdsAsList(0, 100).size());
+
+    relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
+    relationshipManager.confirm(demoIdentity, johnIdentity);
+    restartTransaction();
+
+    deleteRelationshipAutomaticActivities(demoIdentity);
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(2, activities.getSize());
+    assertEquals(2, activities.loadAsList(0, 100).size());
+    assertEquals(2, activities.loadIdsAsList(0, 100).size());
+
+    // demo posts activities to space
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    for (int i = 0; i < 10; i++) {
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title: " + i);
+      activity.setUserId(demoIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title: " + i);
+      activity.setUserId(johnIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+    }
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(12, activities.getSize());
+    assertEquals(12, activities.loadAsList(0, 100).size());
+    assertEquals(12, activities.loadIdsAsList(0, 100).size());
+
+    spaceService.removeMember(space, demoIdentity.getRemoteId());
+    ((CachedActivityStorage) activityStorage).clearCache();
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(2, activities.getSize());
+    assertEquals(2, activities.loadAsList(0, 100).size());
+    assertEquals(2, activities.loadIdsAsList(0, 100).size());
+  }
+
+  public void testGetActivitiesBySpace() {
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'john' user stream by 'john'");
+    activity.setUserId(johnIdentity.getId());
+    activityManager.saveActivityNoReturn(johnIdentity, activity);
+
+    activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'mary' user stream by 'demo'");
+    activity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(maryIdentity, activity);
+
+    activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to own stream");
+    activity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(demoIdentity, activity);
+
+    Space space1 = this.getSpaceInstance(0);
+    Space space2 = this.getSpaceInstance(1);
+    restartTransaction();
+
+    Identity space1Identity = identityManager.getOrCreateSpaceIdentity(space1.getPrettyName());
+    Identity space2Identity = identityManager.getOrCreateSpaceIdentity(space2.getPrettyName());
+
+    deleteSpaceAutomaticActivities(space1);
+    deleteSpaceAutomaticActivities(space2);
+
+    ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setStreamType(ActivityStreamType.ANY_SPACE_ACTIVITY);
+    activityFilter.setSpaceIdentityId(space1Identity.getId());
+
+    relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
+    relationshipManager.confirm(demoIdentity, johnIdentity);
+    restartTransaction();
+
+    deleteRelationshipAutomaticActivities(demoIdentity);
+    RealtimeListAccess<ExoSocialActivity> activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+
+    for (int i = 0; i < 10; i++) {
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title Space 1: " + i);
+      activity.setUserId(demoIdentity.getId());
+      activityManager.saveActivityNoReturn(space1Identity, activity);
+
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title Space 2: " + i);
+      activity.setUserId(demoIdentity.getId());
+      activityManager.saveActivityNoReturn(space2Identity, activity);
+    }
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(10, activities.getSize());
+    assertEquals(10, activities.loadAsList(0, 100).size());
+    assertEquals(10, activities.loadIdsAsList(0, 100).size());
+
+    spaceService.removeMember(space1, demoIdentity.getRemoteId());
+    ((CachedActivityStorage) activityStorage).clearCache();
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+  }
+
+  public void testGetActivitiesBySpaceAndUser() {
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'john' user stream by 'john'");
+    activity.setUserId(johnIdentity.getId());
+    activityManager.saveActivityNoReturn(johnIdentity, activity);
+
+    activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to 'mary' user stream by 'demo'");
+    activity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(maryIdentity, activity);
+
+    activity = new ExoSocialActivityImpl();
+    activity.setTitle("Post activity to own stream");
+    activity.setUserId(demoIdentity.getId());
+    activityManager.saveActivityNoReturn(demoIdentity, activity);
+
+    Space space1 = this.getSpaceInstance(0);
+    Space space2 = this.getSpaceInstance(1);
+    restartTransaction();
+
+    Identity space1Identity = identityManager.getOrCreateSpaceIdentity(space1.getPrettyName());
+    Identity space2Identity = identityManager.getOrCreateSpaceIdentity(space2.getPrettyName());
+
+    deleteSpaceAutomaticActivities(space1);
+    deleteSpaceAutomaticActivities(space2);
+
+    ActivityFilter spaceActivityFilter = new ActivityFilter();
+    spaceActivityFilter.setStreamType(ActivityStreamType.ANY_SPACE_ACTIVITY);
+    spaceActivityFilter.setSpaceIdentityId(space1Identity.getId());
+    spaceActivityFilter.setUserId(demoIdentity.getId());
+
+    ActivityFilter userActivityFilter = new ActivityFilter();
+    userActivityFilter.setStreamType(ActivityStreamType.USER_STREAM);
+    userActivityFilter.setSpaceIdentityId(space1Identity.getId());
+    userActivityFilter.setUserId(demoIdentity.getId());
+
+    relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
+    relationshipManager.confirm(demoIdentity, johnIdentity);
+    restartTransaction();
+
+    deleteRelationshipAutomaticActivities(demoIdentity);
+    RealtimeListAccess<ExoSocialActivity> activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, spaceActivityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, userActivityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+
+    for (int i = 0; i < 10; i++) {
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title Space 1: " + i);
+      activity.setUserId(johnIdentity.getId());
+      activityManager.saveActivityNoReturn(space1Identity, activity);
+
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title Space 2: " + i);
+      activity.setUserId(demoIdentity.getId());
+      activityManager.saveActivityNoReturn(space2Identity, activity);
+    }
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, spaceActivityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, userActivityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+
+    for (int i = 0; i < 10; i++) {
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title Space 1: " + i);
+      activity.setUserId(demoIdentity.getId());
+      activityManager.saveActivityNoReturn(space1Identity, activity);
+    }
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, spaceActivityFilter);
+    assertEquals(10, activities.getSize());
+    assertEquals(10, activities.loadAsList(0, 100).size());
+    assertEquals(10, activities.loadIdsAsList(0, 100).size());
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, userActivityFilter);
+    assertEquals(10, activities.getSize());
+    assertEquals(10, activities.loadAsList(0, 100).size());
+    assertEquals(10, activities.loadIdsAsList(0, 100).size());
+
+    spaceService.removeMember(space1, demoIdentity.getRemoteId());
+    ((CachedActivityStorage) activityStorage).clearCache();
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, spaceActivityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, userActivityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+  }
+
   public void testGetActivitiesWithLastCommentedFirst() {
     ExoSocialActivity johnActivity = new ExoSocialActivityImpl();
     johnActivity.setTitle("Post activity to 'john' user stream by 'john'");

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -169,7 +169,7 @@ public class ActivityRest implements ResourceContainer {
         throw new WebApplicationException(Response.Status.UNAUTHORIZED);
       }
       Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
-      activityFilter.setSpaceId(spaceIdentity.getId());
+      activityFilter.setSpaceIdentityId(spaceIdentity.getId());
       canPost = activityManager.canPostActivityInStream(currentUser, spaceIdentity);
     } else {
       canPost = activityManager.canPostActivityInStream(currentUser, currentUserIdentity);

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
@@ -311,7 +311,7 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
 
     collections = (CollectionEntity) response.getEntity();
-    assertEquals(4, collections.getEntities().size());
+    assertEquals(3, collections.getEntities().size());
 
     // Get space favorite activities
     response =


### PR DESCRIPTION
Prior to this change, when displaying a Space Stream, then the user stream activities are displayed as well. This change will ensure to display the selected space's stream only when displaying it.

Resolves Meeds-io/meeds#3428