### PR TITLE
fix: Fix adding and removing a multiValue user profile field whe it is not editable - MEED-8907 - Meeds-io/meeds#3094

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -22,10 +22,12 @@
           <profile-contact-edit-multi-field
             v-else-if="property.multiValued || property?.children?.length"
             :property="property"
+            :disabled="disabledField(property)"
             @propertyUpdated="propertyUpdated" />
           <profile-dropdown-property
             v-else-if="property.dropdownList"
             :property="property"
+            :disabled="disabledField(property)"
             :property-label="getResolvedName(property)"
             @property-updated="propertyUpdated" />
           <div v-else>

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileDropdownProperty.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileDropdownProperty.vue
@@ -33,6 +33,7 @@
         item-text="translatedValue"
         item-value="id"
         clear-icon="fas fa-times"
+        :disabled="disabled"
         clearable
         single-line
         solo
@@ -49,7 +50,7 @@
         v-if="!multiValued"
         :property="propertyObject" />
       <v-btn
-        v-if="multiValued"
+        v-if="multiValued && !disabled"
         icon
         @click="$emit('remove')">
         <v-icon
@@ -85,6 +86,10 @@ export default {
       default: null
     },
     multiValued: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
       type: Boolean,
       default: false
     }

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfileContactEditMultiField.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfileContactEditMultiField.vue
@@ -15,6 +15,7 @@
           class="px-0"
           link
           text
+          v-if="!disabled"
           @click="addNewItem">
           + {{ $t('profileContactInformation.addNew') }}
         </v-btn>
@@ -27,6 +28,7 @@
         <profile-dropdown-property
           v-if="property.dropdownList"
           :multi-valued="true"
+          :disabled="disabled"
           :parent-property="property"
           :property="childProperty"
           :property-label="getResolvedName(childProperty)"
@@ -36,6 +38,7 @@
           v-else
           :property="childProperty"
           :parent-propery="property"
+          :disabled="disabled"
           :properties="property.children"
           :multi-valued="property.multiValued"
           @propertyUpdated="propertyUpdated"
@@ -51,6 +54,10 @@ export default {
     property: {
       type: Object,
       default: () => null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfileContactEditMultiFieldSelect.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfileContactEditMultiFieldSelect.vue
@@ -30,6 +30,7 @@
       small
       class="removeMultiFieldValue  error--text"
       :class="hasParent && 'hasParent' ||'noParent'"
+      v-if="!disabled"
       @click="$emit('remove')">
       fa-minus
     </v-icon>
@@ -58,6 +59,10 @@ export default {
     multiValued: {
       type: Boolean,
       default: () => null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   


### PR DESCRIPTION

Prior to this change, when a multiValue user profile fields is not editable, we can add a new value and remove an old value for both types text or dropdownlist. After this commit, we ensure to hide the add and remove buttons for the multiValue field and also disable the combobox of simple dropdownlist field.

Resolves Meeds-io/meeds#3094