### PR TITLE
fix: Fix non editable fields after importing users for non-root administrators - MEED-9977 - Meeds-io/meeds#3863

### DIFF
--- a/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
+++ b/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
@@ -93,11 +93,11 @@ public class UserImportService {
 
   private static final String                   GUEST                             = "Guest";
 
-  private static final List<String>             SYSTEM_PARENT_MULTIVALUED_FIELDS  = Arrays.asList("user",
-                                                                                                  "phones",
-                                                                                                  "ims",
-                                                                                                  "urls",
-                                                                                                  "manager");
+  private static final List<String>             SYSTEM_PARENT_MULTIVALUED_FIELDS  = new ArrayList<>(Arrays.asList("user",
+                                                                                                                  "phones",
+                                                                                                                  "ims",
+                                                                                                                  "urls",
+                                                                                                                  "manager"));
 
   private static final String                   TYPE_FIELD                        = "type";
 
@@ -545,6 +545,9 @@ public class UserImportService {
       if (!STANDARD_FIELDS.contains(field)) {
         if (!field.contains(".")) {
           ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(field);
+          if (propertySetting != null && propertySetting.isMultiValued()) {
+            SYSTEM_PARENT_MULTIVALUED_FIELDS.add(field);
+          }
           if (propertySetting == null) {
             userImportResult.addWarnMessage("ALL", "PROFILE_PROPERTY_DOES_NOT_EXIST:" + field);
             unauthorizedFields.add(field);
@@ -558,6 +561,9 @@ public class UserImportService {
         } else {
           String[] fieldNames = field.split("\\.");
           ProfilePropertySetting parentProperty = profilePropertyService.getProfileSettingByName(fieldNames[0]);
+          if (parentProperty != null && parentProperty.isMultiValued()) {
+            SYSTEM_PARENT_MULTIVALUED_FIELDS.add(fieldNames[0]);
+          }
           if (fieldNames.length > 2) {
             userImportResult.addWarnMessage("ALL", "PROPERTY_HAS_MORE_THAN_ONE_PARENT:" + field);
             unauthorizedFields.add(field);


### PR DESCRIPTION
Prior to this change, when an admin, other than the super admin, set a profile property as anon-editable and multivalued field, after importing users from a CSV file, the values of non-editable and multivalued fields were neither imported nor displayed on their profile pages. This change will fix this problem.