### PR TITLE
fix: Allow to export portlet settings (attachment and translations) - MEED-9809 - meeds-io/meeds#3780

### DIFF
--- a/webapp/src/main/java/io/meeds/social/portlet/CmsPortletWithMetadata.java
+++ b/webapp/src/main/java/io/meeds/social/portlet/CmsPortletWithMetadata.java
@@ -1,8 +1,6 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
- *
  * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
- *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -11,7 +9,6 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
@@ -20,30 +17,52 @@ package io.meeds.social.portlet;
 
 import io.meeds.social.translation.model.TranslationField;
 import io.meeds.social.translation.service.TranslationService;
+
 import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import lombok.SneakyThrows;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.social.attachment.AttachmentService;
+import org.exoplatform.social.attachment.model.UploadedAttachmentDetail;
 import org.exoplatform.social.rest.api.RestUtils;
+import org.exoplatform.upload.UploadResource;
+import org.json.JSONObject;
 
-import java.security.SecureRandom;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class CmsPortletWithMetadata extends CMSPortlet {
 
+  private static final Log LOG = ExoLogger.getLogger(CmsPortletWithMetadata.class);
+
   public static final String OBJECT_TYPE = "cmsPortlet";
 
-  private       TranslationService translationService;
+  private static final String EXPORT_DATA_INIT_PREFERENCE_NAME = "export.data.init";
 
-  private       AttachmentService  attachmentService;
+  private static final String EXPORT_DATA_ALT_INIT_PREFERENCE_NAME = "export.data.alt.init";
+
+  private static final String EXPORT_DATA_TRANSLATIONS_INIT_PREFERENCE_NAME = "export.data.translation.init";
+
+  private TranslationService translationService;
+
+  private AttachmentService attachmentService;
 
   @Override
   protected void setViewRequestAttributes(String name, RenderRequest request, RenderResponse response) {
     PortletPreferences preferences = request.getPreferences();
-    String initTranslationIdentifier = preferences.getValue(DATA_INIT_PREFERENCE_NAME,null);
+    String initTranslationIdentifier = preferences.getValue(DATA_INIT_PREFERENCE_NAME, null);
     if (initTranslationIdentifier != null) {
       // creation new translations
       try {
@@ -77,9 +96,23 @@ public class CmsPortletWithMetadata extends CMSPortlet {
                                              null,
                                              RestUtils.getCurrentUserIdentityId());
 
-
-
       savePreference(DATA_INIT_PREFERENCE_NAME, null);
+    }
+  }
+
+  @Override
+  protected void preSettingInit(PortletPreferences preferences, String name) {
+    String imageContent = preferences.getValue(EXPORT_DATA_INIT_PREFERENCE_NAME, null);
+    String imageAlt = preferences.getValue(EXPORT_DATA_ALT_INIT_PREFERENCE_NAME, null);
+    if (StringUtils.isNotBlank(imageContent)) {
+      initImageAttachmentContent(name, imageContent, imageAlt);
+      savePreference(EXPORT_DATA_INIT_PREFERENCE_NAME, null);
+    }
+
+    String translations = preferences.getValue(EXPORT_DATA_TRANSLATIONS_INIT_PREFERENCE_NAME, null);
+    if (StringUtils.isNotBlank(translations)) {
+      initTranslations(name, translations);
+      savePreference(EXPORT_DATA_TRANSLATIONS_INIT_PREFERENCE_NAME, null);
     }
   }
 
@@ -95,5 +128,64 @@ public class CmsPortletWithMetadata extends CMSPortlet {
       attachmentService = ExoContainerContext.getService(AttachmentService.class);
     }
     return attachmentService;
+  }
+
+  @SneakyThrows
+  private void initImageAttachmentContent(String name, String imageContent, String imageAlt) {
+    File tempFile = File.createTempFile("image", ".png");
+    try {
+      try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+        IOUtils.write(Base64.decodeBase64(imageContent), outputStream);
+      }
+      initImageWithAttachmentFullPath(name, tempFile.getAbsolutePath(), imageAlt);
+    } finally {
+      try {
+        Files.delete(tempFile.toPath());
+      } catch (Exception e) {
+        LOG.warn("Error deleting temporary file {}", tempFile.getAbsoluteFile(), e);
+      }
+    }
+  }
+
+  @SneakyThrows
+  private void initImageWithAttachmentFullPath(String name, String resourcePath, String imageAlt) {
+    String uploadId = "CmsPortletWithMetadata-" + name;
+    UploadResource uploadResource = new UploadResource(uploadId);
+    uploadResource.setFileName(new File(resourcePath).getName());
+    uploadResource.setMimeType("image/png");
+    uploadResource.setStatus(UploadResource.UPLOADED_STATUS);
+    uploadResource.setStoreLocation(resourcePath);
+    UploadedAttachmentDetail uploadedAttachmentDetail = new UploadedAttachmentDetail(uploadResource);
+    uploadedAttachmentDetail.setAltText(imageAlt);
+    getAttachmentService().saveAttachment(uploadedAttachmentDetail,
+                                          OBJECT_TYPE,
+                                          name,
+                                          null,
+                                          RestUtils.getCurrentUserIdentityId());
+  }
+
+  private void initTranslations(String name, String translations) {
+    JSONObject translationJson = new JSONObject(translations);
+    translationJson.keySet().forEach(key -> {
+      JSONObject translation = translationJson.getJSONObject(key);
+
+      Map<Locale, String> translationsLabel = new HashMap<>();
+      translation.keySet().forEach(localeKey -> {
+        Locale locale = Locale.forLanguageTag(localeKey);
+        String value = translation.getString(localeKey);
+        translationsLabel.put(locale, value);
+      });
+      if (!translationsLabel.isEmpty()) {
+        try {
+          getTranslationService().saveTranslationLabels(OBJECT_TYPE,
+                                                        name,
+                                                        key,
+                                                        translationsLabel,
+                                                        false);
+        } catch (ObjectNotFoundException o) {
+          //nothing to do, no translations to copy
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
Before this fix, attachments and translation for logins portlets (sidebarlogin and loginForm) cannot be exported. This commit ensure to export this information and reread it at display

Resolves meeds-io/meeds#3780

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
