### PR TITLE
Fix: Mustache syntax (double curly braces) in a task comment displays an empty comment - meed-9327 - meeds-io/meeds#3439 

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/DynamicHTMLElement.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/DynamicHTMLElement.vue
@@ -1,6 +1,14 @@
 <script>
 export default {
   render: function (createElement) {
+    if (this.html) {
+      const formattedHtml = ExtendedDomPurify.purify(`<div>${this.html}</div>`);
+      return createElement(this.element || 'div', {
+        domProps: {
+          innerHTML: formattedHtml
+        }
+      });
+    }
     return createElement(
       this.element || 'div',
       this.$slots.default,
@@ -22,6 +30,10 @@ export default {
       type: Object,
       default: () => null,
     },
+    html: {
+      type: String,
+      default: ''
+    }
   },
 };
 </script>


### PR DESCRIPTION
Before this change, when adding a comment containing mustache syntax (double curly braces) in a task and checking the comment, the typed content isn't displayed as text between double curly braces is considered a Vue.js variable that is not defined. To fix this problem, in dynamic-html-element, add an HTML prop to be injected directly into the DOM using the domProps option provided by render(createElement). After this change, add an HTML prop to display an HTML in the DOM.
Resolves https://github.com/Meeds-io/meeds/issues/3439