### PR TITLE
Fix: User contact information can't be updated if dropdown attribute is not editable - MEED-10022 - meeds-io/meeds#3886

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -257,7 +257,7 @@ export default {
       if (item.value && (!item.multiValued && item.children.length)) {
         item.children = [];
       }
-      if (!this.propertiesToSave.some(e => e.id === item.id)) {
+      if (!this.propertiesToSave.some(e => e.id === item.id) && item.editable) {
         this.propertiesToSave.push(item);
       }    
     },


### PR DESCRIPTION
Before this change, create profile attribute has a dropdown list and not editable then connect with any user and go to your profile and try to update any profile attribute, no update can be made and 401 error displayed on netwrok tab. To fix this problem, add a condition, before adding it to the list of attributes near save, if it is editable. After this change, user can update his profile editable attributes and saved.
