### PR TITLE
fix: Missing settings in the login form drawer - MEED-9702 - meeds-io/MIPs#203

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -20,6 +20,14 @@
 -->
 <template>
   <v-app class="mx-auto" v-show="this.init" style="max-width: 375px;">
+    <login-form-settings-drawer
+          :translation-identifier="values.translationIdentifier"
+          :register-enabled="values.registerEnabled"
+          :signin-option="signinOption"
+          :display-signin-email-button-icon="displaySigninEmailButtonIcon"
+          :list-external-providers="listExternalProviders"
+          :display-providers-icons="displayProvidersIcons"
+          :display-welcome-message="displayWelcomeMessage" />
     <v-hover v-slot="{ hover }">
       <v-card
         class="rounded-0 transparent pa-5"
@@ -181,15 +189,6 @@
         </div>
       </v-card>
     </v-hover>
-    <login-form-settings-drawer
-      :translation-identifier="values.translationIdentifier"
-      :register-enabled="values.registerEnabled"
-      :signin-option="signinOption"
-      :display-signin-email-button-icon="displaySigninEmailButtonIcon"
-      :list-external-providers="listExternalProviders"
-      :display-providers-icons="displayProvidersIcons"
-      :display-welcome-message="displayWelcomeMessage" />
-
   </v-app>
 </template>
 <script>


### PR DESCRIPTION
Before this fix, in some cases, the loginFormSettingsDrawer do not contains all settings. This is because the providers are loaded before the drawer is created, so the js event is not registred in the drawer when it is launched. This commit move the creation of the drawer before providers, so it ensure the drawer is correctly created before.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
