### PR TITLE
Fix: Delegated admins cannot filter users - MEED-9986 - meeds-io/meeds#3870

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileFilter.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/profile/ProfileFilter.java
@@ -79,6 +79,8 @@ public class ProfileFilter implements Cloneable {
 
   private List<String> remoteIds = null;
 
+  private List<String> groupIds = null;
+
   private Sorting sorting;
 
   private Map<String, String> profileSettings;
@@ -311,6 +313,14 @@ public class ProfileFilter implements Cloneable {
 
   public List<String> getRemoteIds() {
     return remoteIds;
+  }
+
+  public void setGroupIds(List<String> groupIds) {
+    this.groupIds = groupIds;
+  }
+
+  public List<String> getGroupIds() {
+    return groupIds;
   }
 
   /**

--- a/component/api/src/main/java/org/exoplatform/social/core/storage/api/IdentityStorage.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/storage/api/IdentityStorage.java
@@ -367,8 +367,15 @@ public interface IdentityStorage {
    * @param offset
    * @param limit
    * @return
+   * @deprecated The old getIdentities method without remoteIds no longer exists, use getIdentities with the remoteIds parameter instead.
    */
-  public List<Identity> getIdentities(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected, String enrollmentStatus, long offset, long limit);
+  @Deprecated(forRemoval = true, since = "7.2.0")
+  default List<Identity> getIdentities(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected, String enrollmentStatus, long offset, long limit) {
+    return getIdentities(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, null, offset, limit);
+  }
+  default List<Identity> getIdentities(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected, String enrollmentStatus, List<String> remoteIds, long offset, long limit){
+    return Collections.emptyList();
+  }
 
   /**
    * Get list of identities by providerId
@@ -383,10 +390,15 @@ public interface IdentityStorage {
    * @param offset
    * @param limit
    * @return {@link List} of identity ids
+   * @deprecated The old getIdentityIds method without remoteIds no longer exists, use getIdentityIds with the remoteIds parameter instead.
    */
+  @Deprecated(forRemoval = true, since = "7.2.0")
   default List<String> getIdentityIds(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected, String enrollmentStatus, long offset, long limit) { // NOSONAR parameters count
-    List<Identity> identities = getIdentities(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, offset, limit);
-    return identities == null ? Collections.emptyList() : identities.stream().map(String::valueOf).toList();
+    return getIdentityIds(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, null, offset, limit);
+  }
+
+  default List<String> getIdentityIds(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected, String enrollmentStatus, List<String> remoteIds, long offset, long limit) { // NOSONAR parameters count
+    return Collections.emptyList();
   }
 
   /**

--- a/component/core/src/main/java/org/exoplatform/social/core/identity/ProfileFilterListAccess.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/identity/ProfileFilterListAccess.java
@@ -18,14 +18,17 @@
  */
 package org.exoplatform.social.core.identity;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
+import java.util.*;
+import org.apache.commons.collections4.CollectionUtils;
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.profile.ProfileFilter;
 import org.exoplatform.social.core.search.Sorting;
+import org.exoplatform.social.core.space.SpaceUtils;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
 
 /**
@@ -143,9 +146,33 @@ public class ProfileFilterListAccess implements ListAccess<Identity> {
           String userType = profileFilter.getUserType();
           Boolean isConnected = profileFilter.isConnected();
           String enrollmentStatus = profileFilter.getEnrollmentStatus();
-
+          List<String> remoteIds = profileFilter.getRemoteIds();
           String sortFieldName = sorting == null || sorting.sortBy == null ? null : sorting.sortBy.getFieldName();
           String sortDirection = sorting == null || sorting.sortBy == null ? null : sorting.orderBy.name();
+          List<String> groupIds = profileFilter.getGroupIds();
+          if (CollectionUtils.isNotEmpty(groupIds)) {
+            Set<String> userNames = new HashSet<>();
+            for (String groupId : groupIds) {
+              OrganizationService organizationService = ExoContainerContext.getService(OrganizationService.class);
+              Group group = organizationService.getGroupHandler().findGroupById(groupId);
+              ListAccess<Membership> membershipsListAccess =
+                      organizationService.getMembershipHandler().findAllMembershipsByGroup(group);
+              int membershipSize = membershipsListAccess.getSize();
+              if (membershipSize > 0) {
+                Membership[] memberships = membershipsListAccess.load(0, membershipSize);
+                Arrays.stream(memberships)
+                      .filter(Objects::nonNull)
+                      .map(Membership::getUserName)
+                      .forEach(userNames::add);
+              }
+            }
+            if (CollectionUtils.isEmpty(remoteIds)) {
+              remoteIds = new ArrayList<>(userNames);
+            } else {
+              remoteIds.retainAll(userNames);
+            }
+          }
+          profileFilter.setRemoteIds(remoteIds);
           identities = identityStorage.getIdentities(providerId,
                                                      sortFieldName,
                                                      sortDirection,
@@ -153,6 +180,7 @@ public class ProfileFilterListAccess implements ListAccess<Identity> {
                                                      userType,
                                                      isConnected,
                                                      enrollmentStatus,
+                                                     remoteIds,
                                                      offset,
                                                      usedLimit);
         }
@@ -167,6 +195,18 @@ public class ProfileFilterListAccess implements ListAccess<Identity> {
                                                                     usedLimit);
       }
     } else {
+      List<String> groupIds = profileFilter.getGroupIds();
+      if (CollectionUtils.isNotEmpty(groupIds)) {
+        SpaceUtils spaceUtils = ExoContainerContext.getService(SpaceUtils.class);
+        Set<String> groupIdentityIds = spaceUtils.getUserPermissionsIdentityIds(groupIds);
+        List<String> spaceIdentityIds = profileFilter.getSpaceIdentityIds();
+        if (CollectionUtils.isEmpty(spaceIdentityIds)) {
+          profileFilter.setSpaceIdentityIds(new ArrayList<>(groupIdentityIds));
+        } else {
+          spaceIdentityIds.retainAll(groupIdentityIds);
+          profileFilter.setSpaceIdentityIds(spaceIdentityIds);
+        }
+      }
       identities = identityStorage.getIdentitiesForMentions(providerId, profileFilter, null, offset, usedLimit, forceLoadProfile);
     }
     if (profileFilter != null && profileFilter.getViewerIdentity() != null) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileIndexingServiceConnector.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.search.domain.Document;
 import org.exoplatform.commons.search.index.impl.ElasticIndexingServiceConnector;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
@@ -49,6 +50,7 @@ import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertyOption;
 import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
 import org.exoplatform.social.core.relationship.model.Relationship;
+import org.exoplatform.social.core.space.SpaceUtils;
 
 public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConnector {
 
@@ -366,24 +368,7 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
   }
 
   private Set<String> getGroupIdentityIds(Identity ownerIdentity) {
-    Set<String> groups = userACL.getUserIdentity(ownerIdentity.getRemoteId()).getGroups();
-    Set<String> groupIdentityIds = new HashSet<>();
-
-    for (String groupId : groups) {
-      if (groupId.startsWith("/spaces/")) {
-        String spacePrettyName = groupId.substring("/spaces/".length());
-        Identity identity = identityManager.getOrCreateSpaceIdentity(spacePrettyName);
-        if (identity != null) {
-          groupIdentityIds.add(identity.getId());
-        }
-      } else {
-        Identity identity = identityManager.getOrCreateGroupIdentity(groupId);
-        if (identity != null) {
-          groupIdentityIds.add(identity.getId());
-        }
-      }
-    }
-
-    return groupIdentityIds;
+    SpaceUtils spaceUtils = ExoContainerContext.getService(SpaceUtils.class);
+    return spaceUtils.getUserPermissionsIdentityIds(ownerIdentity);
   }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -183,6 +183,9 @@ public class ProfileSearchConnector {
       appendCommar = true;
     }
     if (filter.getUserType() != null && !filter.getUserType().isEmpty()) {
+      if(appendCommar) {
+        esSubQuery.append("      ,\n");
+      }
       if (filter.getUserType().equals("internal")) {
         esSubQuery.append("    \"should\": [\n");
         esSubQuery.append("                  {\n");
@@ -213,10 +216,16 @@ public class ProfileSearchConnector {
         subQueryEmpty = false;
         appendCommar = true;
       }
-      esSubQuery.append("                  ,\"minimum_should_match\" : 1\n");
+      if(appendCommar) {
+        esSubQuery.append("                  ,\n");
+      }
+      esSubQuery.append("\"minimum_should_match\" : 1\n");
 
     }
     if (filter.isConnected() != null) {
+      if(appendCommar) {
+        esSubQuery.append("      ,\n");
+      }
       esSubQuery.append("    \"should\": [\n");
       esSubQuery.append("                  {\n");
       esSubQuery.append("                    \"bool\": {\n");
@@ -237,6 +246,9 @@ public class ProfileSearchConnector {
       appendCommar = true;
     }
     if(filter.getEnrollmentStatus() != null && !filter.getEnrollmentStatus().isEmpty()) {
+      if(appendCommar) {
+        esSubQuery.append("      ,\n");
+      }
       switch (filter.getEnrollmentStatus()) {
         case "enrolled": {
           esSubQuery.append("    \"should\": [\n");
@@ -325,13 +337,16 @@ public class ProfileSearchConnector {
         }
         remoteIds.append("\"").append(remoteId).append("\"");
       }
+      if(appendCommar) {
+        esSubQuery.append("      ,\n");
+      }
       esSubQuery.append("      \"must\" : {\n");
       esSubQuery.append("        \"terms\" :{\n");
       esSubQuery.append("          \"userName\" : [" + remoteIds.toString() + "]\n");
       esSubQuery.append("        } \n");
-      esSubQuery.append("      },\n");
+      esSubQuery.append("      }\n");
       subQueryEmpty = false;
-      appendCommar = false;
+      appendCommar = true;
     }
     if (identity != null && type != null) {
       if(appendCommar) {
@@ -586,7 +601,7 @@ public class ProfileSearchConnector {
     query.append("          ]\n");
     query.append("        }\n");
     query.append("      }\n");
-    query.append("    ],\n");
+    query.append("    ]\n");
     return query.toString();
   }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSIdentityStorageImpl.java
@@ -732,7 +732,7 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
 
   @Override
   public int getIdentitiesByProfileFilterCount(String providerId, ProfileFilter profileFilter) throws IdentityStorageException {
-    return getIdentityDAO().getAllIdsCountByProvider(providerId, profileFilter.getUserType(), profileFilter.isConnected(), profileFilter.isEnabled(), profileFilter.getEnrollmentStatus());
+    return getIdentityDAO().getAllIdsCountByProvider(providerId, profileFilter.getUserType(), profileFilter.isConnected(), profileFilter.isEnabled(), profileFilter.getEnrollmentStatus(), profileFilter.getRemoteIds());
   }
 
   public List<Identity> getIdentitiesForUnifiedSearch(final String providerId,
@@ -936,9 +936,10 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
                                       String userType,
                                       Boolean isConnected,
                                       String enrollmentStatus,
+                                      List<String> remoteIds,
                                       long offset,
                                       long limit) {
-    List<String> usernames = getIdentityDAO().getAllIdsByProviderSorted(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, offset, limit);
+    List<String> usernames = getIdentityDAO().getAllIdsByProviderSorted(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, remoteIds, offset, limit);
     List<Identity> identities = new ArrayList<>();
     if (usernames != null && !usernames.isEmpty()) {
       for (String username : usernames) {
@@ -959,6 +960,7 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
                                      String userType,
                                      Boolean isConnected,
                                      String enrollmentStatus,
+                                     List<String> remoteIds,
                                      long offset,
                                      long limit) {
     return getIdentityDAO().getIdentityIdsByProviderSorted(providerId,
@@ -968,6 +970,7 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
                                                            userType,
                                                            isConnected,
                                                            enrollmentStatus,
+                                                           remoteIds,
                                                            offset,
                                                            limit)
                            .stream()
@@ -977,7 +980,7 @@ public class RDBMSIdentityStorageImpl implements IdentityStorage {
 
   @Override
   public List<Identity> getIdentities(final String providerId, long offset, long limit) throws IdentityStorageException {
-    return this.getIdentities(providerId, null, null, true, null, null, null, offset, limit);
+    return this.getIdentities(providerId, null, null, true, null, null, null, null,offset, limit);
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAO.java
@@ -70,8 +70,16 @@ public interface IdentityDAO extends GenericDAO<IdentityEntity, Long> {
    * @param offset
    * @param limit
    * @return
+   * @deprecated The old getAllIdsByProviderSorted method without remoteIds no longer exists, use getAllIdsByProviderSorted with the remoteIds parameter instead.
    */
-  List<String> getAllIdsByProviderSorted(String providerId, String sortField, String sortDirection, boolean enabled, String userType, Boolean isConnected, String enrollmentStatus, long offset, long limit);
+  @Deprecated(forRemoval = true, since = "7.2.0")
+  default List<String> getAllIdsByProviderSorted(String providerId, String sortField, String sortDirection, boolean enabled, String userType, Boolean isConnected, String enrollmentStatus, long offset, long limit) {
+    return getAllIdsByProviderSorted(providerId, sortField, sortDirection, enabled, userType, isConnected, enrollmentStatus, null, offset, limit);
+  }
+
+  default List<String> getAllIdsByProviderSorted(String providerId, String sortField, String sortDirection, boolean enabled, String userType, Boolean isConnected, String enrollmentStatus, List<String> remoteIds, long offset, long limit) {
+    return Collections.emptyList();
+  }
 
   /**
    * Get identity ids by providerId sorted by sortField
@@ -86,7 +94,9 @@ public interface IdentityDAO extends GenericDAO<IdentityEntity, Long> {
    * @param offset
    * @param limit
    * @return
+   *@deprecated The old getIdentityIdsByProviderSorted method without remoteIds no longer exists, use getIdentityIdsByProviderSorted with the remoteIds parameter instead.
    */
+  @Deprecated(forRemoval = true, since = "7.2.0")
   default List<Long> getIdentityIdsByProviderSorted(String providerId,
                                                     String sortField,
                                                     String sortDirection,
@@ -96,12 +106,25 @@ public interface IdentityDAO extends GenericDAO<IdentityEntity, Long> {
                                                     String enrollmentStatus,
                                                     long offset,
                                                     long limit) {
-    List<String> remoteIds = getAllIdsByProviderSorted(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, offset, limit);
+    return getIdentityIdsByProviderSorted(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, null, offset, limit);
+  }
+
+  default List<Long> getIdentityIdsByProviderSorted(String providerId,
+                                                    String sortField,
+                                                    String sortDirection,
+                                                    boolean isEnabled,
+                                                    String userType,
+                                                    Boolean isConnected,
+                                                    String enrollmentStatus,
+                                                    List<String> remoteIds,
+                                                    long offset,
+                                                    long limit) {
+    remoteIds = getAllIdsByProviderSorted(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, remoteIds, offset, limit);
     return remoteIds == null ? Collections.emptyList() :
-                             remoteIds.stream()
-                                      .map(remoteId -> findIdByProviderAndRemoteId(providerId, remoteId))
-                                      .filter(Objects::nonNull)
-                                      .toList();
+            remoteIds.stream()
+                    .map(remoteId -> findIdByProviderAndRemoteId(providerId, remoteId))
+                    .filter(Objects::nonNull)
+                    .toList();
   }
 
   /**
@@ -112,8 +135,16 @@ public interface IdentityDAO extends GenericDAO<IdentityEntity, Long> {
    * @param isConnected
    * @param enabled
    * @return
+   *@deprecated The old getAllIdsCountByProvider method without remoteIds no longer exists, use getAllIdsCountByProvider with the remoteIds parameter instead.
    */
-  int getAllIdsCountByProvider(String providerId, String userType, Boolean isConnected, boolean enabled, String enrollmentStatus);
+  @Deprecated(forRemoval = true, since = "7.2.0")
+  default int getAllIdsCountByProvider(String providerId, String userType, Boolean isConnected, boolean enabled, String enrollmentStatus) {
+    return getAllIdsCountByProvider(providerId, userType, isConnected, enabled, enrollmentStatus, null);
+  }
+
+  default int getAllIdsCountByProvider(String providerId, String userType, Boolean isConnected, boolean enabled, String enrollmentStatus, List<String> remoteIds) {
+    return 0;
+  }
 
   default Long findIdByProviderAndRemoteId(String providerId, String remoteId) {
     IdentityEntity identity = findByProviderAndRemoteId(providerId, remoteId);

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/IdentityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/IdentityDAOImpl.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
@@ -133,7 +134,7 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
 
   @Override
   public ListAccess<Map.Entry<IdentityEntity, ConnectionEntity>> findAllIdentitiesWithConnections(long identityId, String sortField, String sortDirection) {
-    Query listQuery = getIdentitiesQuerySortedByField(OrganizationIdentityProvider.NAME, sortField, sortDirection, true, null, null, null);
+    Query listQuery = getIdentitiesQuerySortedByField(OrganizationIdentityProvider.NAME, sortField, sortDirection, true, null, null, null, null);
 
     TypedQuery<ConnectionEntity> connectionsQuery = getEntityManager().createNamedQuery("SocConnection.findConnectionsByIdentityIds", ConnectionEntity.class);
 
@@ -167,21 +168,21 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
   }
 
   @Override
-  public List<String> getAllIdsByProviderSorted(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected,String enrollmentStatus, long offset, long limit) {
-    Query query = getIdentitiesQuerySortedByField(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus);
+  public List<String> getAllIdsByProviderSorted(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected,String enrollmentStatus, List<String> remoteIds, long offset, long limit) {
+    Query query = getIdentitiesQuerySortedByField(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, remoteIds);
     return getResultsFromQuery(query, 0, offset, limit, String.class);
   }
 
   @Override
-  public List<Long> getIdentityIdsByProviderSorted(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected,String enrollmentStatus, long offset, long limit) {
-    Query query = getIdentitiesQuerySortedByField(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus);
+  public List<Long> getIdentityIdsByProviderSorted(String providerId, String sortField, String sortDirection, boolean isEnabled, String userType, Boolean isConnected,String enrollmentStatus, List<String> remoteIds,long offset, long limit) {
+    Query query = getIdentitiesQuerySortedByField(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, remoteIds);
     return getResultsFromQuery(query, 1, offset, limit, Long.class);
   }
 
   @Override
-  public int getAllIdsCountByProvider(String providerId, String userType, Boolean isConnected, boolean isEnabled, String enrollmentStatus) {
+  public int getAllIdsCountByProvider(String providerId, String userType, Boolean isConnected, boolean isEnabled, String enrollmentStatus, List<String> remoteIds) {
     boolean noEnrollmentPossible = enrollmentStatus != null && !enrollmentStatus.isEmpty() && enrollmentStatus.equals(NO_ENROLLMENT_POSSIBLE);
-    Query query = getIdentitiesQueryCount(providerId, userType, isConnected, isEnabled, enrollmentStatus);
+    Query query = getIdentitiesQueryCount(providerId, userType, isConnected, isEnabled, enrollmentStatus, remoteIds);
     int totalCount = ((Number) query.getSingleResult()).intValue();
     if(noEnrollmentPossible) {
       Query externalQuery = getExternalIdentitiesQueryCount(providerId, isEnabled);
@@ -378,7 +379,7 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
     }
   }
 
-  private Query getIdentitiesQueryCount(String providerId, String userType, Boolean isConnected, boolean isEnabled, String enrollmentStatus) {
+  private Query getIdentitiesQueryCount(String providerId, String userType, Boolean isConnected, boolean isEnabled, String enrollmentStatus, List<String> remoteIds) {
 
     boolean isUserTypeFilter = userType != null && ( userType.equals(INTERNAL) || userType.equals(EXTERNAL));
     boolean isEnrollmentStatusFilter = enrollmentStatus != null && !enrollmentStatus.isEmpty();
@@ -468,8 +469,15 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
     queryStringBuilder.append(" WHERE identity_1.provider_id = '").append(providerId).append("' \n");
     queryStringBuilder.append(" AND identity_1.deleted = FALSE \n");
     queryStringBuilder.append(" AND identity_1.enabled = ").append(isEnabled).append(" \n");
+    if (CollectionUtils.isNotEmpty(remoteIds)) {
+      queryStringBuilder.append(" AND identity_1.remote_id IN (:remoteIds) \n");
+    }
 
-    return getEntityManager().createNativeQuery(queryStringBuilder.toString());
+    Query query = getEntityManager().createNativeQuery(queryStringBuilder.toString());
+    if (CollectionUtils.isNotEmpty(remoteIds)){
+      query.setParameter("remoteIds", remoteIds);
+    }
+    return query;
   }
 
   private Query getExternalIdentitiesQueryCount(String providerId, boolean isEnabled) {
@@ -498,7 +506,8 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
                                                 boolean isEnabled,
                                                 String userType,
                                                 Boolean isConnected,
-                                                String enrollmentStatus) {
+                                                String enrollmentStatus,
+                                                List<String> remoteIds) {
     StringBuilder queryStringBuilder = null;
     boolean isUserTypeFilter = userType != null && ( userType.equals(INTERNAL) || userType.equals(EXTERNAL));
     boolean isEnrollmentStatusFilter = enrollmentStatus != null && !enrollmentStatus.isEmpty();
@@ -600,7 +609,9 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
     queryStringBuilder.append(" WHERE identity_1.provider_id = '").append(providerId).append("' \n");
     queryStringBuilder.append(" AND identity_1.deleted = FALSE \n");
     queryStringBuilder.append(" AND identity_1.enabled = ").append(isEnabled).append(" \n");
-
+    if (CollectionUtils.isNotEmpty(remoteIds)) {
+      queryStringBuilder.append(" AND identity_1.remote_id IN (:remoteIds) \n");
+    }
     if(isEnrollmentStatusFilter && enrollmentStatus.equals(NO_ENROLLMENT_POSSIBLE)) {
       queryStringBuilder.append(" \n");
       queryStringBuilder.append("UNION").append(" \n");
@@ -626,15 +637,20 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
       queryStringBuilder.append(" WHERE identity_1.provider_id = '").append(providerId).append("' \n");
       queryStringBuilder.append(" AND identity_1.deleted = FALSE \n");
       queryStringBuilder.append(" AND identity_1.enabled = ").append(isEnabled).append(" \n");
-
+      if (CollectionUtils.isNotEmpty(remoteIds)) {
+        queryStringBuilder.append(" AND identity_1.remote_id IN (:remoteIds) \n");
+      }
     }
 
     if (StringUtils.isNotBlank(sortField) && StringUtils.isNotBlank(sortDirection)) {
       queryStringBuilder.append(" ORDER BY prop_order_field " + sortDirection);
     }
 
-
-    return getEntityManager().createNativeQuery(queryStringBuilder.toString());
+    Query query = getEntityManager().createNativeQuery(queryStringBuilder.toString());
+    if (CollectionUtils.isNotEmpty(remoteIds)){
+      query.setParameter("remoteIds", remoteIds);
+    }
+    return query;
   }
 
   @SuppressWarnings("unchecked")

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -29,6 +29,7 @@ import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.SiteType;
 import org.exoplatform.portal.mop.navigation.NavigationContext;
@@ -607,6 +608,33 @@ public class SpaceUtils {
       }
       return null;
     }).filter(Objects::nonNull).toList();
+  }
+
+  public static Set<String> getUserPermissionsIdentityIds(Identity ownerIdentity) {
+    UserACL userACL = ExoContainerContext.getService(UserACL.class);
+    Set<String> groupIds = userACL.getUserIdentity(ownerIdentity.getRemoteId()).getGroups();
+    return getUserPermissionsIdentityIds(groupIds);
+  }
+
+  public static Set<String> getUserPermissionsIdentityIds(Collection<String> groupIds) {
+    Set<String> groupIdentityIds = new HashSet<>();
+    SpaceService spaceService = ExoContainerContext.getService(SpaceService.class);
+    IdentityManager identityManager = ExoContainerContext.getService(IdentityManager.class);
+    for (String groupId : groupIds) {
+      if (groupId.startsWith("/spaces/")) {
+        Space space = spaceService.getSpaceByGroupId(groupId);
+        if (space != null) {
+          Identity identity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+          groupIdentityIds.add(identity.getId());
+        }
+      } else {
+        Identity identity = identityManager.getOrCreateGroupIdentity(groupId);
+        if (identity != null) {
+          groupIdentityIds.add(identity.getId());
+        }
+      }
+    }
+    return groupIdentityIds;
   }
 
   private static String computeSpacePermissionFromTemplate(String p, String groupId) {

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedIdentityStorage.java
@@ -370,6 +370,7 @@ public class CachedIdentityStorage implements IdentityStorage {
                                      String userType,
                                      Boolean isConnected,
                                      String enrollmentStatus,
+                                     List<String> remoteIds,
                                      long offset,
                                      long limit) {
     ProfileFilter profileFilter = new ProfileFilter();
@@ -377,6 +378,7 @@ public class CachedIdentityStorage implements IdentityStorage {
     profileFilter.setUserType(userType);
     profileFilter.setConnected(isConnected);
     profileFilter.setEnrollmentStatus(enrollmentStatus);
+    profileFilter.setRemoteIds(remoteIds);
     profileFilter.setSorting(Sorting.valueOf(sortField, sortDirection));
 
     //
@@ -392,6 +394,7 @@ public class CachedIdentityStorage implements IdentityStorage {
                                                         userType,
                                                         isConnected,
                                                         enrollmentStatus,
+                                                        remoteIds,
                                                         offset,
                                                         limit);
       return new ListIdentitiesData(identityIds.stream().map(IdentityKey::new).toList());
@@ -407,15 +410,16 @@ public class CachedIdentityStorage implements IdentityStorage {
                                       String userType,
                                       Boolean isConnected,
                                       String enrollmentStatus,
+                                      List<String> remoteIds,
                                       long offset,
                                       long limit) {
-    List<String> identityIds = getIdentityIds(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, offset, limit);
+    List<String> identityIds = getIdentityIds(providerId, sortField, sortDirection, isEnabled, userType, isConnected, enrollmentStatus, remoteIds, offset, limit);
     return buildIdentities(identityIds);
   }
 
   @Override
   public List<Identity> getIdentities(String providerId, long offset, long limit) {
-    return getIdentities(providerId, null, null, true, null, null, null, offset, limit);
+    return getIdentities(providerId, null, null, true, null, null, null, null, offset, limit);
   }
 
   @Override

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -125,88 +125,92 @@ public class ProfileSearchConnectorTest {
         filter.setProfileSettings(profileSettings);
         filter.setExcludedIdentityList(excludedIdentityList);
         String index = "profile_alias";
-        String query = "{\n" +
-                "   \"from\" : 0, \"size\" : 10,\n" +
-                "   \"sort\": {\"firstName.raw\": {\"order\": \"DESC\"}}\n" +
-                "       ,\n" +
-                "\"query\" : {\n" +
-                "      \"constant_score\" : {\n" +
-                "        \"filter\" : {\n" +
-                "          \"bool\" :{\n" +
-                buildAdvancedFilterQuery(filter) +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": false\n" +
-                "                    }\n" +
-                "                  },\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must_not\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"external\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must_not\": [{\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"enrollmentDate\"\n" +
-                "                          }\n" +
-                "                        },\n" +
-                "                      {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }],\n" +
-                "                      \"must\": {\n" +
-                "                       \"term\": {\n" +
-                "                         \"external\": false\n" +
-                "                         }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "      ,\n" +
-                "      \"must_not\": [\n" +
-                "        {\n" +
-                "          \"ids\" : {\n" +
-                "             \"values\" : [\"null\",\"null\"]\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ]\n" +
-                "      ,\n" +
-                "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( name.whitespace:*te-s* OR email:*te-s* OR userName:*te-s*) AND ( name.whitespace:*t* OR email:*t* OR userName:*t*)\"\n" +
-                "          }\n" +
-                "      }\n" +
-                "    ]\n" +
-                "     } \n" +
-                "   } \n" +
-                "  }\n" +
-                " }\n" +
-                ",\"_source\": false\n" +
-                ",\"fields\": [\"_id\"]\n" +
-                "}\n";
+        String query = """
+          {
+             "from" : 0, "size" : 10,
+             "sort": {"firstName.raw": {"order": "DESC"}}
+                 ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+              "should": [
+                            {
+                              "term": {
+                                "external": false
+                              }
+                            },
+                            {
+                              "bool": {
+                                "must_not": {
+                                  "exists": {
+                                    "field": "external"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,
+          "minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must_not": [{
+                                  "exists": {
+                                    "field": "enrollmentDate"
+                                    }
+                                  },
+                                {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }],
+                                "must": {
+                                 "term": {
+                                   "external": false
+                                   }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+                "must_not": [
+                  {
+                    "ids" : {
+                       "values" : ["null","null"]
+                    }
+                  }
+                ]
+                ,
+              "filter": [
+                {          "query_string": {
+                      "query": "( name.whitespace:*te-s* OR email:*te-s* OR userName:*te-s*) AND ( name.whitespace:*t* OR email:*t* OR userName:*t*)"
+                    }
+                }
+              ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+                """;
         long offset = 0;
         long limit = 10;
         when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
@@ -242,88 +246,173 @@ public class ProfileSearchConnectorTest {
         filter.setExcludedIdentityList(excludedIdentityList);
         filter.setRemoteIds(Collections.singletonList("test"));
         String index = "profile_alias";
-        String query = "{\n" +
-                "   \"from\" : 0, \"size\" : 10,\n" +
-                "   \"sort\": {\"lastUpdatedDate\": {\"order\": \"DESC\"}}\n" +
-                "       ,\n" +
-                "\"query\" : {\n" +
-                "      \"constant_score\" : {\n" +
-                "        \"filter\" : {\n" +
-                "          \"bool\" :{\n" +
-                buildAdvancedFilterQuery(filter) +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must_not\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"enrollmentDate\"\n" +
-                "                          }\n" +
-                "                        },\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  },\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "      \"must\" : {\n" +
-                "        \"terms\" :{\n" +
-                "          \"userName\" : [\"test\"]\n" +
-                "        } \n" +
-                "      },\n" +
-                "      \"must_not\": [\n" +
-                "        {\n" +
-                "          \"ids\" : {\n" +
-                "             \"values\" : [\"null\",\"null\"]\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ]\n" +
-                "      ,\n" +
-                "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( name.whitespace:*\\\"te-s*) AND ( name.whitespace:*t\\\"*)\"\n" +
-                "          }\n" +
-                "      }\n" +
-                "    ]\n" +
-                "     } \n" +
-                "   } \n" +
-                "  }\n" +
-                " }\n" +
-                ",\"_source\": false\n" +
-                ",\"fields\": [\"_id\"]\n" +
-                "}\n";
+        String query = """
+          {
+             "from" : 0, "size" : 10,
+             "sort": {"lastUpdatedDate": {"order": "DESC"}}
+                 ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+              "should": [
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,
+          "minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must_not": {
+                                  "exists": {
+                                    "field": "enrollmentDate"
+                                    }
+                                  },
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+                "must" : {
+                  "terms" :{
+                    "userName" : ["test"]
+                  }\s
+                }
+                ,
+                "must_not": [
+                  {
+                    "ids" : {
+                       "values" : ["null","null"]
+                    }
+                  }
+                ]
+                ,
+              "filter": [
+                {          "query_string": {
+                      "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
+                    }
+                }
+              ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+                """;
         when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
         COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);
         long offset = 0;
         long limit = 10;
         List<String>  result = profileSearchConnector.search(null, filter, null, offset, limit);
+        Assert.assertEquals(1, result.size());
+
+        //when
+        filter.setEnrollmentStatus("enrolled");
+        query = """
+          {
+             "from" : 0, "size" : 10,
+             "sort": {"lastUpdatedDate": {"order": "DESC"}}
+                 ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+              "should": [
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,
+          "minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "enrollmentDate"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+                "must" : {
+                  "terms" :{
+                    "userName" : ["test"]
+                  }\s
+                }
+                ,
+                "must_not": [
+                  {
+                    "ids" : {
+                       "values" : ["null","null"]
+                    }
+                  }
+                ]
+                ,
+              "filter": [
+                {          "query_string": {
+                      "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
+                    }
+                }
+              ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+          """;
+        when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
+        result = profileSearchConnector.search(null, filter, null, offset, limit);
         Assert.assertEquals(1, result.size());
     }
 
@@ -356,87 +445,94 @@ public class ProfileSearchConnectorTest {
         filter.setExcludedIdentityList(excludedIdentityList);
         filter.setRemoteIds(Collections.singletonList("test"));
         String index = "profile_alias";
-        String query = "{\n" +
-                "   \"from\" : 0, \"size\" : 10,\n" +
-                "   \"sort\": {\"lastUpdatedDate\": {\"order\": \"DESC\"}}\n" +
-                "       ,\n" +
-                "\"query\" : {\n" +
-                "      \"constant_score\" : {\n" +
-                "        \"filter\" : {\n" +
-                "          \"bool\" :{\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must_not\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"enrollmentDate\"\n" +
-                "                          }\n" +
-                "                        },\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  },\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "      \"must\" : {\n" +
-                "        \"terms\" :{\n" +
-                "          \"userName\" : [\"test\"]\n" +
-                "        } \n" +
-                "      },\n" +
-                "      \"must_not\": [\n" +
-                "        {\n" +
-                "          \"ids\" : {\n" +
-                "             \"values\" : [\"null\",\"null\"]\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ]\n" +
-                "      ,\n" +
-                "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( name.whitespace:*\\\"te-s*) AND ( name.whitespace:*t\\\"*)\"\n" +
-                "          }\n" +
-                "      }\n" +
-                ",  {\n" +
-                "    \"match_phrase\": {\n" +
-                "      \"testProperty\": \"valueProperty\"\n" +
-                "    }\n" +
-                " }\n" +
-                "    ]\n" +
-                "     } \n" +
-                "   } \n" +
-                "  }\n" +
-                " }\n" +
-                ",\"_source\": false\n" +
-                ",\"fields\": [\"_id\"]\n" +
-                "}\n";
+        String query = """
+          {
+             "from" : 0, "size" : 10,
+             "sort": {"lastUpdatedDate": {"order": "DESC"}}
+                 ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+              "should": [
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,
+          "minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must_not": {
+                                  "exists": {
+                                    "field": "enrollmentDate"
+                                    }
+                                  },
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+                "must" : {
+                  "terms" :{
+                    "userName" : ["test"]
+                  }\s
+                }
+                ,
+                "must_not": [
+                  {
+                    "ids" : {
+                       "values" : ["null","null"]
+                    }
+                  }
+                ]
+                ,
+              "filter": [
+                {          "query_string": {
+                      "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
+                    }
+                }
+          ,  {
+              "match_phrase": {
+                "testProperty": "valueProperty"
+              }
+           }
+              ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+                """;
         when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
         COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);
         long offset = 0;
@@ -473,87 +569,94 @@ public class ProfileSearchConnectorTest {
         filter.setExcludedIdentityList(excludedIdentityList);
         filter.setRemoteIds(Collections.singletonList("test"));
         String index = "profile_alias";
-        String query = "{\n" +
-                "   \"from\" : 0, \"size\" : 10,\n" +
-                "   \"sort\": {\"lastUpdatedDate\": {\"order\": \"DESC\"}}\n" +
-                "       ,\n" +
-                "\"query\" : {\n" +
-                "      \"constant_score\" : {\n" +
-                "        \"filter\" : {\n" +
-                "          \"bool\" :{\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must_not\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"enrollmentDate\"\n" +
-                "                          }\n" +
-                "                        },\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  },\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "      \"must\" : {\n" +
-                "        \"terms\" :{\n" +
-                "          \"userName\" : [\"test\"]\n" +
-                "        } \n" +
-                "      },\n" +
-                "      \"must_not\": [\n" +
-                "        {\n" +
-                "          \"ids\" : {\n" +
-                "             \"values\" : [\"null\",\"null\"]\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ]\n" +
-                "      ,\n" +
-                "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( name.whitespace:*\\\"te-s*) AND ( name.whitespace:*t\\\"*)\"\n" +
-                "          }\n" +
-                "      }\n" +
-                ",  {\n" +
-                "    \"query_string\": {\n" +
-                "      \"query\": \" testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*\"\n" +
-                "    }\n" +
-                " }\n" +
-                "    ]\n" +
-                "     } \n" +
-                "   } \n" +
-                "  }\n" +
-                " }\n" +
-                ",\"_source\": false\n" +
-                ",\"fields\": [\"_id\"]\n" +
-                "}\n";
+        String query = """
+          {
+             "from" : 0, "size" : 10,
+             "sort": {"lastUpdatedDate": {"order": "DESC"}}
+                 ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+              "should": [
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,
+          "minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must_not": {
+                                  "exists": {
+                                    "field": "enrollmentDate"
+                                    }
+                                  },
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+                "must" : {
+                  "terms" :{
+                    "userName" : ["test"]
+                  }\s
+                }
+                ,
+                "must_not": [
+                  {
+                    "ids" : {
+                       "values" : ["null","null"]
+                    }
+                  }
+                ]
+                ,
+              "filter": [
+                {          "query_string": {
+                      "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
+                    }
+                }
+          ,  {
+              "query_string": {
+                "query": " testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*"
+              }
+           }
+              ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+                """;
         when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
         COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);
         long offset = 0;
@@ -591,87 +694,94 @@ public class ProfileSearchConnectorTest {
         filter.setExcludedIdentityList(excludedIdentityList);
         filter.setRemoteIds(Collections.singletonList("test"));
         String index = "profile_alias";
-        String query = "{\n" +
-                "   \"from\" : 0, \"size\" : 10,\n" +
-                "   \"sort\": {\"lastUpdatedDate\": {\"order\": \"DESC\"}}\n" +
-                "       ,\n" +
-                "\"query\" : {\n" +
-                "      \"constant_score\" : {\n" +
-                "        \"filter\" : {\n" +
-                "          \"bool\" :{\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must_not\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"enrollmentDate\"\n" +
-                "                          }\n" +
-                "                        },\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  },\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "      \"must\" : {\n" +
-                "        \"terms\" :{\n" +
-                "          \"userName\" : [\"test\"]\n" +
-                "        } \n" +
-                "      },\n" +
-                "      \"must_not\": [\n" +
-                "        {\n" +
-                "          \"ids\" : {\n" +
-                "             \"values\" : [\"null\",\"null\"]\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ]\n" +
-                "      ,\n" +
-                "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( name.whitespace:*\\\"te-s*) AND ( name.whitespace:*t\\\"*)\"\n" +
-                "          }\n" +
-                "      }\n" +
-                ",  {\n" +
-                "    \"query_string\": {\n" +
-                "      \"query\": \" testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*\"\n" +
-                "    }\n" +
-                " }\n" +
-                "    ]\n" +
-                "     } \n" +
-                "   } \n" +
-                "  }\n" +
-                " }\n" +
-                ",\"_source\": false\n" +
-                ",\"fields\": [\"_id\"]\n" +
-                "}\n";
+        String query = """
+          {
+             "from" : 0, "size" : 10,
+             "sort": {"lastUpdatedDate": {"order": "DESC"}}
+                 ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+              "should": [
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,
+          "minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must_not": {
+                                  "exists": {
+                                    "field": "enrollmentDate"
+                                    }
+                                  },
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+                "must" : {
+                  "terms" :{
+                    "userName" : ["test"]
+                  }\s
+                }
+                ,
+                "must_not": [
+                  {
+                    "ids" : {
+                       "values" : ["null","null"]
+                    }
+                  }
+                ]
+                ,
+              "filter": [
+                {          "query_string": {
+                      "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
+                    }
+                }
+          ,  {
+              "query_string": {
+                "query": " testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*"
+              }
+           }
+              ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+                """;
         when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
         COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);
         long offset = 0;
@@ -705,83 +815,89 @@ public class ProfileSearchConnectorTest {
         filter.setExcludedIdentityList(excludedIdentityList);
         filter.setRemoteIds(Collections.singletonList("test"));
         String index = "profile_alias";
-        String query = "{\n" +
-                "   \"from\" : 0, \"size\" : 1,\n" +
-                "   \"sort\": {\"lastUpdatedDate\": {\"order\": \"DESC\"}}\n" +
-                "       ,\n" +
-                "\"query\" : {\n" +
-                "      \"constant_score\" : {\n" +
-                "        \"filter\" : {\n" +
-                "          \"bool\" :{\n" +
-                buildAdvancedFilterQuery(filter) +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "    \"should\": [\n" +
-                "                  {\n" +
-                "                    \"bool\": {\n" +
-                "                      \"must_not\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"enrollmentDate\"\n" +
-                "                          }\n" +
-                "                        },\n" +
-                "                      \"must\": {\n" +
-                "                        \"exists\": {\n" +
-                "                          \"field\": \"lastLoginTime\"\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  },\n" +
-                "                  {\n" +
-                "                    \"term\": {\n" +
-                "                      \"external\": true\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                  ]\n" +
-                "                  ,\"minimum_should_match\" : 1\n" +
-                "      \"must\" : {\n" +
-                "        \"terms\" :{\n" +
-                "          \"userName\" : [\"test\"]\n" +
-                "        } \n" +
-                "      },\n" +
-                "      \"must_not\": [\n" +
-                "        {\n" +
-                "          \"ids\" : {\n" +
-                "             \"values\" : [\"null\",\"null\"]\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ]\n" +
-                "      ,\n" +
-                "    \"filter\": [\n" +
-                "      {          \"query_string\": {\n" +
-                "            \"query\": \"( name.whitespace:*\\\"te-s*) AND ( name.whitespace:*t\\\"*)\"\n" +
-                "          }\n" +
-                "      }\n" +
-                "    ]\n" +
-                "     } \n" +
-                "   } \n" +
-                "  }\n" +
-                " }\n" +
-                ",\"_source\": false\n" +
-                ",\"fields\": [\"_id\"]\n" +
-                "}\n";
+        String query = """
+          {
+             "from" : 0, "size" : 1,
+             "sort": {"lastUpdatedDate": {"order": "DESC"}}
+                 ,
+          "query" : {
+                "constant_score" : {
+                  "filter" : {
+                    "bool" :{
+              "should": [
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,
+          "minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+              "should": [
+                            {
+                              "bool": {
+                                "must_not": {
+                                  "exists": {
+                                    "field": "enrollmentDate"
+                                    }
+                                  },
+                                "must": {
+                                  "exists": {
+                                    "field": "lastLoginTime"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "term": {
+                                "external": true
+                              }
+                            }
+                            ]
+                            ,"minimum_should_match" : 1
+                ,
+                "must" : {
+                  "terms" :{
+                    "userName" : ["test"]
+                  }\s
+                }
+                ,
+                "must_not": [
+                  {
+                    "ids" : {
+                       "values" : ["null","null"]
+                    }
+                  }
+                ]
+                ,
+              "filter": [
+                {          "query_string": {
+                      "query": "( name.whitespace:*\\"te-s*) AND ( name.whitespace:*t\\"*)"
+                    }
+                }
+              ]
+               }\s
+             }\s
+            }
+           }
+          ,"_source": false
+          ,"fields": ["_id"]
+          }
+                """;
         when(elasticSearchClient.sendRequest(query, index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"test\"]},\"sort\":[\"test\"]}]}}");
 
 
@@ -803,76 +919,81 @@ public class ProfileSearchConnectorTest {
       filter.setSpaceIdentityIds(Arrays.asList("5"));
       filter.setEnrollmentStatus("noEnrollmentPossible");
       String index = "profile_alias";
-      String expectedQuery = "{\n" +
-              "   \"from\" : 0, \"size\" : 10,\n" +
-              "   \"sort\": {\"lastName.raw\": {\"order\": \"ASC\"}}\n" +
-              "       ,\n" +
-              "\"query\" : {\n" +
-              "      \"constant_score\" : {\n" +
-              "        \"filter\" : {\n" +
-              "          \"bool\" :{\n" +
-              "    \"must\": [\n" +
-              "      {\n" +
-              "        \"terms\": {\n" +
-              "          \"permissions\": [\n" +
-              "5\n" +
-              "          ]\n" +
-              "        }\n" +
-              "      }\n" +
-              "    ],\n" +
-              "    \"should\": [\n" +
-              "                  {\n" +
-              "                    \"term\": {\n" +
-              "                      \"external\": false\n" +
-              "                    }\n" +
-              "                  },\n" +
-              "                  {\n" +
-              "                    \"bool\": {\n" +
-              "                      \"must_not\": {\n" +
-              "                        \"exists\": {\n" +
-              "                          \"field\": \"external\"\n" +
-              "                        }\n" +
-              "                      }\n" +
-              "                    }\n" +
-              "                  }\n" +
-              "                  ]\n" +
-              "                  ,\"minimum_should_match\" : 1\n" +
-              "    \"should\": [\n" +
-              "                  {\n" +
-              "                    \"bool\": {\n" +
-              "                      \"must_not\": {\n" +
-              "                        \"exists\": {\n" +
-              "                          \"field\": \"enrollmentDate\"\n" +
-              "                          }\n" +
-              "                        },\n" +
-              "                      \"must\": {\n" +
-              "                        \"exists\": {\n" +
-              "                          \"field\": \"lastLoginTime\"\n" +
-              "                        }\n" +
-              "                      }\n" +
-              "                    }\n" +
-              "                  },\n" +
-              "                  {\n" +
-              "                    \"term\": {\n" +
-              "                      \"external\": true\n" +
-              "                    }\n" +
-              "                  }\n" +
-              "                  ]\n" +
-              "                  ,\"minimum_should_match\" : 1\n" +
-              "      ,\n" +
-              "    \"filter\": [\n" +
-              "      {          \"query_string\": {\n" +
-              "            \"query\": \"name.whitespace:*\\\"aaa\\\"*\"\n" +
-              "          }\n" +
-              "      }\n" +
-              "    ]\n" +
-              "     } \n" +
-              "   } \n" +
-              "  }\n" +
-              " }\n" +
-              ",\"_source\": false\n" +
-              ",\"fields\": [\"_id\"]\n" +
-              "}\n";
+      String expectedQuery = """
+        {
+           "from" : 0, "size" : 10,
+           "sort": {"lastName.raw": {"order": "ASC"}}
+               ,
+        "query" : {
+              "constant_score" : {
+                "filter" : {
+                  "bool" :{
+            "must": [
+              {
+                "terms": {
+                  "permissions": [
+        5
+                  ]
+                }
+              }
+            ]
+              ,
+            "should": [
+                          {
+                            "term": {
+                              "external": false
+                            }
+                          },
+                          {
+                            "bool": {
+                              "must_not": {
+                                "exists": {
+                                  "field": "external"
+                                }
+                              }
+                            }
+                          }
+                          ]
+                          ,
+        "minimum_should_match" : 1
+              ,
+            "should": [
+                          {
+                            "bool": {
+                              "must_not": {
+                                "exists": {
+                                  "field": "enrollmentDate"
+                                  }
+                                },
+                              "must": {
+                                "exists": {
+                                  "field": "lastLoginTime"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "term": {
+                              "external": true
+                            }
+                          }
+                          ]
+                          ,"minimum_should_match" : 1
+              ,
+            "filter": [
+              {          "query_string": {
+                    "query": "name.whitespace:*\\"aaa\\"*"
+                  }
+              }
+            ]
+             }\s
+           }\s
+          }
+         }
+        ,"_source": false
+        ,"fields": ["_id"]
+        }
+              """;
       when(elasticSearchClient.sendRequest(expectedQuery,
                                            index)).thenReturn("{\"took\":39,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[{\"_index\":\"profile_v2\",\"_type\":\"_doc\",\"_id\":\"6\",\"_score\":null,\"fields\":{\"userName\":[\"aaa\"]},\"sort\":[\"aaa\"]}]}}");
       COMMONS_UTILS.when(() -> CommonsUtils.getService(Mockito.any())).thenReturn(identityManager);

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/IdentityStorageTest.java
@@ -19,6 +19,7 @@
 package org.exoplatform.social.core.jpa.storage;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -425,12 +426,15 @@ public class IdentityStorageTest extends AbstractCoreTest {
       identityStorage.saveProfile(profile);
       identity.setProfile(profile);
     }
-
+    List<String> remoteIds = new ArrayList<>();
     for (int i = 7; i < total; i++) {
       String remoteId = remoteIdPrefix + i;
       Identity identity = new Identity(OrganizationIdentityProvider.NAME, remoteId + i);
       identityStorage.saveIdentity(identity);
       tearDownIdentityList.add(identity);
+      if (i == total - 1) {
+        remoteIds.add(identity.getRemoteId());
+      }
 
       Profile profile = new Profile(identity);
       profile.setProperty(Profile.FIRST_NAME, "FirstName" + i);
@@ -441,7 +445,6 @@ public class IdentityStorageTest extends AbstractCoreTest {
       identityStorage.saveProfile(profile);
       identity.setProfile(profile);
     }
-
     long offset = 0;
     long limit = Integer.MAX_VALUE;
     String providerId = OrganizationIdentityProvider.NAME;
@@ -452,6 +455,10 @@ public class IdentityStorageTest extends AbstractCoreTest {
     String fieldName = Profile.FULL_NAME;
     List<Identity> result = identityStorage.getIdentities(providerId, sortField, sortDirection, true, null, null,null, offset, limit);
     assertTrue("Returned result count is not consistent", result.size() >= total);
+    assertSorted(remoteIdPrefix, fieldName, result);
+
+    result = identityStorage.getIdentities(providerId, sortField, sortDirection, true, null, null,null, remoteIds, offset, limit);
+    assertEquals(result.size(), 1);
     assertSorted(remoteIdPrefix, fieldName, result);
 
     fieldName = Profile.LAST_NAME;
@@ -514,6 +521,10 @@ public class IdentityStorageTest extends AbstractCoreTest {
     assertTrue("Returned result count is not consistent", result.size() == 3);
     assertSorted(remoteIdPrefix, fieldName, result);
 
+    result = identityStorage.getIdentities(providerId, sortField, sortDirection, true, null, null, "noEnrollmentPossible", remoteIds, offset, limit);
+    assertEquals( result.size(), 1);
+    assertSorted(remoteIdPrefix, fieldName, result);
+
     result = identityStorage.getIdentities(providerId, sortField, sortDirection, true, null, null, "enrolled", offset, limit);
     assertTrue("Returned result count is not consistent", result.size() == 3);
     assertSorted(remoteIdPrefix, fieldName, result);
@@ -564,6 +575,12 @@ public class IdentityStorageTest extends AbstractCoreTest {
     Identity identity = identityStorage.findIdentity(OrganizationIdentityProvider.NAME, "username1");
     identityStorage.processEnabledIdentity(identity, false);
     assertEquals(4, identityStorage.getIdentitiesByProfileFilterCount("organization", pf));
+
+    pf.setRemoteIds(List.of("username1"));
+    identityStorage.processEnabledIdentity(identity, true);
+    assertEquals(1, identityStorage.getIdentitiesByProfileFilterCount("organization", pf));
+    identityStorage.processEnabledIdentity(identity, false);
+    pf.setRemoteIds(new ArrayList<>());
     
     //enable username1
     identityStorage.processEnabledIdentity(identity, true);
@@ -677,9 +694,42 @@ public class IdentityStorageTest extends AbstractCoreTest {
       identities = identityStorage.getIdentitiesByProfileFilter("organization", pf, 30, 40, false);
     } catch (Exception ext) {
       assert false : "Can not get Identity by profile filter. " + ext ;
-    } 
+    }
+    List<String> groupIds = new ArrayList<>();
+    groupIds.add("/organization/employees");
+    pf.setGroupIds(groupIds);
+    identities = identityStorage.getIdentitiesByProfileFilter("organization", pf, 0, 20, false);
+    assertEquals("Number of identities must be " + identities.size(), 5, identities.size());
   }
-  
+
+  /**
+   * Tests {@link IdenityStorage#getIdentitiesByProfileFilter(String, ProfileFilter, int, int, boolean)}
+   *
+   */
+  public void testGetIdentitiesByGroupsIdsAccessList() throws Exception {
+    ProfileFilter pf = new ProfileFilter();
+    Identity identity = new Identity(OrganizationIdentityProvider.NAME, "test");
+    identityStorage.saveIdentity(identity);
+    tearDownIdentityList.add(identity);
+    Profile profile = new Profile(identity);
+    profile.setProperty(Profile.FIRST_NAME, "test");
+    profile.setProperty(Profile.LAST_NAME, "test");
+    profile.setProperty(Profile.FULL_NAME, "test test");
+    profile.setProperty(Profile.ENROLLMENT_DATE, new Date().getTime());
+    identityStorage.saveProfile(profile);
+    identity.setProfile(profile);
+    List<String> groupIds = new ArrayList<>();
+    groupIds.add("/organization/test");
+    pf.setGroupIds(groupIds);
+
+    List<Identity> identities = identityStorage.getIdentitiesByProfileFilter("organization", pf, 0, 20, false);
+    assertEquals("Number of identities must be " + identities.size(), 1, identities.size());
+
+    pf.setName("test");
+
+    identities = identityStorage.getIdentitiesByProfileFilter("organization", pf, 0, 20, false);
+    assertEquals("Number of identities must be " + identities.size(), 1, identities.size());
+  }
   /**
    * Tests {@link IdenityStorage#findIdentityByProfileFilterCount(String, ProfileFilter)}
    * 
@@ -758,6 +808,11 @@ public class IdentityStorageTest extends AbstractCoreTest {
     ProfileFilter profileFilter = new ProfileFilter();
     ProfileFilter firstProfileFilter = new ProfileFilter();
 
+    assertThrows(IllegalStateException.class,
+      () -> identityStorage.getSpaceMemberIdentitiesByProfileFilter(new Space(), profileFilter, SpaceMemberFilterListAccess.Type.MEMBER, 0, 9));
+
+    assertThrows(IllegalArgumentException.class,
+      () -> identityStorage.countSpaceMemberIdentitiesByProfileFilter(null, firstProfileFilter, SpaceMemberFilterListAccess.Type.MEMBER));
     // Test on first character field choice
     profileFilter.setSorting(new Sorting(SortBy.FULLNAME, Sorting.OrderBy.ASC));
     List<Identity> identities = identityStorage.getSpaceMemberIdentitiesByProfileFilter(space, profileFilter, SpaceMemberFilterListAccess.Type.MEMBER, 0, 9);

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/IdentityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/IdentityManagerTest.java
@@ -19,12 +19,7 @@
 package org.exoplatform.social.core.manager;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import java.util.*;
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
 
@@ -535,5 +530,21 @@ public class IdentityManagerTest extends AbstractCoreTest {
     assertNotNull("gotRootIdentity.getId() must not be null", gotRootIdentity.getId());
     assertEquals("gotRootIdentity.getProfile().getProperty(Profile.FIRST_NAME) must be updated: "
         + newFirstName, newFirstName, gotRootIdentity.getProfile().getProperty(Profile.FIRST_NAME));
+  }
+
+  public void testGetIdentitiesByGroupsIdsAccessList() throws Exception {
+    ProfileFilter pf = new ProfileFilter();
+    List<String> groupIds = new ArrayList<>();
+    groupIds.add("/platform/administrators");
+    pf.setGroupIds(groupIds);
+    List<Identity> identities = identityManager.getIdentitiesByProfileFilter("organization", pf);
+    assertTrue("Number of identities must be " + identities.size(), identities.size() > 0);
+    ProfileFilter pf1 = new ProfileFilter();
+    Map<String, String> profileSettings = new HashMap<>();
+    profileSettings.put("fullName","john");
+    pf1.setProfileSettings(profileSettings);
+    pf1.setGroupIds(groupIds);
+    List<Identity> identities1 = identityManager.getIdentitiesByProfileFilter("organization", pf1);
+    assertTrue("Number of identities must be " + identities1.size(), identities.size() > 0);
   }
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -67,6 +67,7 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.services.organization.*;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.picocontainer.Startable;
@@ -85,13 +86,7 @@ import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.rest.UserFieldValidator;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.Query;
-import org.exoplatform.services.organization.User;
-import org.exoplatform.services.organization.UserHandler;
-import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.organization.idm.UserImpl;
-import org.exoplatform.services.organization.search.UserSearchService;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.rest.http.PATCH;
 import org.exoplatform.services.rest.resource.ResourceContainer;
@@ -234,8 +229,6 @@ public class UserRest implements ResourceContainer, Startable {
 
   private SpaceService                    spaceService;
 
-  private UserSearchService               userSearchService;
-
   private ImageThumbnailService           imageThumbnailService;
 
   private ProfilePropertyService          profilePropertyService;
@@ -265,7 +258,6 @@ public class UserRest implements ResourceContainer, Startable {
                   UserStateService userStateService,
                   SpaceService spaceService,
                   UploadService uploadService,
-                  UserSearchService userSearchService,
                   UserExportService userExportService,
                   UserImportService userImportService,
                   ImageThumbnailService imageThumbnailService,
@@ -281,7 +273,6 @@ public class UserRest implements ResourceContainer, Startable {
     this.userStateService = userStateService;
     this.spaceService = spaceService;
     this.uploadService = uploadService;
-    this.userSearchService = userSearchService;
     this.userExportService = userExportService;
     this.userImportService = userImportService;
     this.imageThumbnailService = imageThumbnailService;
@@ -397,6 +388,14 @@ public class UserRest implements ResourceContainer, Startable {
       throw new WebApplicationException(Response.Status.FORBIDDEN);
     }
 
+    if (isDisabled && StringUtils.isNotBlank(q)) {
+        Map<String, String> error = Map.of("error", "Unsupported operation: Can't search for disabled users!");
+        return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(error)
+                        .type(MediaType.APPLICATION_JSON)
+                        .build();
+    }
+
     if (StringUtils.isNotBlank(exportId) && download) {
       try {
         InputStream inputStream = userExportService.downloadUsersExport(exportId, username);
@@ -487,68 +486,20 @@ public class UserRest implements ResourceContainer, Startable {
       filter.setConnected(isConnected != null ? isConnected.equals(CONNECTED) : null);
       filter.setEnrollmentStatus(enrollmentStatus);
       if (!RestUtils.isMemberOfAdminGroup()
-          && RestUtils.isMemberOfDelegatedGroup()
-          && userType != null
-          && !userType.equals(INTERNAL)) {
-        Query query = new Query();
-        if (q != null && !q.isEmpty()) {
-          query.setUserName(q);
-        }
-        List<String> groupIds = ConversationState.getCurrent()
-                                                 .getIdentity()
-                                                 .getMemberships()
-                                                 .stream()
-                                                 .filter(m -> StringUtils.equals("manager", m.getMembershipType()) || StringUtils.equals("*", m.getMembershipType()))
-                                                 .map(MembershipEntry::getGroup)
-                                                 .toList();
-
-        ListAccess<User> usersListAccess = null;
-        if (CollectionUtils.isNotEmpty(groupIds)) {
-          usersListAccess = organizationService.getUserHandler()
-                                               .findUsersByQuery(query,
-                                                                 groupIds,
-                                                                 isDisabled ? UserStatus.DISABLED : UserStatus.ENABLED);
-        }
-
-        totalSize = usersListAccess == null ? 0 : usersListAccess.getSize();
-        int limitToFetch = limit;
-        if (totalSize < (offset + limitToFetch)) {
-          limitToFetch = totalSize - offset;
-        }
-
-        User[] users;
-        if (limitToFetch <= 0 || usersListAccess == null) {
-          users = new User[0];
-        } else {
-          users = usersListAccess.load(offset, limitToFetch);
-        }
-
-        identities = Arrays.stream(users)
-                           .map(user -> identityManager.getOrCreateUserIdentity(user.getUserName()))
-                           .toArray(Identity[]::new);
-      } else if (isDisabled && q != null && !q.isEmpty()) {
-        ListAccess<User> usersListAccess = userSearchService.searchUsers(q, UserStatus.DISABLED);
-        totalSize = usersListAccess.getSize();
-        int limitToFetch = limit;
-        if (totalSize < (offset + limitToFetch)) {
-          limitToFetch = totalSize - offset;
-        }
-
-        User[] users;
-        if (limitToFetch <= 0) {
-          users = new User[0];
-        } else {
-          users = usersListAccess.load(offset, limitToFetch);
-        }
-        identities = Arrays.stream(users)
-                           .map(user -> identityManager.getOrCreateUserIdentity(user.getUserName()))
-                           .toArray(Identity[]::new);
-      } else {
-        ListAccess<Identity> list = identityManager.getIdentitiesByProfileFilter(OrganizationIdentityProvider.NAME, filter, true);
-        identities = list.load(offset, limit);
-        if (returnSize) {
+            && RestUtils.isMemberOfDelegatedGroup()) {
+          List<String> groupIds = ConversationState.getCurrent()
+                  .getIdentity()
+                  .getMemberships()
+                  .stream()
+                  .filter(m -> StringUtils.equals("manager", m.getMembershipType()) || StringUtils.equals("*", m.getMembershipType()))
+                  .map(MembershipEntry::getGroup)
+                  .toList();
+          filter.setGroupIds(groupIds);
+      }
+      ListAccess<Identity> list = identityManager.getIdentitiesByProfileFilter(OrganizationIdentityProvider.NAME, filter, true);
+      identities = list.load(offset, limit);
+      if (returnSize) {
           totalSize = list.getSize();
-        }
       }
     }
     List<DataEntity> profileInfos = new ArrayList<>();

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -18,39 +18,11 @@
  */
 package org.exoplatform.social.rest.impl.users;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.awt.image.BufferedImage;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.FileReader;
-import java.io.InputStream;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-
-import javax.imageio.ImageIO;
-import javax.ws.rs.core.MultivaluedMap;
-
+import io.meeds.social.core.identity.model.UserImportResult;
+import io.meeds.social.core.identity.service.UserExportService;
+import io.meeds.social.core.identity.service.UserImportService;
+import io.meeds.web.security.service.OtpService;
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.ws.frameworks.cometd.ContinuationService;
-import org.json.JSONArray;
-import org.json.JSONObject;
-
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.utils.IOUtil;
 import org.exoplatform.commons.utils.ListAccess;
@@ -58,10 +30,10 @@ import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.cache.CacheService;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.UserStatus;
-import org.exoplatform.services.organization.search.UserSearchService;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.rest.impl.ContainerResponse;
 import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
+import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.services.thumbnail.ImageThumbnailService;
 import org.exoplatform.services.user.UserStateService;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -89,11 +61,24 @@ import org.exoplatform.social.service.test.AbstractResourceTest;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.web.login.recovery.PasswordRecoveryService;
+import org.exoplatform.ws.frameworks.cometd.ContinuationService;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
-import io.meeds.social.core.identity.model.UserImportResult;
-import io.meeds.social.core.identity.service.UserExportService;
-import io.meeds.social.core.identity.service.UserImportService;
-import io.meeds.web.security.service.OtpService;
+import javax.imageio.ImageIO;
+import javax.ws.rs.core.MultivaluedMap;
+import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.FileReader;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 public class UserRestResourcesTest extends AbstractResourceTest {
 
@@ -116,8 +101,6 @@ public class UserRestResourcesTest extends AbstractResourceTest {
   private UserStateService             userStateService;
 
   private MockUploadService            uploadService;
-
-  private UserSearchService            userSearchService;
 
   private UserExportService            userExportService;
 
@@ -161,7 +144,6 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                             settingsService);
     uploadService = (MockUploadService) getContainer().getComponentInstanceOfType(UploadService.class);
     organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
-    userSearchService = getContainer().getComponentInstanceOfType(UserSearchService.class);
     userExportService = mock(UserExportService.class);
     userImportService = new UserImportService();
     userImportService.setIdentityManager(identityManager);
@@ -192,7 +174,6 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                 userStateService,
                                                 spaceService,
                                                 uploadService,
-                                                userSearchService,
                                                 userExportService,
                                                 userImportService,
                                                 imageThumbnailService,
@@ -227,27 +208,27 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     // when
     ContainerResponse response = service("GET", getURLResource("users?q=mar&isDisabled=true&limit=5&offset=0"), "", null, null);
     // then
-    assertEquals(200, response.getStatus());
-    CollectionEntity collections = (CollectionEntity) response.getEntity();
-    assertEquals(0, collections.getEntities().size());
+    assertEquals(400, response.getStatus());
+    Map<String, String> error = (Map<String, String>) response.getEntity();
+    assertEquals("Unsupported operation: Can't search for disabled users!", error.get("error"));
 
     // when
     organizationService.getUserHandler().setEnabled("mary", false, false);
     response = service("GET", getURLResource("users?q=mar&isDisabled=true&limit=5&offset=0"), "", null, null);
 
     // then
-    assertEquals(200, response.getStatus());
-    collections = (CollectionEntity) response.getEntity();
-    assertEquals(1, collections.getEntities().size());
+    assertEquals(400, response.getStatus());
+    error = (Map<String, String>) response.getEntity();
+    assertEquals("Unsupported operation: Can't search for disabled users!", error.get("error"));
 
     // then
     organizationService.getUserHandler().setEnabled("mary", true, false);
     response = service("GET", getURLResource("users?q=mar&isDisabled=true&limit=5&offset=0"), "", null, null);
 
     // then
-    assertEquals(200, response.getStatus());
-    collections = (CollectionEntity) response.getEntity();
-    assertEquals(0, collections.getEntities().size());
+    assertEquals(400, response.getStatus());
+    error = (Map<String, String>) response.getEntity();
+    assertEquals("Unsupported operation: Can't search for disabled users!", error.get("error"));
 
     // test when isDisabled false
     removeResource(UserRest.class);
@@ -275,7 +256,6 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                               userStateService,
                                               spaceService,
                                               uploadService,
-                                              userSearchService,
                                               userExportService,
                                               userImportService,
                                               imageThumbnailService,
@@ -291,7 +271,7 @@ public class UserRestResourcesTest extends AbstractResourceTest {
 
     // then
     assertEquals(200, response.getStatus());
-    collections = (CollectionEntity) response.getEntity();
+    CollectionEntity collections = (CollectionEntity) response.getEntity();
     assertEquals(1, collections.getEntities().size());
 
     // when
@@ -1520,5 +1500,17 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertEquals(1, ((List<DataEntity>) dataEntity.get("managers")).size());
     assertEquals(0, (int) dataEntity.get("managedUsersCount"));
     endSession();
+  }
+
+  public void testGetUsersByDelegatedAdmin() throws Exception {
+
+    startSessionAs("john", new HashSet<MembershipEntry>(Arrays.asList(new MembershipEntry("/platform/delegated", "member"), new MembershipEntry("/platform/users", "manager"), new MembershipEntry("/platform/users", "member"))));
+    getSpaceInstance(700, "john");
+
+    ContainerResponse response = service("GET", getURLResource("users?limit=5&offset=0"), "", null, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    CollectionEntity collections = (CollectionEntity) response.getEntity();
+    assertEquals(4, collections.getEntities().size());
   }
 }


### PR DESCRIPTION
Before this change, as a delegated admin (* in platform/delegated and manager of a group), it was not possible to filter the user list like any other admin. To fix this problem, remove the conditions applied to filter in the userRest, and if the user is a member in platform/delegated, retrieve their groupIds and remoteIds and add them to the filter. After this change, the identityManager service that manages the filter uses Elasticsearch, which requires groupIds, if it has queries in the filter; otherwise, it uses RDBMS, which requires remoteIds.