### PR TITLE
Fix: Editing a post creates new <p> - MEED-9669 - meeds-io/meeds#3616

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -551,7 +551,6 @@ export default {
       content = content.replace(/]]&gt;/g, ']]>');
       content = content.replace(/&lt;!\[CDATA\[/g, '<![CDATA[');
       content = content.replace(/<div><!\[CDATA\[(.*)]]><\/div>/g, '');
-      content = content.replace(/ {2}/g, '&nbsp;&nbsp;');
       return this.replaceWithSuggesterClass(content);
     },
     getContentToCompare(content) {
@@ -686,6 +685,8 @@ export default {
       }
     },
     replaceWithSuggesterClass(message) {
+      message = message.replace(/&nbsp;|&#160;/g, ' ');
+      message = message.replace(/\u00A0/g, ' ');
       const tempdiv = $('<div class=\'temp\'/>').html(message || '');
       tempdiv.find('a[href*="/profile"]')
         .each(function() {


### PR DESCRIPTION
Before this change, when adding a post with original content containing non-breaking spaces and opening it for editing, the content of the post is changed. To fix this problem, replace the HTML entities that are the HTML encodings of non-breaking spaces with normal spaces. After this change, the format of the content in edit mode does not change unless the user does so.