### PR TITLE
fix: Display the total number of comments in activity details and the comment drawer - MEED-9450 - Meeds-io/Meeds#3455

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -626,9 +626,9 @@ public interface ActivityManager {
   /**
    * Gets the number of comments and subcomments of an activity.
    *
-   * @param existingActivity
+   * @param activityId {@link ExoSocialActivity} identifier
    * @return
    */
-  int getNumberOfAllComments(ExoSocialActivity existingActivity);
+  int getNumberOfAllComments(String activityId);
 
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -623,4 +623,12 @@ public interface ActivityManager {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Gets the number of comments and subcomments of an activity.
+   *
+   * @param existingActivity
+   * @return
+   */
+  int getNumberOfAllComments(ExoSocialActivity existingActivity);
+
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
@@ -629,6 +629,14 @@ public interface ActivityStorage {
   public int getNumberOfComments(ExoSocialActivity existingActivity);
 
   /**
+   * Gets the number of comments and subcomments of an activity.
+   *
+   * @param existingActivity
+   * @return
+   */
+  public int getNumberOfAllComments(ExoSocialActivity existingActivity);
+
+  /**
    * Gets the number of newer comments of an activity based on a comment.
    *
    * @param existingActivity

--- a/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
@@ -631,10 +631,10 @@ public interface ActivityStorage {
   /**
    * Gets the number of comments and subcomments of an activity.
    *
-   * @param existingActivity
+   @param activityId {@link ExoSocialActivity} identifier
    * @return
    */
-  public int getNumberOfAllComments(ExoSocialActivity existingActivity);
+  public int getNumberOfAllComments(String activityId);
 
   /**
    * Gets the number of newer comments of an activity based on a comment.

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -1492,6 +1492,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
   }
 
   @Override
+  public int getNumberOfAllComments(ExoSocialActivity existingActivity) {
+    return (int) activityDAO.getNumberOfAllComments(Long.valueOf(existingActivity.getId()));
+  }
+
+  @Override
   public int getNumberOfNewerComments(ExoSocialActivity existingActivity, ExoSocialActivity baseComment) {
     return getNewerComments(existingActivity, baseComment, 0).size();
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -1492,8 +1492,8 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
   }
 
   @Override
-  public int getNumberOfAllComments(ExoSocialActivity existingActivity) {
-    return (int) activityDAO.getNumberOfAllComments(Long.valueOf(existingActivity.getId()));
+  public int getNumberOfAllComments(String activityId) {
+    return activityDAO.getNumberOfAllComments(Long.parseLong(activityId));
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
@@ -423,7 +423,7 @@ public interface ActivityDAO extends GenericDAO<ActivityEntity, Long> {
    * @param activityId the Id of activity
    * @return the total number of comments
    */
-  long getNumberOfAllComments(long activityId);
+  int getNumberOfAllComments(long activityId);
 
   /**
    *

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
@@ -420,6 +420,12 @@ public interface ActivityDAO extends GenericDAO<ActivityEntity, Long> {
   long getNumberOfComments(long activityId);
 
   /**
+   * @param activityId the Id of activity
+   * @return the total number of comments
+   */
+  long getNumberOfAllComments(long activityId);
+
+  /**
    *
    * @param activityId the Id of activity
    * @param offset the start index

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -824,6 +824,13 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   }
 
   @Override
+  public long getNumberOfAllComments(long activityId) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("SocActivity.numberCommentsAndSubCommentsOfActivity", Long.class);
+    query.setParameter(ACTIVITY_ID_PARAM, activityId);
+    return query.getSingleResult();
+  }
+
+  @Override
   public List<ActivityEntity> findCommentsOfActivities(List<Long> ids) {
     TypedQuery<ActivityEntity> query = getEntityManager().createNamedQuery("SocActivity.findCommentsOfActivities", ActivityEntity.class);
     query.setParameter("ids", ids);

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -824,10 +824,10 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   }
 
   @Override
-  public long getNumberOfAllComments(long activityId) {
+  public int getNumberOfAllComments(long activityId) {
     TypedQuery<Long> query = getEntityManager().createNamedQuery("SocActivity.numberCommentsAndSubCommentsOfActivity", Long.class);
     query.setParameter(ACTIVITY_ID_PARAM, activityId);
-    return query.getSingleResult();
+    return query.getSingleResult().intValue();
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ActivityEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ActivityEntity.java
@@ -77,6 +77,7 @@ import lombok.Setter;
         @NamedQuery(name = "SocActivity.findCommentsAndSubCommentsOfActivity", query = "SELECT a FROM SocActivity a "
         + " WHERE a.parent.id = :activityId OR a.parent.parent.id = :activityId ORDER BY a.posted ASC"),
         @NamedQuery(name = "SocActivity.numberCommentsOfActivity", query = "SELECT count(distinct a.id) FROM SocActivity a WHERE a.parent.id = :activityId"),
+        @NamedQuery(name = "SocActivity.numberCommentsAndSubCommentsOfActivity", query = "SELECT count(distinct a.id) FROM SocActivity a WHERE a.parent.id = :activityId OR a.parent.parent.id = :activityId"),
         @NamedQuery(name = "SocActivity.findNewerCommentsOfActivity",
                 query = "SELECT a FROM SocActivity a WHERE a.parent.id = :activityId AND a.posted > :sinceTime ORDER BY a.updatedDate ASC"),
         @NamedQuery(name = "SocActivity.findOlderCommentsOfActivity",

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -996,6 +996,11 @@ public class ActivityManagerImpl implements ActivityManager {
     return false;
   }
 
+  @Override
+  public int getNumberOfAllComments(ExoSocialActivity existingActivity){
+    return activityStorage.getNumberOfAllComments(existingActivity);
+  }
+
   public boolean isAutomaticActivity(ExoSocialActivity activity) {
     // Only not automatic created comments are editable
     return activity != null

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -997,8 +997,8 @@ public class ActivityManagerImpl implements ActivityManager {
   }
 
   @Override
-  public int getNumberOfAllComments(ExoSocialActivity existingActivity){
-    return activityStorage.getNumberOfAllComments(existingActivity);
+  public int getNumberOfAllComments(String activityId){
+    return activityStorage.getNumberOfAllComments(activityId);
   }
 
   public boolean isAutomaticActivity(ExoSocialActivity activity) {

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
@@ -1129,14 +1129,12 @@ public class CachedActivityStorage implements ActivityStorage {
                                .build();
   }
 
-  /**
-   * {@inheritDoc}
-   */
-  public int getNumberOfAllComments(final ExoSocialActivity existingActivity) {
-    ActivityListKey key = new ActivityListKey(existingActivity.getId(), ActivityType.COMMENTS);
+  @Override
+  public int getNumberOfAllComments(String activityId) {
+    ActivityListKey key = new ActivityListKey(activityId, ActivityType.COMMENTS);
     return activitiesCountCache.get(new ServiceContext<IntegerData>() {
       public IntegerData execute() {
-        return new IntegerData(storage.getNumberOfAllComments(existingActivity));
+        return new IntegerData(storage.getNumberOfAllComments(activityId));
       }
     }, key).build();
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
@@ -1132,6 +1132,18 @@ public class CachedActivityStorage implements ActivityStorage {
   /**
    * {@inheritDoc}
    */
+  public int getNumberOfAllComments(final ExoSocialActivity existingActivity) {
+    ActivityListKey key = new ActivityListKey(existingActivity.getId(), ActivityType.COMMENTS);
+    return activitiesCountCache.get(new ServiceContext<IntegerData>() {
+      public IntegerData execute() {
+        return new IntegerData(storage.getNumberOfAllComments(existingActivity));
+      }
+    }, key).build();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public int getNumberOfNewerComments(final ExoSocialActivity existingActivity, final ExoSocialActivity baseComment) {
     return storage.getNumberOfNewerComments(existingActivity, baseComment);
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -1329,7 +1329,7 @@ public class EntityBuilder {
       activityEntity.setMetadatas(activityMetadatasToPublish);
     }
     if (expandFields.contains(TOTAL_COMMENTS_COUNT)) {
-      activityEntity.setTotalCommentsCount(getActivityManager().getNumberOfAllComments(activity));
+      activityEntity.setTotalCommentsCount(getActivityManager().getNumberOfAllComments(activity.getId()));
     }
     return activityEntity;
   }
@@ -1438,15 +1438,6 @@ public class EntityBuilder {
     }
   }
 
-  public static boolean expandTotalActivityCommentsCount(String expand) {
-    if (StringUtils.isNotEmpty(expand)) {
-      List<String> expandFields = Arrays.asList(expand.split(","));
-      return expandFields.contains(TOTAL_COMMENTS_COUNT);
-    } else {
-      return false;
-    }
-  }
-
   public static CommentEntity buildEntityFromComment(ExoSocialActivity comment,
                                                      Identity authentiatedUser,
                                                      String restPath,
@@ -1544,12 +1535,8 @@ public class EntityBuilder {
         }
       }
     }
-    int totalActivityCommentsCount = getActivityManager().getNumberOfAllComments(activity);
     for (ExoSocialActivity comment : comments) {
       CommentEntity commentInfo = buildEntityFromComment(comment, authentiatedUser, restPath, expand, true);
-      if (expandTotalActivityCommentsCount(expand)) {
-        commentInfo.setTotalCommentsCount(totalActivityCommentsCount);
-      }
       commentsEntity.add(commentInfo.getDataEntity());
     }
     return commentsEntity;

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -225,6 +225,8 @@ public class EntityBuilder {
 
   private static final String             COMMENT_PARAM                              = "comment";
 
+  public static final String              TOTAL_COMMENTS_COUNT                       = "totalCommentsCount";
+
   private static final int                DEFAULT_LIKERS_LIMIT                       = 4;
 
   private static UserPortalConfigService  userPortalConfigService;
@@ -1326,6 +1328,9 @@ public class EntityBuilder {
     if (MapUtils.isNotEmpty(activityMetadatasToPublish)) {
       activityEntity.setMetadatas(activityMetadatasToPublish);
     }
+    if (expandFields.contains(TOTAL_COMMENTS_COUNT)) {
+      activityEntity.setTotalCommentsCount(getActivityManager().getNumberOfAllComments(activity));
+    }
     return activityEntity;
   }
 
@@ -1433,6 +1438,15 @@ public class EntityBuilder {
     }
   }
 
+  public static boolean expandTotalActivityCommentsCount(String expand) {
+    if (StringUtils.isNotEmpty(expand)) {
+      List<String> expandFields = Arrays.asList(expand.split(","));
+      return expandFields.contains(TOTAL_COMMENTS_COUNT);
+    } else {
+      return false;
+    }
+  }
+
   public static CommentEntity buildEntityFromComment(ExoSocialActivity comment,
                                                      Identity authentiatedUser,
                                                      String restPath,
@@ -1530,8 +1544,12 @@ public class EntityBuilder {
         }
       }
     }
+    int totalActivityCommentsCount = getActivityManager().getNumberOfAllComments(activity);
     for (ExoSocialActivity comment : comments) {
       CommentEntity commentInfo = buildEntityFromComment(comment, authentiatedUser, restPath, expand, true);
+      if (expandTotalActivityCommentsCount(expand)) {
+        commentInfo.setTotalCommentsCount(totalActivityCommentsCount);
+      }
       commentsEntity.add(commentInfo.getDataEntity());
     }
     return commentsEntity;

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ActivityCommentCollectionEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ActivityCommentCollectionEntity.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.rest.entity;
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class ActivityCommentCollectionEntity extends CollectionEntity {
+
+  private static final long serialVersionUID = 1331039452620840730L;
+
+  public ActivityCommentCollectionEntity(List<? extends DataEntity> entities, String key, int offset, int limit) {
+    super(entities, key, offset, limit);
+  }
+
+  public int getTotalCommentsSize() {
+    Integer totalCommentsSize = (Integer) get("totalCommentsSize");
+    return (totalCommentsSize == null) ? -1 : totalCommentsSize;
+  }
+
+  public void setTotalCommentsSize(int totalCommentsSize) {
+    put("totalCommentsSize", totalCommentsSize);
+  }
+
+}

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ActivityEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ActivityEntity.java
@@ -361,4 +361,14 @@ public class ActivityEntity extends BaseEntity {
     return (List<String>) getProperty("targetSpaces");
   }
 
+  public ActivityEntity setTotalCommentsCount(int totalCommentsCount) {
+    setProperty("totalCommentsCount", totalCommentsCount);
+    return this;
+  }
+
+  public int getTotalCommentsCount() {
+    Object count = getProperty("totalCommentsCount");
+    return count == null ? 0 : Integer.parseInt(count.toString());
+  }
+
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -72,6 +72,7 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.rest.api.EntityBuilder;
 import org.exoplatform.social.rest.api.RestUtils;
+import org.exoplatform.social.rest.entity.ActivityCommentCollectionEntity;
 import org.exoplatform.social.rest.entity.ActivityEntity;
 import org.exoplatform.social.rest.entity.ActivitySearchResultEntity;
 import org.exoplatform.social.rest.entity.CollectionEntity;
@@ -513,11 +514,12 @@ public class ActivityRest implements ResourceContainer {
                                                                            sortDescending,
                                                                            offset,
                                                                            limit);
-    CollectionEntity collectionComment = new CollectionEntity(commentsEntity, EntityBuilder.COMMENTS_TYPE, offset, limit);
+    ActivityCommentCollectionEntity collectionComment = new ActivityCommentCollectionEntity(commentsEntity, EntityBuilder.COMMENTS_TYPE, offset, limit);
     if (returnSize) {
       boolean expandSubComments = EntityBuilder.expandSubComments(expand);
       RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getCommentsWithListAccess(activity, expandSubComments);
       collectionComment.setSize(listAccess.getSize());
+      collectionComment.setTotalCommentsSize(activityManager.getNumberOfAllComments(activityId));
     }
     //
     return EntityBuilder.getResponse(collectionComment, uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -89,6 +89,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import static org.exoplatform.social.rest.api.EntityBuilder.TOTAL_COMMENTS_COUNT;
+
 @Path(VersionResources.VERSION_ONE + "/social/activities")
 @Tag(name = VersionResources.VERSION_ONE + "/social/activities", description = "Managing activities together with comments and likes")
 public class ActivityRest implements ResourceContainer {
@@ -519,6 +521,8 @@ public class ActivityRest implements ResourceContainer {
       boolean expandSubComments = EntityBuilder.expandSubComments(expand);
       RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getCommentsWithListAccess(activity, expandSubComments);
       collectionComment.setSize(listAccess.getSize());
+    }
+    if (StringUtils.contains(expand, TOTAL_COMMENTS_COUNT)) {
       collectionComment.setTotalCommentsSize(activityManager.getNumberOfAllComments(activityId));
     }
     //

--- a/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactions.vue
@@ -48,6 +48,7 @@
       :activity="activity"
       :likers-number="likersNumber"
       :comment-number="commentNumber"
+      :total-comments-number="totalCommentsNumber"
       class="d-flex d-lg-none align-center"
       @openDrawer="openDrawer" />
   </div>
@@ -72,6 +73,10 @@ export default {
       default: 0
     },
     commentNumber: {
+      type: Number,
+      default: 0
+    },
+    totalCommentsNumber: {
       type: Number,
       default: 0
     },

--- a/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsMobile.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsMobile.vue
@@ -14,7 +14,7 @@
       v-if="commentNumber > 0"
       class="my-1 me-2 CommentsNumber"
       @click="openComments">
-      {{ commentNumber }} {{ $t('UIActivity.comment.commentsLabel') }}
+      {{ totalCommentsNumber }} {{ $t('UIActivity.comment.commentsLabel') }}
     </a>
     <extension-registry-components
       :params="extensionParams"
@@ -37,6 +37,10 @@ export default {
       default: 0
     },
     commentNumber: {
+      type: Number,
+      default: 0
+    },
+    totalCommentsNumber: {
       type: Number,
       default: 0
     }

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/ActivityFooter.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/ActivityFooter.vue
@@ -15,6 +15,7 @@
         :likers="likers"
         :likers-number="likersCount"
         :comment-number="commentsCount"
+        :total-comments-number="totalCommentsCount"
         class="flex-grow-1 ps-4" />
       <activity-actions
         :activity="activity"
@@ -48,6 +49,7 @@ export default {
   data: () => ({
     likersCount: 0,
     commentsCount: 0,
+    totalCommentsCount: 0,
     likers: [],
   }),
   computed: {
@@ -99,6 +101,7 @@ export default {
     },
     checkCommentsSize() {
       this.commentsCount = this.activity.commentsSize;
+      this.totalCommentsCount = this.activity.totalCommentsSize;
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -170,6 +170,7 @@ export default {
     this.$root.$on('activities-refresh', this.refreshActivities);
     this.$root.$on('activity-read', this.markActivityAsRead);
     this.$root.$on('activity-loaded', this.refreshUnreadCount);
+    this.$root.$on('set-activity-comment-size', this.setActivityCommentSize);
     document.addEventListener('categories-updated', this.refreshActivitiesByCategories);
     document.addEventListener('activity-deleted', this.handleDeletedByEvent);
     document.addEventListener('activity-pinned', this.handlePinnedByEvent);
@@ -195,6 +196,7 @@ export default {
     this.$root.$off('activities-refresh', this.refreshActivities);
     this.$root.$off('activity-read', this.markActivityAsRead);
     this.$root.$off('activity-loaded', this.refreshUnreadCount);
+    this.$root.$off('set-activity-comment-size', this.setActivityCommentSize);
     document.removeEventListener('categories-updated', this.refreshActivitiesByCategories);
     document.removeEventListener('activity-deleted', this.handleDeletedByEvent);
     document.removeEventListener('activity-pinned', this.handlePinnedByEvent);
@@ -450,6 +452,13 @@ export default {
     displayAlert(message, type) {
       this.$root.$emit('alert-message', message, type || 'success');
     },
+    setActivityCommentSize(activityId, activityCommentSize, activityTotalCommentSize) {
+      const activity = this.activities.find(activity => activity.id === activityId);
+      if (activity) {
+        activity.totalCommentsSize = activityTotalCommentSize;
+        activity.commentsSize = activityCommentSize;
+      }
+    }
   },
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
@@ -270,7 +270,7 @@ export default {
         .then(data => {
           let comments = data && data.comments || [];
           this.commentsSize = data && data.size && Number(data.size) || 0;
-          this.totalCommentsSize = comments[0]?.totalCommentsCount;
+          this.totalCommentsSize = this.activity.totalCommentsSize = data?.totalCommentsSize && Number(data.totalCommentsSize) || 0;
           this.pagesCount = parseInt((this.commentsSize + this.limit - 1) / this.limit);
           if (loadLastComments) {
             this.page = this.pagesCount;

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
@@ -71,6 +71,7 @@ export default {
   data: () => ({
     comments: [],
     commentsSize: 0,
+    totalCommentsSize: 0,
     activity: null,
     initialized: false,
     drawerOpened: false,
@@ -93,12 +94,12 @@ export default {
     commentsTitle() {
       if (!this.initialized) {
         return '';
-      } else if (this.commentsSize === 0) {
+      } else if (this.totalCommentsSize === 0) {
         return this.$t('activity.noComments');
-      } else if (this.commentsSize === 1) {
+      } else if (this.totalCommentsSize === 1) {
         return this.$t('activity.singleComment');
       } else {
-        return this.$t('activity.commentsCount', {0: this.commentsSize});
+        return this.$t('activity.commentsCount', {0: this.totalCommentsSize});
       }
     },
     enabled() {
@@ -133,6 +134,7 @@ export default {
     reset() {
       this.comments = [];
       this.commentsSize = 0;
+      this.totalCommentsSize = 0;
       this.drawerOpened = false;
       this.page = 1;
       this.offset = 0;
@@ -268,6 +270,7 @@ export default {
         .then(data => {
           let comments = data && data.comments || [];
           this.commentsSize = data && data.size && Number(data.size) || 0;
+          this.totalCommentsSize = comments[0]?.totalCommentsCount;
           this.pagesCount = parseInt((this.commentsSize + this.limit - 1) / this.limit);
           if (loadLastComments) {
             this.page = this.pagesCount;

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsDrawer.vue
@@ -270,7 +270,8 @@ export default {
         .then(data => {
           let comments = data && data.comments || [];
           this.commentsSize = data && data.size && Number(data.size) || 0;
-          this.totalCommentsSize = this.activity.totalCommentsSize = data?.totalCommentsSize && Number(data.totalCommentsSize) || 0;
+          this.totalCommentsSize = data?.totalCommentsSize && Number(data.totalCommentsSize) || 0;
+          this.$root.$emit('set-activity-comment-size', this.activity.id, this.commentsSize, this.totalCommentsSize);
           this.pagesCount = parseInt((this.commentsSize + this.limit - 1) / this.limit);
           if (loadLastComments) {
             this.page = this.pagesCount;

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
@@ -95,7 +95,7 @@ export default {
           this.$nextTick().then(() => {
             this.comments = data && data.comments || [];
             this.activity.commentsSize = this.commentsSize = data && data.size && Number(data.size) || 0;
-            this.totalCommentsSize = this.activity.totalCommentsSize = this.comments[0]?.totalCommentsCount || 0;
+            this.totalCommentsSize = this.activity.totalCommentsSize = data?.totalCommentsSize && Number(data.totalCommentsSize) || 0;
             this.$root.$emit('activity-comments-retrieved', this.activity, this.comments);
           });
         })

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
@@ -22,7 +22,7 @@
       link
       text
       @click="openCommentsDrawer">
-      {{ $t('UIActivity.label.Show_All_Comments', {0: commentsSize}) }}
+      {{ $t('UIActivity.label.Show_All_Comments', {0: totalCommentsSize}) }}
     </v-btn>
   </div>
 </template>
@@ -50,6 +50,7 @@ export default {
   data: () => ({
     comments: [],
     commentsSize: 0,
+    totalCommentsSize: 0,
     limit: 2,
     loading: true,
   }),
@@ -76,6 +77,7 @@ export default {
       this.$nextTick().then(() => {
         this.comments = this.$activityService.computeParentCommentsList(this.activity.comments) || [];
         this.activity.commentsSize = this.commentsSize = this.activity.commentsCount && Number(this.activity.commentsCount) || 0;
+        this.totalCommentsSize = this.activity.totalCommentsSize = this.activity.totalCommentsCount && Number(this.activity.totalCommentsCount) || 0;
         this.$root.$emit('activity-comments-retrieved', this.activity, this.comments);
         this.loading = false;
       });
@@ -93,6 +95,7 @@ export default {
           this.$nextTick().then(() => {
             this.comments = data && data.comments || [];
             this.activity.commentsSize = this.commentsSize = data && data.size && Number(data.size) || 0;
+            this.totalCommentsSize = this.activity.totalCommentsSize = this.comments[0]?.totalCommentsCount || 0;
             this.$root.$emit('activity-comments-retrieved', this.activity, this.comments);
           });
         })

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/list/ActivityCommentsPreview.vue
@@ -76,8 +76,9 @@ export default {
       this.loading = true;
       this.$nextTick().then(() => {
         this.comments = this.$activityService.computeParentCommentsList(this.activity.comments) || [];
-        this.activity.commentsSize = this.commentsSize = this.activity.commentsCount && Number(this.activity.commentsCount) || 0;
-        this.totalCommentsSize = this.activity.totalCommentsSize = this.activity.totalCommentsCount && Number(this.activity.totalCommentsCount) || 0;
+        this.commentsSize = this.activity.commentsCount && Number(this.activity.commentsCount) || 0;
+        this.totalCommentsSize = this.activity.totalCommentsCount && Number(this.activity.totalCommentsCount) || 0;
+        this.$root.$emit('set-activity-comment-size', this.activity.id, this.commentsSize, this.totalCommentsSize);
         this.$root.$emit('activity-comments-retrieved', this.activity, this.comments);
         this.loading = false;
       });
@@ -94,8 +95,9 @@ export default {
           this.commentsSize = 0;
           this.$nextTick().then(() => {
             this.comments = data && data.comments || [];
-            this.activity.commentsSize = this.commentsSize = data && data.size && Number(data.size) || 0;
-            this.totalCommentsSize = this.activity.totalCommentsSize = data?.totalCommentsSize && Number(data.totalCommentsSize) || 0;
+            this.commentsSize = data && data.size && Number(data.size) || 0;
+            this.totalCommentsSize = data?.totalCommentsSize && Number(data.totalCommentsSize) || 0;
+            this.$root.$emit('set-activity-comment-size', this.activity.id, this.commentsSize, this.totalCommentsSize);
             this.$root.$emit('activity-comments-retrieved', this.activity, this.comments);
           });
         })

--- a/webapp/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
@@ -4,6 +4,6 @@ export default {
   FULL_ACTIVITY_IDS_EXPAND: 'ids,identity,likes,shared,commentsPreview,subComments,favorite',
   FULL_ACTIVITY_EXPAND: 'identity,likes,shared,commentsPreview,subComments,favorite,totalCommentsCount',
   ACTIVITY_EXPAND: 'identity,likes,shared',
-  FULL_COMMENT_EXPAND: 'identity,likes,subComments',
+  FULL_COMMENT_EXPAND: 'identity,likes,subComments,totalCommentsCount',
   COMMENT_MAX_LENGTH: 1300,
 };

--- a/webapp/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
@@ -4,6 +4,6 @@ export default {
   FULL_ACTIVITY_IDS_EXPAND: 'ids,identity,likes,shared,commentsPreview,subComments,favorite',
   FULL_ACTIVITY_EXPAND: 'identity,likes,shared,commentsPreview,subComments,favorite,totalCommentsCount',
   ACTIVITY_EXPAND: 'identity,likes,shared',
-  FULL_COMMENT_EXPAND: 'identity,likes,subComments,totalCommentsCount',
+  FULL_COMMENT_EXPAND: 'identity,likes,subComments',
   COMMENT_MAX_LENGTH: 1300,
 };

--- a/webapp/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/js/ActivityConstants.js
@@ -2,8 +2,8 @@ export default {
   // Attention!!! when changing this, the list of preloaded
   // URLs has to change in JSP as well
   FULL_ACTIVITY_IDS_EXPAND: 'ids,identity,likes,shared,commentsPreview,subComments,favorite',
-  FULL_ACTIVITY_EXPAND: 'identity,likes,shared,commentsPreview,subComments,favorite',
+  FULL_ACTIVITY_EXPAND: 'identity,likes,shared,commentsPreview,subComments,favorite,totalCommentsCount',
   ACTIVITY_EXPAND: 'identity,likes,shared',
-  FULL_COMMENT_EXPAND: 'identity,likes,subComments',
+  FULL_COMMENT_EXPAND: 'identity,likes,subComments,totalCommentsCount',
   COMMENT_MAX_LENGTH: 1300,
 };


### PR DESCRIPTION
Prior to this change, the number of activity comments displayed reflected only the top-level comments. This update now displays the total number of comments for an activity, including replies.