### PR TITLE
fix: adapt the favorite filter implementation in the unified search -MEED-9870 - meeds-io/meeds#3763. 

### DIFF
--- a/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchFavoriteSelector.vue
+++ b/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchFavoriteSelector.vue
@@ -22,9 +22,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <v-chip
     :outlined="!isFavoritesFilter"
     :color="isFavoritesFilter ? 'primary' : ''"
-    :aria-pressed="isFavoritesFilter"
+    :aria-pressed="String(isFavoritesFilter)"
     :aria-label="$t('search.filter.favorite')"
     class="me-1 text-body border-color flex-shrink-0"
+    role="button"
     tabindex="0"
     @keydown.enter="emitFavoritesChange"
     @click="emitFavoritesChange">


### PR DESCRIPTION
before this change, when access to Unified search and enable and disable the favorites filter, the status isn't taken into account and the status (Enabled and disabled) of the Favorite filter isn't rendered by screen reader. To fix this problem, add the role button and change the value of aria-pressed to string. After this change, this button works correctly.