### PR TITLE
feat: Retrieve Memberships from User ACL instead of OrganizationService - MEED-10149 - Meeds-io/MIPs#240

### DIFF
--- a/component/core/src/main/java/io/meeds/social/observe/plugin/ActivityOberverPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/observe/plugin/ActivityOberverPlugin.java
@@ -18,13 +18,9 @@
  */
 package io.meeds.social.observe.plugin;
 
-import java.util.List;
-
 import org.exoplatform.commons.exception.ObjectNotFoundException;
-import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.security.Identity;
-import org.exoplatform.services.security.IdentityRegistry;
-import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -33,26 +29,22 @@ import io.meeds.social.observe.model.ObserverObject;
 
 public class ActivityOberverPlugin extends ObserverPlugin {
 
-  public static final String  OBJECT_TYPE                = "activity";
+  public static final String    OBJECT_TYPE                = "activity";
 
-  private static final String ACTIVITY_WITH_ID_NOT_FOUND = "Activity with id  %s doesn't exist";
+  private static final String   ACTIVITY_WITH_ID_NOT_FOUND = "Activity with id  %s doesn't exist";
 
-  private ActivityManager     activityManager;
+  private final ActivityManager activityManager;
 
-  private IdentityManager     identityManager;
+  private final IdentityManager identityManager;
 
-  private IdentityRegistry    identityRegistry;
-
-  private OrganizationService organizationService;
+  private final UserACL         userAcl;
 
   public ActivityOberverPlugin(ActivityManager activityManager,
                                IdentityManager identityManager,
-                               OrganizationService organizationService,
-                               IdentityRegistry identityRegistry) {
+                               UserACL userAcl) {
     this.activityManager = activityManager;
     this.identityManager = identityManager;
-    this.organizationService = organizationService;
-    this.identityRegistry = identityRegistry;
+    this.userAcl = userAcl;
   }
 
   @Override
@@ -71,7 +63,7 @@ public class ActivityOberverPlugin extends ObserverPlugin {
       throw new ObjectNotFoundException(String.format("Identity with id  %s doesn't exist", identityId));
     }
     try {
-      Identity aclIdentity = getIdentity(identity.getRemoteId());
+      Identity aclIdentity = userAcl.getUserIdentity(identity.getRemoteId());
       return activityManager.isActivityViewable(activity, aclIdentity);
     } catch (Exception e) {
       throw new IllegalStateException(String.format("Error retrieving ACL identity of %s", identityId), e);
@@ -110,18 +102,4 @@ public class ActivityOberverPlugin extends ObserverPlugin {
     }
   }
 
-  private Identity getIdentity(String userId) throws Exception {
-    Identity aclIdentity = identityRegistry.getIdentity(userId);
-    if (aclIdentity == null) {
-      List<MembershipEntry> entries = organizationService.getMembershipHandler()
-                                                         .findMembershipsByUser(userId)
-                                                         .stream()
-                                                         .map(membership -> new MembershipEntry(membership.getGroupId(),
-                                                                                                membership.getMembershipType()))
-                                                         .toList();
-      aclIdentity = new Identity(userId, entries);
-      identityRegistry.register(aclIdentity);
-    }
-    return aclIdentity;
-  }
 }

