### PR TITLE
fix: unify close button click handling in ExoDrawer - MEED-10002 - Meeds-io/meeds#3884

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -130,11 +130,11 @@
                 </v-btn>
                 <v-btn
                   :title="$t('label.close')"
-                  icon>
+                  icon
+                  @click="close()">
                   <v-icon
                     class="icon-default-color"
-                    size="20"
-                    @click="close()">
+                    size="20">
                     fa-times
                   </v-icon>
                 </v-btn>


### PR DESCRIPTION
Prior to this change, the click event was attached to the `v-icon `inside the button, creating multiple clickable targets (a button inside a button) in the DOM, which caused an accessibility issue. This change moves the click handler to the `v-btn`, resolving the issue.