### PR TITLE
fix: Mark Sidebar Configuration as Updated when changing icon - MEED-9654 - Meeds-io/meeds#3614

### DIFF
--- a/webapp/src/main/webapp/vue-apps/general-settings/components/navigation/sidebar/drawer/NavigationSettingsAddSidebarSiteDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/navigation/sidebar/drawer/NavigationSettingsAddSidebarSiteDrawer.vue
@@ -172,8 +172,8 @@ export default {
     },
     modified() {
       return this.isNew
-        || (this.isSiteOption && (this.siteId !== this.item?.properties?.siteId || this.item?.properties?.expandPages !== this.expandPages))
-        || (this.isPageOption && this.nodeId !== this.item?.properties?.navigationNodeId);
+        || (this.isSiteOption && (this.siteId !== this.item?.properties?.siteId || this.item?.properties?.expandPages !== this.expandPages || this.item?.icon !== this.icon))
+        || (this.isPageOption && (this.nodeId !== this.item?.properties?.navigationNodeId || this.item?.icon !== this.icon));
     },
     isSiteOption() {
       return this.option === 'SITE' || this.expandPages === 'true';
@@ -219,12 +219,12 @@ export default {
       }
     },
     siteIcon() {
-      if (this.drawer && this.isSiteOption) {
+      if (this.drawer && this.isSiteOption && (this.initialized || !this.icon)) {
         this.icon = this.siteIcon || this.icon || 'fa-project-diagram';
       }
     },
     pageIcon() {
-      if (this.drawer && this.isPageOption) {
+      if (this.drawer && this.isPageOption && (this.initialized || !this.icon)) {
         this.icon = this.pageIcon || this.icon || 'fa-project-diagram';
       }
     },


### PR DESCRIPTION
Prior to this change, when editing a Sidebar Page or Site configuration using the drawer, the 'Update' button stills disabled while it should be switched as enabled in order to update the Page or Site Setting. This change will add the condition of icon change in order to detect whether the Setting has changed or not.

Resolves Meeds-io/meeds#3614