### PR TITLE
fix: Fix displayed activities in general stream - MEED-9719 - Meeds-io/meeds#3640

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -346,7 +346,7 @@ export default {
         categoryIds: this.selectedCategoryIds,
         excludedCategoryIds: this.excludeCategoryIds,
         expand: this.$activityConstants.FULL_ACTIVITY_IDS_EXPAND,
-        showPinned: true
+        showPinned: this.spaceId && true
       })
         .then(data => {
           this.$emit('can-post-loaded', data.canPost);


### PR DESCRIPTION
Before this change, after creating and pinning some activities in a space, they were displayed at the top of the general stream. This fix will resolve this issue by displaying activities according to the first in first out approach.