### PR TITLE
fix: multivalue dropdown attribute required but never checked - MEED-9482 - meeds-io/meeds#3485

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileDropdownProperty.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileDropdownProperty.vue
@@ -22,6 +22,7 @@
   <div :class="{'mx-4 mt-2': !multiValued}">
     <label class="font-weight-bold text-color text-capitalize-first-letter">
       {{ propertyLabel }}
+      <span v-if="property.required" class="ms-n1">*</span>
     </label>
     <div class="d-flex align-center">
       <v-combobox
@@ -29,6 +30,7 @@
         :items="mappedOptions"
         :ref="`propertyOptions${property.id}`"
         :name="`propertyOptions${property.id}`"
+        :required="property.required"
         class="elevation-0 mt-2 pt-0 no-border dropdownPropertyInput"
         item-text="translatedValue"
         item-value="id"


### PR DESCRIPTION
before this change, when create new profile attribute dropdown which and has set of drop-down values as required then userX changes his personal information, dropdown attribute isn't marked as required and if dropdown is empty, the profile info drawer is saved. After this change, as required, dropdown attribute a asterisk displayed and the profile info drawer is not saved if dropdown isn't filled + focus on required attribute + display message.

(cherry-picked from https://github.com/Meeds-io/social/pull/5068)