### PR TITLE
fix: use correct aria role for provider button - MEED-9757 - meeds-io/MIPs#203

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login/components/provider/LoginProviderLink.vue
+++ b/webapp/src/main/webapp/vue-apps/login/components/provider/LoginProviderLink.vue
@@ -20,33 +20,28 @@
 -->
 <template>
   <div v-if="loaded">
-    <v-tooltip bottom>
-      <template #activator="{ on, attrs }">
-        <v-btn
-          :id="id"
-          :href="link"
-          :target="targetLink"
-          :aria-label="providerButtonLabel"
-          min-width="auto"
-          color="primary"
-          class="text-none elevation-0 white-background"
-          v-bind="attrs"
-          outlined
-          v-on="on"
-          @click="clickOnProviderButton">
-          <v-img
-            v-if="providerImage && displayProvidersIcons"
-            :src="providerImage"
-            :class="displayText && 'me-2'"
-            height="25"
-            max-width="25"
-            eager />
-          <v-icon v-else :class="providerIcon" />
-          <span v-if="displayText" class="text-body text-truncate">{{ providerButtonLabel }}</span>
-        </v-btn>
-      </template>
-      <span>{{ providerButtonLabel }}</span>
-    </v-tooltip>
+    <v-btn
+      :id="id"
+      :href="link"
+      :target="targetLink"
+      :aria-label="providerButtonLabel"
+      :title="providerButtonLabel"
+      min-width="auto"
+      color="primary"
+      class="text-none elevation-0 white-background"
+      outlined
+      v-on="on"
+      @click="clickOnProviderButton">
+      <v-img
+        v-if="providerImage && displayProvidersIcons"
+        :src="providerImage"
+        :class="displayText && 'me-2'"
+        height="25"
+        max-width="25"
+        eager />
+      <v-icon v-else :class="providerIcon" />
+      <span v-if="displayText" class="text-body text-truncate">{{ providerButtonLabel }}</span>
+    </v-btn>
   </div>
 </template>
 <script>


### PR DESCRIPTION
Before this fix, a role="button" was assigned to provider button. As it opens a new page,  it must not have button role but link role

This commit removes the v-tooltip component, which force the role=button for v-btn

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
