### PR TITLE
fix: Incorrect aria-label rendering - MEED-9866 - meeds-io/meeds#3759

### DIFF
--- a/component/service/src/main/resources/locale/social/Webui_en.properties
+++ b/component/service/src/main/resources/locale/social/Webui_en.properties
@@ -86,6 +86,9 @@ BaseUIActivity.msg.info.Activity_No_Longer_Exist=This activity no longer exists.
 #####################################################################################
 #                                  UIActivity                                       #
 #####################################################################################
+UIActivity.aria.Comment=You commented
+UIActivity.aria.Like=You liked
+UIActivity.aria.Share=You shared
 UIActivity.label.Source=Source
 UIActivity.label.Activity_Can_Be_Deleted=This activity was not found.
 UIActivity.label.Comment=Comment


### PR DESCRIPTION
before this change, when Create an article then publish it in the stream then like it, comment it and share it, the aria-labels of Like, comment and Share icons are incorrectly rendered. To fix this problem, add keys in the properties file. After this change, The aria-labels is rendered correctly.