### PR TITLE
fix: Fix ActivityManager API breaking Change - MEED-9450 - Meeds-io/Meeds#3455

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -629,6 +629,8 @@ public interface ActivityManager {
    * @param activityId {@link ExoSocialActivity} identifier
    * @return
    */
-  int getNumberOfAllComments(String activityId);
+  default int getNumberOfAllComments(String activityId) {
+    throw new UnsupportedOperationException();
+  }
 
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
@@ -634,7 +634,9 @@ public interface ActivityStorage {
    @param activityId {@link ExoSocialActivity} identifier
    * @return
    */
-  public int getNumberOfAllComments(String activityId);
+  default int getNumberOfAllComments(String activityId) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Gets the number of newer comments of an activity based on a comment.


### PR DESCRIPTION
Prior to this change, the newly added method 'getNumberOfAllComments' isn't added in all upper layer mocked implementations. This change ensures to not break the API when adding a new method in the existing API of ActivityManager Service.

Resolves Meeds-io/Meeds#3455