### PR TITLE
fix: fix contrast issue of text in warning message when sharing a post - MEED-10111 - Meeds-io/meeds#3972

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/ActivityShareDrawer.vue
@@ -48,7 +48,7 @@
           </div>
           <div class="d-flex flex-row mt-4">
             <v-icon class="warning--text">warning</v-icon>
-            <span class="ms-2 grey--text">
+            <span class="ms-2 text-subtitle">
               {{ $t('UIActivity.share.warnMessage') }}
             </span>
           </div>


### PR DESCRIPTION
Prior to this change, the warning message text displayed when sharing a post used the grey--text helper class, which resulted in poor contrast and readability. 
This update replaces grey--text with text-subtitle, improving the text contrast and ensuring better accessibility and visibility of the warning message.
