### PR TITLE
fix: Update the shortcut for opening notif center - MEED-9284 - Meeds-io/meeds#3404

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/main.js
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/main.js
@@ -56,7 +56,7 @@ export function init(badge) {
         created() {
           document.addEventListener('extension-WebNotification-notification-content-extension-updated', this.refreshNotificationExtensions);
           this.refreshNotificationExtensions();
-          this.$utils.addShortcutsListener(['r'], () => document.dispatchEvent(new CustomEvent('notifications-drawer-open')));
+          this.$utils.addShortcutsListener(['e'], () => document.dispatchEvent(new CustomEvent('notifications-drawer-open')));
           window.setInterval(() => this.now = Date.now(), 60000);
         },
         methods: {


### PR DESCRIPTION
Prior to this change, the shortcut `Ctrl + Shift + r` was used to open the notification drawer. This change updates the shortcut to `Ctrl + Shift + e` instead