### PR TITLE
fix: Fix extra space before group role label when copying links - MEED-9620 - Meeds-io/meeds#3292

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -232,9 +232,9 @@ public class LinkProvider {
                       .append(" data-role=\"")
                       .append(role)
                       .append("\">")
-                      .append("<i aria-hidden=\"true\" class=\"v-icon fa ")
+                      .append("<i aria-hidden=\"true\" class=\"me-1 v-icon fa ")
                       .append(getRoleIcon(role))
-                      .append("\" style=\"font-size: var(--appTextFontSize, var(--allPagesBaseTextFontSize, 16px));\"></i> ")
+                      .append("\" style=\"font-size: var(--appTextFontSize, var(--allPagesBaseTextFontSize, 16px));\"></i>")
                       .append(getGroupRoleLabel(role, locale))
                       .append("</a>")
                       .toString();


### PR DESCRIPTION
This change will fix the extra space before the group role label by using CSS margin instead of literal space.
This fix is ​​needed because the original literal space between the <i> icon and the label caused unwanted extra space when copying and pasting the link.