### PR TITLE
fix: allow creating a subspace from a parent space without requiring parent template permissions - MEED-10029 - Meeds-io/MIPs#227

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
@@ -19,6 +19,7 @@
 package io.meeds.social.space.template.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -151,6 +152,36 @@ public class SpaceTemplateService {
                               .map(SpaceTemplate::getId)
                               .toList();
   }
+
+  public List<SpaceTemplate> getAllowedSubspaceTemplates(long templateId, String username, Locale locale) throws ObjectNotFoundException,
+                                                                                           IllegalAccessException {
+
+    SpaceTemplate parentTemplate = spaceTemplateStorage.getSpaceTemplate(templateId);
+
+    if (parentTemplate == null || parentTemplate.isDeleted()) {
+      throw new ObjectNotFoundException("Template not found: " + templateId);
+    }
+
+    List<String> allowedTemplates = parentTemplate.getAllowedSubspaceTemplates();
+    if (CollectionUtils.isEmpty(allowedTemplates)) {
+      return Collections.emptyList();
+    }
+
+    List<Long> templateIds = allowedTemplates.stream()
+                                             .map(item -> item.split(":")[0])
+                                             .map(Long::parseLong)
+                                             .toList();
+    List<SpaceTemplate> allowedSubspaceTemplates = templateIds.stream().map(id -> getSpaceTemplate(id, locale, true))
+            .filter(Objects::nonNull)
+            .filter(spaceTemplate -> canViewTemplate(spaceTemplate, username)).toList();
+
+    if (CollectionUtils.isEmpty(allowedSubspaceTemplates) && CollectionUtils.isNotEmpty(templateIds)) {
+      throw new IllegalAccessException("User '" + username + "' has no access to allowed subspace templates of template "
+          + templateId);
+    }
+    return allowedSubspaceTemplates;
+  }
+
 
   public long countManagingSpaceTemplates(String username) {
     List<SpaceTemplate> spaceTemplates = spaceTemplateStorage.getSpaceTemplates(Pageable.unpaged());

--- a/component/core/src/test/java/io/meeds/social/space/template/service/SpaceTemplateServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/space/template/service/SpaceTemplateServiceTest.java
@@ -29,14 +29,23 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.social.core.space.SpaceFilter;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.domain.Pageable;
 
@@ -269,6 +278,56 @@ public class SpaceTemplateServiceTest {
     spaceTemplateService.deleteSpaceTemplate(2l, TEST_USER);
     verify(spaceTemplateStorage).updateSpaceTemplate(savedSpaceTemplate);
     assertTrue(savedSpaceTemplate.isDeleted());
+  }
+
+  @Test
+  public void testGetAllowedSubspaceTemplates() throws Exception {
+    // parent template not found
+    when(spaceTemplateStorage.getSpaceTemplate(1L)).thenReturn(null);
+    
+    assertThrows(ObjectNotFoundException.class,
+            () -> spaceTemplateService.getAllowedSubspaceTemplates(1L, "user", null));
+    // parent template deleted
+    SpaceTemplate spaceTemplate = Mockito.mock(SpaceTemplate.class);
+    when(spaceTemplate.isDeleted()).thenReturn(true);
+    when(spaceTemplateStorage.getSpaceTemplate(anyLong())).thenReturn(null).thenReturn(spaceTemplate);
+
+    assertThrows(ObjectNotFoundException.class,
+            () -> spaceTemplateService.getAllowedSubspaceTemplates(1L, "user", null));
+
+    // parent template has no allowed subspace template
+    when(spaceTemplate.isDeleted()).thenReturn(false);
+    when(spaceTemplate.getAllowedSubspaceTemplates()).thenReturn(Collections.emptyList());
+
+    List<SpaceTemplate> empty = spaceTemplateService.getAllowedSubspaceTemplates(1L, "user", null);
+    assertTrue(empty.isEmpty());
+    // subspace template not accessible for user
+    when(spaceTemplate.getAllowedSubspaceTemplates()).thenReturn(List.of("10:5"));
+    when(userAcl.isAnonymousUser(anyString())).thenReturn(false);
+    org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
+    when(userAcl.getUserIdentity(anyString())).thenReturn(identity);
+    when(spaceTemplateStorage.getSpaceTemplates(any(Pageable.class))).thenReturn(List.of(spaceTemplate));
+    SpaceTemplate subspaceTemplate = mock(SpaceTemplate.class);
+    when(subspaceTemplate.isEnabled()).thenReturn(true);
+    when(subspaceTemplate.getId()).thenReturn(10L);
+    when(spaceTemplateStorage.getSpaceTemplate(10L)).thenReturn(subspaceTemplate);
+    try(MockedStatic<CommonsUtils> mockedUtils = mockStatic(CommonsUtils.class)) {
+      SpaceService spaceService = mock(SpaceService.class);
+      mockedUtils.when(() -> CommonsUtils.getService(SpaceService.class)).thenReturn(spaceService);
+      ListAccess<Space> spaceList = mock(ListAccess.class);
+      when(spaceService.getAccessibleSpacesByFilter(anyString(), any(SpaceFilter.class)))
+              .thenReturn(spaceList);
+      when(spaceList.getSize()).thenReturn(0);
+      assertThrows(IllegalAccessException.class,
+              () -> spaceTemplateService.getAllowedSubspaceTemplates(1L, "user", null));
+      // subspace accessible for user
+      // user is member in the parent space
+      when(spaceList.getSize()).thenReturn(1);
+      when(subspaceTemplate.getPermissions()).thenReturn(List.of("*:/platform/users"));
+      when(identity.isMemberOf(any(MembershipEntry.class))).thenReturn(true);
+      List<SpaceTemplate> result = spaceTemplateService.getAllowedSubspaceTemplates(1L, "user", null);
+      assertTrue(CollectionUtils.isNotEmpty(result));
+    }
   }
 
   private void setCanViewTemplate(boolean hasAccess) {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,6 +60,11 @@ public class ProfileSearchConnectorTest {
     private ProfilePropertyService profilePropertyService;
 
     private static final MockedStatic<CommonsUtils> COMMONS_UTILS = mockStatic(CommonsUtils.class);
+
+    @AfterClass
+    public static void tearDown() {
+      COMMONS_UTILS.close();
+    }
 
     @Test
     public void testSearch() {

--- a/component/service/src/main/java/io/meeds/social/space/template/rest/SpaceTemplateRest.java
+++ b/component/service/src/main/java/io/meeds/social/space/template/rest/SpaceTemplateRest.java
@@ -73,6 +73,26 @@ public class SpaceTemplateRest {
     return spaceTemplateService.getSpaceTemplates(spaceTemplateFilter, Pageable.unpaged(), true);
   }
 
+  @GetMapping("/{templateId}/subspace-templates")
+  @Secured("users")
+  @Operation(summary = "Retrieve allowed subspace templates", description = "Returns the list of subspace templates allowed for the given template.")
+  @ApiResponses(value = {
+          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+          @ApiResponse(responseCode = "403", description = "Forbidden"),
+          @ApiResponse(responseCode = "404", description = "Not found") })
+  public List<SpaceTemplate> getAllowedSubspaceTemplates(HttpServletRequest request,
+                                               @Parameter(description = "Whether include disabled templates or not", required = true)
+                                               @PathVariable("templateId")
+                                               long templateId) {
+    try {
+      return spaceTemplateService.getAllowedSubspaceTemplates(templateId, request.getRemoteUser(), request.getLocale());
+    } catch (ObjectNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    } catch (IllegalAccessException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+  }
+
   @GetMapping("{id}")
   @Secured("users")
   @Operation(summary = "Retrieve a Space template designated by its id", method = "GET",

--- a/webapp/src/main/webapp/vue-apps/common/js/SpaceTemplateService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/SpaceTemplateService.js
@@ -30,6 +30,19 @@ export function getSpaceTemplates(includeDisabled) {
   });
 }
 
+export function getAllowedSubspaceTemplates(id) {
+  return fetch(`/social/rest/space/templates/${id}/subspace-templates`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp?.ok) {
+      throw new Error('Error when retrieving space template');
+    } else {
+      return resp.json();
+    }
+  });
+}
+
 export function getSpaceTemplate(id) {
   return fetch(`/social/rest/space/templates/${id}`, {
     method: 'GET',

--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -52,7 +52,7 @@
             class="space-template-card col-6 mt-0 mb-4 mx-0 ps-4 pa-0"
             height="136"
             flat
-            @click="openParentSpaceList(item.id)">
+            @click="openParentSpaceListFromClick(item.id, parentSpaceId)">
             <v-hover v-slot="{hover}">
               <div class="d-flex flex-column border-color align-center full-height full-width pb-3 px-2">
                 <div
@@ -277,7 +277,8 @@ export default {
     spaceParentSelecting: false,
     parentSpaces: [],
     parentSpacesSize: 0,
-    selectedParentSpace: null
+    selectedParentSpace: null,
+    parentSpaceId: null,
   }),
   computed: {
     drawerTitle() {
@@ -446,6 +447,7 @@ export default {
   },
   methods: {
     async openParentSpaceList(templateId, space, spaceTemplates, parentSpaceId) {
+      this.parentSpaceId = parentSpaceId;
       this.templateId = templateId;
       if (!this.$root.spaceTemplates) {
         this.$root.spaceTemplates = await this.$spaceTemplateService.getSpaceTemplates();
@@ -457,14 +459,14 @@ export default {
       }
       this.setSpaceTemplateProperties();
       const filteredTemplateIds = this.templates
-        .filter(template =>
+        .filter(template => (this.parentSpaceId && (template.id === this.templateId)) ||
           Array.isArray(template.allowedSubspaceTemplates) &&
               template.allowedSubspaceTemplates.some(subspaceId =>
                 Number(subspaceId.split(':')[0]) === this.templateId
               )
         )
         .map(template => template.id);
-      if (filteredTemplateIds?.length > 0) {
+      if (filteredTemplateIds?.length > 0 && !this.parentSpaceId) {
         const data = await this.$spaceService.getSpacesByFilter({
           offset: 0,
           limit: 20,
@@ -476,7 +478,7 @@ export default {
       }
       if (this.parentSpacesSize === 1) {
         this.selectParentSpace(this.parentSpaces[0]);
-      } else if (parentSpaceId) {
+      } else if (this.parentSpaceId) {
         const parentSpace = await this.$spaceService.getSpaceById(parentSpaceId);
         this.selectParentSpace(parentSpace);
         this.$refs.spaceFormDrawer.open();
@@ -487,6 +489,9 @@ export default {
         this.spaceParentSelecting = true;
         this.$refs.spaceFormDrawer.open();
       }
+    },
+    openParentSpaceListFromClick(templateId, parentSpaceId) {
+      this.openParentSpaceList(templateId, null, null, parentSpaceId);
     },
     selectParentSpace(space) {
       this.selectedParentSpace = space;

--- a/webapp/src/main/webapp/vue-apps/space-settings/components/drawer/SpaceSettingSubspacesDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-settings/components/drawer/SpaceSettingSubspacesDrawer.vue
@@ -108,13 +108,7 @@ export default {
       }
     },
     async addSubspace() {
-      const spaceTemplates = await this.$spaceTemplateService.getSpaceTemplates();
-      const selectedTemplate = spaceTemplates.find(t => String(t.id) === String(this.templateId));
-      const allowedSubspaceTemplatesIds = selectedTemplate.allowedSubspaceTemplates
-        ?.map(item => item.split(':')[0]) || [];
-      const allowedSubspaceTemplates = spaceTemplates.filter(t =>
-        allowedSubspaceTemplatesIds.includes(String(t.id))
-      );
+      const allowedSubspaceTemplates = await this.$spaceTemplateService.getAllowedSubspaceTemplates(this.templateId);
       window.require(['SHARED/spaceForm'], drawer => drawer.open(null, allowedSubspaceTemplates, eXo.env.portal.spaceId));
     },
   },


### PR DESCRIPTION
Prior to this change, creating a subspace from the space settings would throw an error because the parent space template was not accessible.
This update adds an entry point to retrieve the accessible allowed subspace templates and suggest them during subspace creation, resolving the issue