### PR TITLE
fix: Change portlets InternalRegistration and Register to not automatically redirect if user is already loggued - MEED-9827 - meeds-io/meeds#3739

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/registerForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/registerForm.jsp
@@ -58,11 +58,7 @@
     class="v-application white v-application--is-ltr theme--light registerForm"
     id="<%=id%>">
     <script type="text/javascript">
-      if (eXo.env.portal.userName && eXo.env.portal.userName !== '' ) {
-        window.location.href='/';
-      } else {
-        require(['PORTLET/social/RegisterForm'], app =>app.init('<%=id%>',JSON.stringify(<%=params.toString()%>)));
-      }
+      require(['PORTLET/social/RegisterForm'], app =>app.init('<%=id%>',JSON.stringify(<%=params.toString()%>)));
     </script>
   </div>
 </div>

--- a/webapp/src/main/webapp/vue-apps/login-internal-onboarding/components/InternalOnboarding.vue
+++ b/webapp/src/main/webapp/vue-apps/login-internal-onboarding/components/InternalOnboarding.vue
@@ -25,8 +25,9 @@
       max-width="100%"
       class="mx-auto px-4 transparent"
       flat>
+      <portal-internal-onboarding-already-authenticated v-if="authenticated" />
       <portal-internal-onboarding-expired
-        v-if="action === 'expired'" />
+        v-else-if="action === 'expired'" />
       <portal-internal-onboarding-reset-form
         v-else-if="action === 'createUser'"
         :username-param="this.username"
@@ -40,6 +41,12 @@ export default {
     username: '',
     action: '',
   }),
+  computed: {
+    authenticated() {
+      console.log('OnboardingResigter authenticated ? ', eXo.env.portal.userName && eXo.env.portal.userName !== '');
+      return eXo.env.portal.userName && eXo.env.portal.userName !== '';
+    },
+  },
   created() {
     this.token = new URLSearchParams(window.location.search).get('token');
     if (this.token) {

--- a/webapp/src/main/webapp/vue-apps/login-internal-onboarding/components/InternalOnboardingAlreadyAuthenticated.vue
+++ b/webapp/src/main/webapp/vue-apps/login-internal-onboarding/components/InternalOnboardingAlreadyAuthenticated.vue
@@ -1,0 +1,45 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-card flat class="transparent">
+    <v-card-title class="text-body px-0">
+      <span class="mx-auto text-center full-width">{{ $t('onboarding.alreadyLoggedInPart1') }}</span>
+      <span class="mx-auto text-center mt-4 full-width">{{ $t('onboarding.alreadyLoggedInPart2') }}</span>
+    </v-card-title>
+    <div class="d-flex ma-0 flex-column">
+      <div class="pa-0">
+        <v-row class="mx-0 mt-8 pa-0">
+          <v-btn
+            :aria-label="$t('forgotpassword.backToLogin')"
+            href="/portal/login"
+            color="primary"
+            width="222"
+            max-width="100%"
+            tabindex="0"
+            class="mx-auto login-button text-none"
+            elevation="0">
+            {{ $t('forgotpassword.go') }}
+          </v-btn>
+        </v-row>
+      </div>
+    </div>
+  </v-card>
+</template>

--- a/webapp/src/main/webapp/vue-apps/login-internal-onboarding/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/login-internal-onboarding/initComponents.js
@@ -20,11 +20,13 @@
 import InternalOnboarding from './components/InternalOnboarding.vue';
 import InternalOnboardingExpired from './components/InternalOnboardingExpired.vue';
 import InternalOnboardingResetForm from './components/InternalOnboardingResetForm.vue';
+import InternalOnboardingAlreadyAuthenticated from './components/InternalOnboardingAlreadyAuthenticated.vue';
 
 const components = {
   'portal-internal-onboarding': InternalOnboarding,
   'portal-internal-onboarding-expired': InternalOnboardingExpired,
   'portal-internal-onboarding-reset-form': InternalOnboardingResetForm,
+  'portal-internal-onboarding-already-authenticated': InternalOnboardingAlreadyAuthenticated,
 };
 
 for (const key in components) {

--- a/webapp/src/main/webapp/vue-apps/user-register/components/Register.vue
+++ b/webapp/src/main/webapp/vue-apps/user-register/components/Register.vue
@@ -20,7 +20,8 @@
 -->
 <template>
   <v-app>
-    <portal-register-main :params="jsonParams" />
+    <portal-register-already-authenticated v-if="authenticated" />
+    <portal-register-main v-else :params="jsonParams" />
   </v-app>
 </template>
 <script>
@@ -35,7 +36,13 @@ export default {
       jsonParams: null,
     };
   },
+  computed: {
+    authenticated() {
+      return eXo.env.portal.userName && eXo.env.portal.userName !== '';
+    },
+  },
   created() {
+    console.log('Register.vue');
     this.jsonParams = JSON.parse(this.params);
   },
   mounted() {

--- a/webapp/src/main/webapp/vue-apps/user-register/components/RegisterAlreadyAuthenticated.vue
+++ b/webapp/src/main/webapp/vue-apps/user-register/components/RegisterAlreadyAuthenticated.vue
@@ -1,0 +1,45 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-card flat class="transparent">
+    <v-card-title class="text-body px-0">
+      <span class="mx-auto text-center full-width">{{ $t('onboarding.alreadyLoggedInPart1') }}</span>
+      <span class="mx-auto text-center mt-4 full-width">{{ $t('onboarding.alreadyLoggedInPart2') }}</span>
+    </v-card-title>
+    <div class="d-flex ma-0 flex-column">
+      <div class="pa-0">
+        <v-row class="mx-0 mt-8 pa-0">
+          <v-btn
+            :aria-label="$t('forgotpassword.backToLogin')"
+            href="/portal/login"
+            color="primary"
+            width="222"
+            max-width="100%"
+            tabindex="0"
+            class="mx-auto login-button text-none"
+            elevation="0">
+            {{ $t('forgotpassword.go') }}
+          </v-btn>
+        </v-row>
+      </div>
+    </div>
+  </v-card>
+</template>

--- a/webapp/src/main/webapp/vue-apps/user-register/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/user-register/initComponents.js
@@ -20,12 +20,14 @@ import Register from './components/Register.vue';
 import RegisterMain from './components/RegisterMain.vue';
 import RegisterExtensions from './components/RegisterExtensions.vue';
 import RegisterSeparator from './components/RegisterSeparator.vue';
+import RegisterAlreadyAuthenticated from './components/RegisterAlreadyAuthenticated.vue';
 
 const components = {
   'portal-register': Register,
   'portal-register-main': RegisterMain,
   'portal-register-extensions': RegisterExtensions,
   'portal-register-separator': RegisterSeparator,
+  'portal-register-already-authenticated': RegisterAlreadyAuthenticated,
 };
 
 for (const key in components) {


### PR DESCRIPTION
Before this fix, portlets InternalRegistration and Register cannot be displayed in edit mode if user is authenticated. This commit ensure to display a message "Already authenticated", based on message displayed in ExternalRegistration, in order to be able to see portlets in editLayout context

Resolves meeds-io/meeds#3739

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
