### PR TITLE
fix: Fix the search of content writers in space settings drawer - MEED-9961 - Meeds-io/meeds#3816

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-settings/components/drawer/SpaceSettingUsersListDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-settings/components/drawer/SpaceSettingUsersListDrawer.vue
@@ -180,10 +180,6 @@ export default {
         if (this.role === 'manager') {
           this.isLastAdmin = this.users?.length < 2;
         }
-        if (this.role === 'redactor'
-            && !this.users?.length) {
-          this.$refs.drawer.close();
-        }
       } finally {
         this.loading = false;
       }


### PR DESCRIPTION
Before this change, when attempting to search for redactors who, did not exist, in the dedicated drawer in the space settings, the drawer closed, when we should have received the message “No matching users” in the opened drawer. This change will resolve this issue.

Resolves: Meeds-io/meeds#3816
