### PR TITLE
fix: Allow Space Admin to access Managing Spaces Stream - MEED-9324 - Meeds-io/meeds#3438

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityFilter.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/activity/ActivityFilter.java
@@ -31,11 +31,11 @@ public class ActivityFilter implements Serializable {
 
   private String             term;
 
-  private String             userId;
+  private long               userId;
 
-  private String             posterId;
+  private long               posterId;
 
-  private String             spaceIdentityId;
+  private long               spaceIdentityId;
 
   private List<Long>         categoryIds;
 

--- a/component/api/src/main/java/org/exoplatform/social/core/identity/model/Identity.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/identity/model/Identity.java
@@ -115,6 +115,10 @@ public class Identity implements CacheEntry, Cloneable {
     return id;
   }
 
+  public long getIdentityId() {
+    return Long.parseLong(id);
+  }
+
   /**
    * Sets the id.
    *

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -294,9 +294,11 @@ public interface ActivityManager {
    * @param viewerIdentity The viewer identity.
    * @param activityFilter The activity filter.
    * @return The activities.
+   * @throws ObjectNotFoundException when target space (if designated in filter selection) not found
+   * @throws IllegalAccessException when user can't acccess target space stream (if designated in filter selection)
    */
   default RealtimeListAccess<ExoSocialActivity> getActivitiesByFilterWithListAccess(Identity viewerIdentity,
-                                                                                    ActivityFilter activityFilter) {
+                                                                                    ActivityFilter activityFilter) throws ObjectNotFoundException, IllegalAccessException {
     throw new UnsupportedOperationException();
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -541,22 +541,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
                                                        ActivityFilter activityFilter,
                                                        long offset,
                                                        long limit) {
-    if (activityFilter.getSpaceIdentityId() != null) {
-      Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
-      if (spaceIdentity == null || spaceIdentity.isDeleted() || !spaceIdentity.isEnable()) {
-        return Collections.emptyList();
-      } else {
-        Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
-        if (space == null || !ArrayUtils.contains(space.getMembers(), viewerIdentity.getRemoteId())) {
-          return Collections.emptyList();
-        }
-      }
-    }
     List<String> streamIdentityIds = null;
     switch (activityFilter.getStreamType()) {
     case USER_STREAM:
-      activityFilter.setUserId(viewerIdentity.getId());
-      if (activityFilter.getSpaceIdentityId() == null) {
+      activityFilter.setUserId(viewerIdentity.getIdentityId());
+      if (activityFilter.getSpaceIdentityId() == 0) {
         streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                        String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                        0,
@@ -574,12 +563,12 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       break;
     case UNREAD_SPACES_STREAM:
       List<Long> activityIds;
-      if (StringUtils.isBlank(activityFilter.getSpaceIdentityId())) {
+      if (activityFilter.getSpaceIdentityId() == 0) {
         activityIds = spaceWebNotificationService.getUnreadActivityIds(viewerIdentity.getRemoteId(), offset, limit);
       } else {
         try {
           activityIds = spaceWebNotificationService.getUnreadActivityIdsBySpace(viewerIdentity.getRemoteId(),
-                                                                                Long.parseLong(activityFilter.getSpaceIdentityId()),
+                                                                                activityFilter.getSpaceIdentityId(),
                                                                                 offset,
                                                                                 limit);
         } catch (Exception e) {
@@ -604,13 +593,13 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case ANY_SPACE_ACTIVITY:
-      if (activityFilter.getSpaceIdentityId() == null) {
+      if (activityFilter.getSpaceIdentityId() == 0) {
         return Collections.emptyList();
       }
       activityFilter.setShowPinned(true);
       break;
     case ALL_STREAM:
-      activityFilter.setPosterId(viewerIdentity.getId());
+      activityFilter.setPosterId(viewerIdentity.getIdentityId());
       streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                      String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                      0,
@@ -635,22 +624,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
 
   @Override
   public List<String> getActivityIdsByFilter(Identity viewerIdentity, ActivityFilter activityFilter, long offset, long limit) {
-    if (activityFilter.getSpaceIdentityId() != null) {
-      Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
-      if (spaceIdentity == null || spaceIdentity.isDeleted() || !spaceIdentity.isEnable()) {
-        return Collections.emptyList();
-      } else {
-        Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
-        if (space == null || !ArrayUtils.contains(space.getMembers(), viewerIdentity.getRemoteId())) {
-          return Collections.emptyList();
-        }
-      }
-    }
     List<String> streamIdentityIds = null;
     switch (activityFilter.getStreamType()) {
     case USER_STREAM:
-      activityFilter.setUserId(viewerIdentity.getId());
-      if (activityFilter.getSpaceIdentityId() == null) {
+      activityFilter.setUserId(viewerIdentity.getIdentityId());
+      if (activityFilter.getSpaceIdentityId() == 0) {
         streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                        String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                        0,
@@ -670,11 +648,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       break;
     case UNREAD_SPACES_STREAM:
       List<Long> unreadActivityIds;
-      if (StringUtils.isBlank(activityFilter.getSpaceIdentityId())) {
+      if (activityFilter.getSpaceIdentityId() == 0) {
         unreadActivityIds = spaceWebNotificationService.getUnreadActivityIds(viewerIdentity.getRemoteId(), offset, limit);
       } else {
         try {
-          Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
+          Identity spaceIdentity = identityStorage.findIdentityById(String.valueOf(activityFilter.getSpaceIdentityId()));
           if (spaceIdentity == null || !spaceIdentity.isEnable() || spaceIdentity.isDeleted() || !spaceIdentity.isSpace()) {
             return Collections.emptyList();
           }
@@ -705,13 +683,13 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case ANY_SPACE_ACTIVITY:
-      if (activityFilter.getSpaceIdentityId() == null) {
+      if (activityFilter.getSpaceIdentityId() == 0) {
         return Collections.emptyList();
       }
       activityFilter.setShowPinned(true);
       break;
     case ALL_STREAM:
-      activityFilter.setPosterId(viewerIdentity.getId());
+      activityFilter.setPosterId(viewerIdentity.getIdentityId());
       streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                      String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                      0,
@@ -745,22 +723,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
 
   @Override
   public int getActivitiesCountByFilter(Identity viewerIdentity, ActivityFilter activityFilter) {
-    if (activityFilter.getSpaceIdentityId() != null) {
-      Identity spaceIdentity = identityStorage.findIdentityById(activityFilter.getSpaceIdentityId());
-      if (spaceIdentity == null || spaceIdentity.isDeleted() || !spaceIdentity.isEnable()) {
-        return 0;
-      } else {
-        Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
-        if (space == null || !ArrayUtils.contains(space.getMembers(), viewerIdentity.getRemoteId())) {
-          return 0;
-        }
-      }
-    }
     List<String> streamIdentityIds = null;
     switch (activityFilter.getStreamType()) {
     case USER_STREAM:
-      activityFilter.setUserId(viewerIdentity.getId());
-      if (activityFilter.getSpaceIdentityId() == null) {
+      activityFilter.setUserId(viewerIdentity.getIdentityId());
+      if (activityFilter.getSpaceIdentityId() == 0) {
         streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                        String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                        0,
@@ -776,12 +743,12 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case UNREAD_SPACES_STREAM:
-      if (StringUtils.isBlank(activityFilter.getSpaceIdentityId())) {
+      if (activityFilter.getSpaceIdentityId() == 0) {
         return (int) spaceWebNotificationService.countUnreadActivities(viewerIdentity.getRemoteId());
       } else {
         try {
           return (int) spaceWebNotificationService.countUnreadActivitiesBySpace(viewerIdentity.getRemoteId(),
-                                                                                Long.parseLong(activityFilter.getSpaceIdentityId()));
+                                                                                activityFilter.getSpaceIdentityId());
         } catch (Exception e) {
           throw new IllegalStateException(String.format("Unable to retrieve activities for user %s with filtered space %s",
                                                         viewerIdentity.getRemoteId(),
@@ -799,7 +766,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case ALL_STREAM:
-      activityFilter.setPosterId(viewerIdentity.getId());
+      activityFilter.setPosterId(viewerIdentity.getIdentityId());
       streamIdentityIds = spaceStorage.getSpaceIdentityIdsByUserRole(viewerIdentity.getRemoteId(),
                                                                      String.valueOf(SpaceMembershipStatus.MEMBER),
                                                                      0,
@@ -813,7 +780,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       break;
     case ANY_SPACE_ACTIVITY:
-      if (activityFilter.getSpaceIdentityId() == null) {
+      if (activityFilter.getSpaceIdentityId() == 0) {
         return 0;
       }
       break;
@@ -823,12 +790,12 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
     return activityDAO.getActivitiesCountByFilter(activityFilter, streamIdentityIds);
   }
 
-  public List<ExoSocialActivity> getFavoriteActivities(Identity viewerIdentity, String spaceId) {
+  public List<ExoSocialActivity> getFavoriteActivities(Identity viewerIdentity, long spaceIdentityId) {
     long userIdentityId = Long.parseLong(viewerIdentity.getId());
     FavoriteService favoriteService = ExoContainerContext.getService(FavoriteService.class);
     List<MetadataItem> metadataItems = new ArrayList<>();
-    if (StringUtils.isNotBlank(spaceId)) {
-      Identity spaceIdentity = identityStorage.findIdentityById(spaceId);
+    if (spaceIdentityId > 0) {
+      Identity spaceIdentity = identityStorage.findIdentityById(String.valueOf(spaceIdentityId));
       if (spaceIdentity != null) {
         Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
         metadataItems =

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -976,19 +976,19 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
     if (!count) {
       query.setParameter(MAIN_STREAM_TYPES_PARAM, MAIN_STREAM_TYPES);
     }
-    if (activityFilter.getSpaceIdentityId() != null) {
+    if (activityFilter.getSpaceIdentityId() > 0) {
       query.setParameter(ACTIVITY_OWNER_IDS, Collections.singleton(activityFilter.getSpaceIdentityId()));
-      if (activityFilter.getUserId() != null) {
+      if (activityFilter.getUserId() > 0) {
         query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getUserId());
       }
-    } else if (activityFilter.getUserId() != null) {
+    } else if (activityFilter.getUserId() > 0) {
       query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getUserId());
       query.setParameter(USER_PROVIDER_ID, OrganizationIdentityProvider.NAME);
       if (CollectionUtils.isNotEmpty(streamIdentityIds)) {
         query.setParameter(SPACE_PROVIDER_ID, SpaceIdentityProvider.NAME);
         query.setParameter(ACTIVITY_OWNER_IDS, streamIdentityIds);
       }
-    } else if (activityFilter.getPosterId() == null) {
+    } else if (activityFilter.getPosterId() == 0) {
       query.setParameter(ACTIVITY_OWNER_IDS, streamIdentityIds == null ? Collections.emptyList() : streamIdentityIds);
     } else if (CollectionUtils.isEmpty(streamIdentityIds)) {
       query.setParameter(ACTIVITY_POSTER_ID, activityFilter.getPosterId());
@@ -1007,15 +1007,15 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
                                List<String> streamIdentityIds,
                                List<String> suffixes,
                                List<String> predicates) {
-    if (activityFilter.getSpaceIdentityId() != null) {
-      if (activityFilter.getUserId() != null) {
+    if (activityFilter.getSpaceIdentityId() > 0) {
+      if (activityFilter.getUserId() > 0) {
         suffixes.add("PostedSpaceStream");
         predicates.add("activity.posterId = :posterId");
       } else {
         suffixes.add("SpaceStream");
       }
       predicates.add("activity.ownerId in (:ownerIds)");
-    } else if (activityFilter.getUserId() != null) {
+    } else if (activityFilter.getUserId() > 0) {
       predicates.add("activity.posterId = :posterId");
       if (CollectionUtils.isEmpty(streamIdentityIds)) {
         suffixes.add("PostedActivitiesInUserStreams");
@@ -1024,7 +1024,7 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
         suffixes.add("PostedActivitiesInAllStreams");
         predicates.add("(activity.providerId = :userProviderId OR (activity.providerId = :spaceProviderId AND activity.ownerId in (:ownerIds)))");
       }
-    } else if (activityFilter.getPosterId() == null) {
+    } else if (activityFilter.getPosterId() == 0) {
       suffixes.add("SpacesAndConnectionsStream");
       predicates.add("activity.ownerId in (:ownerIds)");
     } else if (CollectionUtils.isEmpty(streamIdentityIds)) {

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -666,11 +666,23 @@ public class ActivityManagerImpl implements ActivityManager {
     return new ActivitiesRealtimeListAccess(activityStorage, ActivityType.VIEW_USER_ACTIVITIES, ownerIdentity, viewerIdentity);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
-  public RealtimeListAccess<ExoSocialActivity> getActivitiesByFilterWithListAccess(Identity viewerIdentity, ActivityFilter activityFilter){
+  public RealtimeListAccess<ExoSocialActivity> getActivitiesByFilterWithListAccess(Identity viewerIdentity,
+                                                                                   ActivityFilter activityFilter) throws ObjectNotFoundException,
+                                                                                                                  IllegalAccessException {
+    if (activityFilter.getSpaceIdentityId() > 0) {
+      Identity spaceIdentity = identityManager.getIdentity(activityFilter.getSpaceIdentityId());
+      if (spaceIdentity == null || spaceIdentity.isDeleted()) {
+        throw new ObjectNotFoundException(String.format("Space with identity id %s doesn't exist",
+                                                        activityFilter.getSpaceIdentityId()));
+      } else {
+        Space space = spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId());
+        if (!spaceService.canViewSpace(space, viewerIdentity.getRemoteId())) {
+          throw new IllegalAccessException(String.format("Space with identity id %s isn't accessible",
+                                                         activityFilter.getSpaceIdentityId()));
+        }
+      }
+    }
     return new ActivitiesRealtimeListAccess(activityStorage, viewerIdentity, activityFilter);
   }
 

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.social.core.manager;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,11 +84,8 @@ import org.exoplatform.social.core.test.AbstractCoreTest;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.social.metadata.favorite.model.Favorite;
 
-/**
- * Unit Test for {@link ActivityManager}, including cache tests.
- * 
- * @author hoat_le
- */
+import lombok.SneakyThrows;
+
 public class ActivityManagerTest extends AbstractCoreTest {
 
   private static final Log        LOG               = ExoLogger.getLogger(ActivityManagerTest.class);
@@ -710,6 +708,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
    * Test {@link ActivityManager#pinActivity(String, String)} Test
    * {@link ActivityManager#unpinActivity(String)}
    */
+  @SneakyThrows
   public void testPinActivity() throws Exception {
     String activityTitle = "activity title";
     String userId = johnIdentity.getId();
@@ -744,6 +743,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(0, activities.size());
   }
 
+  @SneakyThrows
   public void testLoadSpaceActivities() {
     String activityTitle = "activity title";
     String userId = johnIdentity.getId();
@@ -1548,6 +1548,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
                  parentActivity.getUserId());
   }
 
+  @SneakyThrows
   public void testGetActivitiesByUser() {
     String activityTitle = "title";
     String userId = rootIdentity.getId();
@@ -1583,6 +1584,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(21, activityList.size());
   }
 
+  @SneakyThrows
   public void testGetActivitiesByUserAndConnectionsAndSpaces() {
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("Post activity to 'john' user stream by 'john'");
@@ -1659,6 +1661,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(11, activities.loadIdsAsList(0, 100).size());
   }
 
+  @SneakyThrows
   public void testGetActivitiesPostedByUser() {
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("Post activity to 'john' user stream by 'john'");
@@ -1728,6 +1731,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(2, activities.loadIdsAsList(0, 100).size());
   }
 
+  @SneakyThrows
   public void testGetActivitiesBySpace() {
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("Post activity to 'john' user stream by 'john'");
@@ -1756,7 +1760,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
 
     ActivityFilter activityFilter = new ActivityFilter();
     activityFilter.setStreamType(ActivityStreamType.ANY_SPACE_ACTIVITY);
-    activityFilter.setSpaceIdentityId(space1Identity.getId());
+    activityFilter.setSpaceIdentityId(space1Identity.getIdentityId());
 
     relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
     relationshipManager.confirm(demoIdentity, johnIdentity);
@@ -1790,12 +1794,11 @@ public class ActivityManagerTest extends AbstractCoreTest {
     ((CachedActivityStorage) activityStorage).clearCache();
     restartTransaction();
 
-    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
-    assertEquals(0, activities.getSize());
-    assertEquals(0, activities.loadAsList(0, 100).size());
-    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+    assertThrows(IllegalAccessException.class,
+                 () -> activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter));
   }
 
+  @SneakyThrows
   public void testGetActivitiesBySpaceAndUser() {
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("Post activity to 'john' user stream by 'john'");
@@ -1824,13 +1827,13 @@ public class ActivityManagerTest extends AbstractCoreTest {
 
     ActivityFilter spaceActivityFilter = new ActivityFilter();
     spaceActivityFilter.setStreamType(ActivityStreamType.ANY_SPACE_ACTIVITY);
-    spaceActivityFilter.setSpaceIdentityId(space1Identity.getId());
-    spaceActivityFilter.setUserId(demoIdentity.getId());
+    spaceActivityFilter.setSpaceIdentityId(space1Identity.getIdentityId());
+    spaceActivityFilter.setUserId(demoIdentity.getIdentityId());
 
     ActivityFilter userActivityFilter = new ActivityFilter();
     userActivityFilter.setStreamType(ActivityStreamType.USER_STREAM);
-    userActivityFilter.setSpaceIdentityId(space1Identity.getId());
-    userActivityFilter.setUserId(demoIdentity.getId());
+    userActivityFilter.setSpaceIdentityId(space1Identity.getIdentityId());
+    userActivityFilter.setUserId(demoIdentity.getIdentityId());
 
     relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
     relationshipManager.confirm(demoIdentity, johnIdentity);
@@ -1890,16 +1893,89 @@ public class ActivityManagerTest extends AbstractCoreTest {
     ((CachedActivityStorage) activityStorage).clearCache();
     restartTransaction();
 
-    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, spaceActivityFilter);
-    assertEquals(0, activities.getSize());
-    assertEquals(0, activities.loadAsList(0, 100).size());
-    assertEquals(0, activities.loadIdsAsList(0, 100).size());
-    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, userActivityFilter);
-    assertEquals(0, activities.getSize());
-    assertEquals(0, activities.loadAsList(0, 100).size());
-    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+    assertThrows(IllegalAccessException.class,
+                 () -> activityManager.getActivitiesByFilterWithListAccess(demoIdentity, spaceActivityFilter));
+    spaceActivityFilter.setSpaceIdentityId(55896473l);
+    assertThrows(ObjectNotFoundException.class,
+                 () -> activityManager.getActivitiesByFilterWithListAccess(demoIdentity, spaceActivityFilter));
+    assertThrows(IllegalAccessException.class,
+                 () -> activityManager.getActivitiesByFilterWithListAccess(demoIdentity, userActivityFilter));
+    userActivityFilter.setSpaceIdentityId(55896473l);
+    assertThrows(ObjectNotFoundException.class,
+                 () -> activityManager.getActivitiesByFilterWithListAccess(demoIdentity, userActivityFilter));
   }
 
+  @SneakyThrows
+  public void testGetActivitiesWhenManager() {
+    Space space = this.getSpaceInstance(0);
+    restartTransaction();
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+
+    deleteSpaceAutomaticActivities(space);
+
+    spaceService.removeMember(space, johnIdentity.getRemoteId());
+    ((CachedActivityStorage) activityStorage).clearCache();
+    restartTransaction();
+
+    ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setSpaceIdentityId(spaceIdentity.getIdentityId());
+    activityFilter.setStreamType(ActivityStreamType.ANY_SPACE_ACTIVITY);
+
+    RealtimeListAccess<ExoSocialActivity> activities = activityManager.getActivitiesByFilterWithListAccess(johnIdentity,
+                                                                                                           activityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+
+    // demo posts activities to space
+    for (int i = 0; i < 10; i++) {
+      ExoSocialActivity activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title: " + i);
+      activity.setUserId(demoIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+
+      activity = new ExoSocialActivityImpl();
+      activity.setTitle("Activity Title: " + i);
+      activity.setUserId(johnIdentity.getId());
+      activityManager.saveActivityNoReturn(spaceIdentity, activity);
+    }
+    restartTransaction();
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(20, activities.getSize());
+    assertEquals(20, activities.loadAsList(0, 100).size());
+    assertEquals(20, activities.loadIdsAsList(0, 100).size());
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(johnIdentity, activityFilter);
+    assertEquals(20, activities.getSize());
+    assertEquals(20, activities.loadAsList(0, 100).size());
+    assertEquals(20, activities.loadIdsAsList(0, 100).size());
+
+    activityFilter.setSpaceIdentityId(0l);
+    activityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
+    activities = activityManager.getActivitiesByFilterWithListAccess(johnIdentity, activityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(20, activities.getSize());
+    assertEquals(20, activities.loadAsList(0, 100).size());
+    assertEquals(20, activities.loadIdsAsList(0, 100).size());
+
+    activityFilter.setUserId(johnIdentity.getIdentityId());
+    activityFilter.setStreamType(ActivityStreamType.USER_STREAM);
+    activities = activityManager.getActivitiesByFilterWithListAccess(johnIdentity, activityFilter);
+    assertEquals(0, activities.getSize());
+    assertEquals(0, activities.loadAsList(0, 100).size());
+    assertEquals(0, activities.loadIdsAsList(0, 100).size());
+    activities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertEquals(10, activities.getSize());
+    assertEquals(10, activities.loadAsList(0, 100).size());
+    assertEquals(10, activities.loadIdsAsList(0, 100).size());
+  }
+
+  @SneakyThrows
   public void testGetActivitiesWithLastCommentedFirst() {
     ExoSocialActivity johnActivity = new ExoSocialActivityImpl();
     johnActivity.setTitle("Post activity to 'john' user stream by 'john'");
@@ -1986,6 +2062,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(maryActivity.getId(), activityIds.get(0));
   }
 
+  @SneakyThrows
   public void testGetActivitiesByCategoryIds() throws ActivityStorageException {
     String activityTitle = "title";
     String userId = rootIdentity.getId();
@@ -2556,6 +2633,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(10, johnSpaceActivitiesFeed.getSize());
   }
 
+  @SneakyThrows
   public void testGetActivityByStreamTypeWithListAccess() throws ObjectAlreadyExistsException {
     populateActivityMass(demoIdentity, 1);
     populateActivityMass(maryIdentity, 2);
@@ -3280,6 +3358,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     }
   }
 
+  @SneakyThrows
   private void deleteRelationshipAutomaticActivities(Identity identity) {
     ActivityFilter userActivityFilter = new ActivityFilter();
     userActivityFilter.setStreamType(ActivityStreamType.ALL_STREAM);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -169,7 +169,7 @@ public class ActivityRest implements ResourceContainer {
         throw new WebApplicationException(Response.Status.UNAUTHORIZED);
       }
       Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
-      activityFilter.setSpaceIdentityId(spaceIdentity.getId());
+      activityFilter.setSpaceIdentityId(spaceIdentity.getIdentityId());
       canPost = activityManager.canPostActivityInStream(currentUser, spaceIdentity);
     } else {
       canPost = activityManager.canPostActivityInStream(currentUser, currentUserIdentity);
@@ -181,7 +181,14 @@ public class ActivityRest implements ResourceContainer {
     } else {
       activityFilter.setStreamType(ActivityStreamType.ALL_STREAM);
     }
-    RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getActivitiesByFilterWithListAccess(currentUserIdentity, activityFilter);
+    RealtimeListAccess<ExoSocialActivity> listAccess;
+    try {
+      listAccess = activityManager.getActivitiesByFilterWithListAccess(currentUserIdentity, activityFilter);
+    } catch (IllegalAccessException e) {
+      throw new WebApplicationException(e, Response.Status.UNAUTHORIZED);
+    } catch (ObjectNotFoundException e) {
+      throw new WebApplicationException(e, Response.Status.NOT_FOUND);
+    }
 
     String entitiesName = null;
     List<DataEntity> activityEntities = null;


### PR DESCRIPTION
Prior to this change, when a space template administrator or Platform Administrator attempts to access a space stream, the stream seems empty. This change ensures to display the space stream for Super Space Managers even when not member of the space.

Resolves Meeds-io/meeds#3438