### PR TITLE
fix: Review the search page display when no results are found - MEED-9872 - Meeds-io/meeeds#3769

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -704,6 +704,7 @@ Search.activity.inSpace=In space
 Search.activity.open=Open activity
 Search.activity.commentsCount={0} Comments
 Search.activity.likesCount={0} like(s)
+Search.noResults.placeholder=No results found. Please, try again.
 Search.noResults=No results found
 Search.noResultsMessage=Sorry, we couldn't find any matching result
 Search.page.title=Search

--- a/webapp/src/main/webapp/skin/less/portlet/Search/Style.less
+++ b/webapp/src/main/webapp/skin/less/portlet/Search/Style.less
@@ -21,22 +21,6 @@
 @import "../../variables.less"; 
 @import "../../mixins.less";
 
-#searchDialog {
-  .searchNoResultsParent {
-    .uiIconSearchLight {
-      font-size: 160px;
-
-      .uiIconCloseLight {
-        font-size:60px;
-        position: absolute;
-        left: 45px;
-        top: 28px;
-        font-weight: bold;
-      }
-    }
-  }
-}
-
 @media (min-width: @minDesktop) {
   .HamburgerMenuSticky #searchDialog {
     top: 0;

--- a/webapp/src/main/webapp/vue-apps/search/components/SearchResults.vue
+++ b/webapp/src/main/webapp/vue-apps/search/components/SearchResults.vue
@@ -33,17 +33,21 @@
           :term="term" />
       </div>
     </div>
-    <v-flex v-if="noResults && !$root.disablePlaceholder" class="searchNoResultsParent d-flex my-auto border-box-sizing">
+    <v-card
+      flat
+      v-if="noResults && !$root.disablePlaceholder"
+      min-height="calc(var(--100vh, 100vh) - 350px)"
+      class="d-flex justify-center align-center">
       <div class="d-flex flex-column ma-auto text-center text-subtitle">
-        <div class="position-relative">
-          <i class="uiIconSearchLight icon-default-color my-auto position-relative">
-            <i class="uiIconCloseLight icon-default-color"></i>
-          </i>
-        </div>
-        <span class="headline">{{ $t('Search.noResults') }}</span>
-        <span class="caption">{{ $t('Search.noResultsMessage') }}</span>
+        <v-icon
+          class="tertiary-color my-auto"
+          size="60"
+          color="tertiary">
+          fas fa-search
+        </v-icon>
+        <span class="headline">{{ $t('Search.noResults.placeholder') }}</span>
       </div>
-    </v-flex>
+    </v-card>
     <v-flex v-if="hasMore" class="searchLoadMoreParent d-flex my-4 border-box-sizing">
       <v-btn
         :loading="loading"


### PR DESCRIPTION
Prior to this change, when no results were found in the global search, two icons and placeholders were displayed. This update reviews the search page display to show only one search icon and its corresponding placeholder, both centered on the page.