### PR TITLE
fix: Fix Space Description Alignment in Favorite Drawer - MEED-9468 - Meeds-io/meeds#3495

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-favorites/components/SpaceFavoriteItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-favorites/components/SpaceFavoriteItem.vue
@@ -40,7 +40,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           v-sanitized-html="spaceName"></p>
       </v-list-item-title>
       <v-list-item-subtitle v-if="expanded" class="d-flex full-width overflow-hidden pt-2px">
-        <span class="flex-grow-1 flex-shrink-0">{{ membersCount }} {{ $t('space.logo.banner.popover.members') }}</span>
+        <span class="flex-grow-0 flex-shrink-0">{{ membersCount }} {{ $t('space.logo.banner.popover.members') }}</span>
         <v-icon class="flex-grow-0 flex-shrink-0 mx-2" size="2">fa-circle</v-icon>
         <span class="flex-grow-1 flex-shrink-1 text-truncate">{{ descriptionText }}</span>
       </v-list-item-subtitle>


### PR DESCRIPTION
Prior to this change, the Space Description is centered in Favorite Drawer while it should be left aligned. This change will make the description left aligned by deleting the flex grow = 1 to the Text before which displays the members count.