### PR TITLE
Fix: Allow expression searches when inserting objects - MEED-9731 - meeds-io/meeds#3667.

### DIFF
--- a/webapp/src/main/webapp/js/ckeditorPlugins/insertContentLink/plugin.js
+++ b/webapp/src/main/webapp/js/ckeditorPlugins/insertContentLink/plugin.js
@@ -109,9 +109,8 @@
   
       function matchCallback(text, offset) {
         const left = text.slice(0, offset);
-        let match = left?.split(/\s/)?.pop?.()?.trim?.()?.match?.(/^\/([a-z]*)(:[^>^<^.]*)?$/);
+        let match = left.match(/\/([a-z]*)(:[^>^<^.]*)?$/);
         if (match?.length) {
-          match = left.match(/\/([a-z]*)(:[^>^<^.]*)?$/);
           return {
             start: match.index + 1,
             end: offset,

--- a/webapp/src/main/webapp/vue-apps/content-link/components/ContentLinkCommandMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/content-link/components/ContentLinkCommandMenu.vue
@@ -290,7 +290,7 @@ export default {
       this.loading = true;
       try {
         if (this.keyword?.length && this.plugin?.objectType) {
-          this.links = await this.$contentLinkService.searchLinks(this.plugin?.objectType, this.keyword, 0, 10);
+          this.links = await this.$contentLinkService.searchLinks(this.plugin?.objectType, this.normaliserEspaces(String(this.keyword || '')), 0, 10);
         } else {
           this.links = [];
         }
@@ -340,6 +340,13 @@ export default {
       if (!event.target.closest('#contentLinkCommandMenu')) {
         this.unWatch();
       }
+    },
+    normaliserEspaces(texte) {
+      return texte.replace(/\u00A0/g, ' ')
+        .replace(/\u2007/g, ' ')
+        .replace(/\u202F/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
     },
     unWatch() {
       if (this.textWatcher) {


### PR DESCRIPTION
Before this change, when inserting objects using shortcuts editor /note for example, then it is not possible to search for an expression; at the moment you add a space, the search is canceled. To fix this problem, modify the Regex to accept spaces. After this change, expression searches are allowed and the user can cancel them by removing the shortcut from the body text.
Resolves https://github.com/Meeds-io/meeds/issues/3667
