### PR TITLE
fix: Filter Category identities when updating via UI - MEED-9380 - Meeds-io/meeds#3460

### DIFF
--- a/webapp/src/main/webapp/vue-apps/category-management/components/drawer/CategoryFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/category-management/components/drawer/CategoryFormDrawer.vue
@@ -282,7 +282,7 @@ export default {
     },
     nextStep() {
       if (this.step === 2 && this.drawer && this.isNew && !this.category.linkPermissionIds?.length) {
-        this.category.linkPermissionIds = this.category.accessPermissionIds.slice();
+        this.category.linkPermissionIds = this.category.accessPermissionIds.slice().filter(id => id && id !== '0');
       }
       this.step++;
     },
@@ -303,6 +303,9 @@ export default {
     async save() {
       this.saving = true;
       try {
+        if (this.category?.linkPermissionIds?.length) {
+          this.category.linkPermissionIds = this.category.linkPermissionIds.filter(id => id && id !== '0');
+        }
         if (this.isNew) {
           this.category = await this.$categoryService.createCategory(this.category);
           await this.$nextTick();

--- a/webapp/src/main/webapp/vue-apps/category-management/components/form/Permissions.vue
+++ b/webapp/src/main/webapp/vue-apps/category-management/components/form/Permissions.vue
@@ -155,7 +155,7 @@ export default {
   async created() {
     const identityIds = this.value?.slice?.() || [];
     const permissions = await Promise.all(identityIds.map(this.retrieveGroupIdByIdentityId));
-    this.isAnyPermissions = permissions?.find?.(p => p === this.$root.everyonePermission) && true || false;
+    this.isAnyPermissions = this.showAny && permissions?.find?.(p => p === this.$root.everyonePermission) && true || false;
     this.isUserPermissions = permissions?.find?.(p => p === this.$root.usersPermission) && true || false;
     this.isGuestPermissions = permissions?.find?.(p => p === this.$root.guestsPermission) && true || false;
     this.specificGroupEntries = [];


### PR DESCRIPTION
Prior to this change, when updating the Category permission identities and when it has a technical id (0), then the list isn't updated correctly. This is due to the fact that the link permission ids are duplicated from Access permissions without filtering on permission 'Everyone'.

Resolves Meeds-io/meeds#3460