--- a/component/core/src/test/java/io/meeds/social/observer/plugin/ActivityOberverPluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/observer/plugin/ActivityOberverPluginTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import org.exoplatform.portal.config.UserACL;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,11 +79,14 @@ public class ActivityOberverPluginTest {
   @Mock
   private org.exoplatform.services.security.Identity aclIdentity;
 
+  @Mock
+  private UserACL                                    userACL;
+
   ActivityOberverPlugin                              activityOberverPlugin;
 
   @Before
   public void setUp() {
-    activityOberverPlugin = new ActivityOberverPlugin(activityManager, identityManager, organizationService, identityRegistry);
+    activityOberverPlugin = new ActivityOberverPlugin(activityManager, identityManager, userACL);
     when(identity.getRemoteId()).thenReturn(USER_NAME);
     when(activity.getSpaceId()).thenReturn(SPACE_ID);
     when(activity.getActivityStream()).thenReturn(activityStream);
@@ -100,8 +104,8 @@ public class ActivityOberverPluginTest {
     when(activityManager.getActivity(OBJECT_ID)).thenReturn(activity);
     assertThrows(ObjectNotFoundException.class, () -> activityOberverPlugin.canObserve(IDENTITY_ID, OBJECT_ID));
     when(identityManager.getIdentity(IDENTITY_ID)).thenReturn(identity);
+    when(userACL.getUserIdentity(USER_NAME)).thenThrow(IllegalStateException.class).thenReturn(aclIdentity);
     assertThrows(IllegalStateException.class, () -> activityOberverPlugin.canObserve(IDENTITY_ID, OBJECT_ID));
-    when(identityRegistry.getIdentity(USER_NAME)).thenReturn(aclIdentity);
     assertFalse(activityOberverPlugin.canObserve(IDENTITY_ID, OBJECT_ID));
     when(activityManager.isActivityViewable(activity, aclIdentity)).thenReturn(true);
     assertTrue(activityOberverPlugin.canObserve(IDENTITY_ID, OBJECT_ID));

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentWatchPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentWatchPlugin.java
@@ -18,7 +18,6 @@
  */
 package org.exoplatform.social.notification.plugin;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,10 +27,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.services.organization.Membership;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.security.IdentityRegistry;
-import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -44,24 +41,21 @@ public class ActivityCommentWatchPlugin extends ActivityCommentPlugin {
 
   public static final String  ID = "ActivityCommentWatchPlugin";
 
-  private ObserverService     observerService;
+  private final ObserverService     observerService;
 
-  private IdentityManager     identityManager;
+  private final IdentityManager     identityManager;
 
-  private IdentityRegistry    identityRegistry;
-
-  private OrganizationService organizationService;
+  private final UserACL             userAcl;
 
   public ActivityCommentWatchPlugin(ObserverService observerService,
                                     IdentityManager identityManager,
-                                    IdentityRegistry identityRegistry,
+                                    UserACL userAcl,
                                     OrganizationService organizationService,
                                     InitParams initParams) {
     super(initParams);
     this.observerService = observerService;
     this.identityManager = identityManager;
-    this.identityRegistry = identityRegistry;
-    this.organizationService = organizationService;
+    this.userAcl = userAcl;
   }
 
   @Override
@@ -90,7 +84,7 @@ public class ActivityCommentWatchPlugin extends ActivityCommentPlugin {
                                           .map(this::getUsername)
                                           .filter(u -> !commentReceivers.contains(u))
                                           .filter(username -> {
-                                            org.exoplatform.services.security.Identity aclIdentity = getAclIdentity(username);
+                                            org.exoplatform.services.security.Identity aclIdentity = userAcl.getUserIdentity(username);
                                             return aclIdentity != null
                                                 && Utils.getActivityManager().isActivityViewable(comment, aclIdentity);
                                           })
@@ -130,26 +124,8 @@ public class ActivityCommentWatchPlugin extends ActivityCommentPlugin {
   }
 
   private String getUsername(long identityId) {
-    Identity identity = identityManager.getIdentity(String.valueOf(identityId));
+    Identity identity = identityManager.getIdentity(identityId);
     return identity == null ? null : identity.getRemoteId();
-  }
-
-  private org.exoplatform.services.security.Identity getAclIdentity(String userId) {
-    org.exoplatform.services.security.Identity aclIdentity = identityRegistry.getIdentity(userId);
-    if (aclIdentity == null) {
-      try {
-        Collection<Membership> memberships = organizationService.getMembershipHandler().findMembershipsByUser(userId);
-        List<MembershipEntry> entries = memberships.stream()
-                                                   .map(membership -> new MembershipEntry(membership.getGroupId(),
-                                                                                          membership.getMembershipType()))
-                                                   .toList();
-        aclIdentity = new org.exoplatform.services.security.Identity(userId, entries);
-        identityRegistry.register(aclIdentity);
-      } catch (Exception e) {
-        return null;
-      }
-    }
-    return aclIdentity;
   }
 
 }


### PR DESCRIPTION
This change will centralize the users memberships retrieval to be made from `UserACL` Service rather than `OrganizationService`. This centralization will allow to optimize the Code enhancements and evolutivity.