### PR TITLE
fix: Allow to access Space Templates for Anonymous User - MEED-10156 - Meeds-io/meeds#4006

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
@@ -21,12 +21,9 @@ package io.meeds.social.space.template.service;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -172,9 +169,11 @@ public class SpaceTemplateService {
                                              .filter(part -> !part.isEmpty() && NumberUtils.isCreatable(part))
                                              .map(Long::parseLong)
                                              .toList();
-    List<SpaceTemplate> allowedSubspaceTemplates = templateIds.stream().map(id -> getSpaceTemplate(id, locale, true))
-            .filter(Objects::nonNull)
-            .filter(spaceTemplate -> canViewTemplate(spaceTemplate, username)).toList();
+    List<SpaceTemplate> allowedSubspaceTemplates = templateIds.stream()
+                                                              .map(id -> getSpaceTemplate(id, locale, true))
+                                                              .filter(Objects::nonNull)
+                                                              .filter(spaceTemplate -> canViewTemplate(spaceTemplate, username))
+                                                              .toList();
 
     if (CollectionUtils.isEmpty(allowedSubspaceTemplates) && CollectionUtils.isNotEmpty(templateIds)) {
       throw new IllegalAccessException("User '" + username + "' has no access to allowed subspace templates of template "

--- a/component/service/src/main/java/io/meeds/social/space/template/rest/SpaceTemplateRest.java
+++ b/component/service/src/main/java/io/meeds/social/space/template/rest/SpaceTemplateRest.java
@@ -60,7 +60,6 @@ public class SpaceTemplateRest {
   private SpaceTemplateService spaceTemplateService;
 
   @GetMapping
-  @Secured("users")
   @Operation(summary = "Retrieve space templates", method = "GET", description = "This retrieves space templates")
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"), })
   public List<SpaceTemplate> getSpaceTemplates(HttpServletRequest request,
@@ -74,7 +73,6 @@ public class SpaceTemplateRest {
   }
 
   @GetMapping("/{templateId}/subspace-templates")
-  @Secured("users")
   @Operation(summary = "Retrieve allowed subspace templates", description = "Returns the list of subspace templates allowed for the given template.")
   @ApiResponses(value = {
           @ApiResponse(responseCode = "200", description = "Request fulfilled"),
@@ -94,7 +92,6 @@ public class SpaceTemplateRest {
   }
 
   @GetMapping("/subspaceTemplateIds")
-  @Secured("users")
   @Operation(
           summary = "Retrieve subspace template IDs",
           description = "Returns the list of subspace template IDs accessible to the current user."
@@ -105,7 +102,6 @@ public class SpaceTemplateRest {
   }
 
   @GetMapping("{id}")
-  @Secured("users")
   @Operation(summary = "Retrieve a Space template designated by its id", method = "GET",
              description = "This will retrieve a Space template designated by its id")
   @ApiResponses(value = {

--- a/webapp/src/main/webapp/vue-apps/space-creation/components/SpaceCreation.vue
+++ b/webapp/src/main/webapp/vue-apps/space-creation/components/SpaceCreation.vue
@@ -49,7 +49,7 @@
 export default {
   methods: {
     addNewSpace() {
-      window.require(['SHARED/spaceForm'], drawer => drawer.open(false, this.$root.spaceTemplates));
+      window.require(['SHARED/spaceForm'], drawer => drawer.open(null, this.$root.spaceTemplates));
     },
     openDrawerSettings() {
       this.$root.$emit('space-creation-settings-open');

--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -463,17 +463,8 @@ export default {
         this.$refs.spaceFormDrawer.open();
         return;
       }
-      if (!this.templates) {
-        if (!this.$root.spaceTemplates) {
-          this.$root.spaceTemplates = await this.$spaceTemplateService.getSpaceTemplates();
-        }
-        this.templates = this.$root.spaceTemplates;
-      }
-      if (!this.$root.subspaceTemplateIds) {
-        this.$root.subspaceTemplateIds = await this.$spaceTemplateService.getSubspaceTemplateIds();
-      }
-      this.subspaceTemplateIds = this.$root.subspaceTemplateIds;
-      if (this.templates?.length === 1) {
+      await this.refreshTemplates();
+      if (this.templates?.length === 1 && !templateId) {
         this.templateId = this.templates[0].id;
       }
       this.setSpaceTemplateProperties();
@@ -552,12 +543,9 @@ export default {
       if (spaceTemplates) {
         this.templates = spaceTemplates;
       } else {
-        if (!this.$root.spaceTemplates) {
-          this.$root.spaceTemplates = await this.$spaceTemplateService.getSpaceTemplates();
-        }
-        this.templates = this.$root.spaceTemplates;
+        await this.refreshTemplates();
       }
-      if (this.templates?.length === 1) {
+      if (this.templates?.length === 1 && !this.templateId) {
         this.templateId = this.templates[0].id;
       }
       this.setSpaceTemplateProperties();
@@ -652,6 +640,30 @@ export default {
     },
     avatarUpdated(avatar) {
       this.previewAvatar = avatar;
+    },
+    async refreshTemplates() {
+      if (!this.templates) {
+        if (!this.$root.spaceTemplates) {
+          try {
+            this.$root.spaceTemplates = await this.$spaceTemplateService.getSpaceTemplates();
+            this.templates = this.$root.spaceTemplates;
+          } catch (e) {
+            this.templates = [];
+          }
+        } else {
+          this.templates = this.$root.spaceTemplates;
+        }
+      }
+      if (!this.subspaceTemplateIds) {
+        if (!this.$root.subspaceTemplateIds) {
+          try {
+            this.$root.subspaceTemplateIds = await this.$spaceTemplateService.getSubspaceTemplateIds();
+          } catch (e) {
+            this.templates = [];
+          }
+        }
+        this.subspaceTemplateIds = this.$root.subspaceTemplateIds;
+      }
     },
     goBack() {
       this.templateId = null;

--- a/webapp/src/main/webapp/vue-apps/spaces-list-components/components/common/SpaceCreationButton.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list-components/components/common/SpaceCreationButton.vue
@@ -169,11 +169,11 @@ export default {
       this.displaySpaceCreationMenu = this.isMemberInParentSpace && this.subspaceTemplateIds.length && !this.$root.openedSpaceTemplateId;
     },
     addNewSpace() {
-      const spaceTemplate = this.$root.openedSpaceTemplateId;
+      const spaceTemplateId = this.$root.openedSpaceTemplateId;
       if (this.requireFormDrawer) {
-        window.require(['SHARED/spaceForm'], drawer => drawer.open(spaceTemplate, !spaceTemplate && this.filteredSpaceTemplates));
+        window.require(['SHARED/spaceForm'], drawer => drawer.open(spaceTemplateId, !spaceTemplateId && this.filteredSpaceTemplates));
       } else {
-        this.$root.$emit('addNewSpace', spaceTemplate, !spaceTemplate && this.filteredSpaceTemplates);
+        this.$root.$emit('addNewSpace', spaceTemplateId, !spaceTemplateId && this.filteredSpaceTemplates);
       }
     },
     addNewSubSpace() {


### PR DESCRIPTION
Prior to this change, when attempting to create a space using a template accessible to 'everyone' using an anonymous user, the space form isn't displayed. This change ensures to allow accessing the allowed space templates even anonymously.

Resolves Meeds-io/meeds#4006