### PR TITLE
fix: add the ability to make the space avatar and user avatar component non focusable - MEED-9594 - Meeds-io/meeds#3589

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/SpaceAvatar.vue
@@ -6,6 +6,7 @@
     v-identity-popover="space">
     <a
       v-if="notAccessibleSpace"
+      :tabindex="isNotFocusable ? -1 : 0"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar not-clickable-link">
       <v-avatar
         v-if="avatar || !isMobile"
@@ -38,6 +39,7 @@
       :href="url"
       :target="linkTarget"
       :aria-label="$t('space.avatar.href.title',{0:displayName})"
+      :tabindex="isNotFocusable ? -1 : 0"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
@@ -59,6 +61,7 @@
       :id="id"
       :href="url"
       :target="linkTarget"
+      :tabindex="isNotFocusable ? -1 : 0"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <div
         v-if="displayName || $slots.subTitle"
@@ -84,6 +87,7 @@
       :href="url"
       :target="linkTarget"
       :aria-label="$t('space.avatar.href.title',{0:displayName})"
+      :tabindex="isNotFocusable ? -1 : 0"
       class="flex-nowrap flex-shrink-0 d-flex spaceAvatar">
       <v-avatar
         :size="size"
@@ -184,6 +188,10 @@ export default {
       type: String,
       default: () => 'text-truncate',
     },
+    focusable: {
+      type: Boolean,
+      default: () => true,
+    },
   },
   data() {
     return {
@@ -238,6 +246,9 @@ export default {
     },
     subtitleNewLineClass() {
       return !this.subtitleNewLine && `d-flex ${this.pullLeft}` || this.pullLeft;
+    },
+    isNotFocusable() {
+      return this.focusable === false || this.focusable === 'false';
     },
   },
   created() {

--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -13,6 +13,7 @@
       :href="profileUrl"
       :aria-label="ariaLabel ? ariaLabel : $t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
+      :tabindex="isNotFocusable ? -1 : 0"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
@@ -68,6 +69,7 @@
       :href="profileUrl"
       :aria-label="ariaLabel ? ariaLabel : $t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
+      :tabindex="isNotFocusable ? -1 : 0"
       class="d-flex flex-nowrap flex-grow-1 text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
@@ -122,6 +124,7 @@
       :href="profileUrl"
       :aria-label="ariaLabel ? ariaLabel : $t('popover.userAvatar.title',{0:userFullname})"
       :class="componentClass"
+      :tabindex="isNotFocusable ? -1 : 0"
       class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid"
       @click="clickable && $emit('avatar-click', $event)">
       <v-avatar
@@ -334,6 +337,10 @@ export default {
       type: String,
       default: () => '',
     },
+    focusable: {
+      type: Boolean,
+      default: () => true,
+    },
   },
   data() {
     return {
@@ -432,6 +439,9 @@ export default {
           || !Object.hasOwn(this.identity, 'deleted')
           || !Object.hasOwn(this.identity, 'primaryProperty')
           || (!Object.hasOwn(this.identity, 'external') && !Object.hasOwn(this.identity, 'isInternal'));
+    },
+    isNotFocusable() {
+      return this.focusable === false || this.focusable === 'false';
     },
   },
   created() {


### PR DESCRIPTION
In some cases and for accessibility reasons, we need to make avatars non-focusable. 
This change adds a focusable prop to the space and user avatar components.