### PR TITLE
fix: Automatic redirection on oidc is not working with PWA - MEED-9446

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/openid/OpenIdAuthenticationFilter.java
@@ -20,10 +20,9 @@
 package io.meeds.oauth.web.openid;
 
 import io.meeds.oauth.common.OAuthConstants;
-import io.meeds.oauth.exception.OAuthException;
 import io.meeds.oauth.openid.OpenIdAccessTokenContext;
-import io.meeds.oauth.openid.OpenIdProcessor;
 import io.meeds.oauth.spi.OAuthPrincipal;
+import io.meeds.oauth.spi.OAuthProviderType;
 import io.meeds.oauth.spi.OAuthProviderTypeRegistry;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -32,6 +31,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.User;
@@ -39,12 +39,12 @@ import org.exoplatform.web.security.AuthenticationRegistry;
 import org.gatein.sso.agent.filter.api.AbstractSSOInterceptor;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
   private static Log log = ExoLogger.getLogger(OpenIdAuthenticationFilter.class);
   private AuthenticationRegistry authenticationRegistry;
-  private OpenIdProcessor openIdProcessor;
+  private OAuthProviderTypeRegistry oAuthProviderTypeRegistry;
+  private OAuthProviderType oAuthProviderType;
 
   private boolean openIdEnabled;
   @Override
@@ -52,13 +52,10 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
     this.openIdEnabled = Boolean.parseBoolean(System.getProperty("exo.oauth.openid.enabled"));
     if (this.openIdEnabled) {
       authenticationRegistry = getExoContainer().getComponentInstanceOfType(AuthenticationRegistry.class);
-      OAuthProviderTypeRegistry
-          oAuthProviderTypeRegistry =
+      oAuthProviderTypeRegistry =
           getExoContainer().getComponentInstanceOfType(OAuthProviderTypeRegistry.class);
-      openIdProcessor =
-          (OpenIdProcessor) oAuthProviderTypeRegistry.getOAuthProvider(OAuthConstants.OAUTH_PROVIDER_KEY_OPEN_ID,
-                                                                       OpenIdAccessTokenContext.class)
-                                                     .getOauthProviderProcessor();
+      oAuthProviderType = oAuthProviderTypeRegistry.getOAuthProvider(OAuthConstants.OAUTH_PROVIDER_KEY_OPEN_ID,
+                                                                    OpenIdAccessTokenContext.class);
     }
   }
 
@@ -101,11 +98,12 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
       return;
     }
 
-    checkAccessTokenInCookies(request,response);
-    filterChain.doFilter(request, response);
+    if (!checkAccessTokenInCookies(request,response)) {
+      filterChain.doFilter(request, response);
+    }
   }
 
-  private void checkAccessTokenInCookies(HttpServletRequest request, HttpServletResponse response) {
+  private boolean checkAccessTokenInCookies(HttpServletRequest request, HttpServletResponse response) {
     Cookie[] cookies = request.getCookies();
 
     if (cookies != null) {
@@ -113,14 +111,21 @@ public class OpenIdAuthenticationFilter extends AbstractSSOInterceptor {
         if (cookie.getName().equals("OPENID_ACCESS_TOKEN")) {
           try {
             saveInitialURI(request);
-            openIdProcessor.processOAuthInteraction(request, response);
-          } catch (OAuthException | ExecutionException | InterruptedException | IOException ex) {
-            log.error("Error during OAuth flow with: " + ex.getMessage(), ex);
-            return;
+            String contextPath = request.getContextPath();
+            String initialUri = request.getParameter("initialURI");
+            if (StringUtils.isBlank(initialUri)) {
+              initialUri = contextPath;
+            }
+            String initOauthURI = oAuthProviderType.getInitOAuthURL(contextPath,initialUri);
+            response.sendRedirect(initOauthURI);
+            return true;
+          } catch (IOException ex) {
+            log.error("Error when initializing OAuth flow with: " + ex.getMessage(), ex);
           }
         }
       }
     }
+    return false;
   }
   private void saveInitialURI(HttpServletRequest request) {
     String initialURI = request.getParameter("initialURI");


### PR DESCRIPTION
Before this fix, the automatic redirection on oidc was not working with PWA This fix improve the redirection : instead of calling initInteraction in an incorrect context, the filter now redirect on the url openidAuth, which init the interaction in a correct context

Resolves meeds-io/meeds#3491

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
