### PR TITLE
fix: Enable post button in activity composer when category filtering is off - MEED-9493 - Meeds-io/meeds#3513

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -257,7 +257,7 @@ export default {
           || (!this.activityAttachmentsEdited && !this.messageLength && !this.activityBodyEdited)
           || (this.postInYourSpacesChoice && !(this.spaceId || this.activityType?.toString()?.includes('poll') && eXo.env.portal.spaceId))
           || (!this.postToNetwork && !eXo.env.portal.spaceId && !this.spaceId && !this.messageEdited)
-          || (this.isFilteredStream && !this.selectedCategoryIds?.length);
+          || (this.allowFilteringPerCategory && this.isFilteredStream && !this.selectedCategoryIds?.length);
     },
     metadataObjectId() {
       return this.templateParams?.metadataObjectId || this.activityId;


### PR DESCRIPTION
This change will enable post button in activity composer when category filtering is off.