### PR TITLE
fix: Content link menu not displayed properly when there is no space at the bottom - MEED-9277 - Meeds-io/meeds#3390

### DIFF
--- a/webapp/src/main/webapp/vue-apps/content-link/components/ContentLinkCommandMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/content-link/components/ContentLinkCommandMenu.vue
@@ -34,8 +34,7 @@
     z-index="2000"
     absolute
     offset-y
-    bottom
-    attach>
+    bottom>
     <v-list
       v-if="isCommandFiltering"
       class="pa-0"


### PR DESCRIPTION
Prior to this change, the content link menu was not displayed properly when there was no space at the bottom. The issue was caused by the menu being attached to the editor, which prevented automatic repositioning when there was insufficient space at the bottom of the screen. This change removes the attach property, resolving the issue
