### PR TITLE
fix : make initialUrl working when using externalProviders - MEED-10016 - meeds-io/meeds#3896

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/spi/OAuthProviderType.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/spi/OAuthProviderType.java
@@ -90,11 +90,16 @@ public class OAuthProviderType<T extends AccessTokenContext> {
   }
 
   public String getInitOAuthURL(String contextPath, String requestURI) {
-    requestURI = OAuthUtils.encodeParam(requestURI);
+    if (requestURI != null) {
+      requestURI = OAuthUtils.encodeParam(requestURI);
+    }
 
-    return contextPath + initOAuthURL
-        + "?" + OAuthConstants.PARAM_OAUTH_INTERACTION + "=" + OAuthConstants.PARAM_OAUTH_INTERACTION_VALUE_START
-        + "&" + OAuthConstants.PARAM_INITIAL_URI + "=" + requestURI;
+    String result = contextPath + initOAuthURL
+        + "?" + OAuthConstants.PARAM_OAUTH_INTERACTION + "=" + OAuthConstants.PARAM_OAUTH_INTERACTION_VALUE_START;
+    if (requestURI != null) {
+      result += "&" + OAuthConstants.PARAM_INITIAL_URI + "=" + requestURI;
+    }
+    return result;
   }
 
   public String getFriendlyName() {

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/OauthLoginParamsExtension.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/OauthLoginParamsExtension.java
@@ -75,13 +75,10 @@ public class OauthLoginParamsExtension implements UIParamsExtension {
       oAuthProvidersParams.put(OAUTH_PROVIDER_TYPES_PARAM, new JSONArray(oAuthProviderTypes));
 
       String contextPath = controllerContext.getRequest().getContextPath();
-      String initialUri = controllerContext.getRequest().getParameter("initialURI");
-      if (StringUtils.isBlank(initialUri)) {
-        initialUri = contextPath;
-      }
+
       for (OAuthProviderType<?> oAuthProvType : oAuthProviderTypeRegistry.getEnabledOAuthProviders()) {
         String oAuthProvTypeKey = oAuthProvType.getKey();
-        String oAuthInitURL = oAuthProvType.getInitOAuthURL(contextPath, initialUri);
+        String oAuthInitURL = oAuthProvType.getInitOAuthURL(contextPath, null);
         oAuthProvidersParams.put(OAUTH_PROVIDER_URL_PARAM_PREFIX + oAuthProvTypeKey, oAuthInitURL);
       }
       return oAuthProvidersParams;

--- a/webapp/src/main/webapp/vue-apps/login/components/provider/LoginProviderLink.vue
+++ b/webapp/src/main/webapp/vue-apps/login/components/provider/LoginProviderLink.vue
@@ -84,10 +84,21 @@ export default {
     id() {
       return `login-${this.providerKeyLowerCase}`;
     },
+    initialUri() {
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.has('initialURI')) {
+        return urlParams.get('initialURI');
+      }
+      return null;
+    },
     link() {
-      const link = this.provider?.url;
+      let link = this.provider?.url;
       if (link && link.startsWith('/')) {
-        return this.rememberme && `${link}&_rememberme=true` || link;
+        link = this.rememberme && `${link}&_rememberme=true` || link;
+      }
+      if (this.initialUri) {
+        const separator = link.includes('?') ? '&' : '?';
+        link = `${link}${separator}_initialURI=${this.initialUri}`;
       }
       return link;
     },


### PR DESCRIPTION
Before this fix, the initialUrl is not correctly read by the login form application, and then, when using an external login provider it is not used. This commit ensure to correctly provide the initialUri when starting a external provider login workflow

Resolves meeds-io/meeds#3896

(cherry picked from commit 23e639cfc9fda86ca2a680c4486963e389e15f2b)