### PR TITLE
fix: Refresh search connector when a space search result element changes - MEED-9874 - Meeds-io/meeds#3768 (#5321)

### DIFF
--- a/webapp/src/main/webapp/vue-apps/search-space/components/SearchSpaceCard.vue
+++ b/webapp/src/main/webapp/vue-apps/search-space/components/SearchSpaceCard.vue
@@ -38,14 +38,19 @@ export default {
   created() {
     document.addEventListener('extension-profile-extension-action-updated', this.refreshExtensions);
     this.refreshExtensions();
+    this.$root.$on('spaces-list-refresh', this.emitRefresh);
   },
   beforeDestroy() {
     document.removeEventListener('extension-profile-extension-action-updated', this.refreshExtensions);
+    this.$root.$off('spaces-list-refresh', this.emitRefresh);
   },
   methods: {
     refreshExtensions() {
       this.spaceActionExtensions = extensionRegistry.loadExtensions('profile-extension', 'action') || [];
     },
+    emitRefresh() {
+      this.$emit('refresh');
+    }
   }
 };
 </script>


### PR DESCRIPTION
Prior to this change, space search results were not refreshed when an action was performed on an item. This update ensures that the search connector refreshes whenever an element changes.
