### PR TITLE
fix: do not expose user email in url during registration process - MEED-9829 - meeds-io/meeds#3778

### DIFF
--- a/component/service/src/main/java/io/meeds/social/security/rest/LoginRest.java
+++ b/component/service/src/main/java/io/meeds/social/security/rest/LoginRest.java
@@ -166,7 +166,8 @@ public class LoginRest {
       try {
         String email = finishUserCreation(username, request, token, request.getLocale());
         cleanCapcha(request.getSession(),"email-validation");
-        return ResponseEntity.status(HttpStatus.FOUND).header(LOCATION_HEADER, LOGIN_PATH + "?email="+email).build();
+        return ResponseEntity.status(HttpStatus.FOUND).header(LOCATION_HEADER, LOGIN_PATH).body(new JSONObject()
+                                                                                                    .put("username", email).toString());
       } catch (Exception e) {
         LOG.warn("Error while registering external user", e);
         return ResponseEntity.internalServerError().body(new JSONObject()
@@ -374,7 +375,7 @@ public class LoginRest {
       String username = createUser(email, firsname, lastname, password);
       passwordRecoveryService.sendAccountCreatedConfirmationEmail(username, locale, getUrl(request));
       remindPasswordTokenService.deleteToken(token);      cleanCapcha(session, "external-registration");
-      return ResponseEntity.status(HttpStatus.FOUND).header(LOCATION_HEADER, "/portal/login?email="+email).build();
+      return ResponseEntity.status(HttpStatus.FOUND).header(LOCATION_HEADER, LOGIN_PATH).build();
     } catch (Exception e) {
       LOG.warn("Error while registering external user", e);
       return ResponseEntity.internalServerError().body(new JSONObject()
@@ -550,9 +551,6 @@ public class LoginRest {
       if (passwordRecoveryService.changePass(token, "onboard", username, password)) {
         User user = findUser(username);
         String loginPath = LOGIN_PATH;
-        if (user != null) {
-          loginPath += "?email=" + user.getEmail();
-        }
         return ResponseEntity.status(HttpStatus.FOUND).header(LOCATION_HEADER, loginPath).build();
       } else {
         return ResponseEntity.badRequest().body(new JSONObject()

--- a/component/service/src/test/java/io/meeds/social/security/rest/LoginRestTest.java
+++ b/component/service/src/test/java/io/meeds/social/security/rest/LoginRestTest.java
@@ -366,7 +366,7 @@ public class LoginRestTest {
                                                  .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                                                  .accept(MediaType.APPLICATION_JSON));
     response.andExpect(status().isFound())
-            .andExpect(header().string("Location","/portal/login?email=jsmith@acme.com"));
+            .andExpect(header().string("Location","/portal/login"));
   }
 
 
@@ -557,7 +557,7 @@ public class LoginRestTest {
                                                  .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                                                  .accept(MediaType.APPLICATION_JSON));
     response.andExpect(status().isFound())
-            .andExpect(header().string("Location","/portal/login?email=jsmith@acme.com"));
+            .andExpect(header().string("Location","/portal/login"));
   }
 
   @Test
@@ -715,7 +715,7 @@ public class LoginRestTest {
                                                  .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                                                  .accept(MediaType.APPLICATION_JSON));
     response.andExpect(status().isFound())
-            .andExpect(header().string("Location","/portal/login?email=jsmith@acme.com"));
+            .andExpect(header().string("Location","/portal/login"));
   }
 
   private RequestPostProcessor testSimpleUser() {

--- a/webapp/src/main/webapp/vue-apps/login-external-onboarding/components/ExternalOnboardingCreateUserForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-external-onboarding/components/ExternalOnboardingCreateUserForm.vue
@@ -305,6 +305,7 @@ export default {
               });
             } else {
               if (resp.redirected) {
+                sessionStorage.setItem('email',this.email);
                 window.location.href = resp.url;
               } else {
                 this.success = true;

--- a/webapp/src/main/webapp/vue-apps/login-forgot-password/components/ForgotPasswordResetForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-forgot-password/components/ForgotPasswordResetForm.vue
@@ -164,6 +164,7 @@ export default {
           }
         } else {
           if (resp.redirected) {
+            sessionStorage.setItem('email',this.usernameParam);
             window.location.href = resp.url;
           }
         }

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -332,11 +332,15 @@ export default {
       this.displayBackButton = !this.displayBackButton;
     },
     setupUserName(){
-      const urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.has('username')) {
-        this.username = urlParams.get('username');
-      } else if (urlParams.has('email')) {
-        this.username = urlParams.get('email');
+      if (sessionStorage.getItem('email') != null) {
+        this.username = sessionStorage.getItem('email');
+      } else {
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('username')) {
+          this.username = urlParams.get('username');
+        } else if (urlParams.has('email')) {
+          this.username = urlParams.get('email');
+        }
       }
     },
     toggleShow() {
@@ -345,6 +349,7 @@ export default {
     validateForm() {
       this.loading = this.$refs.form.reportValidity();
       window.setTimeout(() => this.loading = false, 10000);
+      sessionStorage.removeItem('email');
       return true;
     },
     displayAlert(message, type) {

--- a/webapp/src/main/webapp/vue-apps/login-internal-onboarding/components/InternalOnboardingResetForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-internal-onboarding/components/InternalOnboardingResetForm.vue
@@ -196,6 +196,7 @@ export default {
           }
         } else {
           if (resp.redirected) {
+            sessionStorage.setItem('email',this.usernameParam);
             window.location.href = resp.url;
           }
         }


### PR DESCRIPTION
Before this fix, during registration processus, email is exposed in urls This commit ensure to not use url to transmit email, and use sessionStorage

Resolves meeds-io/meeds#3778

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
