### PR TITLE
fix: Hide embedded content when searching for articles - MEED-9584 - Meeds-io/meeds#3550

### DIFF
--- a/webapp/src/main/webapp/js/sanitize-html-directive.js
+++ b/webapp/src/main/webapp/js/sanitize-html-directive.js
@@ -49,6 +49,10 @@
       if (content && content.includes('<div><![CDATA[') && content.includes(']]></div>')) {
         content = content.replace(/<div><!\[CDATA\[(.*)]]><\/div>/g, '');
       }
+      if (content && content.includes('<iframe') && content.includes('</iframe>')) {
+        content = content.replace(/<div[^>]*><iframe[^>]*><\/iframe><\/div>/g, '');
+      }
+
     }
     el.innerHTML = content && ExtendedDomPurify.purify(content) || '';
   });


### PR DESCRIPTION
This change will hide embedded content when using inline frame for 'sanitized-html-no-embed' directive.
