### PR TITLE
fix: Update a user profile attribute after changing its multivalued property - MEED-9830 - Meeds-io/meeds#3671

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/profile/UserProfileComparator.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profile/UserProfileComparator.java
@@ -60,13 +60,15 @@ public class UserProfileComparator {
           && (((newValue instanceof String) && StringUtils.isNotBlank(newValue.toString()))
               || ((newValue instanceof List) && !((List<?>) newValue).isEmpty())
               || (newValue instanceof Date));
-    } else if (oldValue instanceof String) {
-      newValue = newValue == null ? StringUtils.EMPTY : String.valueOf(newValue);
-      return !StringUtils.equals((String) oldValue, (String) newValue);
+    } else if ((oldValue instanceof String && newValue instanceof List) || (oldValue instanceof List && newValue instanceof String)) {
+      return true;
     } else if (oldValue instanceof List) {
       List<Map<String, Object>> newValueList = (List<Map<String, Object>>) newValue;
       List<Map<String, Object>> oldValueList = (List<Map<String, Object>>) oldValue;
       return !isEquals(oldValueList, newValueList);
+    } else if (oldValue instanceof String) {
+      newValue = newValue == null ? StringUtils.EMPTY : String.valueOf(newValue);
+      return !StringUtils.equals((String) oldValue, (String) newValue);
     } else {
       return !ObjectUtils.equals(newValue, oldValue);
     }

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -111,7 +111,7 @@ export default {
     },
     filteredProperties() {
       return this.properties.filter(property => property.visible && !this.excludedDropdown(property, property)
-               && (property.value || (property.children?.some(e => e.value && !this.excludedDropdown(e, property)))));
+               && (property.value || (property.multiValued && (property.children?.some(e => e.value && !this.excludedDropdown(e, property))))));
     },
     title() {
       return this.owner && this.$t('profileContactInformation.yourContactInformation') || this.$t('profileContactInformation.contactInformation');

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -20,7 +20,7 @@
             :property="property"
             @property-updated="propertyUpdated" />
           <profile-contact-edit-multi-field
-            v-else-if="property.multiValued || property?.children?.length"
+            v-else-if="property.multiValued || (property?.children?.some(child => child.default) ?? false)"
             :property="property"
             :disabled="disabledField(property)"
             @propertyUpdated="propertyUpdated" />
@@ -98,7 +98,7 @@ export default {
     },
     isEmailPropertyHidden() {
       return this.emailProperty?.visible === false || this.emailProperty?.hiddenable === false;
-    },
+    }
   },
   created() {
     this.$root.$on('open-profile-contact-information-drawer', this.open);
@@ -137,7 +137,6 @@ export default {
     },
     save() {
       this.fieldError = false;
-      
       this.resetCustomValidity();
       let proptocheck = this.propertiesToSave.find(property => property.propertyName === 'urls');
       if (proptocheck && proptocheck.children.length > 0) {
@@ -255,6 +254,9 @@ export default {
     },
     propertyUpdated(item) {
       this.disabled = false;
+      if (item.value && (!item.multiValued && item.children.length)) {
+        item.children = [];
+      }
       if (!this.propertiesToSave.some(e => e.id === item.id)) {
         this.propertiesToSave.push(item);
       }    


### PR DESCRIPTION
Prior to this change, when a user changed a multi-value attribute from ON to OFF, then filled in the attribute with a value and saved it, the attribute would no longer display. This change resolves this issue.

Resolves: Meeds-io/meeds#3671