### PR TITLE
fix: Add Activity Head Ellipsis in Space Name - MEED-9319 - Meeds-io/meeds#3431 (#4938)

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHead.vue
@@ -21,6 +21,7 @@
         <v-list-item-title class="d-flex align-center mb-0">
           <exo-user-avatar
             :identity="posterIdentity"
+            class="flex-grow-0 flex-shrink-1"
             fullname
             popover
             bold-title
@@ -30,18 +31,19 @@
             <v-icon
               v-if="$vuetify.rtl"
               size="8"
-              class="mx-1 ps-1">
+              class="flex-grow-0 flex-shrink-0 mx-1 ps-1">
               fa-chevron-left
             </v-icon>
             <v-icon
               v-else
               size="8"
-              class="mx-1 ps-1">
+              class="flex-grow-0 flex-shrink-0 mx-1 ps-1">
               fa-chevron-right
             </v-icon>
             <exo-space-avatar
               :space="space"
               :size="20"
+              class="flex-grow-0 flex-shrink-1 text-truncate"
               bold-title
               link-style
               popover />

--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -47,7 +47,7 @@
         <span>{{ markingAsReadDisabled && $t('Notification.label.NoMarkAllAsRead') || $t('Notification.label.MarkAsRead', {0: $t(`Notification.label.types.${groupName}`)}) }}</span>
       </v-tooltip>
       <v-tooltip bottom>
-        <template #activator="{on, bind}">
+        <template #activator="{on, attrs}">
           <v-btn
             :href="settingsLink"
             icon

--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -52,7 +52,12 @@
             :href="settingsLink"
             icon
             v-on="on"
-            v-bind="bind"
+            v-bind="{
+              ...attrs,
+              'aria-label': $t('UIIntranetNotificationsPortlet.title.NotificationsSetting'),
+              role: null,
+              'aria-haspopup': null,
+              'aria-expanded': null}"
             @click="openSettings">
             <v-icon size="18" class="notifDrawerSettings">fa-sliders-h</v-icon>
           </v-btn>


### PR DESCRIPTION
Prior to this change, the space name doesn't ally an ellipsis when it's long and even it hides poster user name. This change ensures that neither user name nor space name hides each other when one of it is long.

(cherry picked from commit 8037019d745370990b4242adad3cc00a9d60f61b)