### PR TITLE
fix: Login Portlets (loginForm, sidebarLogin, platformName and platformLogo) cant be added twice on the same page - meeds-io/MIPs#203 - MEED-9515

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/loginForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/loginForm.jsp
@@ -21,8 +21,12 @@
 <%@ page import="org.exoplatform.portal.config.UserACL"%>
 <%@ page import="io.meeds.social.translation.service.TranslationService" %>
 <%@ page import="org.exoplatform.portal.localization.LocaleContextInfoUtils" %>
-
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+<portlet:defineObjects />
 <%
+
+  String id = "loginForm-" + renderRequest.getWindowID();
+
 
   JSONObject params = new JSONObject();
 
@@ -107,9 +111,9 @@
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application white v-application--is-ltr theme--light loginForm"
-    id="loginFormApplication">
+    id="<%=id%>">
     <script type="text/javascript">
-      require(['PORTLET/social/LoginForm'], app =>app.init(JSON.stringify(<%=params.toString()%>)));
+      require(['PORTLET/social/LoginForm'], app =>app.init('<%=id%>',JSON.stringify(<%=params.toString()%>)));
     </script>
   </div>
 </div>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/platformLogo.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/platformLogo.jsp
@@ -5,8 +5,13 @@
 <%@page import="org.exoplatform.services.security.ConversationState"%>
 <%@ page import="org.exoplatform.portal.application.PortalRequestContext"%>
 <%@ page import="org.exoplatform.portal.config.model.Page"%>
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+<portlet:defineObjects />
 
 <%
+
+  String id = "platformLogo-" + renderRequest.getWindowID();
+
   String portletStorageId = ((String) request.getAttribute("portletStorageId"));
   String hAlign = request.getAttribute("hAlign") == null ? "CENTER" : ((String[]) request.getAttribute("hAlign"))[0];
   String vAlign = request.getAttribute("vAlign") == null ? "CENTER" : ((String[]) request.getAttribute("vAlign"))[0];
@@ -20,9 +25,9 @@
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application white v-application--is-ltr theme--light platformLogo"
-    id="platformLogoApplication">
+    id="<%=id%>">
     <script type="text/javascript">
-      require(['PORTLET/social/PlatformLogo'], app =>app.init(
+      require(['PORTLET/social/PlatformLogo'], app =>app.init('<%=id%>',
         '<%=portletStorageId%>',
         '<%=hAlign%>',
         '<%=vAlign%>',

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/platformName.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/platformName.jsp
@@ -1,8 +1,12 @@
 <%@ page import="org.exoplatform.portal.branding.BrandingService"%>
 <%@ page import="org.exoplatform.commons.utils.CommonsUtils"%>
 <%@ page import="java.net.URLEncoder"%>
-
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+<portlet:defineObjects />
 <%
+
+  String id = "platformName-" + renderRequest.getWindowID();
+
   BrandingService brandingService = CommonsUtils.getService(BrandingService.class);
   String platformName = brandingService.getCompanyName();
 %>
@@ -10,9 +14,9 @@
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application white v-application--is-ltr theme--light platformName"
-    id="platformNameApplication">
+    id="<%=id%>">
     <script type="text/javascript">
-      require(['PORTLET/social/PlatformName'], app =>app.init('<%=URLEncoder.encode(platformName.replace(" ", "._.")).replace("._.", " ")%>'));
+      require(['PORTLET/social/PlatformName'], app =>app.init('<%=id%>','<%=URLEncoder.encode(platformName.replace(" ", "._.")).replace("._.", " ")%>'));
     </script>
   </div>
 </div>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/sidebarLogin.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/sidebarLogin.jsp
@@ -7,9 +7,13 @@
 <%@ page import="org.exoplatform.container.ExoContainerContext"%>
 <%@ page import="org.exoplatform.portal.config.UserACL"%>
 <%@page import="org.apache.commons.text.StringEscapeUtils"%>
-
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+<portlet:defineObjects />
 
 <%
+
+  String id = "sideBarLogin-" + renderRequest.getWindowID();
+
   BrandingService brandingService = CommonsUtils.getService(BrandingService.class);
   String branding = EntityBuilder.toJsonString(brandingService.getBrandingInformation(false));
 
@@ -25,9 +29,9 @@
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application white v-application--is-ltr theme--light sidebarLogin"
-    id="sidebarLoginApplication">
+    id="<%=id%>">
     <script type="text/javascript">
-      require(['PORTLET/social/SidebarLogin'], app =>app.init(
+      require(['PORTLET/social/SidebarLogin'], app =>app.init('<%=id%>',
         "<%=StringEscapeUtils.escapeJava(branding)%>",
         '<%=portletStorageId%>',
         '<%=hAlign%>',

--- a/webapp/src/main/webapp/vue-apps/login-form/main.js
+++ b/webapp/src/main/webapp/vue-apps/login-form/main.js
@@ -18,8 +18,6 @@
  */
 import './initComponents.js';
 
-const appId = 'loginFormApplication';
-
 //getting language of the PLF
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
@@ -29,7 +27,7 @@ const urls = [
   `/social/i18n/locale.portal.login?lang=${lang}`
 ];
 
-export function init(params) {
+export function init(appId, params) {
   const jsonParams = JSON.parse(params);
   exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
     // init Vue app when locale ressources are ready

--- a/webapp/src/main/webapp/vue-apps/platform-logo/main.js
+++ b/webapp/src/main/webapp/vue-apps/platform-logo/main.js
@@ -19,9 +19,6 @@
 
 import './initComponents.js';
 
-
-const appId = 'platformLogoApplication';
-
 //getting language of the PLF
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
@@ -30,7 +27,7 @@ const urls = [
   `/layout/i18n/locale.portlet.LayoutEditor?lang=${lang}`
 ];
 
-export function init(
+export function init(appId,
   portletStorageId,
   hAlign,
   vAlign,

--- a/webapp/src/main/webapp/vue-apps/platform-name/main.js
+++ b/webapp/src/main/webapp/vue-apps/platform-name/main.js
@@ -19,9 +19,6 @@
 
 import './initComponents.js';
 
-
-const appId = 'platformNameApplication';
-
 //getting language of the PLF
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
@@ -29,7 +26,7 @@ const urls = [
 
 ];
 
-export function init(platformName) {
+export function init(appId, platformName) {
   const decodeName = decodeURIComponent(platformName);
   exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
     // init Vue app when locale ressources are ready

--- a/webapp/src/main/webapp/vue-apps/sidebar-login/main.js
+++ b/webapp/src/main/webapp/vue-apps/sidebar-login/main.js
@@ -19,9 +19,6 @@
 
 import './initComponents.js';
 
-
-const appId = 'sidebarLoginApplication';
-
 //getting language of the PLF
 const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
@@ -32,7 +29,7 @@ const urls = [
   `/social/i18n/locale.portlet.GeneralSettings?lang=${lang}`,
 ];
 
-export function init(branding,
+export function init(appId, branding,
   portletStorageId,
   hAlign,
   vAlign,


### PR DESCRIPTION
Before this fix, the 4 login portlets cant be used twice or more on the same page This problem is due to the portlet applicationId which is the same for all instances This commit changes the appId to use the windowId into, so that, same portlet on same page have not hte same id.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
