### PR TITLE
feat: make email, call and messaging properties linkable - MEED-10167, MEED-10168 - Meeds-io/MIPs#231

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/ProfileContactInformation_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/ProfileContactInformation_en.properties
@@ -41,3 +41,6 @@ profileContactInformation.quickSearch.noPeople=No People
 profileContactInformation.quickSearch.resetFilter=Reset
 profileContactInformation.invisible.property.cant.be.hidden.label=The attribute is already hidden by the administrator
 profileContactInformation.dropdown.property.choose.label=Choose a value
+profileContactInformation.message.field.required=This field is required
+profileContactInformation.message.field.call.invalid=Invalid call/service number format
+profileContactInformation.message.field.email.invalid=Invalid email address

--- a/webapp/src/main/resources/locale/portlet/social/ProfileContactInformation_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/social/ProfileContactInformation_fr.properties
@@ -41,3 +41,6 @@ profileContactInformation.quickSearch.noPeople=Aucun utilisateur
 profileContactInformation.quickSearch.resetFilter=Réinitialiser
 profileContactInformation.invisible.property.cant.be.hidden.label=L'attribut est déjà masqué par l'administrateur
 profileContactInformation.dropdown.property.choose.label=Choisir une valeur
+profileContactInformation.message.field.required=Ce champ est obligatoire
+profileContactInformation.message.field.call.invalid=Format de num\u00E9ro d'appel/service invalide
+profileContactInformation.message.field.email.invalid=Adresse e-mail invalide

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -2870,24 +2870,7 @@
       <adapter>
         (function() {
           <include>/js/lib/autolinker.min.js</include>
-          Vue.directive('autolinker',(el, binding) => el.innerHTML = Autolinker.link(binding.value, {
-            sanitizeHtml: true,
-            replaceFn : function (match) {
-              switch(match.getType()) {
-                case 'url' :
-                  if(match.getUrl().indexOf('/') === 0 || match.getUrl().indexOf(window.location.origin) === 0) {
-                    return true;
-                  } else {
-                    const tag = match.buildTag();
-                    tag.setAttr('target', '_blank');
-                    tag.setAttr('rel', 'nofollow noopener noreferrer');
-                    return tag;
-                  }
-                default :
-                  return true;
-              }
-            }
-          }));
+          <include>/js/autolinker.directive.js</include>
           return Autolinker;
         })();
       </adapter>

