### PR TITLE
fix: Allow to select a Cotnent Link by click - MEED-9423 - Meeds-io/meeds#3486

### DIFF
--- a/webapp/src/main/webapp/js/ckeditorPlugins/insertContentLink/plugin.js
+++ b/webapp/src/main/webapp/js/ckeditorPlugins/insertContentLink/plugin.js
@@ -109,8 +109,9 @@
   
       function matchCallback(text, offset) {
         const left = text.slice(0, offset);
-        const match = left?.match?.(/\/([a-z]*)(:[^>^<^.]*)?$/);
+        let match = left?.split(/\s/)?.pop?.()?.trim?.()?.match?.(/^\/([a-z]*)(:[^>^<^.]*)?$/);
         if (match?.length) {
+          match = left.match(/\/([a-z]*)(:[^>^<^.]*)?$/);
           return {
             start: match.index + 1,
             end: offset,
@@ -170,6 +171,8 @@
             getWindow().document.dispatchEvent(new CustomEvent('custom-link-item-select-up'));
           } else if (evt.data.keyCode == 13) {
             getWindow().document.dispatchEvent(new CustomEvent('custom-link-item-select'));
+          } else if (evt.data.keyCode == 27) {
+            getWindow().document.dispatchEvent(new CustomEvent('content-link-menu-close'));
           }
         }
       }

--- a/webapp/src/main/webapp/vue-apps/content-link/components/ContentLinkCommandMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/content-link/components/ContentLinkCommandMenu.vue
@@ -46,6 +46,7 @@
           :value="index"
           class="ps-0"
           dense
+          @mousedown.stop.prevent="0"
           @click.stop.prevent="selectCommand(p)">
           <v-list-item-icon class="my-auto mx-2">
             <v-card
@@ -81,6 +82,7 @@
               :key="link.objectId"
               :value="index"
               dense
+              @mousedown.stop.prevent="0"
               @click.prevent.stop="selectItem(link)">
               <v-list-item-content class="text-truncate">
                 <v-list-item-title :title="link.title" class="text-truncate">{{ link.title }}</v-list-item-title>
@@ -240,6 +242,7 @@ export default {
         const textToInsert = query?.length ? plugin.command.replace(query, '') : plugin.command;
         this.$root.editor.insertText(`${textToInsert}:`);
         this.plugin = plugin;
+        this.query = `${textToInsert}:`;
       }
     },
     async selectItem(link) {


### PR DESCRIPTION
Prior to this change, when clicking on a searched content to link in CKEditor, the menu is closed and the content isn't selected. This change ensures to select the content before closing the menu.

Resolves Meeds-io/meeds#3486