### PR TITLE
fix: Use a customized background to 'see more' in posts - MEED-10163 - Meeds-io/meeds#4016

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -12,7 +12,7 @@
     <v-btn
       v-if="collapsed && !fullContent && readMore"
       :aria-label="$t('UIActivity.label.seeMore')"
-      :class="!isComment && 'linear-gradient-white-background' || 'linear-gradient-comment-background'"
+      :class="!isComment && 'linear-gradient-app-background' || 'linear-gradient-comment-background'"
       class="d-flex ms-auto mb-0 pb-2px pl-2 pr-0 height-auto position-absolute text-light-color r-0 b-0 hover-underline hover-blue-color"
       text
       plain


### PR DESCRIPTION
Prior to this change, when adding a customized background for the user activity stream, the “See More” button in posts did not have the selected background. This change will use a helper class 'linear-gradient-app-background' instead of 'linear-gradient-white-background' that applies the customized background for this application.