### PR TITLE
Fix: Chat and videoconference settings disabled on roles - MEED-9978 - meeds-io/meeds#3840.

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
+++ b/webapp/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
@@ -32,6 +32,7 @@
       <space-setting-sovereign />
       <template>
         <extension-registry-components
+          v-if="isActiveSection"
           :params="extensionParams"
           name="SpaceSettings"
           type="space-settings-components"
@@ -48,6 +49,9 @@ export default {
       return {
         spaceId: this.$root.spaceId,
       };
+    },
+    isActiveSection() {
+      return !this.$root.activeSection;
     },
   },
 };


### PR DESCRIPTION
Before this change, go to space roles parameters on its settings page and refresh the page, the chat and videoconference settings are displayed below. To fix this problem, add a condition in this template to not display if the activeSection in the existing . After this change, the page display any not related settings.