### PR TITLE
fix : Unable to update non modifiable property by an admin using REST service - MEED-10110 - meeds-io/meeds#3971

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -1137,7 +1137,7 @@ public class UserRest implements ResourceContainer, Startable {
         profile.removeProperty(name);
         identityManager.updateProfile(profile, getCurrentUser(), true);
       } else {
-        updateProfileField(profile, fieldName, value, true);
+        updateProfileField(profile, fieldName, value, true,currentUser);
       }
     } catch (IllegalAccessException e) {
       LOG.error("User {} is not allowed to update attribute {}", currentUser, name);
@@ -1213,7 +1213,7 @@ public class UserRest implements ResourceContainer, Startable {
 
     try {
       Map<String, Object> userProfileProperties = extractPropertiesFromEntities(profileEntity);
-      saveProfile(username, userProfileProperties);
+      saveProfile(username, userProfileProperties, currentUser);
     } catch (IllegalAccessException e) {
       LOG.error("User {} is not allowed to update attributes", currentUser);
       return Response.status(Status.UNAUTHORIZED).build();
@@ -1326,7 +1326,7 @@ public class UserRest implements ResourceContainer, Startable {
       }
       try {
         if (!(profileProperty.isMultiValued() || !profileProperty.getChildren().isEmpty())) {
-          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), false);
+          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), false, currentUser);
           updateProfilePropertyVisibility(userIdentity, profileProperty);
         } else {
           List<Map<String, String>> maps = new ArrayList<>();
@@ -1343,7 +1343,7 @@ public class UserRest implements ResourceContainer, Startable {
               maps.add(childrenMap);
             }
           });
-          updateProfileField(profile, profileProperty.getPropertyName(), maps, false);
+          updateProfileField(profile, profileProperty.getPropertyName(), maps, false, currentUser);
           updateProfilePropertyVisibility(userIdentity, profileProperty);
         }
       } catch (IllegalAccessException e) {
@@ -1867,7 +1867,7 @@ public class UserRest implements ResourceContainer, Startable {
     return usersLength > 1 || (usersLength == 1 && !StringUtils.equals(users.load(0, 1)[0].getUserName(), username));
   }
 
-  private void saveProfile(String username, Map<String, Object> profileProperties) throws IllegalAccessException,
+  private void saveProfile(String username, Map<String, Object> profileProperties, String modifierUsername) throws IllegalAccessException,
                                                                                    ObjectNotFoundException {
     Identity userIdentity = getUserIdentity(username);
     if (userIdentity == null) {
@@ -1880,7 +1880,7 @@ public class UserRest implements ResourceContainer, Startable {
         String name = entry.getKey();
         Object value = entry.getValue();
         String fieldName = ProfileEntity.getFieldName(name);
-        updateProfileField(profile, fieldName, value, false);
+        updateProfileField(profile, fieldName, value, false, modifierUsername);
       }
       identityManager.updateProfile(profile, getCurrentUser(), true);
     }
@@ -1956,7 +1956,7 @@ public class UserRest implements ResourceContainer, Startable {
     if (onBoardingEmailSent) {
       Identity userIdentity = identityManager.getOrCreateUserIdentity(user.getUserName());
       Profile profile = userIdentity.getProfile();
-      updateProfileField(profile, Profile.ENROLLMENT_DATE, String.valueOf(Calendar.getInstance().getTimeInMillis()), true);
+      updateProfileField(profile, Profile.ENROLLMENT_DATE, String.valueOf(Calendar.getInstance().getTimeInMillis()), true,null);
     }
   }
 
@@ -1964,9 +1964,10 @@ public class UserRest implements ResourceContainer, Startable {
   private void updateProfileField(Profile profile,
                                   String name,
                                   Object value,
-                                  boolean save) throws IllegalAccessException {
+                                  boolean save,
+                                  String modifierUsername) throws IllegalAccessException {
     ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(name);
-    if (propertySetting != null && !propertySetting.isEditable()) {
+    if (propertySetting != null && !propertySetting.isEditable() && (modifierUsername==null || !userACL.getUserIdentity(modifierUsername).isMemberOf(userACL.getAdminGroups()))) {
       throw new IllegalAccessException(String.format("Not allowed to update non modifiable field '%s'", name));
     } else if (Profile.EXTERNAL.equals(name)) {
       throw new IllegalAccessException("Not allowed to update EXTERNAL field");


### PR DESCRIPTION
Before this fix, when and admin try to update a non modifiable profile property using rest, he receive a 403 error, because the user role is not checked in this particular case. This commit ensure to verify the user role when updating a profile property, and allow the user to execute the query if he has admin role. It do not allow the request if the user have not the admin role, even if the user tries to update his own profile

Resolves meeds-io/meeds#3971

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
