### PR TITLE
fix: SideBar Login Title display a technical label - MEED-9820 - meeds-io/meeds#3740

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/sidebarLogin.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/sidebarLogin.jsp
@@ -9,7 +9,6 @@
 <%@page import="org.apache.commons.text.StringEscapeUtils"%>
 <%@ page import="java.net.URLEncoder"%>
 <%@ page import="io.meeds.social.translation.service.TranslationService" %>
-<%@ page import="org.exoplatform.portal.localization.LocaleContextInfoUtils" %>
 <%@ page import="org.exoplatform.commons.file.model.FileItem" %>
 <%@ page import="org.exoplatform.commons.file.services.FileService" %>
 <%@page import="org.exoplatform.web.PortalHttpServletResponseWrapper"%>
@@ -39,11 +38,11 @@
   TranslationService translationService = CommonsUtils.getService(TranslationService.class);
 
   String title = translationService.getTranslationLabelOrDefault(objectType,
-              settingName, "brandingTitle", LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
+              settingName, "brandingTitle", request.getLocale());
   title = title == null ? null : URLEncoder.encode(title.replace(" ", "._.")).replace("._.", " ");
 
   String subtitle = translationService.getTranslationLabelOrDefault(objectType,
-                settingName, "brandingSubtitle", LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
+                settingName, "brandingSubtitle", request.getLocale());
   subtitle = subtitle == null ? null : URLEncoder.encode(subtitle.replace(" ", "._.")).replace("._.", " ");
 
 

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -249,7 +249,6 @@ export default {
     },
   },
   created() {
-    console.log('LoginForm component created');
     this.values = JSON.parse(this.params);
     this.signinOption = this.values?.signinOption || 'loginform';
     this.welcomeBack = decodeURIComponent(this.values?.welcomeBack || this.$t('portal.login.WelcomeBack'));

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
@@ -217,7 +217,6 @@ export default {
     providers: [],
   }),
   created() {
-    console.log('LoginFormSettingsDrawer - created');
     this.$root.$on('login-form-settings', this.open);
     this.$root.$on('login-providers-refreshed', (providers) => {
       this.initProviders(providers);
@@ -392,7 +391,6 @@ export default {
       return `${providerName.toLowerCase().charAt(0).toUpperCase()}${providerName.toLowerCase().substring(1)}`;
     },
     initProviders(providers) {
-      console.log('LoginFormSettingsDrawer - login-providers-refreshed event received', providers);
       this.providers = providers;
       this.providers.forEach((provider) => {
         provider.translations = {};

--- a/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLoginSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLoginSettingsDrawer.vue
@@ -45,7 +45,8 @@
             :object-type="$root.objectType"
             field-name="brandingTitle"
             class="width-auto flex-grow-1"
-            drawer-title="sidebarLogin.drawer.label.branding.title" />
+            drawer-title="sidebarLogin.drawer.label.branding.title"
+            verify-i18n />
         </v-card-text>
       </v-card>
 
@@ -74,7 +75,7 @@
         <div class="text-header">
           {{ $t('sidebarLogin.drawer.label.branding.background') }}
         </div>
-        <div class="spacer" />
+        <div class="spacer"></div>
         <v-btn
           v-if="canDeleteBackground"
           :title="$t('sidebarLogin.drawer.label.branding.background.restore')"
@@ -113,62 +114,62 @@
       <v-card
         class="ma-4"
         flat>
-          <div class="text-header">
-            {{ $t('layout.alignApp') }}
+        <div class="text-header">
+          {{ $t('layout.alignApp') }}
+        </div>
+        <div class="d-flex">
+          <div class="col-6 pa-0">
+            <v-radio-group v-model="hAlign" class="ma-0">
+              <v-radio
+                value="START"
+                class="ma-0 pa-0">
+                <template #label>
+                  <span class="text-body">{{ $t('layout.alignLeft') }}</span>
+                </template>
+              </v-radio>
+              <v-radio
+                value="CENTER"
+                class="ma-0 pa-0">
+                <template #label>
+                  <span class="text-body">{{ $t('layout.alignCenter') }}</span>
+                </template>
+              </v-radio>
+              <v-radio
+                value="END"
+                class="ma-0 pa-0">
+                <template #label>
+                  <span class="text-body">{{ $t('layout.alignRight') }}</span>
+                </template>
+              </v-radio>
+            </v-radio-group>
           </div>
-          <div class="d-flex">
-            <div class="col-6 pa-0">
-              <v-radio-group v-model="hAlign" class="ma-0">
-                <v-radio
-                  value="START"
-                  class="ma-0 pa-0">
-                  <template #label>
-                    <span class="text-body">{{ $t('layout.alignLeft') }}</span>
-                  </template>
-                </v-radio>
-                <v-radio
-                  value="CENTER"
-                  class="ma-0 pa-0">
-                  <template #label>
-                    <span class="text-body">{{ $t('layout.alignCenter') }}</span>
-                  </template>
-                </v-radio>
-                <v-radio
-                  value="END"
-                  class="ma-0 pa-0">
-                  <template #label>
-                    <span class="text-body">{{ $t('layout.alignRight') }}</span>
-                  </template>
-                </v-radio>
-              </v-radio-group>
-            </div>
-            <div class="col-6 pa-0">
-              <v-radio-group v-model="vAlign" class="ma-0">
-                <v-radio
-                  value="START"
-                  class="ma-0 pa-0">
-                  <template #label>
-                    <span class="text-body">{{ $t('layout.alignTop') }}</span>
-                  </template>
-                </v-radio>
-                <v-radio
-                  value="CENTER"
-                  class="ma-0 pa-0">
-                  <template #label>
-                    <span class="text-body">{{ $t('layout.alignMiddle') }}</span>
-                  </template>
-                </v-radio>
-                <v-radio
-                  value="END"
-                  class="ma-0 pa-0">
-                  <template #label>
-                    <span class="text-body">{{ $t('layout.alignBottom') }}</span>
-                  </template>
-                </v-radio>
-              </v-radio-group>
-            </div>
+          <div class="col-6 pa-0">
+            <v-radio-group v-model="vAlign" class="ma-0">
+              <v-radio
+                value="START"
+                class="ma-0 pa-0">
+                <template #label>
+                  <span class="text-body">{{ $t('layout.alignTop') }}</span>
+                </template>
+              </v-radio>
+              <v-radio
+                value="CENTER"
+                class="ma-0 pa-0">
+                <template #label>
+                  <span class="text-body">{{ $t('layout.alignMiddle') }}</span>
+                </template>
+              </v-radio>
+              <v-radio
+                value="END"
+                class="ma-0 pa-0">
+                <template #label>
+                  <span class="text-body">{{ $t('layout.alignBottom') }}</span>
+                </template>
+              </v-radio>
+            </v-radio-group>
           </div>
-        </v-card>
+        </div>
+      </v-card>
     </template>
     <template #footer>
       <div class="d-flex align-center">


### PR DESCRIPTION
Before this fix, the login filed for Sidebar login display a technical label This is because the flasg verifyI18n was missing for the translation component

This commit also remove uneeded console.log statement, and finally, ensure to use the current request locale as it was already done for loginForm

Resolves meeds-io/meeds#3740

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
