### PR TITLE
fix: Click on an anchor open a news tab instead of scrolling - MEED-8740 - meeds-io/meeds#2936 

### DIFF
--- a/webapp/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/src/main/webapp/js/ExtendedDomPurify.js
@@ -55,7 +55,8 @@
         // add noopener attribute to external links to eliminate vulnerabilities
         if (nodeLink) {
           // Open external links in a new Browser Tab
-          if (nodeLink.indexOf('/') !== 0 && nodeLink.indexOf(window.location.origin) === -1) {
+          if (nodeLink.indexOf('/') !== 0 && nodeLink.indexOf(window.location.origin) === -1
+                && !nodeLink.startsWith('#')) {
             node.setAttribute('target', '_blank');
             node.setAttribute('rel', 'nofollow noopener noreferrer');
           }


### PR DESCRIPTION
before this change, when create a news, add an anchor on the news, add a link to the anchor in the news, publish the article and click on the anchor in the article, a new tab opens then I scroll the anchor. To fix this problem, add a condition if the link is an anchor, do not add anything for the link because the default value of the target is _self. After this change, the page scrolls to the anchor instead of opening a new tab.
Resolves https://github.com/Meeds-io/meeds/issues/2936