### PR TITLE
fix: Add an alternative to distinguish the active tags - MEED-9871 - meeds-io/meeds#3756.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchTagList.vue
+++ b/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchTagList.vue
@@ -35,7 +35,7 @@
         <span v-if="!searching" class="font-weight-bold pl-1">{{ $t('Tag.last.added') }}</span>
         <v-chip-group
           v-model="value"
-          active-class="primary--text"
+          active-class="primary--text primary-border-color"
           class="pt-2"
           multiple>
           <v-chip


### PR DESCRIPTION
Before this change, when access to Unified search then click on the tag button and activate a tag in the opened selection module, the activated tag is distinguished only by color. To fix this problem, add the primary-border-color class to the button tag. After this change, a border with primary color is added on the active.