### PR TITLE
fix: Fix people and users admin pages - MEED-9690 - Meeds-io/meeds#3627

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
@@ -299,6 +299,7 @@ export default {
               thirdField: thirdField
             };
             this.$root.$emit('alert-message', this.$t('profileSettings.userCard.settings.saved.success'), 'success');
+            this.getSettings();
             this.$refs.userCardSettings.close();
           }).catch(() => {
             this.$root.$emit('alert-message', this.$t('profileSettings.userCard.settings.saved.error'), 'error');


### PR DESCRIPTION
Prior to this change, after updating the user card settings and then selecting a property used in the card, the multi-value field remained enabled because the settings had not yet been updated. This commit will allow the new settings to be obtained after the card has been saved.