### PR TITLE
fix: Add external-link icon in external links in sublevel navigation - MEED-9328 - Meeds-io/meeds#3442

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -52,6 +52,12 @@
             @mouseleave="showMenu = false"
             @mouseover="showMenu = true">
             <span class="text-body">{{ navigation.label }}</span>
+            <v-icon
+              v-if="navigation.target === 'NEW_TAB'"
+              size="12"
+              class="mx-1">
+              fa-external-link-alt
+            </v-icon>
           </v-list-item-title>
           <v-list-item-icon
             v-if="hasChildren && childrenHasPage"


### PR DESCRIPTION
This change will add external-link icon in external links in sublevel navigation.

Resolves Meeds-io/meeds#3442