### PR TITLE
fix: Display the see all buttons when focusing - MEED-9939 - Meeds-io/meeds#3831 (#5398)

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/Widget.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/Widget.vue
@@ -19,8 +19,12 @@
     :class="extraClass"
     :height="height"
     :min-width="minWidth"
-    class="d-flex flex-column"
-    flat>
+    :tabindex="tabindex"
+    :ripple="false"
+    class="d-flex flex-column not-clickable"
+    flat
+    @focusin="$emit('focusin', $event)"
+    @focusout="$emit('focusout', $event)">
     <div
       :class="!noMargin && 'pa-5'"
       class="d-flex flex-column flex-grow-1">
@@ -96,6 +100,10 @@ export default {
     loading: {
       type: Boolean,
       default: () => false,
+    },
+    tabindex: {
+      type: String,
+      default: () => '',
     },
     height: {
       type: String,


### PR DESCRIPTION
Prior to this change, the widget component needed to have better accessibility. Therefore, focusin/focusout events were added to make the component more accessible.

(cherry picked from commit bfcea5c01dbf9f25c128129f86d9b352d792d8cf) (cherry picked from commit 94e803624be37d45d41f23ff68b83657de049a24)
