### PR TITLE
fix: Make settings drawer accessible by keyboard navigation on login portlet - MEED-9785 - meeds-io/MIPs#203

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -417,6 +417,10 @@ export default {
         this.drawer = true;
       }
       this.resetFilter();
+      this.$nextTick(() => {
+        window.setTimeout(() =>
+          this.$el.querySelector('input')?.focus(), 50);
+      });
     },
     mountOnParent() {
       // Re-append the drawer to open in order

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -51,7 +51,7 @@
           </v-btn>
         </div>
         <div
-          v-if="values.canEdit && hover"
+          v-if="values.canEdit"
           class="position-absolute t-0"
           :class="{
             'l-0': $vuetify.rtl,
@@ -63,7 +63,11 @@
               class="z-index-two me-2 mt-2"
               small
               icon
-              @click="$root.$emit('login-form-settings')">
+              @click="$root.$emit('login-form-settings')"
+              taxindex="0"
+              @focus="focus = true"
+              @focusout="focus = false"
+              :style="{ opacity: (focus || hover) ? 1 : 0 }">
               <v-icon size="18">fa-cog</v-icon>
             </v-btn>
           </v-fab-transition>
@@ -223,6 +227,7 @@ export default {
     displayProvidersIcons: true,
     displayBackButton: false,
     displayWelcomeMessage: true,
+    focus: false,
   }),
   watch: {
     errorMessage: {

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
@@ -41,6 +41,7 @@
           <div class="spacer" />
           <v-switch
             v-model="displayWelcomeMessage"
+            ref="switchWelcomeMessage"
             class="mt-0" />
         </v-card-text>
         <div v-if="!registerEnabled && displayWelcomeMessage" class="mb-7">

--- a/webapp/src/main/webapp/vue-apps/platform-logo/components/PlatformLogo.vue
+++ b/webapp/src/main/webapp/vue-apps/platform-logo/components/PlatformLogo.vue
@@ -24,7 +24,7 @@
       <v-card flat
         class="fill-height rounded-0 transparent">
         <div
-          v-if="$root.canEdit && hover"
+          v-if="$root.canEdit"
           class="position-absolute t-0 r-0"
           :class="{
             'l-0': $vuetify.rtl,
@@ -36,7 +36,11 @@
               class="z-index-two me-2 mt-2"
               small
               icon
-              @click="$root.$emit('platform-logo-settings')">
+              @click="$root.$emit('platform-logo-settings')"
+              taxindex="0"
+              @focus="focus = true"
+              @focusout="focus = false"
+              :style="{ opacity: (focus || hover) ? 1 : 0 }">
               <v-icon size="18">fa-cog</v-icon>
             </v-btn>
           </v-fab-transition>
@@ -62,6 +66,9 @@ export default {
       default: null,
     },
   },
+  data: () => ({
+    focus: false,
+  }),
   computed: {
     align() {
       let align = 'object-position:';

--- a/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLogin.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLogin.vue
@@ -27,7 +27,7 @@
         class="rounded-0  transparent full-height d-flex"
         :class="textAlign">
         <div
-          v-if="$root.canEdit && hover"
+          v-if="$root.canEdit"
           class="position-absolute t-0 r-0"
           :class="{
             'l-0': $vuetify.rtl,
@@ -39,7 +39,11 @@
               class="z-index-two me-2 mt-2"
               small
               icon
-              @click="$root.$emit('sidebar-login-settings')">
+              @click="$root.$emit('sidebar-login-settings')"
+              taxindex="0"
+              @focus="focus = true"
+              @focusout="focus = false"
+              :style="{ opacity: (focus || hover) ? 1 : 0 }">
               <v-icon size="18">fa-cog</v-icon>
             </v-btn>
           </v-fab-transition>
@@ -75,7 +79,8 @@ export default {
   data: () => ({
     branding: null,
     refreshImageIndex: Date.now(),
-    backgroundAltText: null
+    backgroundAltText: null,
+    focus: false,
   }),
   computed: {
     title() {


### PR DESCRIPTION
Before this fix, the edit settings button in login porlet is not accessible by keyboard, This commit ensure that the button appear when navigate with keyboard. In addition, the ExoDrawer component was modified to autofocus the first input of the drawer if exists.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
