### PR TITLE
fix: Error in server console after adding option in a profile property - MEED-9541 - meeds-io/meeds#3382 

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -336,8 +336,11 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
   }
 
   private String parseValue(ProfilePropertySetting profilePropertySetting, String value) {
-    if (!profilePropertySetting.isDropdownList()) {
+    if (!profilePropertySetting.isDropdownList() || StringUtils.isBlank(value)) {
       return value;
+    }
+    if (!StringUtils.isNumeric(value)) {
+      return null;
     }
     String optionValue = profilePropertySetting.getPropertyOptions()
                                                .stream()


### PR DESCRIPTION
before this change, when create a new profile property props of type text then ensure to set DropDown list = false and set props to String Value and edit the property props and activate dropdown list & Add 2 options then via fetch query or curl admin changes userA's props value to 123456, error while updating index entry of entity, type = profile, id =8, cause: [o.e.c.s.i.i.ElasticIndexingOperationProcessor] java.lang.NumberFormatException: For input string: String Value. To fix this problem, add a check to the value so that it contains only numbers. After this change, The string value is ignored + not indexed + no error in server log should be generated.