### PR TITLE
fix: Fix people and users admin pages - MEED-9690 - Meeds-io/meeds#3627

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyService.java
@@ -157,4 +157,12 @@ public interface ProfilePropertyService {
    * @return {@link List} of {@link String}
    */
   List<String> getExcludedAnalyticsIndexProperties();
+
+  /**
+   * Check if the property name appears in the first,
+   * second or third field of the profile card
+   *
+   * @param propertyName property name
+   */
+  boolean isUserCardFieldSettings(String propertyName);
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
@@ -23,7 +23,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
@@ -91,6 +93,8 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
   private List<String>                               excludedQuickSearchProps               = new ArrayList<>();
 
   private List<String>                               excludedAnalyticsIndexProps            = new ArrayList<>();
+
+  private static final String                        USER_CARD_SETTINGS                     = "UserCardSettings";
 
   public ProfilePropertyServiceImpl(InitParams params,
                                     ProfileSettingStorage profileSettingStorage,
@@ -204,6 +208,9 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     if (profilePropertySetting.isHiddenbale()
         && getUnhiddenableProfileProperties().contains(profilePropertySetting.getPropertyName())) {
       throw new IllegalArgumentException(String.format("%s cannot be hidden", profilePropertySetting.getPropertyName()));
+    }
+    if (profilePropertySetting.isMultiValued() && isUserCardFieldSettings(profilePropertySetting.getPropertyName())) {
+      throw new IllegalArgumentException(String.format("%s cannot be multivalued", profilePropertySetting.getPropertyName()));
     }
     if (!isGroupSynchronizedEnabledProperty(profilePropertySetting)) {
       profilePropertySetting.setGroupSynchronized(false);
@@ -409,6 +416,21 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
       return parent == null || !synchronizedGroupDisabledProperties.contains(parent.getPropertyName());
     }
     return true;
+  }
+
+  public boolean isUserCardFieldSettings(String propertyName) {
+    SettingValue<?> userCardFirstFieldSetting = settingService.get(Context.GLOBAL,
+                                                                   new Scope(Scope.GLOBAL.getName(), USER_CARD_SETTINGS),
+                                                                   "UserCardFirstFieldSetting");
+    SettingValue<?> userCardSecondFieldSetting = settingService.get(Context.GLOBAL,
+                                                                   new Scope(Scope.GLOBAL.getName(), USER_CARD_SETTINGS),
+                                                                   "UserCardSecondFieldSetting");
+    SettingValue<?> userCardThirdFieldSetting = settingService.get(Context.GLOBAL,
+                                                                   new Scope(Scope.GLOBAL.getName(), USER_CARD_SETTINGS),
+                                                                   "UserCardThirdFieldSetting");
+    return Stream.of(userCardFirstFieldSetting, userCardSecondFieldSetting, userCardThirdFieldSetting)
+                 .filter(Objects::nonNull)
+                 .anyMatch(setting -> propertyName.equals(setting.getValue()));                                            
   }
 
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -550,7 +550,12 @@ public class EntityBuilder {
   
   private static String getProfilePropertyValue(Profile profile, String propertyName) {
     ProfilePropertySetting propertySetting = getProfilePropertyService().getProfileSettingByName(propertyName);
-    String profilePropertyValue = (String) profile.getProperty(propertyName);
+    String profilePropertyValue;
+    if (profile.getProperty(propertyName) instanceof List) {
+      profilePropertyValue = profile.getProperty(propertyName).toString();
+    } else {
+      profilePropertyValue = (String) profile.getProperty(propertyName);
+    }
     return propertySetting != null && propertySetting.isDropdownList()
         && NumberUtils.isCreatable(profilePropertyValue) ? getTranslationService().getTranslationLabelOrDefault(PROFILE_PROPERTY_OBJECT_TYPE, Long.parseLong(profilePropertyValue), PROFILE_PROPERTY_FIELD_NAME, LocaleContextInfoUtils.getUserLocale(getCurrentUserName())) : profilePropertyValue;
   }
@@ -2099,6 +2104,7 @@ public class EntityBuilder {
                                                                                                     objectType);
       if (profilePropertySettingEntity != null) {
         profilePropertySettingEntity.setHidden(hiddenPropertyIds.contains(profilePropertySettingEntity.getId()));
+        profilePropertySettingEntity.setUserCardFieldSettings(profilePropertyService.isUserCardFieldSettings(profilePropertySettingEntity.getPropertyName()));
         profilePropertySettingsList.add(profilePropertySettingEntity);
       }
     }

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/ProfilePropertySettingEntity.java
@@ -83,6 +83,8 @@ public class ProfilePropertySettingEntity {
 
   private boolean                            isDefault;
 
+  private boolean                            isUserCardFieldSettings;
+
   public List<ProfilePropertySettingEntity> getChildren() {
     if (children != null) {
       return children;

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/ProfileSettings.vue
@@ -299,6 +299,7 @@ export default {
               thirdField: thirdField
             };
             this.$root.$emit('alert-message', this.$t('profileSettings.userCard.settings.saved.success'), 'success');
+            this.getSettings();
             this.$refs.userCardSettings.close();
           }).catch(() => {
             this.$root.$emit('alert-message', this.$t('profileSettings.userCard.settings.saved.error'), 'error');

--- a/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-settings/components/drawers/ProfileSettingFormDrawer.vue
@@ -287,7 +287,7 @@
             <v-list-item-action>
               <v-switch
                 v-model="setting.multiValued"
-                :disabled="saving || setting.default"
+                :disabled="saving || setting.default || setting.userCardFieldSettings"
                 :ripple="false"
                 color="primary"
                 class="requiredSwitcher my-auto" />


### PR DESCRIPTION
Prior to this change, the people and users admin page didn't work because of the use of an attribute with multiple values in the profile card . This commit will resolve this issue and disable the save button when changing an attribute to have multi values used in the first, second and third fields in the profile card.
