### PR TITLE
fix: Fix Space Template Permission Check - Meeds-io/MIPs#187

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
@@ -400,7 +400,10 @@ public class SpaceServiceImpl implements SpaceService {
   @Override
   public Space createSpace(Space space, String username, List<Identity> identitiesToInvite) throws SpaceException {
     if (!getSpaceTemplateService().canCreateSpace(space.getTemplateId(), username)) {
-      throw new SpaceException(Code.SPACE_PERMISSION);
+      throw new SpaceException(Code.SPACE_PERMISSION,
+                               String.format("User %s isn't allowed to create space with template %s",
+                                             username,
+                                             space.getTemplateId()));
     }
 
     // Copy only settable properties from provided DTO

--- a/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
@@ -353,7 +353,7 @@ public class SpaceTemplateService {
     return aclIdentity != null
            && (spaceTemplate.getPermissions()
                             .stream()
-                            .anyMatch(expression -> aclIdentity.isMemberOf(getMembershipEntry(expression)))
+                            .anyMatch(expression -> UserACL.EVERYONE.equals(expression) || aclIdentity.isMemberOf(getMembershipEntry(expression)))
                || spaceTemplate.getAdminPermissions()
                                .stream()
                                .anyMatch(expression -> aclIdentity.isMemberOf(getMembershipEntry(expression))));


### PR DESCRIPTION
This change will allow to check whether the space template has a permission set to 'Everyone' or not when creating a new space with a designated Template Identifier.