### PR TITLE
fix: Fix non editable fields after importing users for non-root administrators - MEED-9977 - Meeds-io/meeds#3863

### DIFF
--- a/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
+++ b/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
@@ -601,7 +601,7 @@ public class UserImportService {
                                     boolean save,
                                     String modifierUsername) throws IllegalAccessException, IOException {
     ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(name);
-    if (propertySetting != null && !propertySetting.isEditable() && !StringUtils.equals(userAcl.getSuperUser(), modifierUsername)) {
+    if (propertySetting != null && !propertySetting.isEditable() && !userAcl.getUserIdentity(modifierUsername).isMemberOf(userAcl.getAdminGroups())) {
       throw new IllegalAccessException(String.format("Not allowed to update non modifiable field '%s'", name));
     } else if (Profile.EXTERNAL.equals(name)) {
       throw new IllegalAccessException("Not allowed to update EXTERNAL field");

--- a/component/core/src/test/java/io/meeds/social/core/identity/service/UserImportServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/core/identity/service/UserImportServiceTest.java
@@ -411,8 +411,10 @@ public class UserImportServiceTest {
     s.setPropertyName(COMPANY_PROP);
     s.setEditable(false);
     when(profilePropertyService.getProfileSettingByName(COMPANY_PROP)).thenReturn(s);
-    when(userAcl.getSuperUser()).thenReturn("root");
-
+    org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
+    when(userAcl.getUserIdentity(TEST_USER_2)).thenReturn(identity);
+    when(identity.isMemberOf(userAcl.getAdminGroups())).thenReturn(false); 
+    
     service.updateProfileField(profile,
                                COMPANY_PROP,
                                COMPANY_VALUE,


### PR DESCRIPTION
Prior to this change, when an admin, other than the super admin, set a profile property as anon-editable field, after importing users from a CSV file, the values of non-editable fields were neither imported nor displayed on their profile pages. This fix allows all values to be imported and sets the data as uneditable for the non-editable properties.

Resolves: Meeds-io/meeds#3863