### PR TITLE
fix: Make the link field optional - MEED-10072 - Meeds-io/MIPs#232

### DIFF
--- a/webapp/src/main/webapp/vue-apps/component-image-crop/components/ImageCropDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/component-image-crop/components/ImageCropDrawer.vue
@@ -439,7 +439,6 @@ export default {
     rules() {
       return {
         url: [
-          v => !!v?.length || ' ',
           () => this.isValidLink || this.$t('imageCropDrawer.invalidLink'),
         ],
       };


### PR DESCRIPTION
This change will remove the red border when the link field is empty.