### PR TITLE
feat: Display Drawers Overlay On Top of Bottom Drawers - MEED-9250 - Meeds-io/meeds#3436

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
@@ -3,8 +3,8 @@
     <v-fade-transition>
       <v-overlay
         v-show="overlay"
+        :z-index="zIndex"
         id="drawers-overlay"
-        z-index="1030"
         absolute />
     </v-fade-transition>
   </v-app>
@@ -15,8 +15,12 @@ export default {
     openedModals: 0,
     openedDrawers: 0,
     uiPortalApplicationElement: null,
+    drawerZIndex: 1035,
   }),
   computed: {
+    zIndex() {
+      return this.overlay ? (this.drawerZIndex - 1 + (this.openedDrawers || 0)) : this.drawerZIndex - 1;
+    },
     overlay() {
       return this.openedDrawers && !this.openedModals;
     },

--- a/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -10,6 +10,9 @@
       'layout-drawer': isBrandingLayout,
       'z-index-snackbar': increaseZindex,
     }"
+    :style="{
+      'z-index': zIndex,
+    }"
     :absolute="!fixed"
     :fixed="fixed"
     :width="width"
@@ -199,8 +202,12 @@ export default {
     expand: false,
     modalOpened: false,
     increaseZindex: false,
+    drawerZIndex: 1035,
   }),
   computed: {
+    zIndex() {
+      return this.drawer ? (this.drawerZIndex + (eXo.openedDrawers?.length || 0)) : this.drawerZIndex;
+    },
     rightDrawer() {
       return (this.right && eXo.env.portal.orientation === 'ltr') || (this.left && eXo.env.portal.orientation === 'rtl');
     },

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarSecondLevel.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarSecondLevel.vue
@@ -24,9 +24,12 @@
     ref="secondLevelDrawer"
     v-model="drawer"
     :width="drawerWidth"
-    :style="drawerOffsetStyle"
     :right="$vuetify.rtl"
-    class="HamburgerMenuSecondLevelParent layout-side-bar border-box-sizing z-index-drawer"
+    :style="{
+      ...drawerOffsetStyle,
+      'z-index': zIndex,
+    }"
+    class="HamburgerMenuSecondLevelParent layout-side-bar border-box-sizing"
     max-width="100%"
     hide-overlay>
     <v-hover v-if="drawer" v-model="$root.hoverSecondLevel">
@@ -84,13 +87,17 @@ export default {
   },
   data: () => ({
     drawer: false,
+    drawerZIndex: 1035,
   }),
   computed: {
+    zIndex() {
+      return this.drawer ? (this.drawerZIndex + (eXo.openedDrawers?.length || 0)) : this.drawerZIndex;
+    },
     drawerOffset() {
       return this.$root.displaySequentially && this.drawerWidth || 0;
     },
     drawerOffsetStyle() {
-      return this.$vuetify.rtl && `right: ${this.drawerOffset}px;` || `left: ${this.drawerOffset}px;`;
+      return this.$vuetify.rtl && {right: `${this.drawerOffset}px`} || {left: `${this.drawerOffset}px`};
     },
     expand() {
       return this.$root.expand;

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarThirdLevel.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/drawer/SidebarThirdLevel.vue
@@ -23,9 +23,12 @@
     ref="thirdLevelDrawer"
     v-model="drawer"
     :width="drawerWidth"
-    :style="drawerOffsetStyle"
     :right="$vuetify.rtl"
-    class="HamburgerMenuThirdLevelParent layout-side-bar border-box-sizing z-index-drawer"
+    :style="{
+      ...drawerOffsetStyle,
+      'z-index': zIndex,
+    }"
+    class="HamburgerMenuThirdLevelParent layout-side-bar border-box-sizing"
     max-width="100%"
     hide-overlay>
     <v-hover v-if="drawer" v-model="$root.hoverThirdLevel">
@@ -61,13 +64,17 @@ export default {
   },
   data: () => ({
     drawer: false,
+    drawerZIndex: 1035,
   }),
   computed: {
+    zIndex() {
+      return this.drawer ? (this.drawerZIndex + (eXo.openedDrawers?.length || 0)) : this.drawerZIndex;
+    },
     drawerOffset() {
       return this.$root.displaySequentially && this.drawerWidth * 2 || 0;
     },
     drawerOffsetStyle() {
-      return this.$vuetify.rtl && `right: ${this.drawerOffset}px;` || `left: ${this.drawerOffset}px;`;
+      return this.$vuetify.rtl && {right: `${this.drawerOffset}px`} || {left: `${this.drawerOffset}px`};
     },
     expand() {
       return this.$root.expand;


### PR DESCRIPTION
7This change will allow to display Drawers Overlay just on bottom of latest opened drawer, this will allow to expand one drawer and then display the overlay when opening a second level drawer in order to enhance UX.

Resolves Meeds-io/meeds#3436