### PR TITLE
fix: Add an alternative to distinguish the active tags - MEED-9871 - meeds-io/meeds#3756.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchTagSelector.vue
+++ b/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchTagSelector.vue
@@ -4,7 +4,7 @@
     <v-chip
       v-for="(selectedTag, index) in selectedTags"
       :key="selectedTag"
-      class="text-body text-header-color me-1"
+      class="text-body border-color text-header-color me-1 "
       color="primary">
       <v-icon size="16" class="pe-2">
         fas fa-hashtag


### PR DESCRIPTION
before this change, when access to Unified search then click on the tag button and activate a tag in the opened selection module, the activated tag is distinguished only by color. To fix this problem, add the border-color class to the button tag. After this change, a border with primary color is added on the active.