### PR TITLE
fix: Fix profile fields after importing users from a csv file - MEED-9714 - Meeds-io/meeds#3637

### DIFF
--- a/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
+++ b/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
@@ -73,6 +73,7 @@ import org.exoplatform.social.core.storage.IdentityStorageException;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.web.login.recovery.PasswordRecoveryService;
+import org.exoplatform.portal.config.UserACL;
 
 import io.meeds.common.ContainerTransactional;
 import io.meeds.social.core.identity.model.UserImportResult;
@@ -193,6 +194,9 @@ public class UserImportService {
   @Autowired
   @Setter
   private UploadService                         uploadService;
+
+  @Autowired
+  private UserACL                               userAcl;
 
   private Group                                 externalsGroup                    = null;
 
@@ -597,7 +601,7 @@ public class UserImportService {
                                     boolean save,
                                     String modifierUsername) throws IllegalAccessException, IOException {
     ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(name);
-    if (propertySetting != null && !propertySetting.isEditable()) {
+    if (propertySetting != null && !propertySetting.isEditable() && !StringUtils.equals(userAcl.getSuperUser(), modifierUsername)) {
       throw new IllegalAccessException(String.format("Not allowed to update non modifiable field '%s'", name));
     } else if (Profile.EXTERNAL.equals(name)) {
       throw new IllegalAccessException("Not allowed to update EXTERNAL field");

--- a/component/core/src/test/java/io/meeds/social/core/identity/service/UserImportServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/core/identity/service/UserImportServiceTest.java
@@ -56,6 +56,7 @@ import org.mockito.junit.MockitoRule;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.GroupHandler;
 import org.exoplatform.services.organization.MembershipHandler;
@@ -153,6 +154,9 @@ public class UserImportServiceTest {
 
   @Mock
   private ExecutorService         executorService;
+
+  @Mock
+  private UserACL                 userAcl;
 
   @InjectMocks
   private UserImportService       service;
@@ -407,6 +411,7 @@ public class UserImportServiceTest {
     s.setPropertyName(COMPANY_PROP);
     s.setEditable(false);
     when(profilePropertyService.getProfileSettingByName(COMPANY_PROP)).thenReturn(s);
+    when(userAcl.getSuperUser()).thenReturn("root");
 
     service.updateProfileField(profile,
                                COMPANY_PROP,


### PR DESCRIPTION
Prior to this change, when an admin set a profile property as a non-editable field, after importing users from a CSV file, the values of non-editable fields were neither imported nor displayed on their profile pages. This fix allows all values to be imported and sets the data as uneditable for the non-editable properties.