### PR TITLE
fix: ensure to have a focus on the drawer when user open it with keyboard - MEED-9785 - meeds-io/meeds#3743

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -23,7 +23,9 @@
     height="100%"
     max-height="100%"
     max-width="100vw"
-    class="drawerParent overflow-initial">
+    class="drawerParent overflow-initial"
+    ref="drawerParent"
+    tabindex="0">
     <div
       v-if="initialized || eager"
       class="pa-0 fill-width fill-height">
@@ -273,6 +275,10 @@ export default {
     filterPlaceholder: {
       type: String,
       default: null
+    },
+    autofocus: {
+      type: Boolean,
+      default: true
     }
   },
   data: () => ({
@@ -417,10 +423,12 @@ export default {
         this.drawer = true;
       }
       this.resetFilter();
-      this.$nextTick(() => {
-        window.setTimeout(() =>
-          this.$el.querySelector('input')?.focus(), 50);
-      });
+      if (this.autofocus) {
+        this.$nextTick(() => {
+          window.setTimeout(() =>
+            this.$refs.drawerParent?.$el.focus(), 50);
+        });
+      }
     },
     mountOnParent() {
       // Re-append the drawer to open in order

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/parent/SidebarParentDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/parent/SidebarParentDrawer.vue
@@ -27,6 +27,7 @@
     :permanent="permanent"
     :show-overlay="showOverlay"
     :is-branding-layout="false"
+    :autofocus="false"
     no-external-overlay
     attached
     left>


### PR DESCRIPTION
Before this fix, the focus in the drawer is put on the first input of the drawer. But this input can not exists.
To ensure to always put focus in the drawer, we put tabindex=0 on the drawerParent component and put focus on it.

Resolves meeds-io/meeds#3743

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
