### PR TITLE
fix: double curly braces in Activity/comments displays an empty content - meed-9356 - meeds-io/meeds#3447

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -4,7 +4,7 @@
     class="position-relative">
     <dynamic-html-element
       v-if="isBodyNotEmpty"
-      :child="bodyElement"
+      :html="bodyElement"
       :element="element"
       :class="bodyClass"
       class="reset-style-box rich-editor-content text-break"
@@ -53,9 +53,7 @@ export default {
   }),
   computed: {
     bodyElement() {
-      return {
-        template: ExtendedDomPurify.purify(`<div>${this.body}</div>`) || '',
-      };
+      return this.body || '';
     },
     getBody() {
       return this.activityTypeExtension && this.activityTypeExtension.getBody;


### PR DESCRIPTION
before this change, when create activity/activity comment/news comment having double curly braces in content, the typed content isn't displayed as text between double curly braces is considered as vuejs variable that is not defined. To fix this problem, use the html prop instead of child. after this change, the comment is displayed correctly.