### PR TITLE
fix : [admin] Image from sidebar login portlet cannot be removed MEED-10075 - meeds-io/meeds#3946

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLoginSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar-login/components/SidebarLoginSettingsDrawer.vue
@@ -334,12 +334,24 @@ export default {
               });
             });
           } else {
-            this.savePreferences().then(() => {
-              this.$root.$emit('sidebar-login-settings-updated', this.titleTranslations, this.subtitleTranslations, this.vAlign, this.hAlign, this.backgroundFileId);
-              this.$root.$emit('alert-message', this.$t('sidebarLogin.drawer.savedSuccessfully'), 'success');
-            }).finally(() => this.close());
+            this.$fileAttachmentService.getAttachments(this.$root.objectType, this.$root.translationIdentifier).then(data => {
+              const imageItem = data?.attachments?.[0];
+              if (imageItem) {
+                const fileId = imageItem.id;
+                this.$fileAttachmentService.deleteAttachment(this.$root.objectType, this.$root.translationIdentifier,fileId).then(() => {
+                  this.savePreferences().then(() => {
+                    this.$root.$emit('sidebar-login-settings-updated', this.titleTranslations, this.subtitleTranslations, this.vAlign, this.hAlign, this.backgroundFileId);
+                    this.$root.$emit('alert-message', this.$t('sidebarLogin.drawer.savedSuccessfully'), 'success');
+                  }).finally(() => this.close());
+                });
+              } else {
+                this.savePreferences().then(() => {
+                  this.$root.$emit('sidebar-login-settings-updated', this.titleTranslations, this.subtitleTranslations, this.vAlign, this.hAlign, this.backgroundFileId);
+                  this.$root.$emit('alert-message', this.$t('sidebarLogin.drawer.savedSuccessfully'), 'success');
+                }).finally(() => this.close());
+              }
+            });
           }
-
         });
       });
 


### PR DESCRIPTION
Before this fix, when admin removes image in sidebar login, and then refresh the page, the image cames back. This is because the attachement is not removed before saving preferences when the settings drawer is saved This commit ensure to check if an attachment exists, and if yes, remove it if the user had removed it.

Resolves meeds-io/meeds#3946

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
