### PR TITLE
fix: Ability to not set text for login form - MEED-9649 - meeds-io/MIPs#203

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/loginForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/loginForm.jsp
@@ -95,6 +95,7 @@
   boolean displaySigninEmailButtonIcon = request.getAttribute("displaySigninEmailButtonIcon") == null ? true : Boolean.parseBoolean(((String[]) request.getAttribute("displaySigninEmailButtonIcon"))[0]);
   boolean listExternalProviders = request.getAttribute("listExternalProviders") == null ? true : Boolean.parseBoolean(((String[]) request.getAttribute("listExternalProviders"))[0]);
   boolean displayProvidersIcons = request.getAttribute("displayProvidersIcons") == null ? true : Boolean.parseBoolean(((String[]) request.getAttribute("displayProvidersIcons"))[0]);
+  boolean displayWelcomeMessage = request.getAttribute("displayWelcomeMessage") == null ? true : Boolean.parseBoolean(((String[]) request.getAttribute("displayWelcomeMessage"))[0]);
 
 
   params.put("portletStorageId", portletStorageId);
@@ -110,6 +111,7 @@
   params.put("displaySigninEmailButtonIcon", displaySigninEmailButtonIcon);
   params.put("listExternalProviders", listExternalProviders);
   params.put("displayProvidersIcons", displayProvidersIcons);
+  params.put("displayWelcomeMessage", displayWelcomeMessage);
 
 %>
 <div class="VuetifyApp">

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -59,7 +59,7 @@
             </v-btn>
           </v-fab-transition>
         </div>
-        <div v-if="registerEnabled" class="widget-text-header align-center">
+        <div v-if="registerEnabled && displayWelcomeMessage" class="widget-text-header align-center">
           {{ newHere }}
           <a
             :title="createAccount"
@@ -68,7 +68,7 @@
             {{ createAccount }}
           </a>
         </div>
-        <div v-else class="widget-text-header align-center">{{ welcomeBack }}</div>
+        <div v-else-if="displayWelcomeMessage" class="widget-text-header align-center">{{ welcomeBack }}</div>
 
         <portal-login-providers
           :params="values"
@@ -188,7 +188,8 @@
       :signin-option="signinOption"
       :display-signin-email-button-icon="displaySigninEmailButtonIcon"
       :list-external-providers="listExternalProviders"
-      :display-providers-icons="displayProvidersIcons" />
+      :display-providers-icons="displayProvidersIcons"
+      :display-welcome-message="displayWelcomeMessage" />
 
   </v-app>
 </template>
@@ -216,6 +217,7 @@ export default {
     listExternalProviders: true,
     displayProvidersIcons: true,
     displayBackButton: false,
+    displayWelcomeMessage: true,
   }),
   watch: {
     errorMessage: {
@@ -234,6 +236,7 @@ export default {
     this.newHere = decodeURIComponent(this.values?.newHere || this.$t('UILoginForm.label.registerNewAccount'));
     this.createAccount = decodeURIComponent(this.values?.createAccount || this.$t('UILoginForm.button.registerNewAccount'));
     this.displaySigninEmailButtonIcon = this.values?.displaySigninEmailButtonIcon;
+    this.displayWelcomeMessage = this.values?.displayWelcomeMessage;
     this.displayProvidersIcons = this.values?.displayProvidersIcons;
     this.listExternalProviders = this.values?.listExternalProviders;
     this.signinEmailButton = decodeURIComponent(this.values?.signinEmailButton || this.$t('portal.login.SigninUsingEmail'));
@@ -244,7 +247,8 @@ export default {
       signinOption,
       displaySigninEmailButtonIcon,
       listExternalProviders,
-      displayProvidersIcons) => {
+      displayProvidersIcons,
+      displayWelcomeMessage) => {
       this.welcomeBack = welcomeBackTranslations?.[eXo.env.portal.language] || welcomeBackTranslations?.[eXo.env.portal.defaultLanguage] || this.$t('portal.login.WelcomeBack');
       this.newHere = newHereTranslations?.[eXo.env.portal.language] || newHereTranslations?.[eXo.env.portal.defaultLanguage] || this.$t('UILoginForm.label.registerNewAccount');
       this.createAccount = createAccountTranslations?.[eXo.env.portal.language] || createAccountTranslations?.[eXo.env.portal.defaultLanguage] || this.$t('UILoginForm.button.registerNewAccount');
@@ -253,6 +257,7 @@ export default {
       this.displaySigninEmailButtonIcon = displaySigninEmailButtonIcon;
       this.listExternalProviders = listExternalProviders;
       this.displayProvidersIcons = displayProvidersIcons;
+      this.displayWelcomeMessage = displayWelcomeMessage;
     });
     this.$root.$on('login-providers-refreshed', (providers) => {
       this.displayForm = providers.length === 0;

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
@@ -34,10 +34,16 @@
       <v-card
         class="ma-4"
         flat>
-        <div class="text-header mb-4">
-          {{ $t('loginForm.drawer.label.welcome.title') }}
-        </div>
-        <div v-if="!registerEnabled" class="mb-7">
+        <v-card-text class="d-flex pa-0">
+          <div class="text-header mb-4">
+            {{ $t('loginForm.drawer.label.welcome.title') }}
+          </div>
+          <div class="spacer" />
+          <v-switch
+            v-model="displayWelcomeMessage"
+            class="mt-0" />
+        </v-card-text>
+        <div v-if="!registerEnabled && displayWelcomeMessage" class="mb-7">
           <v-card-text class="d-flex pa-0">
             <translation-text-field
               ref="welcomeBackTranslations"
@@ -50,7 +56,7 @@
               @input="translationUpdatedWelcomeBack" />
           </v-card-text>
         </div>
-        <div v-else class="mb-7">
+        <div v-else-if="displayWelcomeMessage" class="mb-7">
           <v-card-text class="d-flex pa-0 mb-3">
             <translation-text-field
               ref="newHereTranslations"
@@ -190,6 +196,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    displayWelcomeMessage: {
+      type: Boolean,
+      default: true,
+    },
     displayProvidersIcons: {
       type: Boolean,
       default: true,
@@ -310,7 +320,8 @@ export default {
           this.signinOption,
           this.displaySigninEmailButtonIcon,
           this.listExternalProviders,
-          this.displayProvidersIcons);
+          this.displayProvidersIcons,
+          this.displayWelcomeMessage);
         this.loading = false;
         this.close();
       });
@@ -342,6 +353,9 @@ export default {
           }, {
             name: 'displayProvidersIcons',
             value: this.displayProvidersIcons,
+          }, {
+            name: 'displayWelcomeMessage',
+            value: this.displayWelcomeMessage,
           }],
         }),
       });


### PR DESCRIPTION
This commit allow to hide the welcome message text in login form portlet

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
