### PR TITLE
fix: Login portlet settings missing when editing login page with oauth registration - MEED-9969 - meeds-io/meeds#3852

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -279,6 +279,7 @@ export default {
       this.displayWelcomeMessage = displayWelcomeMessage;
     });
     this.$root.$on('login-providers-refreshed', (providers) => {
+      this.providers = providers;
       this.displayForm = providers.length === 0;
       const t = this;
       setTimeout(() => {

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginFormSettingsDrawer.vue
@@ -216,6 +216,14 @@ export default {
     translationsSigninEmailButton: {},
     providers: [],
   }),
+  watch: {
+    providersData: {
+      deep: true,
+      handler() {
+        this.initProviders(this.providersData);
+      }
+    }
+  },
   created() {
     this.$root.$on('login-form-settings', this.open);
     this.$root.$on('login-providers-refreshed', (providers) => {


### PR DESCRIPTION
Before this fix, in some cases, providers list is not seen in LoginSettingsDrawer. This problem occurs when the LoginProviders component finished the call to refreshProviders BEFORE LoginFormSettingsDrawer initiate the event. Then LoginProviders emit event 'login-providers-refreshed', which is not seen in LoginFormSettingsDrawer

This commit ensure to pass and watch the providers list from LoginForm to LoginFormSettingsDrawer

Resolves meeds-io/meeds#3852

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
