### PR TITLE
fix: error log when saving loginForm settings first time - MEED-9899 - meeds-io/meeds#3790

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
@@ -263,7 +263,7 @@ export default {
     close() {
       this.$refs.drawer.close();
     },
-    save() {
+    async save() {
       this.loading = true;
       const promise = [];
       let firstTranslation = true;
@@ -274,7 +274,7 @@ export default {
 
       if (this.registerEnabled) {
         if (firstTranslation) {
-          this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, 'newHere', this.translationsNewHere);
+          await this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'newHere', this.translationsNewHere);
           firstTranslation = false;
         } else {
           promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'newHere', this.translationsNewHere));
@@ -282,7 +282,7 @@ export default {
         promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'createAccount', this.translationsCreateAccount));
       } else {
         if (firstTranslation) {
-          this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, 'welcomeBack', this.translationsWelcomeBack);
+          await this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'welcomeBack', this.translationsWelcomeBack);
           firstTranslation = false;
         } else {
           promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'welcomeBack', this.translationsWelcomeBack));
@@ -291,23 +291,25 @@ export default {
 
       if (this.signinOption === 'buttonform') {
         if (firstTranslation) {
-          this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, 'signinEmailButton', this.translationsSigninEmailButton);
+          await this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'signinEmailButton', this.translationsSigninEmailButton);
           firstTranslation = false;
         } else {
           promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, 'signinEmailButton', this.translationsSigninEmailButton));
         }
       }
 
-      this.providers.forEach((provider) => {
+      for (const provider of this.providers) {
         if (provider.translations && Object.keys(provider.translations).length > 0) {
           if (firstTranslation) {
-            this.saveTranslationSynchronously(this.objectType, this.translationIdentifier, provider.key, provider.translations);
+            /* eslint-disable no-await-in-loop */
+            await this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, provider.key, provider.translations);
             firstTranslation = false;
+            /* eslint-enable no-await-in-loop */
           } else {
             promise.push(this.$translationService.saveTranslations(this.objectType, this.translationIdentifier, provider.key, provider.translations));
           }
         }
-      });
+      }
 
       promise.push(this.saveSettings());
       Promise.all(promise).then(() => {
@@ -325,9 +327,6 @@ export default {
         this.loading = false;
         this.close();
       });
-    },
-    async saveTranslationSynchronously(objectType, objectId, fieldName, translations) {
-      await this.$translationService.saveTranslations(objectType, objectId, fieldName, translations);
     },
     saveSettings() {
       const formData = new FormData();


### PR DESCRIPTION
Before this fix, when saving the settings (and specially translations) first time there is an error in server log. This error is due to saveTranslations requests which were send in parallele. But, add the metadata does not exists, both request try to create it, which generate a unicity problem The fix ensure to send the first save translation request synchronously, with async/await, and then launch the others one with promises. As the first already create the metadata, the other requests can be sent in parallel

Resolves meeds-io/meeds#3790

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
