### PR TITLE
fix: Having a relevant title for the profile page - MEED-9886 - meeds-io/meeds#3785.

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/ProfileHeader_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/ProfileHeader_en.properties
@@ -1,3 +1,4 @@
+profileHeader.page.title=Profile of {0} - {1}
 profileHeader.button.changeAvatar=Change picture
 profileHeader.button.connect=Connect
 profileHeader.button.disconnect=Disconnect

--- a/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -170,6 +170,9 @@ export default {
     },
     isAdmin() {
       return this.user?.isAdmin;
+    },
+    userFullname() {
+      return this.user?.fullname;
     }
   },
   watch: {
@@ -178,6 +181,10 @@ export default {
         this.$root.$emit('alert-message', this.errorMessage, 'error');
       }
     },
+    userFullname() {
+      const companyName = eXo.env.portal.companyName;
+      window.document.title = this.$t('profileHeader.page.title',{0: this.userFullname, 1: companyName});
+    }
   },
   created() {
     window.addEventListener('resize', this.calculateAppWidth);


### PR DESCRIPTION
before this change, when accessing any profile user, the page title is in this format [Page Name] - [Platform Name]. To fix this problem, change the page title when the user object is retrieved. After this change, the page title is in this format Profile page = Profile of [display name] - [Platform Name].
Resolves https://github.com/Meeds-io/meeds/issues/3785