### PR TITLE
feat: Allow to define default choice for a notification channel - MEED-9304

### DIFF
--- a/component/notification/src/main/java/io/meeds/social/notification/rest/NotificationSettingsRestService.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/rest/NotificationSettingsRestService.java
@@ -302,6 +302,30 @@ public class NotificationSettingsRestService implements ResourceContainer {
   }
 
   @PATCH
+  @Path("channel/{channelId}/defaultvalue")
+  @RolesAllowed("administrators")
+  @Operation(
+      summary = "Change default value of Channel for all users",
+      description = "Change default value of Channel for all users",
+      method = "PATCH"
+  )
+  @ApiResponses(
+      value = {
+          @ApiResponse(responseCode = "204", description = "Request fulfilled")
+      }
+  )
+  public Response saveChannelDefaultValue(
+      @Parameter(description = "Channel Id like MAIL_CHANNEL, WEB_CHANNEL...", required = true)
+      @PathParam("channelId")
+      String channelId,
+      @Parameter(description = "Enable/disable a channel", required = true)
+      @FormParam("enable")
+      boolean enable) {
+    pluginSettingService.saveChannelDefaultValue(channelId, enable);
+    return Response.noContent().build();
+  }
+
+  @PATCH
   @Path("{id}/spaces/{spaceId}")
   @RolesAllowed("users")
   @Operation(summary = "Change enablement status of Channel for a user", description = "Change enablement status of Channel for a user", method = "PATCH")
@@ -521,6 +545,7 @@ public class NotificationSettingsRestService implements ResourceContainer {
                                         emailDigestChoices,
                                         channelCheckBoxList,
                                         channelStatus,
+                                        setting.getChannelDefaultValue(),
                                         channels,
                                         setting.getMutedSpaces());
   }

--- a/component/notification/src/main/java/io/meeds/social/notification/rest/model/UserNotificationSettings.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/rest/model/UserNotificationSettings.java
@@ -49,6 +49,8 @@ public class UserNotificationSettings {
 
   private Map<String, Boolean>          channelStatus;
 
+  private Map<String, Boolean> channelDefaultValue;
+
   private List<String>                  channels;
 
   private List<Long>                    mutedSpaces;
@@ -74,6 +76,7 @@ public class UserNotificationSettings {
                                   List<EmailDigestChoice> emailDigestChoices,
                                   List<ChannelActivationChoice> channelCheckBoxList,
                                   Map<String, Boolean> channelStatus,
+                                  Map<String, Boolean> channelDefaultValue,
                                   List<String> channels,
                                   List<Long> mutedSpaces) {
     this.groups = groups;
@@ -89,6 +92,7 @@ public class UserNotificationSettings {
     this.channelStatus = channelStatus;
     this.channels = channels;
     this.mutedSpaces = mutedSpaces;
+    this.channelDefaultValue = channelDefaultValue;
   }
 
   public List<GroupProvider> getGroups() {
@@ -201,5 +205,13 @@ public class UserNotificationSettings {
 
   public void setMutedSpaces(List<Long> mutedSpaces) {
     this.mutedSpaces = mutedSpaces;
+  }
+
+  public Map<String, Boolean> getChannelDefaultValue() {
+    return channelDefaultValue;
+  }
+
+  public void setChannelDefaultValue(Map<String, Boolean> channelDefaultValue) {
+    this.channelDefaultValue = channelDefaultValue;
   }
 }

--- a/webapp/src/main/webapp/vue-apps/notification-administration/components/NotificationChannels.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-administration/components/NotificationChannels.vue
@@ -2,16 +2,26 @@
   <v-card flat>
     <div class="pt-8 text-title">{{ $t('NotificationAdmin.allowedNotifications.title') }}</div>
     <div class="text-subtitle">{{ $t('NotificationAdmin.allowedNotifications.subtitle') }}</div>
-    <v-switch
-      v-for="channelId in channelIds"
-      v-model="channelStatus[channelId]"
-      :key="channelId"
-      hide-details
-      @change="saveChannelStatus(channelId, $event)">
-      <template #label>
-        <span class="text-color">{{ channelLabels[channelId] }}</span>
-      </template>
-    </v-switch>
+    <div v-for="channelId in channelIds" :key="channelId">
+      <v-switch
+        v-model="channelStatus[channelId]"
+        hide-details
+        @change="saveChannelStatus(channelId, $event)">
+        <template #label>
+          <span class="text-color">{{ channelLabels[channelId] }}</span>
+        </template>
+      </v-switch>
+      <div v-if="channelStatus[channelId]" class="ms-8">
+        <v-switch
+          v-model="channelDefaultValue[channelId]"
+          @change="saveChannelDefault(channelId, $event)">
+          hide-details>
+          <template #label>
+            <span class="text-color">Default Value</span>
+          </template>
+        </v-switch>
+      </div>
+    </div>
   </v-card>
 </template>
 <script>
@@ -37,11 +47,20 @@ export default {
     channelStatus() {
       return this.settings.channelStatus;
     },
+    channelDefaultValue() {
+      return this.settings.channelDefaultValue;
+    },
   },
   methods: {
     saveChannelStatus(channelId, status) {
       this.saving = true;
       return this.$notificationAdministration.saveChannelStatus(channelId, status)
+        .then(() => this.$root.$emit('refresh'))
+        .finally(() => this.saving = false);
+    },
+    saveChannelDefault(channelId, status) {
+      this.saving = true;
+      return this.$notificationAdministration.saveChannelDefaultValue(channelId, status)
         .then(() => this.$root.$emit('refresh'))
         .finally(() => this.saving = false);
     },

--- a/webapp/src/main/webapp/vue-apps/notification-administration/js/NotificationAdministration.js
+++ b/webapp/src/main/webapp/vue-apps/notification-administration/js/NotificationAdministration.js
@@ -84,3 +84,18 @@ export function saveChannelStatus(channelId, enable) {
     }
   });
 }
+
+export function saveChannelDefaultValue(channelId, enable) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/notifications/settings/channel/${channelId}/defaultvalue`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: `enable=${enable}`
+  }).then(resp => {
+    if (!resp?.ok) {
+      throw new Error('Error saving channel default value setting');
+    }
+  });
+}


### PR DESCRIPTION
Before this fix, there is no possibility to let a notification channel activated (aka. activable by all users) but deactivated by default This commit add an option to set default value for a channel. In addition, it removes the property exo.notification.channels which create problems to activate/deactivate channels

Resolves meeds-io/meeds#3409

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
