### PR TITLE
fix: Display Profile Extended Button in Compact Mode in Mobile View - EXO-83666

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/ActivityComment.vue
@@ -18,7 +18,10 @@
         :options="commentEditOptions" />
     </div>
     <template v-else>
-      <v-list-item tabindex :class="highlightClass" class="pa-0 mb-4 width-fit-content">
+      <v-list-item
+        tabindex
+        :class="highlightClass"
+        class="pa-0 mb-4 width-fit-content">
         <exo-user-avatar
           :identity="posterIdentity"
           :size="33"

--- a/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
@@ -13,7 +13,8 @@
         <component
           v-if="extension.vueComponent"
           :is="extension.vueComponent"
-          :user="user" />
+          :user="user"
+          :compact-display="iconButton" />
         <v-btn
           v-else-if="!extension.init"
           :icon="iconButton"
@@ -170,9 +171,6 @@ export default {
   computed: {
     iconButton() {
       return this.$vuetify.breakpoint.width < this.$vuetify.breakpoint.thresholds.lg;
-    },
-    isMobile() {
-      return this.$vuetify?.breakpoint?.mobile;
     },
     enabledProfileHeaderActionComponents() {
       return this.profileHeaderActionComponents && this.profileHeaderActionComponents.filter(act => act.enabled) || [];


### PR DESCRIPTION
Prior to this change, when displaying the profile buttons registered as extended Vue Components, the '`compactDisplay`' attribute isn't changed to align the display of the extension with other profile Header App buttons display. this change ensures to transmit the attribute with the right value when using Mobile Device to ensure UI consistency.