### PR TITLE
fix: make settings drawers not loaded if user can not edit portlet preferences - MEED-9798 - meeds-io/MIPs#203

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -27,7 +27,8 @@
           :display-signin-email-button-icon="displaySigninEmailButtonIcon"
           :list-external-providers="listExternalProviders"
           :display-providers-icons="displayProvidersIcons"
-          :display-welcome-message="displayWelcomeMessage" />
+          :display-welcome-message="displayWelcomeMessage"
+          v-if="values.canEdit"/>
     <v-hover v-slot="{ hover }">
       <v-card
         class="rounded-0 transparent pa-5"

--- a/webapp/src/main/webapp/vue-apps/platform-logo/components/PlatformLogo.vue
+++ b/webapp/src/main/webapp/vue-apps/platform-logo/components/PlatformLogo.vue
@@ -53,7 +53,7 @@
           :style="align" />
       </v-card>
     </v-hover>
-    <platform-logo-settings-drawer />
+    <platform-logo-settings-drawer v-if="$root.canEdit" />
 
   </v-app>
 </template>

--- a/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLogin.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLogin.vue
@@ -70,7 +70,7 @@
         </v-card>
       </v-card>
     </v-hover>
-    <sidebar-login-settings-drawer :branding="branding" :background-alt-text="this.$root.backgroundFileId !== 0 ? backgroundAltText : null" />
+    <sidebar-login-settings-drawer :branding="branding" :background-alt-text="this.$root.backgroundFileId !== 0 ? backgroundAltText : null" v-if="$root.canEdit" />
   </v-app>
 </template>
 


### PR DESCRIPTION
Before this fix, settings drawer for portlet sidebar login, login from, and platform logo were loaded in the page even if the user is not loggued and cannot edit It generate unecessary load, and create accessibility error due to problems on component ExoDrawer

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
