### PR TITLE
feat: add access permission check for ImageThumbnailPlugin - EXO-83521 - exoplatform/eXIP#33

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/thumbnail/ImageThumbnailServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/thumbnail/ImageThumbnailServiceImpl.java
@@ -133,12 +133,15 @@ public class ImageThumbnailServiceImpl implements ImageThumbnailService {
 
   @Override
   public FileItem getOrCreateThumbnail(String fileType, String id, String userName, int width, int height) throws Exception {
+    ImageThumbnailPlugin imageThumbnailPlugin = imageThumbnailPlugins.get(fileType);
+    if (!imageThumbnailPlugin.hasAccessPermission(id, userName)) {
+      throw new IllegalArgumentException("Error checking access rights for on document'" + id + "' fro user " + userName);
+    }
     String thumnailId = fileType.equals(FileThumbnailPlugin.FILE_TYPE) ? id : fileType + id;
     FileItem thumbnail = getThumbnail(thumnailId, width, height);
     if (thumbnail != null) {
       return thumbnail;
     } else {
-      ImageThumbnailPlugin imageThumbnailPlugin = imageThumbnailPlugins.get(fileType);
       if (imageThumbnailPlugin != null) {
         FileContent fileContent = imageThumbnailPlugin.getImage(id, userName);
         if (fileContent != null) {


### PR DESCRIPTION
Prior to this change, there wasn't an access control applied on existing thumbnail. The ACL is applied on Thumbnail generation which may leak information. This change will check the permissions for a user before accessing the Thumbnail or generating it using the `ImageThumbnailPlugin.hasAccessPermission` operation.