### PR TITLE
fix: update display of button if long label, to use more than one line - MEED-9673 - meeds-io/MIPs#203

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -170,9 +170,9 @@
         <div v-else-if="!displayForm && signinOption !== 'noform'" class="mt-4 center text-body">
           <v-btn
             color="primary"
-            class="elevation-0"
+            class="elevation-0 loginFormSigninEmailButton"
             outlined
-            style="background-color:white"
+            style="background-color:white;"
             @click="clickDisplayForm()">
             <span class="text-body">
               <v-icon class="me-2" v-if="displaySigninEmailButtonIcon" color="primary">fas fa-envelope</v-icon>
@@ -336,3 +336,14 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+  .loginFormSigninEmailButton {
+    min-height: 36px;
+    height: 100% !important;
+  }
+  .loginFormSigninEmailButton > .v-btn__content {
+    max-width: 100%;
+    white-space: normal;
+  }
+</style>


### PR DESCRIPTION
Add specific css to display button text on more than one line This is not possible with standard configuration of vue component, we have to use css.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
