### PR TITLE
fix: Fix Attachment Download URL - MEED-9424 - Meeds-io/meeds#3487

### DIFF
--- a/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsDefaultPreview.vue
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsDefaultPreview.vue
@@ -29,8 +29,8 @@
     <v-btn
       color="primary"
       text
-      :href="downloadURL"
-      :download="attachment.filename">
+      :href="downloadUrl"
+      :download="filename">
       {{ $t('attachment.downloadFile') }}
     </v-btn>
   </v-card>
@@ -58,8 +58,11 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'md';
     },
-    downloadURL() {
-      return `${eXo.env.portal.context}${ this.attachment.downloadUrl}?size=0x0&download=true`;
+    filename() {
+      return this.attachment.filename;
+    },
+    downloadUrl() {
+      return this.attachment.downloadUrl;
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsPreviewDownloadAction.vue
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/components/preview/AttachmentsPreviewDownloadAction.vue
@@ -19,8 +19,8 @@
 <template>
   <v-btn
     id="preview-attachment-download"
-    :href="downloadURL"
-    :download="attachment?.filename"
+    :href="downloadUrl"
+    :download="filename"
     :class="!isMobile && 'icon-large-size' || 'icon-medium-size'"
     :title="$t('attachment.imageDownload')"
     icon
@@ -41,10 +41,12 @@ export default {
     },
   },
   computed: {
-    downloadURL() {
-      return this.attachment && `${eXo.env.portal.context}${ this.attachment.downloadUrl}?size=0x0&download=true`;
-    }
+    filename() {
+      return this.attachment?.filename;
+    },
+    downloadUrl() {
+      return this.attachment?.downloadUrl;
+    },
   },
 };
 </script>
-


### PR DESCRIPTION
Prior to this change, the Download Attachment URL was concatenated with two `'/portal' + '/portal'` and with an additional `'?download=true&size=0x0' + '?download=true&size=0x0'`. This change removes those duplications to retrieve the good path for downloading the attachment.

Resolves Meeds-io/meeds#3487