### PR TITLE
Fix: Activated users still displayed while filtering to deactivated ones - MEED-10050 - meeds-io/meeds#3926

### DIFF
--- a/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
@@ -135,7 +135,7 @@ export default {
       form.append('searchUserName', 'true');
       form.append('userType', this.type || '');
       form.append('status', this.status || 'ENABLED');
-      form.append('q', this.keyword || '');
+      form.append('q', this.status === 'DISABLED' || !this.keyword ? '' : this.keyword);
       if (this.connectionStatus) {
         form.append('isConnected', this.connectionStatus);
       }


### PR DESCRIPTION
Before this change, go to users management and search for activated users then filter to deactivated users, activated users are listed while this should not be the case. To fix this problem, change the keyword to null when the status is disabled. After this change, the list of results is displayed correctly.