### PR TITLE
fix: organizational chart not displayed when username is in email format - MEED-9817 - Meeds-io/meeds#3724

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -532,7 +532,7 @@ public class ProfileSearchConnector {
                 } else {
                   searchedText = removeAccents(splittedValues[i]);
                 }
-                expression.append(" ").append(key.replace(" ", "\\\\ ")).append(":").append(searchedText);
+                expression.append(" ").append(key.replace(" ", "\\\\ ")).append(".whitespace").append(":").append(searchedText);
               }
             }
             query.append("""

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -543,7 +543,7 @@ public class ProfileSearchConnectorTest {
                 "      }\n" +
                 ",  {\n" +
                 "    \"query_string\": {\n" +
-                "      \"query\": \" testProperty:*value* AND  testProperty:*of* AND  testProperty:*test* AND  testProperty:*Property*\"\n" +
+                "      \"query\": \" testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*\"\n" +
                 "    }\n" +
                 " }\n" +
                 "    ]\n" +
@@ -661,7 +661,7 @@ public class ProfileSearchConnectorTest {
                 "      }\n" +
                 ",  {\n" +
                 "    \"query_string\": {\n" +
-                "      \"query\": \" testProperty:*value* AND  testProperty:*of* AND  testProperty:*test* AND  testProperty:*Property*\"\n" +
+                "      \"query\": \" testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*\"\n" +
                 "    }\n" +
                 " }\n" +
                 "    ]\n" +


### PR DESCRIPTION
Prior to this change, the organizational chart was not displayed when the username was in email format and contained reserved characters, causing a mismatch.
This change adds a whitespace subfield to the searched field to ensure correct matching.