### PR TITLE
fix: Fix LDAP/AD sync profile prop with name not containing "." - MEED-9995 - Meeds-io/meeds#3877

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SynchronizedUserProfileListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SynchronizedUserProfileListener.java
@@ -80,7 +80,7 @@ public class SynchronizedUserProfileListener extends Listener<IDMExternalStoreIm
       if (profilePropertySettingNames.contains(name)
           || (name.contains(".") && profilePropertySettingNames.contains(name.substring(0, name.indexOf('.'))))) {
         // check if the parent property exists
-        ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(name.substring(0, name.indexOf('.')));
+        ProfilePropertySetting propertySetting = name.contains(".") ? profilePropertyService.getProfileSettingByName(name.substring(0, name.indexOf('.'))) : null;
         // look for the property that has the full name including the dot "."
         if (propertySetting == null) {
           propertySetting = profilePropertyService.getProfileSettingByName(name);


### PR DESCRIPTION
Prior to this change, when synchronizing a profile property whose name not containing ".", a substring on "." is done to get the parent property if exists even if the "." is not present on the property name which causes an exception. After this change, before doing the substring, we ensure before the existence of the "." in the name in order to avoid the exception.

Resolves Meeds-io/meeds#3877