### PR TITLE
fix: Add external-link icon in external links in sublevel navigation - MEED-9328 - Meeds-io/meeds#3442

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -47,7 +47,7 @@
           <v-list-item-title
             v-on="on"
             v-bind="attrs"
-            class="pt-5 pb-5"
+            class="pt-5 pb-5 d-flex"
             :class="hasPage && ' ' || ' not-clickable '"
             @mouseleave="showMenu = false"
             @mouseover="showMenu = true">


### PR DESCRIPTION
This change will align the external-link icon.

Resolves Meeds-io/meeds#3442