### PR TITLE
fix: Fix the display of ordered pinned activities - MEED-9683 - Meeds-io/meeds#3620

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -152,6 +152,8 @@ public class ActivityRest implements ResourceContainer {
                                 @QueryParam("returnSize") boolean returnSize,
                                 @Parameter(description = "Asking for a full representation of a specific subresource, ex: <em>comments</em> or <em>likes</em>", required = false)
                                 @QueryParam("expand") String expand,
+                                @Parameter(description = "Returning the pinned activities sorted in order or not", required = false)
+                                @QueryParam("showPinned") boolean showPinned,
                                 @Parameter(description = "Activity stream type. Possible values: ALL_STREAM, USER_STREAM, USER_FAVORITE_STREAM, MANAGE_SPACES_STREAM, FAVORITE_SPACES_STREAM.", required = false)
                                 @QueryParam("streamType") ActivityStreamType streamType) {
 
@@ -168,6 +170,7 @@ public class ActivityRest implements ResourceContainer {
 
     boolean canPost;
     ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setShowPinned(showPinned);
     activityFilter.setCategoryIds(categoryIds);
     activityFilter.setExcludedCategoryIds(excludedCategoryIds);
     if (!StringUtils.isBlank(spaceId)) {

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -346,6 +346,7 @@ export default {
         categoryIds: this.selectedCategoryIds,
         excludedCategoryIds: this.excludeCategoryIds,
         expand: this.$activityConstants.FULL_ACTIVITY_IDS_EXPAND,
+        showPinned: true
       })
         .then(data => {
           this.$emit('can-post-loaded', data.canPost);

--- a/webapp/src/main/webapp/vue-apps/common/js/ActivityService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/ActivityService.js
@@ -5,6 +5,7 @@ export function getActivitiesByFilter({
   expand,
   categoryIds,
   excludedCategoryIds,
+  showPinned
 }) {
   const formData = new FormData();
 
@@ -30,6 +31,10 @@ export function getActivitiesByFilter({
 
   if (expand) {
     formData.append('expand', expand);
+  }
+
+  if (showPinned) {
+    formData.append('showPinned', showPinned);
   }
 
   const params = decodeURIComponent(new URLSearchParams(formData).toString());


### PR DESCRIPTION
Prior to this change, pinned activities are not displayed at the top of the feed. This fix will adjust the order of these activities.