### PR TITLE
feat: Avoid Memory Leak in ConversationState ThreadLocal - MEED-9593 - Meeds-io/meeds#3472

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -1660,7 +1660,11 @@ public class UserRest implements ResourceContainer, Startable {
                                 ConversationState currentState) {
     importExecutorService.execute(() -> {
       ConversationState.setCurrent(currentState);
-      this.importUsers(fileLocation, userImportResultEntity, locale, url);
+      try {
+        this.importUsers(fileLocation, userImportResultEntity, locale, url);
+      } finally {
+        ConversationState.setCurrent(null);
+      }
     });
   }
 


### PR DESCRIPTION
Prior to this change, when importing asynchronously users, the ConversationState ThreadLocal isn't cleared. This change ensures to clear it.