### PR TITLE
fix: resolve numeric usernames correctly in suggester endpoint - MEED-10129 - Meeds-io/meeds#3981

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -515,6 +515,10 @@ public class PeopleRestService implements ResourceContainer{
     Identity userIdentity;
     if (StringUtils.isNumeric(userId)) {
       userIdentity = getIdentityManager().getIdentity(userId, false);
+
+      if (userIdentity == null || !OrganizationIdentityProvider.NAME.equals(userIdentity.getProviderId())) {
+        userIdentity = getIdentityManager().getOrCreateUserIdentity(userId);
+      }
     } else {
       userIdentity = getIdentityManager().getOrCreateUserIdentity(userId);
     }


### PR DESCRIPTION
Prior to this change, the suggester endpoint treated numeric usernames as identity IDs. This caused `getIdentity() `to be called instead of resolving a user identity, which could result in returning a space identity when the ID matched.

This fix ensures numeric usernames are always resolved as user identities within the suggester endpoint.
