### PR TITLE
fix: When instanciating a new loginForm portlet, there is an error in server log - meeds-io/MIPs#203 - MEED-9521

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
@@ -257,26 +257,50 @@ export default {
     save() {
       this.loading = true;
       const promise = [];
+      let firstTranslation = true;
+
+      //if we have saveTranslations request, we need to ensure that the first one is executed before the others
+      //because it create the metadata for the translations
+      //if all saveTranslations are executed at the same time, we will have a "unique constraint violation" error because metadata will be created more than once
 
       if (this.registerEnabled) {
-        promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'newHere', this.translationsNewHere));
+        if (firstTranslation) {
+          this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, 'newHere', this.translationsNewHere);
+          firstTranslation = false;
+        } else {
+          promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'newHere', this.translationsNewHere));
+        }
         promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'createAccount', this.translationsCreateAccount));
       } else {
-        promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'welcomeBack', this.translationsWelcomeBack));
+        if (firstTranslation) {
+          this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, 'welcomeBack', this.translationsWelcomeBack);
+          firstTranslation = false;
+        } else {
+          promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'welcomeBack', this.translationsWelcomeBack));
+        }
       }
 
       if (this.signinOption === 'buttonform') {
-        promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'signinEmailButton', this.translationsSigninEmailButton));
+        if (firstTranslation) {
+          this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, 'signinEmailButton', this.translationsSigninEmailButton);
+          firstTranslation = false;
+        } else {
+          promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'signinEmailButton', this.translationsSigninEmailButton));
+        }
       }
 
       this.providers.forEach((provider) => {
         if (provider.translations && Object.keys(provider.translations).length > 0) {
-          promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, provider.key, provider.translations));
+          if (firstTranslation) {
+            this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, provider.key, provider.translations);
+            firstTranslation = false;
+          } else {
+            promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, provider.key, provider.translations));
+          }
         }
       });
 
       promise.push(this.saveSettings());
-
       Promise.all(promise).then(() => {
         this.$root.$emit('login-form-settings-updated',
           this.translationsWelcomeBack,
@@ -290,6 +314,9 @@ export default {
         this.loading = false;
         this.close();
       });
+    },
+    async saveTranslationSynchronously(objectType, objectId, fieldName, translations) {
+      await this.$translationService.saveTranslations(objectType, objectId, fieldName, translations);
     },
     saveSettings() {
       const formData = new FormData();


### PR DESCRIPTION


Before this fix, when saving settings of a new instance of the portlet, in administration -> development -> portlet -> instances, there is an error in server log, related to unique constraint violation. As saveTranslations request are sent in parallele, if there is more than one request, the service try to save the metadata more than once.

This commit ensure to make the first saveTranslation request synchronously, before the other request. So when second and after request are launched, the metadata exists, and is not recreated.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
