### PR TITLE
fix: Restrict activity stream category filter visibility to space members and their connections - MEED-9964 - Meeds-io/meeds#3753 (#5504)

### DIFF
--- a/component/api/src/main/java/io/meeds/social/category/plugin/CategoryPlugin.java
+++ b/component/api/src/main/java/io/meeds/social/category/plugin/CategoryPlugin.java
@@ -74,6 +74,16 @@ public interface CategoryPlugin {
     return getCategoryIds();
   }
 
+  /**
+   * param spaceId Space Identifier
+   * @param username User technical name (login identifier)
+   * @return {@link List} of {@link Category} Ids associated to
+   *         objects switch designated spaceId
+   */
+  default List<Long> getCategoryIds(long spaceId, String username) {
+    return getCategoryIds();
+  }
+
   default CategoryObject getObject(CategoryObject metadataObject) {
     return metadataObject;
   }

--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryPluginService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryPluginService.java
@@ -51,9 +51,10 @@ public interface CategoryPluginService {
   /**
    * @param objectType {@link CategoryObject} type
    * @param spaceId {@link Space} identifier
+   * @param username User technical name (login identifier)
    * @return {@link List} of {@link Category} Ids associated to an object type
    */
-  List<Long> getCategoryIds(String objectType, long spaceId);
+  List<Long> getCategoryIds(String objectType, long spaceId, String username);
 
   /**
    * In some cases such as Activities, the Metadata Object is different, thus

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -626,6 +626,16 @@ public interface ActivityManager {
   }
 
   /**
+   * @param spaceId {@link Space} identifier
+   * @param username User technical name (login identifier)
+   * @return {@link List} of category identifiers associated to all activities
+   *         if spaceId = 0 else of designated space activities
+   */
+  default List<Long> getActivityCategoryIds(long spaceId, String username) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Gets the number of comments and subcomments of an activity.
    *
    * @param activityId {@link ExoSocialActivity} identifier

--- a/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/storage/api/ActivityStorage.java
@@ -1196,4 +1196,12 @@ public interface ActivityStorage {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * @param streamFeedOwnerIds Stream feed ownerIds
+   * @return {@link List} of Category Ids used in Activities
+   */
+  default List<Long> getActivityCategoryIds(Set<Long> streamFeedOwnerIds) {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/component/core/src/main/java/io/meeds/social/activity/plugin/ActivityCategoryPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/activity/plugin/ActivityCategoryPlugin.java
@@ -68,6 +68,11 @@ public class ActivityCategoryPlugin implements CategoryPlugin {
   }
 
   @Override
+  public List<Long> getCategoryIds(long spaceId, String username) {
+    return activityManager.getActivityCategoryIds(spaceId, username);
+  }
+
+  @Override
   public CategoryObject getObject(CategoryObject categoryObject) {
     ExoSocialActivity activity = activityManager.getActivity(categoryObject.getId());
     return activity == null ? categoryObject : new CategoryObject(activity.getMetadataObject());

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
@@ -67,8 +67,8 @@ public class CategoryPluginServiceImpl implements CategoryPluginService {
   }
 
   @Override
-  public List<Long> getCategoryIds(String objectType, long spaceId) {
-    return getCategoryPlugin(objectType).getCategoryIds(spaceId);
+  public List<Long> getCategoryIds(String objectType, long spaceId, String username) {
+    return getCategoryPlugin(objectType).getCategoryIds(spaceId, username);
   }
 
   @Override

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
@@ -101,7 +101,7 @@ public class CategoryServiceImpl implements CategoryService {
       categoryIds = Collections.emptySet();
     } else {
       categoryStorage.getLinkedIds(filter.getObjectType());
-      categoryIds = categoryPluginService.getCategoryIds(filter.getObjectType(), filter.getSpaceId())
+      categoryIds = categoryPluginService.getCategoryIds(filter.getObjectType(), filter.getSpaceId(), username)
                                          .stream()
                                          .flatMap(id -> Stream.concat(this.getAncestorIds(id).stream(), Stream.of(id)))
                                          .collect(Collectors.toSet());

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -1264,6 +1264,11 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
     return activityDAO.getActivityCategoryIds(spaceIdentityId);
   }
 
+  @Override
+  public List<Long> getActivityCategoryIds(Set<Long> streamFeedOwnerIds) {
+    return activityDAO.getActivityCategoryIds(streamFeedOwnerIds);
+  }
+
   private boolean hasOtherComment(ActivityEntity activity, String poster) {
     for (ActivityEntity comment : activity.getComments()) {
       if (poster.equals(comment.getPosterId())) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
@@ -20,6 +20,7 @@ package org.exoplatform.social.core.jpa.storage.dao;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import org.exoplatform.commons.api.persistence.GenericDAO;
 import org.exoplatform.social.core.activity.ActivityFilter;
@@ -501,5 +502,12 @@ public interface ActivityDAO extends GenericDAO<ActivityEntity, Long> {
    * @return {@link List} of Category Ids used in Activities
    */
   List<Long> getActivityCategoryIds(long spaceIdentityId);
+
+
+  /**
+   * @param streamFeedOwnerIds Stream feed ownerIds
+   * @return {@link List} of Category Ids used in Activities
+   */
+  List<Long> getActivityCategoryIds(Set<Long> streamFeedOwnerIds);
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -959,16 +959,19 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
   }
 
   @Override
+  public List<Long> getActivityCategoryIds(Set<Long> streamFeedOwnerIds) {
+    return getEntityManager().createNamedQuery("ActivityEntity.getActivityCategoryIds", Long.class)
+                             .setParameter("owners", streamFeedOwnerIds)
+                             .getResultList();
+  }
+
+  @Override
   public List<Long> getActivityCategoryIds(long spaceIdentityId) {
-    if (spaceIdentityId == 0) {
-      return getEntityManager().createNamedQuery("ActivityEntity.getActivityCategoryIds", Long.class)
-                               .getResultList();
-    } else {
-      return getEntityManager().createNamedQuery("ActivityEntity.getActivityCategoryIdsBySpaceId", Long.class)
-                               .setParameter("spaceIdentityId", spaceIdentityId)
-                               .setParameter(STREAM_TYPE, StreamType.SPACE)
-                               .getResultList();
-    }
+    return getEntityManager().createNamedQuery("ActivityEntity.getActivityCategoryIdsBySpaceId", Long.class)
+                             .setParameter("spaceIdentityId", spaceIdentityId)
+                             .setParameter(STREAM_TYPE, StreamType.SPACE)
+                             .getResultList();
+
   }
 
   private <T> TypedQuery<T> buildQueryFromFilter(ActivityFilter activityFilter,

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ActivityEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ActivityEntity.java
@@ -98,6 +98,7 @@ import lombok.Setter;
         @NamedQuery(name = "ActivityEntity.getActivityCategoryIds", query = """
               SELECT DISTINCT c.categoryId FROM SocActivity a
               INNER JOIN a.categories c
+              WHERE a.ownerId IN (:owners)
             """),
         @NamedQuery(name = "ActivityEntity.getActivityCategoryIdsBySpaceId", query = """
               SELECT DISTINCT c.categoryId FROM SocActivity a

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -319,6 +319,23 @@ public class ActivityManagerImpl implements ActivityManager {
     return activityStorage.getActivityCategoryIds(spaceIdentityId);
   }
 
+  @Override
+  public List<Long> getActivityCategoryIds(long spaceId, String username) {
+    long spaceIdentityId = 0;
+    if (spaceId > 0) {
+      Space space = spaceService.getSpaceById(String.valueOf(spaceId));
+      if (space != null) {
+        Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+        spaceIdentityId = Long.parseLong(spaceIdentity.getId());
+      }
+      return activityStorage.getActivityCategoryIds(spaceIdentityId);
+    } else {
+      Identity viewerIdentity = identityManager.getOrCreateUserIdentity(username);
+      Set<Long> streamFeedOwnerIds = activityStorage.getStreamFeedOwnerIds(viewerIdentity);
+      return activityStorage.getActivityCategoryIds(streamFeedOwnerIds);
+    }
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedActivityStorage.java
@@ -2188,6 +2188,11 @@ public class CachedActivityStorage implements ActivityStorage {
     return storage.getActivityCategoryIds(spaceIdentityId);
   }
 
+  @Override
+  public List<Long> getActivityCategoryIds(Set<Long> streamFeedOwnerIds) {
+    return storage.getActivityCategoryIds(streamFeedOwnerIds);
+  }
+
   public void clearActivityCachedByAttachmentId(String attachmentId) {
     try {
       exoActivityCache.select(new ActivityAttachmentCacheSelector(attachmentId));

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -3197,6 +3197,18 @@ public class ActivityManagerTest extends AbstractCoreTest {
     assertEquals(1, johnActivities.load(0, 10).length);
   }
 
+  @SneakyThrows
+  public void testGetActivityCategoryIds() {
+    String userId = rootIdentity.getId();
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    activity.setTitle("activityTitle");
+    activity.setUserId(userId);
+    activity.setCategoryIds(List.of(2L));
+    activityManager.saveActivityNoReturn(rootIdentity, activity);
+
+    assertEquals(List.of(2L), activityManager.getActivityCategoryIds(0L, "root"));
+  }
+
   private void createActivityToOtherIdentity(Identity posterIdentity,
                                              Identity targetIdentity,
                                              int number) {


### PR DESCRIPTION
This change will fix category filter display for stream

(cherry picked from commit 49ba2f4ec2c4b73d9c621b8789fdd5bbf0bb65bd)