--- a/webapp/src/main/webapp/js/autolinker.directive.js
+++ b/webapp/src/main/webapp/js/autolinker.directive.js
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+Vue.directive('autolinker', (el, binding) => {
+  if (!binding.value) {
+    el.innerHTML = '';
+    return;
+  }
+
+  const isPhone = ['phone', 'call', 'messaging'].includes(binding.arg);
+  const isEmail = binding.arg === 'email';
+
+  const autolinker = new Autolinker({
+    sanitizeHtml: true,
+    phone: isPhone,
+    email: isEmail,
+    hashtag: false,
+    mention: false,
+    replaceFn(match) {
+      if (match.getType() === 'url') {
+        const url = match.getUrl();
+        if (url.indexOf('/') === 0 ||
+            url.indexOf(window.location.origin) === 0) {
+          return true;
+        } else {
+          const tag = match.buildTag();
+          tag.setAttr('target', '_blank');
+          tag.setAttr('rel', 'nofollow noopener noreferrer');
+          return tag;
+        }
+      }
+      return true;
+    }
+  });
+
+  let html = autolinker.link(binding.value);
+
+  if (isPhone) {
+    html = html.replaceAll(/([*#+]?\d[\d\s().-]{0,20}#?)/g, match => {
+      if (
+        html.includes(`href="tel:${match}`) ||
+          /<\/?a\b[^>]*>/i.test(match) ||
+          /^(?:https?:\/\/|www\.)[^\s]+$|^[^@\s]+@[^@\s]+\.[A-Za-z]{2,}$/i.test(match)
+      ) {
+        return match;
+      }
+
+      const safeNumber = match
+        .replaceAll(/&/g, '&amp;')
+        .replaceAll(/</g, '&lt;')
+        .replaceAll(/>/g, '&gt;');
+
+      return `<a href="tel:${safeNumber}">${safeNumber}</a>`;
+    });
+  }
+
+  el.innerHTML = html;
+});

--- a/webapp/src/main/webapp/vue-apps/common/js/Utils.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/Utils.js
@@ -1,3 +1,7 @@
+
+const PHONE_REGEX = /^([+*#]?\d{1,20}#?)$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[a-zA-Z]{2,}$/;
+
 const TEXTAREA = document.createElement('textarea');
 const HTML_ENTITIES = {
   nbsp: ' ',
@@ -181,4 +185,20 @@ export function isLinuxOs() {
 
 export function isMacOs() {
   return detectOS() === 'Mac';
+}
+
+export function isValidPhone(value) {
+  return !!value && PHONE_REGEX.test(value);
+}
+
+export function isValidEmail(value) {
+  return !!value && EMAIL_REGEX.test(value);
+}
+
+export function isValidUrl(value) {
+  return !!Autolinker.parse(String(value || ''), {
+    urls: true,
+    email: false,
+    phone: false
+  })?.[0]?.getAnchorHref?.();
 }

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformation.vue
@@ -100,7 +100,8 @@ export default {
     user: null,
     excludedSearchProps: [],
     settings: [],
-    userCardSettings: null
+    userCardSettings: null,
+    nonSearchablePropertyTypes: ['call', 'messaging', 'user', 'email']
   }),
   computed: {
     isMobile() {
@@ -160,8 +161,14 @@ export default {
                                .every(child => child.hidden));
     },
     isSearchable(property) {
-      return property.propertyType !=='user' && !this.excludedSearchProps?.includes(property.propertyName)
-                         && !new RegExp(`^(${this.excludedSearchProps?.join('.|')}.)`)?.exec(property.propertyName) ;
+      if (this.nonSearchablePropertyTypes?.includes(property.propertyType)) {
+        return false;
+      }
+      if (this.excludedSearchProps?.includes(property.propertyName)) {
+        return false;
+      }
+      return !(this.excludedSearchProps?.length &&
+          new RegExp(`^(${this.excludedSearchProps.join('|')})\\.`).test(property.propertyName));
     },
     quickSearch(property, childProperty) {
       if (this.excludedSearchProps.includes(property.propertyName)) {

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/ProfileContactInformationDrawer.vue
@@ -16,7 +16,7 @@
           v-for="property in propertiesToDisplay"
           :key="property.id">
           <profile-contact-user-type-property
-            v-if="property.propertyType=== 'user'"
+            v-if="property.propertyType === 'user'"
             :property="property"
             @property-updated="propertyUpdated" />
           <profile-contact-edit-multi-field
@@ -30,30 +30,13 @@
             :disabled="disabledField(property)"
             :property-label="getResolvedName(property)"
             @property-updated="propertyUpdated" />
-          <div v-else>
-            <v-card-text class="d-flex flex-grow-1 text-no-wrap pb-2">
-              {{ getResolvedName(property) }}
-              <span v-if="property.required">*</span>
-            </v-card-text>
-            <v-card-text class="d-flex py-0">
-              <v-card-text
-                :title="disabledFieldTitle(property)"
-                class="d-flex pa-0">
-                <input
-                  v-model="property.value"
-                  :disabled="saving || disabledField(property)"
-                  :type="property.propertyName==='email' ? 'email' : 'text'"
-                  :required="property.required"
-                  :ref="`${property.propertyName}Input`" 
-                  class="ignore-vuetify-classes"
-                  maxlength="2000"
-                  @change="propertyUpdated(property)"
-                  @input="propertyUpdated(property)">
-              </v-card-text>
-              <profile-hide-property-button
-                :property="property" />
-            </v-card-text>
-          </div>
+          <profile-property-input
+            v-else
+            :property="property"
+            :disabled="saving || disabledField(property)"
+            :disabled-field-title="disabledFieldTitle(property)"
+            :resolved-name="getResolvedName(property)"
+            @updated="onInput(property, $event)" />
         </div>
       </v-form>
     </template>
@@ -79,6 +62,7 @@
 </template>
 
 <script>
+
 export default {
   data: () => ({
     lang: eXo?.env.portal.language,
@@ -98,7 +82,7 @@ export default {
     },
     isEmailPropertyHidden() {
       return this.emailProperty?.visible === false || this.emailProperty?.hiddenable === false;
-    }
+    },
   },
   created() {
     this.$root.$on('open-profile-contact-information-drawer', this.open);
@@ -142,7 +126,7 @@ export default {
       if (proptocheck && proptocheck.children.length > 0) {
         let errorFound = false;
         proptocheck.children.forEach(property => {
-          if (!property.value || property.value.length===0 || !String(property.value).match(/((http(s)?:\/\/.)|www.)[-a-zA-Z0-9@:%._\\+~#=]{2,256}/g)){
+          if (!property.value || property.value.length===0 || !this.$utils.isValidUrl(property.value)) {
             this.$root.$emit('non-valid-url-input', property.value);
             errorFound = true;
           }
@@ -251,6 +235,10 @@ export default {
       this.propertiesToSave = [];
       this.disabled = true;
       this.$refs.profileContactInformationDrawer.open();
+    },
+    onInput(property, propertyValue) {
+      property.value = propertyValue;
+      this.propertyUpdated(property);
     },
     propertyUpdated(item) {
       this.disabled = false;

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileSingleValuedProperty.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/ProfileSingleValuedProperty.vue
@@ -57,7 +57,7 @@
       <span
         v-else
         class="font-weight-regular"
-        v-autolinker="property.value">
+        v-autolinker:[propertyType]="property.value">
         {{ propertyDisplayValue }}
       </span>
     </div>
@@ -100,6 +100,9 @@ export default {
     },
     propertyDisplayValue() {
       return this.propertyOption?.translatedValue ?? this.propertyOption?.value ?? this.property.value;
+    },
+    propertyType() {
+      return this.property?.propertyType;
     }
   },
   methods: {

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfilePropertyInput.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/property-type/action/ProfilePropertyInput.vue
@@ -1,0 +1,119 @@
+<!--
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ -->
+
+<template>
+  <div>
+    <v-card-text class="d-flex flex-grow-1 text-no-wrap pb-2">
+      {{ resolvedName }}
+      <span v-if="isRequired">*</span>
+    </v-card-text>
+    <v-card-text class="d-flex py-0">
+      <v-card-text
+        :title="disabledFieldTitle"
+        class="d-flex pa-0 flex-grow-1">
+        <v-text-field
+          v-model="localValue"
+          :disabled="disabled"
+          :type="inputType"
+          :required="isRequired"
+          :rules="rulesInput"
+          :ref="`${propertyName}Input`"
+          maxlength="2000"
+          hide-details="auto"
+          class="pt-0"
+          dense
+          outlined
+          @input="$emit('updated', localValue)"
+          @change="$emit('updated', localValue)" />
+      </v-card-text>
+      <profile-hide-property-button
+        :property="property" />
+    </v-card-text>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    property: {
+      type: Object,
+      default: null
+    },
+    resolvedName: {
+      type: String,
+      default: null
+    },
+    disabledFieldTitle: {
+      type: String,
+      default: null
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      localValue: this.property?.value || '',
+    };
+  },
+  watch: {
+    'property.value'(newVal) {
+      this.localValue = newVal;
+    }
+  },
+  computed: {
+    isRequired() {
+      return this.property?.required;
+    },
+    propertyName() {
+      return this.property?.propertyName;
+    },
+    inputType() {
+      return (
+        this.property?.propertyName === 'email' ||
+          this.property?.propertyType === 'email'
+      ) ? 'email' : 'text';
+    },
+    rulesInput() {
+      const rules = [];
+      if (this.isRequired) {
+        rules.push(v => !!v
+            || this.$t('profileContactInformation.message.field.required'));
+      }
+      switch (this.property?.propertyType) {
+      case 'call':
+      case 'messaging':
+        rules.push(v => !v || this.$utils.isValidPhone(v)
+            || this.$t('profileContactInformation.message.field.call.invalid'));
+        break;
+      case 'email':
+        rules.push(v => !v || this.$utils.isValidEmail(v)
+            || this.$t('profileContactInformation.message.field.email.invalid'));
+        break;
+      default:
+        break;
+      }
+      return rules;
+    },
+  }
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/initComponents.js
@@ -10,6 +10,7 @@ import ProfileHiddenPropertyInfo from './components/property-type/ProfileHiddenP
 import ProfileContactUserTypeProperty from './components/property-type/ProfileContactUserTypeProperty.vue';
 import ProfileUserTypePropertyValues from './components/property-type/ProfileUserTypePropertyValues.vue';
 import ProfileDropdownProperty from './components/property-type/ProfileDropdownProperty.vue';
+import ProfilePropertyInput from './components/property-type/action/ProfilePropertyInput.vue';
 
 const components = {
   'profile-contact-information': ProfileContactInformation,
@@ -23,7 +24,8 @@ const components = {
   'profile-hidden-property-info': ProfileHiddenPropertyInfo,
   'profile-contact-user-type-property': ProfileContactUserTypeProperty,
   'profile-user-type-property-values': ProfileUserTypePropertyValues,
-  'profile-dropdown-property': ProfileDropdownProperty
+  'profile-dropdown-property': ProfileDropdownProperty,
+  'profile-property-input': ProfilePropertyInput
 };
 
 for (const key in components) {


### PR DESCRIPTION
- Convert email, call and messaging profile properties into clickable links
- Enable opening of dedicated native apps (mail client, phone dialer, messaging app)
- Support service numbers (e.g. *123#,, emergency numbers) for call/messaging types
- Preserve existing autolinker behavior for URLs and normal phone numbers
- Ensure safe parsing (no double-linking, no nested anchors, sanitized output)
