### PR TITLE
fix: correct accesibility problems on login page - MEED-9202 - meeds-io/MIPs#203

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Login_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Login_en.properties
@@ -96,3 +96,7 @@ generalSettings.login.pageTile.on-boarding.label=Onboarding page when users are 
 generalSettings.login.pageTile.register.label=Self-registration page
 generalSettings.login.edit.tooltip=Edit Layout
 generalSettings.login.preview.tooltip=Preview Page
+
+
+loginForm.showPassword=Show Password
+loginForm.hidePassword=Hide Password

--- a/webapp/src/main/resources/locale/portlet/Login_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/Login_fr.properties
@@ -95,3 +95,5 @@ generalSettings.login.pageTile.on-boarding.label=Onboarding page when users are 
 generalSettings.login.pageTile.register.label=Self-registration page
 generalSettings.login.edit.tooltip=Editer la page
 generalSettings.login.preview.tooltip=Pr\u00E9visualier la page
+loginForm.showPassword=Afficher le mot de passe
+loginForm.hidePassword=Masquer le mot de passe

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -128,7 +128,6 @@
                 :title="$t('portal.login.Password')"
                 :placeholder="$t('portal.login.Password')"
                 :type="passwordType"
-                :append-icon="showPassword ? 'fas fa-eye-slash text-font-size mt-0' : 'fas fa-eye text-font-size mt-0'"
                 prepend-inner-icon="fas fa-lock ms-n2 grey--text text--lighten-1"
                 class="login-password border-box-sizing"
                 name="password"
@@ -136,8 +135,17 @@
                 required="required"
                 outlined
                 dense
-                @click:append="toggleShow"
-                background-color="white" />
+                background-color="white">
+                <template #append>
+                  <v-icon
+                  class="v-input__icon text-font-size mt-0"
+                  @click="toggleShow"
+                  :aria-label="showPassword ? $t('loginForm.hidePassword') : $t('loginForm.showPassword')">
+                    {{showPassword ? 'fas fa-eye-slash' : 'fas fa-eye'}}
+                  </v-icon>
+
+                </template>
+              </v-text-field>
             </v-row>
             <v-row class="d-flex flex-column flex-sm-row ma-0 py-0 px-3 px-sm-0" flat>
               <v-checkbox
@@ -162,7 +170,6 @@
             <v-row class="mx-0 mt-8 pa-0 loginButton">
               <v-btn
                 id="loginButton"
-                :aria-label="$t('portal.login.Signin')"
                 :type="'submit'"
                 :loading="loading"
                 width="222"


### PR DESCRIPTION
Before this fix, the aria-label for hide/show password was not correct In addition, the "signin" button have a not needed aria-label, as the text is already present on the button

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
