### PR TITLE
Fix: no results displayed when filtering users using two types & search item - MEED-10030 - meeds-io/meeds#3892.

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/identity/ProfileFilterListAccess.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/ProfileFilterListAccess.java
@@ -203,7 +203,8 @@ public class ProfileFilterListAccess implements ListAccess<Identity> {
         if (CollectionUtils.isEmpty(spaceIdentityIds)) {
           profileFilter.setSpaceIdentityIds(new ArrayList<>(groupIdentityIds));
         } else {
-          spaceIdentityIds.retainAll(groupIdentityIds);
+          List<String> spaceListIdentityIds = new ArrayList<>(spaceIdentityIds);
+          spaceListIdentityIds.retainAll(groupIdentityIds);
           profileFilter.setSpaceIdentityIds(spaceIdentityIds);
         }
       }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -143,190 +143,198 @@ public class ProfileSearchConnector {
     String expEsForAdvancedFilter = MapUtils.isNotEmpty(profileSettings) ? buildAdvancedFilterExpression(filter) : "";
     StringBuilder esQuery = new StringBuilder();
     esQuery.append("{\n");
-    esQuery.append("   \"from\" : " + offset + ", \"size\" : " + limit + ",\n");
+    esQuery.append("   \"from\" : ").append(offset).append(", \"size\" : ").append(limit).append(",\n");
     Sorting sorting = filter.getSorting();
-    if(sorting != null && sorting.sortBy != null) {
-      esQuery.append("   \"sort\": {");
+    esQuery.append("   \"sort\": {");
+    String sortField;
+    String sortOrder = sorting != null && sorting.orderBy != null ? sorting.orderBy.name() : "asc";
+
+    if (sorting != null && sorting.sortBy != null) {
       switch (sorting.sortBy) {
-      case DATE:
-        esQuery.append("\"lastUpdatedDate\"");
-        break;
-      case FIRSTNAME:
-        esQuery.append("\"firstName.raw\"");
-        break;
-      case LASTNAME:
-        esQuery.append("\"lastName.raw\"");
-        break;
-      default:
-        // Title, Fullname, any other condition, we will use the fullname
-        esQuery.append("\"name.raw\"");
-        break;
+        case DATE:
+          sortField = "\"lastUpdatedDate\"";
+          break;
+        case FIRSTNAME:
+          sortField = "\"firstName.raw\"";
+          break;
+        case LASTNAME:
+          sortField = "\"lastName.raw\"";
+          break;
+        default:
+          sortField = "\"name.raw\"";
+          break;
       }
-      esQuery.append(": {\"order\": \"")
-             .append(sorting.orderBy == null ? "asc" : sorting.orderBy.name())
-             .append("\"}}\n");
     } else {
-      esQuery.append("   \"sort\": {\"name.raw\": {\"order\": \"asc\"}}\n");
+      sortField = "\"name.raw\"";
     }
+    esQuery.append(sortField)
+      .append(": {\"order\": \"")
+      .append(sortOrder)
+      .append("\"}}\n");
     StringBuilder esSubQuery = new StringBuilder();
-    esSubQuery.append("       ,\n");
     esSubQuery.append("\"query\" : {\n");
     esSubQuery.append("      \"constant_score\" : {\n");
     esSubQuery.append("        \"filter\" : {\n");
     esSubQuery.append("          \"bool\" :{\n");
     boolean subQueryEmpty = true;
     boolean appendCommar = false;
+    List<String> mustClauses = new ArrayList<>();
+    List<String> mustNotClauses = new ArrayList<>();
+    List<String> filterClauses = new ArrayList<>();
+
     if (CollectionUtils.isNotEmpty(filter.getSpaceIdentityIds())) {
       String permissionsQuery = buildSpacePermissionsExpression(filter);
-      esSubQuery.append(permissionsQuery);
+      mustClauses.add(permissionsQuery);
       subQueryEmpty = false;
-      appendCommar = true;
     }
     if (filter.getUserType() != null && !filter.getUserType().isEmpty()) {
-      if(appendCommar) {
-        esSubQuery.append("      ,\n");
-      }
-      if (filter.getUserType().equals("internal")) {
-        esSubQuery.append("    \"should\": [\n");
-        esSubQuery.append("                  {\n");
-        esSubQuery.append("                    \"term\": {\n");
-        esSubQuery.append("                      \"external\": false\n");
-        esSubQuery.append("                    }\n");
-        esSubQuery.append("                  },\n");
-        esSubQuery.append("                  {\n");
-        esSubQuery.append("                    \"bool\": {\n");
-        esSubQuery.append("                      \"must_not\": {\n");
-        esSubQuery.append("                        \"exists\": {\n");
-        esSubQuery.append("                          \"field\": \"external\"\n");
-        esSubQuery.append("                        }\n");
-        esSubQuery.append("                      }\n");
-        esSubQuery.append("                    }\n");
-        esSubQuery.append("                  }\n");
-        esSubQuery.append("                  ]\n");
-        subQueryEmpty = false;
-        appendCommar = true;
-      } else if (filter.getUserType().equals("external")) {
-        esSubQuery.append("    \"should\": [\n");
-        esSubQuery.append("                  {\n");
-        esSubQuery.append("                    \"term\": {\n");
-        esSubQuery.append("                      \"external\": true\n");
-        esSubQuery.append("                    }\n");
-        esSubQuery.append("                  }\n");
-        esSubQuery.append("                  ]\n");
-        subQueryEmpty = false;
-        appendCommar = true;
-      }
-      if(appendCommar) {
-        esSubQuery.append("                  ,\n");
-      }
-      esSubQuery.append("\"minimum_should_match\" : 1\n");
+      List<String> userTypeShoulds = new ArrayList<>();
 
+      if (filter.getUserType().equals("internal")) {
+        userTypeShoulds.add("                  {\n"
+          + "                    \"term\": {\n"
+          + "                      \"external\": false\n"
+          + "                    }\n"
+          + "                  }");
+        userTypeShoulds.add("                  {\n"
+          + "                    \"bool\": {\n"
+          + "                      \"must_not\": {\n"
+          + "                        \"exists\": {\n"
+          + "                          \"field\": \"external\"\n"
+          + "                        }\n"
+          + "                      }\n"
+          + "                    }\n"
+          + "                  }");
+      } else if (filter.getUserType().equals("external")) {
+        userTypeShoulds.add("                  {\n"
+          + "                    \"term\": {\n"
+          + "                      \"external\": true\n"
+          + "                    }\n"
+          + "                  }");
+      }
+
+      if (CollectionUtils.isNotEmpty(userTypeShoulds)) {
+        StringBuilder userTypeBlockBuilder = new StringBuilder();
+        userTypeBlockBuilder.append("      {\n")
+          .append("        \"bool\": {\n")
+          .append("          \"should\": [\n")
+          .append(String.join(",\n", userTypeShoulds))
+          .append("          ],\n")
+          .append("          \"minimum_should_match\" : 1\n")
+          .append("        }\n")
+          .append("      }");
+        mustClauses.add(userTypeBlockBuilder.toString());
+        subQueryEmpty = false;
+      }
     }
     if (filter.isConnected() != null) {
-      if(appendCommar) {
-        esSubQuery.append("      ,\n");
-      }
-      esSubQuery.append("    \"should\": [\n");
-      esSubQuery.append("                  {\n");
-      esSubQuery.append("                    \"bool\": {\n");
+      StringBuilder existsClauseBuilder = new StringBuilder();
+      existsClauseBuilder.append("                  {\n")
+        .append("                    \"bool\": {\n");
+
       if (filter.isConnected()) {
-        esSubQuery.append("                      \"must\": {\n");
+        existsClauseBuilder.append("                      \"must\": {\n");
       } else {
-        esSubQuery.append("                      \"must_not\": {\n");
+        existsClauseBuilder.append("                      \"must_not\": {\n");
       }
-      esSubQuery.append("                        \"exists\": {\n");
-      esSubQuery.append("                          \"field\": \"lastLoginTime\"\n");
-      esSubQuery.append("                        }\n");
-      esSubQuery.append("                      }\n");
-      esSubQuery.append("                    }\n");
-      esSubQuery.append("                  }\n");
-      esSubQuery.append("                  ]\n");
-      esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
+      existsClauseBuilder.append("                        \"exists\": {\n")
+        .append("                          \"field\": \"lastLoginTime\"\n")
+        .append("                        }\n")
+        .append("                      }\n")
+        .append("                    }\n")
+        .append("                  }");
+
+      StringBuilder connectedBlockBuilder = new StringBuilder();
+      connectedBlockBuilder.append("      {\n")
+        .append("        \"bool\": {\n")
+        .append("          \"should\": [\n")
+        .append(existsClauseBuilder.toString())
+        .append("          ],\n")
+        .append("          \"minimum_should_match\" : 1\n")
+        .append("        }\n")
+        .append("      }");
+      mustClauses.add(connectedBlockBuilder.toString());
       subQueryEmpty = false;
-      appendCommar = true;
     }
     if(filter.getEnrollmentStatus() != null && !filter.getEnrollmentStatus().isEmpty()) {
-      if(appendCommar) {
-        esSubQuery.append("      ,\n");
-      }
+      List<String> enrollmentShoulds = new ArrayList<>();
+
       switch (filter.getEnrollmentStatus()) {
         case "enrolled": {
-          esSubQuery.append("    \"should\": [\n");
-          esSubQuery.append("                  {\n");
-          esSubQuery.append("                    \"bool\": {\n");
-          esSubQuery.append("                      \"must\": {\n");
-          esSubQuery.append("                        \"exists\": {\n");
-          esSubQuery.append("                          \"field\": \"enrollmentDate\"\n");
-          esSubQuery.append("                        }\n");
-          esSubQuery.append("                      }\n");
-          esSubQuery.append("                    }\n");
-          esSubQuery.append("                  }\n");
-          esSubQuery.append("                  ]\n");
-          esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
-          subQueryEmpty = false;
-          appendCommar = true;
+          enrollmentShoulds.add("                  {\n"
+            + "                    \"bool\": {\n"
+            + "                      \"must\": {\n"
+            + "                        \"exists\": {\n"
+            + "                          \"field\": \"enrollmentDate\"\n"
+            + "                        }\n"
+            + "                      }\n"
+            + "                    }\n"
+            + "                  }");
           break;
         }
 
         case "notEnrolled": {
-          esSubQuery.append("    \"should\": [\n");
-          esSubQuery.append("                  {\n");
-          esSubQuery.append("                    \"bool\": {\n");
-          esSubQuery.append("                      \"must_not\": [{\n");
-          esSubQuery.append("                        \"exists\": {\n");
-          esSubQuery.append("                          \"field\": \"enrollmentDate\"\n");
-          esSubQuery.append("                          }\n");
-          esSubQuery.append("                        },\n");
-          esSubQuery.append("                      {\n");
-          esSubQuery.append("                        \"exists\": {\n");
-          esSubQuery.append("                          \"field\": \"lastLoginTime\"\n");
-          esSubQuery.append("                        }\n");
-          esSubQuery.append("                      }],\n");
-          esSubQuery.append("                      \"must\": {\n");
-          esSubQuery.append("                       \"term\": {\n");
-          esSubQuery.append("                         \"external\": false\n");
-          esSubQuery.append("                         }\n");
-          esSubQuery.append("                      }\n");
-          esSubQuery.append("                    }\n");
-          esSubQuery.append("                  }\n");
-          esSubQuery.append("                  ]\n");
-          esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
-          subQueryEmpty = false;
-          appendCommar = true;
+          enrollmentShoulds.add("                  {\n"
+            + "                    \"bool\": {\n"
+            + "                      \"must_not\": [{\n"
+            + "                        \"exists\": {\n"
+            + "                          \"field\": \"enrollmentDate\"\n"
+            + "                          }\n"
+            + "                        },\n"
+            + "                      {\n"
+            + "                        \"exists\": {\n"
+            + "                          \"field\": \"lastLoginTime\"\n"
+            + "                        }\n"
+            + "                      }],\n"
+            + "                      \"must\": {\n"
+            + "                       \"term\": {\n"
+            + "                         \"external\": false\n"
+            + "                         }\n"
+            + "                      }\n"
+            + "                    }\n"
+            + "                  }");
           break;
         }
 
         case "noEnrollmentPossible": {
-
-          esSubQuery.append("    \"should\": [\n");
-          esSubQuery.append("                  {\n");
-          esSubQuery.append("                    \"bool\": {\n");
-          esSubQuery.append("                      \"must_not\": {\n");
-          esSubQuery.append("                        \"exists\": {\n");
-          esSubQuery.append("                          \"field\": \"enrollmentDate\"\n");
-          esSubQuery.append("                          }\n");
-          esSubQuery.append("                        },\n");
-          esSubQuery.append("                      \"must\": {\n");
-          esSubQuery.append("                        \"exists\": {\n");
-          esSubQuery.append("                          \"field\": \"lastLoginTime\"\n");
-          esSubQuery.append("                        }\n");
-          esSubQuery.append("                      }\n");
-          esSubQuery.append("                    }\n");
-          esSubQuery.append("                  },\n");
-          esSubQuery.append("                  {\n");
-          esSubQuery.append("                    \"term\": {\n");
-          esSubQuery.append("                      \"external\": true\n");
-          esSubQuery.append("                    }\n");
-          esSubQuery.append("                  }\n");
-          esSubQuery.append("                  ]\n");
-          esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
-          subQueryEmpty = false;
-          appendCommar = true;
+          enrollmentShoulds.add("                  {\n"
+            + "                    \"bool\": {\n"
+            + "                      \"must_not\": {\n"
+            + "                        \"exists\": {\n"
+            + "                          \"field\": \"enrollmentDate\"\n"
+            + "                          }\n"
+            + "                        },\n"
+            + "                      \"must\": {\n"
+            + "                        \"exists\": {\n"
+            + "                          \"field\": \"lastLoginTime\"\n"
+            + "                        }\n"
+            + "                      }\n"
+            + "                    }\n"
+            + "                  }");
+          enrollmentShoulds.add("                  {\n"
+            + "                    \"term\": {\n"
+            + "                      \"external\": true\n"
+            + "                    }\n"
+            + "                  }");
           break;
         }
 
         default:
           break;
+      }
+
+      if (CollectionUtils.isNotEmpty(enrollmentShoulds)) {
+        StringBuilder enrollmentBlockBuilder = new StringBuilder();
+        enrollmentBlockBuilder.append("      {\n")
+          .append("        \"bool\": {\n")
+          .append("          \"should\": [\n")
+          .append(String.join(",\n", enrollmentShoulds))
+          .append("          ],\n")
+          .append("          \"minimum_should_match\" : 1\n")
+          .append("        }\n")
+          .append("      }");
+        mustClauses.add(enrollmentBlockBuilder.toString());
+        subQueryEmpty = false;
       }
     }
     if (filter.getRemoteIds() != null && !filter.getRemoteIds().isEmpty()) {
@@ -337,75 +345,97 @@ public class ProfileSearchConnector {
         }
         remoteIds.append("\"").append(remoteId).append("\"");
       }
-      if(appendCommar) {
-        esSubQuery.append("      ,\n");
-      }
-      esSubQuery.append("      \"must\" : {\n");
-      esSubQuery.append("        \"terms\" :{\n");
-      esSubQuery.append("          \"userName\" : [" + remoteIds.toString() + "]\n");
-      esSubQuery.append("        } \n");
-      esSubQuery.append("      }\n");
+      StringBuilder remoteIdClauseBuilder = new StringBuilder();
+      remoteIdClauseBuilder.append("      {\n")
+        .append("        \"terms\" :{\n")
+        .append("          \"userName\" : [").append(remoteIds.toString()).append("]\n")
+        .append("        } \n")
+        .append("      }\n");
+
+      mustClauses.add(remoteIdClauseBuilder.toString());
       subQueryEmpty = false;
-      appendCommar = true;
     }
     if (identity != null && type != null) {
+      StringBuilder identityClauseBuilder = new StringBuilder();
+      identityClauseBuilder.append("      {\n")
+        .append("        \"query_string\" : {\n")
+        .append("          \"query\" : \"").append(identity.getId()).append("\",\n")
+        .append("          \"fields\" : [\"").append(buildTypeEx(type)).append("\"]\n")
+        .append("        }\n")
+        .append("      }\n");
+
+      mustClauses.add(identityClauseBuilder.toString());
+      subQueryEmpty = false;
+    } else if (filter.getExcludedIdentityList() != null && filter.getExcludedIdentityList().size() > 0) {
+      StringBuilder excludedClauseBuilder = new StringBuilder();
+      excludedClauseBuilder.append("      {\n")
+        .append("          \"ids\" : {\n")
+        .append("             \"values\" : [").append(buildExcludedIdentities(filter)).append("]\n")
+        .append("          }\n")
+        .append("        }\n");
+
+      mustNotClauses.add(excludedClauseBuilder.toString());
+      subQueryEmpty = false;
+    }
+    if (!expEs.isEmpty() || !expEsForAdvancedFilter.isEmpty()) {
+      if(!expEs.isEmpty()) {
+        StringBuilder qsClause = new StringBuilder();
+        qsClause.append("      {");
+        qsClause.append("          \"query_string\": {\n");
+        if (filter.getName().startsWith("\"") && filter.getName().endsWith("\"")) {
+          qsClause.append("            \"query\": \"").append(expEs).append("\",\n")
+            .append("            \"default_operator\": \"").append("AND").append("\"\n");
+        } else {
+          qsClause.append("            \"query\": \"").append(expEs).append("\"\n");
+        }
+        qsClause.append("          }\n");
+        qsClause.append("      }\n");
+        filterClauses.add(qsClause.toString());
+      }
+
+      if(!expEsForAdvancedFilter.isEmpty()) {
+        filterClauses.add(expEsForAdvancedFilter);
+      }
+    }
+
+    if (CollectionUtils.isNotEmpty(mustClauses)) {
       if(appendCommar) {
         esSubQuery.append("      ,\n");
       }
-      esSubQuery.append("      \"must\" : {\n");
-      esSubQuery.append("        \"query_string\" : {\n");
-      esSubQuery.append("          \"query\" : \""+ identity.getId() +"\",\n");
-      esSubQuery.append("          \"fields\" : [\"" + buildTypeEx(type) + "\"]\n");
-      esSubQuery.append("        }\n");
-      esSubQuery.append("      }\n");
-      subQueryEmpty = false;
+      esSubQuery.append("      \"must\": [\n");
+      esSubQuery.append(String.join(",\n", mustClauses));
+      esSubQuery.append("      ]\n");
       appendCommar = true;
-    } else if (filter.getExcludedIdentityList() != null && filter.getExcludedIdentityList().size() > 0) {
+    }
+
+    if (CollectionUtils.isNotEmpty(mustNotClauses)) {
       if(appendCommar) {
         esSubQuery.append("      ,\n");
       }
       esSubQuery.append("      \"must_not\": [\n");
-      esSubQuery.append("        {\n");
-      esSubQuery.append("          \"ids\" : {\n");
-      esSubQuery.append("             \"values\" : [" + buildExcludedIdentities(filter) + "]\n");
-      esSubQuery.append("          }\n");
-      esSubQuery.append("        }\n");
+      esSubQuery.append(String.join(",\n", mustNotClauses));
       esSubQuery.append("      ]\n");
-      subQueryEmpty = false;
       appendCommar = true;
     }
-    //if the search fields are existing.
-    if (!expEs.isEmpty() || !expEsForAdvancedFilter.isEmpty()) {
+
+    if (CollectionUtils.isNotEmpty(filterClauses)) {
       if(appendCommar) {
         esSubQuery.append("      ,\n");
       }
-      esSubQuery.append("    \"filter\": [\n");
-      if(!expEs.isEmpty()) {
-        esSubQuery.append("      {");
-        esSubQuery.append("          \"query_string\": {\n");
-        if (filter.getName().startsWith("\"") && filter.getName().endsWith("\"")) {
-          esSubQuery.append("            \"query\": \"" + expEs + "\",\n");
-          esSubQuery.append("            \"default_operator\": \"" + "AND" + "\"\n");
-        } else {
-          esSubQuery.append("            \"query\": \"" + expEs + "\"\n");
-        }
-        esSubQuery.append("          }\n");
-        esSubQuery.append("      }\n");
-      }
-      if(!expEsForAdvancedFilter.isEmpty()) {
-        if(!expEs.isEmpty()) {
-          esSubQuery.append(",");
-        }
-        esSubQuery.append(expEsForAdvancedFilter);
-      }
-      esSubQuery.append("    ]\n");
+      esSubQuery.append("      \"filter\": [\n");
+      esSubQuery.append(String.join(",\n", filterClauses));
+      esSubQuery.append("      ]\n");
+      appendCommar = true;
+    }
+    if (appendCommar) {
       subQueryEmpty = false;
-    } //end if
+    }
     esSubQuery.append("     } \n");
     esSubQuery.append("   } \n");
     esSubQuery.append("  }\n");
     esSubQuery.append(" }\n");
     if(!subQueryEmpty) {
+      esQuery.append(",\n");
       esQuery.append(esSubQuery);
     }
 
@@ -592,7 +622,6 @@ public class ProfileSearchConnector {
   private String buildSpacePermissionsExpression(ProfileFilter filter) {
     List<String> permissions = filter.getSpaceIdentityIds();
     StringBuilder query = new StringBuilder();
-    query.append("    \"must\": [\n");
     query.append("      {\n");
     query.append("        \"terms\": {\n");
     query.append("          \"permissions\": [\n");
@@ -600,8 +629,7 @@ public class ProfileSearchConnector {
     query.append("\n");
     query.append("          ]\n");
     query.append("        }\n");
-    query.append("      }\n");
-    query.append("    ]\n");
+    query.append("      }");
     return query.toString();
   }
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -68,27 +68,31 @@ public class ProfileSearchConnectorTest {
         ProfileFilter filter = new ProfileFilter();
         Identity identity1 = new Identity("test","usernameee");
         String index = "profile_alias";
-        String query = "{\n" +
-                "   \"from\" : 0, \"size\" : 10,\n" +
-                "   \"sort\": {\"lastName.raw\": {\"order\": \"ASC\"}}\n" +
-                "       ,\n" +
-                "\"query\" : {\n" +
-                "      \"constant_score\" : {\n" +
-                "        \"filter\" : {\n" +
-                "          \"bool\" :{\n" +
-                "      \"must\" : {\n" +
-                "        \"query_string\" : {\n" +
-                "          \"query\" : \"null\",\n" +
-                "          \"fields\" : [\"connections\"]\n" +
-                "        }\n" +
-                "      }\n" +
-                "     } \n" +
-                "   } \n" +
-                "  }\n" +
-                " }\n" +
-                ",\"_source\": false\n" +
-                ",\"fields\": [\"_id\"]\n" +
-                "}\n";
+        String query = """
+          {
+             "from" : 0, "size" : 10,
+             "sort": {"lastName.raw": {"order": "ASC"}}
+          ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+                "must": [
+                {
+                  "query_string" : {
+                    "query" : "null",
+                    "fields" : ["connections"]
+                  }
+                }
+                ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+          """;
         long offset = 0;
         long limit = 10;
         when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
@@ -129,12 +133,15 @@ public class ProfileSearchConnectorTest {
           {
              "from" : 0, "size" : 10,
              "sort": {"firstName.raw": {"order": "DESC"}}
-                 ,
+          ,
           "query" : {
                 "constant_score" : {
                   "filter" : {
                     "bool" :{
-              "should": [
+                "must": [
+                {
+                  "bool": {
+                    "should": [
                             {
                               "term": {
                                 "external": false
@@ -148,12 +155,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,
-          "minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -162,11 +170,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must_not": [{
@@ -185,24 +195,25 @@ public class ProfileSearchConnectorTest {
                                    }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                }      ]
                 ,
                 "must_not": [
-                  {
+                {
                     "ids" : {
                        "values" : ["null","null"]
                     }
                   }
                 ]
                 ,
-              "filter": [
+                "filter": [
                 {          "query_string": {
                       "query": "( name.whitespace:*te-s* OR email:*te-s* OR userName:*te-s*) AND ( name.whitespace:*t* OR email:*t* OR userName:*t*)"
                     }
                 }
-              ]
+                ]
                }\s
              }\s
             }
@@ -250,22 +261,26 @@ public class ProfileSearchConnectorTest {
           {
              "from" : 0, "size" : 10,
              "sort": {"lastUpdatedDate": {"order": "DESC"}}
-                 ,
+          ,
           "query" : {
                 "constant_score" : {
                   "filter" : {
                     "bool" :{
-              "should": [
+                "must": [
+                {
+                  "bool": {
+                    "should": [
                             {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,
-          "minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -274,11 +289,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must_not": {
@@ -297,30 +314,31 @@ public class ProfileSearchConnectorTest {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-                "must" : {
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
                   "terms" :{
                     "userName" : ["test"]
                   }\s
                 }
+                ]
                 ,
                 "must_not": [
-                  {
+                {
                     "ids" : {
                        "values" : ["null","null"]
                     }
                   }
                 ]
                 ,
-              "filter": [
+                "filter": [
                 {          "query_string": {
                       "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
                     }
                 }
-              ]
+                ]
                }\s
              }\s
             }
@@ -342,22 +360,26 @@ public class ProfileSearchConnectorTest {
           {
              "from" : 0, "size" : 10,
              "sort": {"lastUpdatedDate": {"order": "DESC"}}
-                 ,
+          ,
           "query" : {
                 "constant_score" : {
                   "filter" : {
                     "bool" :{
-              "should": [
+                "must": [
+                {
+                  "bool": {
+                    "should": [
                             {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,
-          "minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -366,11 +388,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -379,30 +403,31 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-                "must" : {
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
                   "terms" :{
                     "userName" : ["test"]
                   }\s
                 }
+                ]
                 ,
                 "must_not": [
-                  {
+                {
                     "ids" : {
                        "values" : ["null","null"]
                     }
                   }
                 ]
                 ,
-              "filter": [
+                "filter": [
                 {          "query_string": {
                       "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
                     }
                 }
-              ]
+                ]
                }\s
              }\s
             }
@@ -449,22 +474,26 @@ public class ProfileSearchConnectorTest {
           {
              "from" : 0, "size" : 10,
              "sort": {"lastUpdatedDate": {"order": "DESC"}}
-                 ,
+          ,
           "query" : {
                 "constant_score" : {
                   "filter" : {
                     "bool" :{
-              "should": [
+                "must": [
+                {
+                  "bool": {
+                    "should": [
                             {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,
-          "minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -473,11 +502,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must_not": {
@@ -496,35 +527,37 @@ public class ProfileSearchConnectorTest {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-                "must" : {
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
                   "terms" :{
                     "userName" : ["test"]
                   }\s
                 }
+                ]
                 ,
                 "must_not": [
-                  {
+                {
                     "ids" : {
                        "values" : ["null","null"]
                     }
                   }
                 ]
                 ,
-              "filter": [
+                "filter": [
                 {          "query_string": {
                       "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
                     }
                 }
-          ,  {
+          ,
+            {
               "match_phrase": {
                 "testProperty": "valueProperty"
               }
            }
-              ]
+                ]
                }\s
              }\s
             }
@@ -573,22 +606,26 @@ public class ProfileSearchConnectorTest {
           {
              "from" : 0, "size" : 10,
              "sort": {"lastUpdatedDate": {"order": "DESC"}}
-                 ,
+          ,
           "query" : {
                 "constant_score" : {
                   "filter" : {
                     "bool" :{
-              "should": [
+                "must": [
+                {
+                  "bool": {
+                    "should": [
                             {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,
-          "minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -597,11 +634,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must_not": {
@@ -620,35 +659,37 @@ public class ProfileSearchConnectorTest {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-                "must" : {
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
                   "terms" :{
                     "userName" : ["test"]
                   }\s
                 }
+                ]
                 ,
                 "must_not": [
-                  {
+                {
                     "ids" : {
                        "values" : ["null","null"]
                     }
                   }
                 ]
                 ,
-              "filter": [
+                "filter": [
                 {          "query_string": {
                       "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
                     }
                 }
-          ,  {
+          ,
+            {
               "query_string": {
                 "query": " testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*"
               }
            }
-              ]
+                ]
                }\s
              }\s
             }
@@ -698,22 +739,26 @@ public class ProfileSearchConnectorTest {
           {
              "from" : 0, "size" : 10,
              "sort": {"lastUpdatedDate": {"order": "DESC"}}
-                 ,
+          ,
           "query" : {
                 "constant_score" : {
                   "filter" : {
                     "bool" :{
-              "should": [
+                "must": [
+                {
+                  "bool": {
+                    "should": [
                             {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,
-          "minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -722,11 +767,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must_not": {
@@ -745,35 +792,37 @@ public class ProfileSearchConnectorTest {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-                "must" : {
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
                   "terms" :{
                     "userName" : ["test"]
                   }\s
                 }
+                ]
                 ,
                 "must_not": [
-                  {
+                {
                     "ids" : {
                        "values" : ["null","null"]
                     }
                   }
                 ]
                 ,
-              "filter": [
+                "filter": [
                 {          "query_string": {
                       "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
                     }
                 }
-          ,  {
+          ,
+            {
               "query_string": {
                 "query": " testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*"
               }
            }
-              ]
+                ]
                }\s
              }\s
             }
@@ -819,22 +868,26 @@ public class ProfileSearchConnectorTest {
           {
              "from" : 0, "size" : 1,
              "sort": {"lastUpdatedDate": {"order": "DESC"}}
-                 ,
+          ,
           "query" : {
                 "constant_score" : {
                   "filter" : {
                     "bool" :{
-              "should": [
+                "must": [
+                {
+                  "bool": {
+                    "should": [
                             {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,
-          "minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must": {
@@ -843,11 +896,13 @@ public class ProfileSearchConnectorTest {
                                   }
                                 }
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-              "should": [
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
+                  "bool": {
+                    "should": [
                             {
                               "bool": {
                                 "must_not": {
@@ -866,30 +921,31 @@ public class ProfileSearchConnectorTest {
                               "term": {
                                 "external": true
                               }
-                            }
-                            ]
-                            ,"minimum_should_match" : 1
-                ,
-                "must" : {
+                            }          ],
+                    "minimum_should_match" : 1
+                  }
+                },
+                {
                   "terms" :{
                     "userName" : ["test"]
                   }\s
                 }
+                ]
                 ,
                 "must_not": [
-                  {
+                {
                     "ids" : {
                        "values" : ["null","null"]
                     }
                   }
                 ]
                 ,
-              "filter": [
+                "filter": [
                 {          "query_string": {
                       "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
                     }
                 }
-              ]
+                ]
                }\s
              }\s
             }
@@ -923,22 +979,22 @@ public class ProfileSearchConnectorTest {
         {
            "from" : 0, "size" : 10,
            "sort": {"lastName.raw": {"order": "ASC"}}
-               ,
+        ,
         "query" : {
               "constant_score" : {
                 "filter" : {
                   "bool" :{
-            "must": [
+              "must": [
               {
                 "terms": {
                   "permissions": [
         5
                   ]
                 }
-              }
-            ]
-              ,
-            "should": [
+              },
+              {
+                "bool": {
+                  "should": [
                           {
                             "term": {
                               "external": false
@@ -952,12 +1008,13 @@ public class ProfileSearchConnectorTest {
                                 }
                               }
                             }
-                          }
-                          ]
-                          ,
-        "minimum_should_match" : 1
-              ,
-            "should": [
+                          }          ],
+                  "minimum_should_match" : 1
+                }
+              },
+              {
+                "bool": {
+                  "should": [
                           {
                             "bool": {
                               "must_not": {
@@ -976,16 +1033,17 @@ public class ProfileSearchConnectorTest {
                             "term": {
                               "external": true
                             }
-                          }
-                          ]
-                          ,"minimum_should_match" : 1
+                          }          ],
+                  "minimum_should_match" : 1
+                }
+              }      ]
               ,
-            "filter": [
+              "filter": [
               {          "query_string": {
                     "query": "name.whitespace:*\\"aaa\\"*"
                   }
               }
-            ]
+              ]
              }\s
            }\s
           }


### PR DESCRIPTION
Before this change, access this user management app and try filtering users per never connected and never enrolled combined with a search term of an existing user, no results displayed. To fix this problem, modify the ProfileSearchConnector query so that it only has one must clause. After this change, results is displayed according to filter and search term.