### PR TITLE
fix: Adjust Login portlet to content - MEED-9470 - mees-io/MIPs#203

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -22,7 +22,8 @@
   <v-app class="mx-auto" v-show="this.init">
     <v-hover v-slot="{ hover }">
       <v-card
-        class="rounded-0 transparent pa-5"
+        class="rounded-0 transparent pa-5 mx-auto"
+        max-width="375"
         flat>
         <div
           v-if="displayBackButton"


### PR DESCRIPTION
Before this fix, the login form portlet take all the container width. This commit limit the width to 375px

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
