### PR TITLE
feat: Add Digest Password Generator Endpoint - EXIP-17

### DIFF
--- a/component/service/src/main/java/io/meeds/social/security/rest/DigestAuthenticatorRest.java
+++ b/component/service/src/main/java/io/meeds/social/security/rest/DigestAuthenticatorRest.java
@@ -1,0 +1,55 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.rest;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.meeds.web.security.authenticator.DigestAuthenticatorService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/digest")
+@Tag(name = "/digest", description = "Manage digest authentication code")
+public class DigestAuthenticatorRest {
+
+  @Autowired
+  private DigestAuthenticatorService digestAuthenticatorService;
+
+  @GetMapping
+  @Secured("users")
+  @Operation(summary = "Generates a temporary password for current user", method = "GET")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "Request fullfilled"),
+  })
+  public String generatePassword(HttpServletRequest request) throws IOException {
+    return digestAuthenticatorService.generatePassword(request.getRemoteUser());
+  }
+
+}


### PR DESCRIPTION
This change will allow to generate a temporary password for current user which may be used in REST endpoints authenticated using Digest method.

Resolves exoplatform/eXIP#1