### PR TITLE
fix: Enhance the content link plugin to detect numeric and UUID identifiers - MEED-81671

### DIFF
--- a/component/api/src/main/java/io/meeds/social/cms/plugin/ContentLinkPlugin.java
+++ b/component/api/src/main/java/io/meeds/social/cms/plugin/ContentLinkPlugin.java
@@ -21,6 +21,7 @@ package io.meeds.social.cms.plugin;
 import java.util.List;
 import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.services.security.Identity;
 
 import io.meeds.social.cms.model.ContentLink;
@@ -57,5 +58,13 @@ public interface ContentLinkPlugin {
    * @return corresponding {@link ContentLink} if found, else null
    */
   String getContentTitle(String objectId, Locale locale);
+
+  /**
+   * @param keyword Keyword Determines whether the given keyword represents an
+   *          identifier.
+   */
+  default boolean isId(String keyword) {
+    return StringUtils.isNumeric(keyword);
+  }
 
 }

--- a/component/api/src/main/java/io/meeds/social/cms/service/ContentLinkPluginService.java
+++ b/component/api/src/main/java/io/meeds/social/cms/service/ContentLinkPluginService.java
@@ -70,4 +70,9 @@ public interface ContentLinkPluginService {
    */
   List<ContentLinkExtension> getExtensions();
 
+  /**
+   * @param objectType Object type
+   * Determines whether the given keyword represents an identifier.
+   */
+  boolean isId(String objectType, String keyword);
 }

--- a/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkPluginServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkPluginServiceImpl.java
@@ -73,6 +73,12 @@ public class ContentLinkPluginServiceImpl implements ContentLinkPluginService {
   }
 
   @Override
+  public boolean isId(String objectType, String keyword) {
+    ContentLinkPlugin contentLinkPlugin = plugins.get(objectType);
+    return contentLinkPlugin.isId(keyword);
+  }
+
+  @Override
   @SneakyThrows
   public ContentLink getLink(ContentLinkIdentifier linkIdentifier) {
     String title = getPlugin(linkIdentifier.getObjectType()).getContentTitle(linkIdentifier.getObjectId(),

--- a/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkServiceImpl.java
@@ -77,7 +77,7 @@ public class ContentLinkServiceImpl implements ContentLinkService {
                                                    int offset,
                                                    int limit) {
     keyword = StringUtils.trim(keyword);
-    if (StringUtils.isNumeric(keyword)) {
+    if (contentLinkPluginService.isId(objectType, keyword) ) {
       try {
         ContentLink link = getLink(new ContentLinkIdentifier(objectType, keyword, locale), username);
         return Collections.singletonList(new ContentLinkSearchResult(link));


### PR DESCRIPTION
Introduced isId method to determine whether a keyword represents an identifier. to supports both numeric IDs and UUID formats.