### PR TITLE
fix : Change SameSite for cookie OPENID_ACCESS_TOKEN - MEED-10018 - meeds-io/meeds#3901

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/openid/OpenIdProcessorImpl.java
@@ -207,7 +207,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
       Date d = new Date();
       d.setTime(d.getTime() + oidcCookieLifetime * 1000);
       String cookieLifeTime = expireFormat.format(d);
-      response.setHeader("Set-Cookie", "OPENID_ACCESS_TOKEN="+tokenResponse.getAccessToken()+" ; Path=/portal/login; Expires=" + cookieLifeTime + "; Secure; HttpOnly; SameSite=strict");
+      response.setHeader("Set-Cookie", "OPENID_ACCESS_TOKEN="+tokenResponse.getAccessToken()+" ; Path=/; Expires=" + cookieLifeTime + "; HttpOnly;SameSite=Lax");
       return new InteractionState<>(InteractionState.State.FINISH, accessTokenContext);
     }
 
@@ -244,6 +244,10 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
     String stateFromSession = (String) session.getAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE);
     String stateFromRequest = request.getParameter(OAuthConstants.STATE_PARAMETER);
     if (stateFromSession == null || stateFromRequest == null || !stateFromSession.equals(stateFromRequest)) {
+
+      session.removeAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE);
+      session.removeAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE);
+
       throw new OAuthException(OAuthExceptionCode.INVALID_STATE,
                                "Validation of state parameter failed. stateFromSession=" + stateFromSession
                                    + ", stateFromRequest=" + stateFromRequest);


### PR DESCRIPTION
Before this fix, the scope of cookie OPENID_ACCESS_TOKEN was SameSite=Strict But, after a first authentication, it the session expires, and if you refresh the current page, the referer of the request is the IDP url, and then, the cookie is not sent, which leads to problem in authentication workflow This commit change the sameSite to lax, so that the cookie is correctly sent.

Resolves meeds-io/meeds#3901

(cherry picked from commit 04621066ca6233f74cd0ed524bfed533b022ba6a)