### PR TITLE
fix: Fix numeric usernames in suggestions - MEED-10129 - Meeds-io/meeds#3981

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/PeopleRestService.java
@@ -512,16 +512,8 @@ public class PeopleRestService implements ResourceContainer{
                                                          String currentUserId,
                                                          boolean filterByName,
                                                          Locale locale) {
-    Identity userIdentity;
-    if (StringUtils.isNumeric(userId)) {
-      userIdentity = getIdentityManager().getIdentity(userId, false);
 
-      if (userIdentity == null || !OrganizationIdentityProvider.NAME.equals(userIdentity.getProviderId())) {
-        userIdentity = getIdentityManager().getOrCreateUserIdentity(userId);
-      }
-    } else {
-      userIdentity = getIdentityManager().getOrCreateUserIdentity(userId);
-    }
+    Identity userIdentity = getIdentityManager().getIdentity(userId, false);
     if (userIdentity == null) {
       LOG.debug("Cannot find user identity by id nor remoteId {}", userId);
       return userInfos;
@@ -554,8 +546,8 @@ public class PeopleRestService implements ResourceContainer{
     String[] spaceMembers = getSpaceService().getSpaceByPrettyName(spaceByPrettyName).getMembers();
     for (String spaceMember : spaceMembers) {
       Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, spaceMember, false);
-      if (identity.isEnable() && !identity.isDeleted()) {
-        userInfos = addUsernameToInfosList(spaceMember, identityFilter, userInfos, currentUser, true, locale);
+      if (identity != null && identity.isEnable() && !identity.isDeleted()) {
+        addUserToInfosList(identity, identityFilter, userInfos, currentUser, true, locale);
         if (userInfos.size() >= SUGGEST_LIMIT) {
           break;
         }


### PR DESCRIPTION
Prior to this change, numeric usernames in addSpaceMembers could cause incorrect identities to be used or fail to appear in the suggestion list, because the system tried to treat them as identity IDs instead of usernames.

Now, numeric usernames are properly converted to Identities via getOrCreateIdentity() before adding to the suggestion list, ensuring the suggester works correctly for all space members.
