### PR TITLE
fix: set correct profile page title for accessibility - MEED-10108 - Meeds-io/meeds#3967

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -169,6 +169,9 @@ export default {
     },
     isAdmin() {
       return this.user?.isAdmin;
+    },
+    isProfilePage() {
+      return eXo?.env?.portal?.selectedNodeUri === 'profile';
     }
   },
   watch: {
@@ -192,6 +195,13 @@ export default {
     });
   },
   methods: {
+    setPageTitle() {
+      if (this.isProfilePage) {
+        const companyName = eXo.env.portal.companyName;
+        const fullName = this.user?.fullname;
+        window.document.title = this.$t('profileHeader.page.title', {0: fullName, 1: companyName});
+      }
+    },
     editAvatar() {
       this.imageType = 'avatar';
       this.$nextTick()
@@ -243,6 +253,7 @@ export default {
       return this.$userService.getUser(eXo.env.portal.profileOwner, 'relationshipStatus,settings')
         .then(user => {
           this.user = user;
+          this.setPageTitle();
           return this.$nextTick();
         })
         .catch((e) => {


### PR DESCRIPTION
Prior to this change, the profile page title displayed "Profile – Company Name", 
which did not include the user's full name and was not fully suitable for accessibility.

This commit changes the page title to display "Profile of {username} – Company Name",
ensuring it includes the user’s full name and improves accessibility for screen readers.
