### PR TITLE
fix: Remove pagination when retrieving space templates - MEED-9752 - Meeds-io/meeds#3676

### DIFF
--- a/component/service/src/main/java/io/meeds/social/space/template/rest/SpaceTemplateRest.java
+++ b/component/service/src/main/java/io/meeds/social/space/template/rest/SpaceTemplateRest.java
@@ -64,14 +64,13 @@ public class SpaceTemplateRest {
   @Operation(summary = "Retrieve space templates", method = "GET", description = "This retrieves space templates")
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"), })
   public List<SpaceTemplate> getSpaceTemplates(HttpServletRequest request,
-                                               Pageable pageable,
                                                @Parameter(description = "Whether include disabled templates or not")
                                                @RequestParam("includeDisabled")
                                                boolean includeDisabled) {
     SpaceTemplateFilter spaceTemplateFilter = new SpaceTemplateFilter(request.getRemoteUser(),
                                                                       request.getLocale(),
                                                                       includeDisabled);
-    return spaceTemplateService.getSpaceTemplates(spaceTemplateFilter, pageable, true);
+    return spaceTemplateService.getSpaceTemplates(spaceTemplateFilter, Pageable.unpaged(), true);
   }
 
   @GetMapping("{id}")


### PR DESCRIPTION
This change will update space template endpoint so that the GET endpoint returns all templates instead of a paginated result.