### PR TITLE
fix: Fix people and users admin pages - MEED-9690 - Meeds-io/meeds#3627

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
@@ -157,4 +157,12 @@ public interface ProfilePropertyService {
    * @return {@link List} of {@link String}
    */
   List<String> getExcludedAnalyticsIndexProperties();
+
+  /**
+   * Check if the property name appears in the first,
+   * second or third field of the profile card
+   *
+   * @param propertyName property name
+   */
+  boolean isUserCardFieldSettings(String propertyName);
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
@@ -23,7 +23,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
@@ -91,6 +93,8 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   private List<String>                               excludedQuickSearchProps               = new ArrayList<>();
 
   private List<String>                               excludedAnalyticsIndexProps            = new ArrayList<>();
+
+  private static final String                        USER_CARD_SETTINGS                     = "UserCardSettings";
 
   public ProfilePropertyServiceImpl(InitParams params,
                                     ProfileSettingStorage profileSettingStorage,
@@ -204,6 +208,9 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     if (profilePropertySetting.isHiddenbale()
         && getUnhiddenableProfileProperties().contains(profilePropertySetting.getPropertyName())) {
       throw new IllegalArgumentException(String.format("%s cannot be hidden", profilePropertySetting.getPropertyName()));
+    }
+    if (profilePropertySetting.isMultiValued() && isUserCardFieldSettings(profilePropertySetting.getPropertyName())) {
+      throw new IllegalArgumentException(String.format("%s cannot be multivalued", profilePropertySetting.getPropertyName()));
     }
     if (!isGroupSynchronizedEnabledProperty(profilePropertySetting)) {
       profilePropertySetting.setGroupSynchronized(false);
@@ -409,6 +416,21 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
       return parent == null || !synchronizedGroupDisabledProperties.contains(parent.getPropertyName());
     }
     return true;
+  }
+
+  public boolean isUserCardFieldSettings(String propertyName) {
+    SettingValue<?> userCardFirstFieldSetting = settingService.get(Context.GLOBAL,
+                                                                   new Scope(Scope.GLOBAL.getName(), USER_CARD_SETTINGS),
+                                                                   "UserCardFirstFieldSetting");
+    SettingValue<?> userCardSecondFieldSetting = settingService.get(Context.GLOBAL,
+                                                                   new Scope(Scope.GLOBAL.getName(), USER_CARD_SETTINGS),
+                                                                   "UserCardSecondFieldSetting");
+    SettingValue<?> userCardThirdFieldSetting = settingService.get(Context.GLOBAL,
+                                                                   new Scope(Scope.GLOBAL.getName(), USER_CARD_SETTINGS),
+                                                                   "UserCardThirdFieldSetting");
+    return Stream.of(userCardFirstFieldSetting, userCardSecondFieldSetting, userCardThirdFieldSetting)
+                 .filter(Objects::nonNull)
+                 .anyMatch(setting -> propertyName.equals(setting.getValue()));                                            
   }
 
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -550,7 +550,12 @@ public class EntityBuilder {
   
   private static String getProfilePropertyValue(Profile profile, String propertyName) {
     ProfilePropertySetting propertySetting = getProfilePropertyService().getProfileSettingByName(propertyName);
-    String profilePropertyValue = (String) profile.getProperty(propertyName);
+    String profilePropertyValue;
+    if (profile.getProperty(propertyName) instanceof List) {
+      profilePropertyValue = profile.getProperty(propertyName).toString();
+    } else {
+      profilePropertyValue = (String) profile.getProperty(propertyName);
+    }
     return propertySetting != null && propertySetting.isDropdownList()
         && NumberUtils.isCreatable(profilePropertyValue) ? getTranslationService().getTranslationLabelOrDefault(PROFILE_PROPERTY_OBJECT_TYPE, Long.parseLong(profilePropertyValue), PROFILE_PROPERTY_FIELD_NAME, LocaleContextInfoUtils.getUserLocale(getCurrentUserName())) : profilePropertyValue;
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -2104,7 +2104,7 @@ public class EntityBuilder {
                                                                                                     objectType);
       if (profilePropertySettingEntity != null) {
         profilePropertySettingEntity.setHidden(hiddenPropertyIds.contains(profilePropertySettingEntity.getId()));
-        profilePropertySettingEntity.setCanEditMultiValued(profilePropertyService.isUserCardFieldSettings(profilePropertySettingEntity.getPropertyName()));
+        profilePropertySettingEntity.setUserCardFieldSettings(profilePropertyService.isUserCardFieldSettings(profilePropertySettingEntity.getPropertyName()));
         profilePropertySettingsList.add(profilePropertySettingEntity);
       }
     }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -2104,6 +2104,7 @@ public class EntityBuilder {
                                                                                                     objectType);
       if (profilePropertySettingEntity != null) {
         profilePropertySettingEntity.setHidden(hiddenPropertyIds.contains(profilePropertySettingEntity.getId()));
+        profilePropertySettingEntity.setCanEditMultiValued(profilePropertyService.isUserCardFieldSettings(profilePropertySettingEntity.getPropertyName()));
         profilePropertySettingsList.add(profilePropertySettingEntity);
       }
     }

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
@@ -83,7 +83,7 @@ public class ProfilePropertySettingEntity {
 
   private boolean                            isDefault;
 
-  private boolean                            canEditMultiValued;
+  private boolean                            isUserCardFieldSettings;
 
   public List<ProfilePropertySettingEntity> getChildren() {
     if (children != null) {

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
@@ -83,6 +83,8 @@ public class ProfilePropertySettingEntity {
 
   private boolean                            isDefault;
 
+  private boolean                            canEditMultiValued;
+
   public List<ProfilePropertySettingEntity> getChildren() {
     if (children != null) {
       return children;

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -410,13 +410,7 @@ export default {
     initialSetting: {},
     initialLabels: [],
     areLabelsChanged: false,
-    translationsUpdated: false,
-    isUserCardFieldSettings: false,
-    userCardSettingsContextKey: 'GLOBAL',
-    userCardSettingScopeKey: 'GLOBAL',
-    userCardFirstFieldSettingKey: 'UserCardFirstFieldSetting',
-    userCardSecondFieldSettingKey: 'UserCardSecondFieldSetting',
-    userCardThirdFieldSettingKey: 'UserCardThirdFieldSetting',
+    translationsUpdated: false
   }),
   computed: {
     propertyTypes () {
@@ -452,7 +446,7 @@ export default {
       return this.setting.propertyType === 'user';
     },
     saveDisabled() {
-      return this.isSaveButtonDisabled || this.saving || !this.valid || (this.setting.multiValued && this.isUserCardFieldSettings);
+      return this.isSaveButtonDisabled || this.saving || !this.valid || (this.setting.multiValued && this.setting.canEditMultiValued);
     }
   },
   watch: {
@@ -484,34 +478,6 @@ export default {
     'setting.dropdownList': function () {
       if (this.isDropdownList) {
         this.setting.propertyType = this.propertyTypes[0];
-      }
-    },
-    'setting.multiValued': function ()  {
-      if (this.setting.multiValued) {
-        this.isUserCardFieldSettings = true;
-        this.$settingService.getSettingValue(this.userCardSettingsContextKey, '', this.userCardSettingScopeKey, 'UserCardSettings', this.userCardFirstFieldSettingKey)
-          .then(firstField => {
-            if (firstField.value === this.setting?.propertyName) {
-              this.isUserCardFieldSettings = true;
-            } else {
-              this.$settingService.getSettingValue(this.userCardSettingsContextKey, '', this.userCardSettingScopeKey, 'UserCardSettings', this.userCardSecondFieldSettingKey)
-                .then(secondField => {
-                  if (secondField.value === this.setting?.propertyName) {
-                    this.isUserCardFieldSettings = true;
-                  } else {
-                    this.$settingService.getSettingValue(this.userCardSettingsContextKey, '', this.userCardSettingScopeKey, 'UserCardSettings', this.userCardThirdFieldSettingKey)
-                      .then(secondField => {
-                        if (secondField.value === this.setting?.propertyName) {
-                          this.isUserCardFieldSettings = true;
-                        }
-                      })
-                      .catch(() => this.isUserCardFieldSettings = true);
-                  }
-                })
-                .catch(() => this.isUserCardFieldSettings = true);
-            }
-          })
-          .catch(() => this.isUserCardFieldSettings = true);
       }
     }
   },

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -364,7 +364,7 @@
           {{ $t('profileSettings.button.cancel') }}
         </v-btn>
         <v-btn
-          :disabled="isSaveButtonDisabled || saving || !valid"
+          :disabled="saveDisabled"
           :loading="saving"
           class="btn btn-primary"
           @click="saveSetting">
@@ -410,7 +410,13 @@ export default {
     initialSetting: {},
     initialLabels: [],
     areLabelsChanged: false,
-    translationsUpdated: false
+    translationsUpdated: false,
+    isUserCardFieldSettings: false,
+    userCardSettingsContextKey: 'GLOBAL',
+    userCardSettingScopeKey: 'GLOBAL',
+    userCardFirstFieldSettingKey: 'UserCardFirstFieldSetting',
+    userCardSecondFieldSettingKey: 'UserCardSecondFieldSetting',
+    userCardThirdFieldSettingKey: 'UserCardThirdFieldSetting',
   }),
   computed: {
     propertyTypes () {
@@ -444,6 +450,9 @@ export default {
     },
     isUserType() {
       return this.setting.propertyType === 'user';
+    },
+    saveDisabled() {
+      return this.isSaveButtonDisabled || this.saving || !this.valid || (this.setting.multiValued && this.isUserCardFieldSettings);
     }
   },
   watch: {
@@ -475,6 +484,34 @@ export default {
     'setting.dropdownList': function () {
       if (this.isDropdownList) {
         this.setting.propertyType = this.propertyTypes[0];
+      }
+    },
+    'setting.multiValued': function ()  {
+      if (this.setting.multiValued) {
+        this.isUserCardFieldSettings = true;
+        this.$settingService.getSettingValue(this.userCardSettingsContextKey, '', this.userCardSettingScopeKey, 'UserCardSettings', this.userCardFirstFieldSettingKey)
+          .then(firstField => {
+            if (firstField.value === this.setting?.propertyName) {
+              this.isUserCardFieldSettings = true;
+            } else {
+              this.$settingService.getSettingValue(this.userCardSettingsContextKey, '', this.userCardSettingScopeKey, 'UserCardSettings', this.userCardSecondFieldSettingKey)
+                .then(secondField => {
+                  if (secondField.value === this.setting?.propertyName) {
+                    this.isUserCardFieldSettings = true;
+                  } else {
+                    this.$settingService.getSettingValue(this.userCardSettingsContextKey, '', this.userCardSettingScopeKey, 'UserCardSettings', this.userCardThirdFieldSettingKey)
+                      .then(secondField => {
+                        if (secondField.value === this.setting?.propertyName) {
+                          this.isUserCardFieldSettings = true;
+                        }
+                      })
+                      .catch(() => this.isUserCardFieldSettings = true);
+                  }
+                })
+                .catch(() => this.isUserCardFieldSettings = true);
+            }
+          })
+          .catch(() => this.isUserCardFieldSettings = true);
       }
     }
   },

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -287,7 +287,7 @@
             <v-list-item-action>
               <v-switch
                 v-model="setting.multiValued"
-                :disabled="saving || setting.default"
+                :disabled="saving || setting.default || setting.userCardFieldSettings"
                 :ripple="false"
                 color="primary"
                 class="requiredSwitcher my-auto" />
@@ -364,7 +364,7 @@
           {{ $t('profileSettings.button.cancel') }}
         </v-btn>
         <v-btn
-          :disabled="saveDisabled"
+          :disabled="isSaveButtonDisabled || saving || !valid"
           :loading="saving"
           class="btn btn-primary"
           @click="saveSetting">
@@ -444,9 +444,6 @@ export default {
     },
     isUserType() {
       return this.setting.propertyType === 'user';
-    },
-    saveDisabled() {
-      return this.isSaveButtonDisabled || this.saving || !this.valid || (this.setting.multiValued && this.setting.canEditMultiValued);
     }
   },
   watch: {


### PR DESCRIPTION
Prior to this change, the people and users admin page didn't work because of the use of an attribute with multiple values in the profile card . This commit will resolve this issue and disable the save button when changing an attribute  to have multi values used in the first, second and third fields in the profile card.