### PR TITLE
fix : Ensure to broadcast profile save event when updating the profile - MEED-9427

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/service/impl/OAuthRegistrationServiceImpl.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/service/impl/OAuthRegistrationServiceImpl.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -161,8 +162,8 @@ public class OAuthRegistrationServiceImpl implements OAuthRegistrationService {
           //if it exists, update the value
           if (setting.isMultiValued()) {
            List<String> values = Arrays.asList(value.split(this.customClaimsMultiValuedSeparator));
-           List<Map<String, String>> maps =
-               values.stream().map(s -> Collections.singletonMap("value", s)).collect(Collectors.toList());
+           List<HashMap<String, String>> maps =
+               values.stream().map(s -> new HashMap<>(Map.of("value", s))).collect(Collectors.toList());
            profile.setProperty(key, maps);
           } else {
             profile.setProperty(key, value);
@@ -173,7 +174,7 @@ public class OAuthRegistrationServiceImpl implements OAuthRegistrationService {
 
       if (isProfileUpdated.get()) {
         //if at least one property was updated, update the profile
-        identityManager.updateProfile(profile);
+        identityManager.updateProfile(profile, true);
       }
     } finally {
       endTransaction();


### PR DESCRIPTION
Before this fix, when login with OIDC using custom claims, the listeners to add users in groups are not launched because broadcast=false In addition, when filling the property, we do not use the correct Map type, so the save was not working.

Resolves meeds-io/meeds#3488

(cherry picked from commit 1dec4d6fa7a180bda5698b729046d59500a87bd7)