### PR TITLE
fix: Invite again a user previously invited or requested to join - MEED-9553 - meeds-io/meeds#3564 

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -604,8 +604,7 @@ public class PeopleRestService implements ResourceContainer{
         opt.setValue(userName);
         opt.setText(fullName);
         opt.setAvatarUrl(identity.getProfile() == null ? null : identity.getProfile().getAvatarUrl());
-      } else if (USER_TO_INVITE.equals(typeOfRelation) && (space == null || (!spaceSrv.isInvitedUser(space, userName)
-                 && !spaceSrv.isPendingUser(space, userName) && !spaceSrv.isMember(space, userName)))) {
+      } else if (USER_TO_INVITE.equals(typeOfRelation) && (space == null || !spaceSrv.isMember(space, userName))) {
         opt.setType("user");
         opt.setValue(userName);
         opt.setText(fullName + " (" + userName + ")");


### PR DESCRIPTION
Before this change, when inviting registered users or receiving a request from them to join your space, even though the UI should help space admins manage pending invitations/requests, it was not possible to send a new invitation to registered users who had already been invited or had already requested to join the space. To resolve this issue, remove the user type check condition. After this change, as a space admin, I can send an invitation to registered users as long as they have not yet joined the space, even if an invitation or request is still pending.
Resolves https://github.com/Meeds-io/meeds/issues/9553