### PR TITLE
fix: Metamsk button is not display when there is an initialURI - MEED-10049 - meeds-io/meeds#3923

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -263,6 +263,7 @@ export default {
     this.displayWelcomeMessage = this.values?.displayWelcomeMessage;
     this.displayProvidersIcons = this.values?.displayProvidersIcons;
     this.listExternalProviders = this.values?.listExternalProviders;
+    this.values.initialUri = this.initialUri;
     this.signinEmailButton = decodeURIComponent(this.values?.signinEmailButton || this.$t('portal.login.SigninUsingEmail'));
     this.$root.$on('login-form-settings-updated', (welcomeBackTranslations,
       newHereTranslations,

--- a/webapp/src/main/webapp/vue-apps/login/components/provider/LoginProviderLink.vue
+++ b/webapp/src/main/webapp/vue-apps/login/components/provider/LoginProviderLink.vue
@@ -96,7 +96,7 @@ export default {
       if (link && link.startsWith('/')) {
         link = this.rememberme && `${link}&_rememberme=true` || link;
       }
-      if (this.initialUri) {
+      if (link && this.initialUri) {
         const separator = link.includes('?') ? '&' : '?';
         link = `${link}${separator}_initialURI=${this.initialUri}`;
       }


### PR DESCRIPTION
Before this fix, the metamask button do not display because the initialUri is not correctly passed. This commit ensure to correctly pass the initialURI

Resolves meeds-io/meeds#3923

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
