### PR TITLE
fix: Emoticon are not correctly displayed in loginForm translations - meeds-io/MIPs#203 - MEED-9520

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/loginForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/loginForm.jsp
@@ -77,15 +77,19 @@
 
   String welcomeBack = translationService.getTranslationLabelOrDefault("cmsPortlet",
             Long.parseLong(translationIdentifier), "welcomeBack", LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
+  welcomeBack = welcomeBack == null ? null : URLEncoder.encode(welcomeBack.replace(" ", "._.")).replace("._.", " ");
 
   String newHere = translationService.getTranslationLabelOrDefault("cmsPortlet",
             Long.parseLong(translationIdentifier), "newHere", LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
+  newHere = newHere == null ? null : URLEncoder.encode(newHere.replace(" ", "._.")).replace("._.", " ");
 
   String createAccount = translationService.getTranslationLabelOrDefault("cmsPortlet",
             Long.parseLong(translationIdentifier), "createAccount", LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
+  createAccount = createAccount == null ? null : URLEncoder.encode(createAccount.replace(" ", "._.")).replace("._.", " ");
 
   String signinEmailButton = translationService.getTranslationLabelOrDefault("cmsPortlet",
             Long.parseLong(translationIdentifier), "signinEmailButton", LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
+  signinEmailButton = signinEmailButton == null ? null : URLEncoder.encode(signinEmailButton.replace(" ", "._.")).replace("._.", " ");
 
   String signinOption = request.getAttribute("signinOption") == null ? "loginform" : ((String[]) request.getAttribute("signinOption"))[0];
   boolean displaySigninEmailButtonIcon = request.getAttribute("displaySigninEmailButtonIcon") == null ? true : Boolean.parseBoolean(((String[]) request.getAttribute("displaySigninEmailButtonIcon"))[0]);

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -212,13 +212,13 @@ export default {
   created() {
     this.values = JSON.parse(this.params);
     this.signinOption = this.values?.signinOption || 'loginform';
-    this.welcomeBack = this.values?.welcomeBack || this.$t('portal.login.WelcomeBack');
-    this.newHere = this.values?.newHere || this.$t('UILoginForm.label.registerNewAccount');
-    this.createAccount = this.values?.createAccount || this.$t('UILoginForm.button.registerNewAccount');
+    this.welcomeBack = decodeURIComponent(this.values?.welcomeBack || this.$t('portal.login.WelcomeBack'));
+    this.newHere = decodeURIComponent(this.values?.newHere || this.$t('UILoginForm.label.registerNewAccount'));
+    this.createAccount = decodeURIComponent(this.values?.createAccount || this.$t('UILoginForm.button.registerNewAccount'));
     this.displaySigninEmailButtonIcon = this.values?.displaySigninEmailButtonIcon;
     this.displayProvidersIcons = this.values?.displayProvidersIcons;
     this.listExternalProviders = this.values?.listExternalProviders;
-    this.signinEmailButton = this.values?.signinEmailButton || this.$t('portal.login.SigninUsingEmail');
+    this.signinEmailButton = decodeURIComponent(this.values?.signinEmailButton || this.$t('portal.login.SigninUsingEmail'));
     this.$root.$on('login-form-settings-updated', (welcomeBackTranslations,
       newHereTranslations,
       createAccountTranslations,


### PR DESCRIPTION
Before this fix, translations in loginForm do not correctly display emoticon due to encoding problem This commit ensure to pass correctly the encoded string so that emoticon are displayed

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
