### PR TITLE
fix: Name of Space Sidebar Setting Drawer Name - MEED-9701 - Meeds-io/meeds#3631

### DIFF
--- a/webapp/src/main/webapp/vue-apps/general-settings/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/general-settings/initComponents.js
@@ -96,7 +96,7 @@ const components = {
   'portal-general-settings-navigation-settings-sidebar-add-button': NavigationSettingsSidebarAddButton,
   'portal-general-settings-navigation-settings-sidebar-add-link-drawer': NavigationSettingsAddSidebarLinkDrawer,
   'portal-general-settings-navigation-settings-sidebar-add-site-drawer': NavigationSettingsAddSidebarSiteDrawer,
-  'portal-general-settings-navigation-settings-icon-add-spaces-drawer': NavigationSettingsAddSidebarSpacesDrawer,
+  'portal-general-settings-navigation-settings-sidebar-add-spaces-drawer': NavigationSettingsAddSidebarSpacesDrawer,
   'portal-general-settings-navigation-settings-icon-input': NavigationSettingsIconInput,
   'portal-general-settings-navigation-settings-icon': NavigationSettingsIcon,
 };


### PR DESCRIPTION
Prior to this change, the name of the Vue component wasn't the same as used in Vue application. This change will fix the name of Spaces Sidebar Setting Drawer in order to instantiate it.