### PR TITLE
fix: Profile banner and profile avatar must be ignored - MEED-9966 - Meeds-io/meeds#9966

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -15,7 +15,6 @@
             :max-height="bannerMaxHeight"
             :height="bannerHeight"
             min-height="60"
-            :alt="$t('profileHeader.banner.alt')"
             width="100%"
             class="profileBannerImg application-border-radius-top"
             lazy />

--- a/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderAvatar.vue
@@ -16,7 +16,6 @@
         :min-height="minSize"
         :max-width="maxSize"
         :max-height="maxSize"
-        :alt="$t('profileHeader.avatar.alt')"
         id="profileAvatarImg"
         transition="none"
         role="presentation"


### PR DESCRIPTION
This commit deletes the label-area and the role from profile banner and avatar.