### PR TITLE
fix : Radius management is not applied on login portlet - meeds-io/MIPs#203 - MEED-9425

### DIFF
--- a/webapp/src/main/webapp/vue-apps/platform-logo/components/PlatformLogo.vue
+++ b/webapp/src/main/webapp/vue-apps/platform-logo/components/PlatformLogo.vue
@@ -19,13 +19,15 @@
 
 -->
 <template>
-  <v-card flat class="d-flex full-height justify-center">
-    <img
-      :src="platformLogo"
-      alt=""
-      width="auto"
-      class="object-fit-contain">
-  </v-card>
+  <v-app>
+    <v-card flat class="d-flex full-height justify-center rounded-0 transparent">
+      <img
+        :src="platformLogo"
+        alt=""
+        width="auto"
+        class="object-fit-contain">
+    </v-card>
+  </v-app>
 </template>
 
 <script>

--- a/webapp/src/main/webapp/vue-apps/platform-name/components/PlatformName.vue
+++ b/webapp/src/main/webapp/vue-apps/platform-name/components/PlatformName.vue
@@ -19,12 +19,14 @@
 
 -->
 <template>
-  <v-card-title
-    class="text-title text-h4 primary--text text-center justify-center full-height py-0">
-    <span class="text-truncate-2 full-width">
-      {{ platformName }}
-    </span>
-  </v-card-title>
+  <v-app>
+    <v-card-title
+      class="text-title text-h4 primary--text text-center justify-center full-height py-0">
+      <span class="text-truncate-2 full-width">
+        {{ platformName }}
+      </span>
+    </v-card-title>
+  </v-app>
 </template>
 
 <script>

--- a/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLogin.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLogin.vue
@@ -19,14 +19,7 @@
 
 -->
 <template>
-  <v-card
-    flat
-    :color="this.backgroundPath && 'transparent' || 'primary'"
-    class="full-height d-flex justify-center align-center">
-    <img v-if="backgroundPath"
-         :src="backgroundPath"
-         :alt="backgroundAlt"
-         class="full-height full-witdh object-fit-cover">
+  <v-app>
     <v-card
       flat
       :color="this.backgroundPath && 'transparent' || 'primary'"
@@ -50,7 +43,7 @@
         </v-card-title>
       </v-card>
     </v-card>
-  </v-card>
+  </v-app>
 </template>
 
 <script>


### PR DESCRIPTION
Before this fix, the radius from page layout is not applied to loginSidebar, platformName, and platformLogo portlet

This fix add v-app component so that radius are correctly applied.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
