### PR TITLE
fix: workaround for selecting text from comment on Safari - MEED-10056

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
@@ -18,7 +18,7 @@
         :options="commentEditOptions" />
     </div>
     <template v-else>
-      <v-list-item :class="highlightClass" class="pa-0 mb-4 width-fit-content">
+      <v-list-item tabindex :class="highlightClass" class="pa-0 mb-4 width-fit-content">
         <exo-user-avatar
           :identity="posterIdentity"
           :size="33"

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/content/ActivityCommentRichText.vue
@@ -1,6 +1,6 @@
 <template>
   <div :id="ckEditorId">
-    <v-list-item class="pa-0">
+    <v-list-item class="pa-0" tabindex>
       <v-list-item-avatar :size="avatarSize" class="mt-0 mb-auto me-2">
         <img
           :src="avatarUrl"


### PR DESCRIPTION


It is not possible tro select text from comments using Safari browser. This is caused by this bug on Vuetify 2
https://github.com/vuetifyjs/vuetify/issues/12826
This bug won't be fixed for Vuetify 2 and is fixed for vuetify 3. We propose in this PR a workaround for this bug.
