### PR TITLE
fix : Unable to update non modifiable property by an admin using RESTservice - MEED-10110 - meeds-io/meeds#3971

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -1186,7 +1186,7 @@ public class UserRest implements ResourceContainer, Startable {
         profile.removeProperty(name);
         identityManager.updateProfile(profile, getCurrentUser(), true);
       } else {
-        updateProfileField(profile, fieldName, value, true);
+        updateProfileField(profile, fieldName, value, true,currentUser);
       }
     } catch (IllegalAccessException e) {
       LOG.error("User {} is not allowed to update attribute {}", currentUser, name);
@@ -1262,7 +1262,7 @@ public class UserRest implements ResourceContainer, Startable {
 
     try {
       Map<String, Object> userProfileProperties = extractPropertiesFromEntities(profileEntity);
-      saveProfile(username, userProfileProperties);
+      saveProfile(username, userProfileProperties, currentUser);
     } catch (IllegalAccessException e) {
       LOG.error("User {} is not allowed to update attributes", currentUser);
       return Response.status(Status.UNAUTHORIZED).build();
@@ -1375,7 +1375,7 @@ public class UserRest implements ResourceContainer, Startable {
       }
       try {
         if (!(profileProperty.isMultiValued() || !profileProperty.getChildren().isEmpty())) {
-          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), false);
+          updateProfileField(profile, profileProperty.getPropertyName(), profileProperty.getValue(), false, currentUser);
           updateProfilePropertyVisibility(userIdentity, profileProperty);
         } else {
           List<Map<String, String>> maps = new ArrayList<>();
@@ -1392,7 +1392,7 @@ public class UserRest implements ResourceContainer, Startable {
               maps.add(childrenMap);
             }
           });
-          updateProfileField(profile, profileProperty.getPropertyName(), maps, false);
+          updateProfileField(profile, profileProperty.getPropertyName(), maps, false, currentUser);
           updateProfilePropertyVisibility(userIdentity, profileProperty);
         }
       } catch (IllegalAccessException e) {
@@ -1916,7 +1916,7 @@ public class UserRest implements ResourceContainer, Startable {
     return usersLength > 1 || (usersLength == 1 && !StringUtils.equals(users.load(0, 1)[0].getUserName(), username));
   }
 
-  private void saveProfile(String username, Map<String, Object> profileProperties) throws IllegalAccessException,
+  private void saveProfile(String username, Map<String, Object> profileProperties, String modifierUsername) throws IllegalAccessException,
                                                                                    ObjectNotFoundException {
     Identity userIdentity = getUserIdentity(username);
     if (userIdentity == null) {
@@ -1929,7 +1929,7 @@ public class UserRest implements ResourceContainer, Startable {
         String name = entry.getKey();
         Object value = entry.getValue();
         String fieldName = ProfileEntity.getFieldName(name);
-        updateProfileField(profile, fieldName, value, false);
+        updateProfileField(profile, fieldName, value, false, modifierUsername);
       }
       identityManager.updateProfile(profile, getCurrentUser(), true);
     }
@@ -2005,7 +2005,7 @@ public class UserRest implements ResourceContainer, Startable {
     if (onBoardingEmailSent) {
       Identity userIdentity = identityManager.getOrCreateUserIdentity(user.getUserName());
       Profile profile = userIdentity.getProfile();
-      updateProfileField(profile, Profile.ENROLLMENT_DATE, String.valueOf(Calendar.getInstance().getTimeInMillis()), true);
+      updateProfileField(profile, Profile.ENROLLMENT_DATE, String.valueOf(Calendar.getInstance().getTimeInMillis()), true,null);
     }
   }
 
@@ -2013,9 +2013,10 @@ public class UserRest implements ResourceContainer, Startable {
   private void updateProfileField(Profile profile,
                                   String name,
                                   Object value,
-                                  boolean save) throws IllegalAccessException {
+                                  boolean save,
+                                  String modifierUsername) throws IllegalAccessException {
     ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(name);
-    if (propertySetting != null && !propertySetting.isEditable()) {
+    if (propertySetting != null && !propertySetting.isEditable() && (modifierUsername==null || !userACL.getUserIdentity(modifierUsername).isMemberOf(userACL.getAdminGroups()))) {
       throw new IllegalAccessException(String.format("Not allowed to update non modifiable field '%s'", name));
     } else if (Profile.EXTERNAL.equals(name)) {
       throw new IllegalAccessException("Not allowed to update EXTERNAL field");


### PR DESCRIPTION
Before this fix, when and admin try to update a non modifiable profile property using rest, he receive a 403 error, because the user role is not checked in this particular case. This commit ensure to verify the user role when updating a profile property, and allow the user to execute the query if he has admin role. It do not allow the request if the user have not the admin role, even if the user tries to update his own profile

Resolves meeds-io/meeds#3971

(cherry picked from commit cbb04b42676ac38d88f65f6d9136bbb63800df79)