### PR TITLE
feat: Hide Email Edit Drawer UI when not modifiable - MEED-9568 - Meeds-io/MIPs#214

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -2041,7 +2041,10 @@ public class UserRest implements ResourceContainer, Startable {
                                   String name,
                                   Object value,
                                   boolean save) throws Exception {
-    if (Profile.EXTERNAL.equals(name)) {
+    ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(name);
+    if (propertySetting != null && !propertySetting.isEditable()) {
+      throw new IllegalAccessException(String.format("Not allowed to update non modifiable field '%s'", name));
+    } else if (Profile.EXTERNAL.equals(name)) {
       throw new IllegalAccessException("Not allowed to update EXTERNAL field");
     } else if (Profile.USERNAME.equals(name)) {
       throw new IllegalAccessException("Not allowed to update USERNAME field");

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/profileproperty/profile-property-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/profileproperty/profile-property-configuration.xml
@@ -171,7 +171,7 @@
 											<boolean>true</boolean>
 										</field>
 										<field  name="editable">
-											<boolean>false</boolean>
+											<boolean>true</boolean>
 										</field>
 										<field  name="active">
 											<boolean>true</boolean>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingSecurity.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingSecurity.jsp
@@ -1,22 +1,20 @@
-<%@ page import="org.gatein.sso.integration.SSOUtils" %>
-<%@ page import="org.exoplatform.commons.utils.CommonsUtils"%>
-<%@ page import="org.exoplatform.web.login.recovery.PasswordRecoveryService" %>
-
+<%@page import="org.exoplatform.container.ExoContainerContext"%>
+<%@page import="org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting"%>
+<%@page import="org.exoplatform.social.core.profileproperty.ProfilePropertyService"%>
+<%@page import="org.gatein.sso.integration.SSOUtils" %>
 <%
   boolean ssoEnabled = SSOUtils.isSSOEnabled();
+  ProfilePropertyService profilePropertyService = ExoContainerContext.getService(ProfilePropertyService.class);
+  ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("email");
+  boolean emailEditable = profilePropertySetting == null || profilePropertySetting.isEditable();
 %>
-
-<% if (!ssoEnabled) { %>
-  <div class="VuetifyApp">
-    <div data-app="true"
-      class="v-application v-application--is-ltr theme--light"
-      id="UserSettingSecurity">
-      <v-cacheable-dom-app cache-id="UserSettingSecurity"></v-cacheable-dom-app>
-      <script type="text/javascript">
-        require(['PORTLET/social/UserSettingSecurity'],
-          app => app.init()
-        );
-      </script>
-    </div>
+<div class="VuetifyApp">
+  <div data-app="true"
+    class="v-application v-application--is-ltr theme--light"
+    id="UserSettingSecurity">
+    <v-cacheable-dom-app cache-id="UserSettingSecurity"></v-cacheable-dom-app>
+    <script type="text/javascript">
+      require(['PORTLET/social/UserSettingSecurity'], app => app.init(<%=ssoEnabled%>, <%=emailEditable%>));
+    </script>
   </div>
-<% } %>
+</div>

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
@@ -28,7 +28,7 @@
         {{ $t('UserSettings.security.title') }}
       </v-card-title>
       <v-list>
-        <v-list-item dense>
+        <v-list-item v-if="$root.isEmailEditable" dense>
           <v-list-item-content>
             <v-list-item-title>
               {{ $t('UserSettings.security.emailChange.title') }}
@@ -53,7 +53,7 @@
             </v-tooltip>  
           </v-list-item-action>
         </v-list-item>
-        <v-list-item dense>
+        <v-list-item v-if="!$root.ssoEnabled" dense>
           <v-list-item-content>
             <v-list-item-title>
               {{ $t('UserSettings.security.passwordChange.title') }}

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/main.js
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/main.js
@@ -41,18 +41,26 @@ const appId = 'UserSettingSecurity';
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-export function init() {
-  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    const appElement = document.createElement('div');
-    appElement.id = appId;
-
-    Vue.createApp({
-      mounted() {
-        document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
-      },
-      template: `<user-setting-security id="${appId}" v-cacheable />`,
-      i18n,
-      vuetify: Vue.prototype.vuetifyOptions,
-    }, appElement, 'User Settings Security');
-  });
+export function init(ssoEnabled, isEmailEditable) {
+  if (!isEmailEditable && ssoEnabled) {
+    Vue.prototype.$updateApplicationVisibility(false, document.querySelector(`#${appId}`));
+  } else {
+    exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+      const appElement = document.createElement('div');
+      appElement.id = appId;
+  
+      Vue.createApp({
+        data: {
+          ssoEnabled,
+          isEmailEditable,
+        },
+        mounted() {
+          document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
+        },
+        template: `<user-setting-security id="${appId}" v-cacheable />`,
+        i18n,
+        vuetify: Vue.prototype.vuetifyOptions,
+      }, appElement, 'User Settings Security');
+    });
+  }
 }


### PR DESCRIPTION
This change will deny any modification of user profile attributes when it has been flagged as 'non modifiable' from Profile Setting Administration. At the same time, the email Field will not be modifiable from User Settings UI when the email isn't set as editable.