### PR TITLE
fix: RTL bad menu display of activity stream post options - MEED-9547 - meeds-io/meeds#3558

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
@@ -27,7 +27,7 @@
           dense
           @click="clickOnAction(action)">
           <v-icon size="16" class="icon-default-color">{{ $t(action.icon) }}</v-icon>
-          <v-list-item-title class="pl-3">{{ $t(action.labelKey) }}</v-list-item-title>
+          <v-list-item-title class="ps-3">{{ $t(action.labelKey) }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>


### PR DESCRIPTION
before this change, when access to any post in stream page and click on the three points button on the top left of the page, the menu appears with bad display. To fix this problem, change pl-3 to ps-3. After this change, on RTL mode, the menu option appears with the right display.
