### PR TITLE
fix: The copy of an attachment copies only the link - MEED-9802 - meeds-io/meeds#3742

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/attachment/AttachmentServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/attachment/AttachmentServiceImpl.java
@@ -403,8 +403,20 @@ public class AttachmentServiceImpl implements AttachmentService {
         Map<String, String> properties = new HashMap<>();
         properties.put(ATTACHMENT_ALT_TEXT, altText);
         properties.put(ATTACHMENT_FORMAT, format);
+        String attachmentIdToLink = attachment.getId();
         try {
-          createAttachment(attachment.getId(),
+          //need to copy the existing attachment before linking it to the new object
+          //if not copied, when removed the attachment from the destObject, it will be also removed from the sourceObject
+          if (!deleteAfterMove) {
+            //if the link between the attachment and the source object is deleted after move, no need to copy the attachment
+            attachmentIdToLink = attachmentStorage.copyAttachment(new ObjectAttachmentId(attachment.getId(),
+                                             sourceObjectType,
+                                             sourceObjectId),
+                                             userIdentityId);
+          }
+
+
+          createAttachment(attachmentIdToLink,
                            destinationObjectType,
                            destinationObjectId,
                            destinationParentObjectId,

--- a/component/core/src/main/java/org/exoplatform/social/core/attachment/storage/FileAttachmentStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/attachment/storage/FileAttachmentStorage.java
@@ -52,6 +52,31 @@ public class FileAttachmentStorage {
     this.imageThumbnailService = imageThumbnailService;
   }
 
+  public String copyAttachment(ObjectAttachmentId sourceAttachmentId, long userIdentityId) {
+    try {
+      FileItem sourceFile = fileService.getFile(Long.parseLong(sourceAttachmentId.getFileId()));
+      if (sourceFile == null) {
+        return null;
+      }
+      FileItem newFileItem =  new FileItem(null,
+                                            sourceFile.getFileInfo().getName(),
+                                            sourceFile.getFileInfo().getMimetype(),
+                                            FILE_API_NAMESPACE,
+                                            sourceFile.getFileInfo().getSize(),
+                                            new Date(),
+                                            String.valueOf(userIdentityId),
+                                           false,
+                                            sourceFile.getAsStream());
+      newFileItem = fileService.writeFile(newFileItem);
+      return String.valueOf(newFileItem.getFileInfo().getId());
+    } catch (Exception e) {
+      LOG.error("Unable to copy attachment with id " + sourceAttachmentId, e);
+      return null;
+    }
+
+  }
+
+
   public String uploadAttachment(Long attachmentId,
                                  String objectType,
                                  String objectId,

--- a/component/core/src/test/java/org/exoplatform/social/attachment/AttachmentServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/attachment/AttachmentServiceTest.java
@@ -408,11 +408,11 @@ public class AttachmentServiceTest extends AbstractCoreTest {
     attachmentService.copyAttachments(OBJECT_TYPE, objectId, DEST_OBJECT_TYPE, destinationObjectId, destinationParentObjectId, Long.parseLong(identityId));
 
     // Verify the attachments are moved to the destination object
+    // and the initial attachment have been duplicated
     ObjectAttachmentList destinationObjectAttachmentList = attachmentService.getAttachments(DEST_OBJECT_TYPE, destinationObjectId);
     assertNotNull(destinationObjectAttachmentList);
     assertEquals(1, destinationObjectAttachmentList.getAttachments().size());
-    assertEquals(fileId, destinationObjectAttachmentList.getAttachments().get(0).getId());
-    assertEquals(fileId, destinationObjectAttachmentList.getAttachments().get(0).getId());
+    assertTrue(!fileId.equals(destinationObjectAttachmentList.getAttachments().get(0).getId()));
 
     // Verify the attachments are NOT removed from the source object
     ObjectAttachmentList sourceObjectAttachmentList = attachmentService.getAttachments(OBJECT_TYPE, objectId);


### PR DESCRIPTION
Before this fix, when an attachment is copied from an object to another one, the attachment linked to the both object is the same. So, if you update the attachment in the target object, the initial attachment is removed and the source object have no more the attachment.

To resolve this problem, we ensure to copy the initial attachment and link the destination object with the new attachment.

Another option is modify the "updateAttachment" behaviour. When changing the attachment of an object, the old attachment is removed. The other option consist in keeping the old attachment, but it can lead to uneeded data retention, so this option was not choosen.

Resolves meeds-io/meeds#3742

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
