### PR TITLE
fix : Make OIDC logout working when end_session_endpoint is present in configuration - MEED-10192 - meeds-io/meeds#4024

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/filter/OAuthLogoutFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/filter/OAuthLogoutFilter.java
@@ -1,0 +1,82 @@
+package io.meeds.oauth.filter;
+
+import co.elastic.clients.elasticsearch.nodes.Http;
+import io.meeds.oauth.spi.AccessTokenContext;
+import io.meeds.oauth.spi.OAuthProviderType;
+import io.meeds.oauth.spi.OAuthProviderTypeRegistry;
+import io.meeds.oauth.spi.SocialNetworkService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.UserProfile;
+import org.gatein.sso.agent.filter.api.AbstractSSOInterceptor;
+
+import java.io.IOException;
+
+public class OAuthLogoutFilter extends AbstractSSOInterceptor {
+
+  protected final Log LOG = ExoLogger.getLogger(OAuthLogoutFilter.class);
+  public static final String OAUTH_LOGOUT_ATTRIBUTE = "OAUTH_LOGOUT_IN_PROGRESS";
+
+
+  public OAuthLogoutFilter() {
+  }
+
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+    HttpServletRequest request = (HttpServletRequest) servletRequest;
+    HttpServletResponse response = (HttpServletResponse) servletResponse;
+    String remoteUser = request.getRemoteUser();
+    if (isPortalLogoutInProgress(request) && !StringUtils.isEmpty(remoteUser)) {
+      //if (StringUtils.isBlank(getPortalLogoutURLFromSession(request))) {
+        //request.getSession().setAttribute(OAUTH_LOGOUT_ATTRIBUTE, request.getRequestURI());
+        try {
+          OAuthProviderTypeRegistry oauthRegistry = getService(OAuthProviderTypeRegistry.class);
+          for (OAuthProviderType oAuthProviderType : oauthRegistry.getEnabledOAuthProviders()) {
+            LOG.debug("Logging out from OAuth provider: " + oAuthProviderType.getKey());
+            if (oAuthProviderType.getOauthProviderProcessor().processLogout(request, response, oAuthProviderType)) {
+              return;
+            }
+          }
+        } catch (Exception e) {
+          LOG.error("Unable to get OAuthProviderTypeRegistry during logout", e);
+        }
+      //}
+    }
+    filterChain.doFilter(servletRequest, servletResponse);
+
+  }
+
+  protected <T> T getService(Class<T> clazz) {
+    return PortalContainer.getInstance().getComponentInstanceOfType(clazz);
+  }
+  public static boolean isPortalLogoutInProgress(HttpServletRequest request) {
+    return request.getRequestURI().equals("/portal/logout") && request.getRemoteUser() != null;
+  }
+
+  @Override
+  protected void initImpl() {
+
+  }
+
+  private static String getPortalLogoutURLFromSession(HttpServletRequest request) {
+    return request.getSession().getAttribute(OAUTH_LOGOUT_ATTRIBUTE) == null ? null
+                                                                             : request.getSession()
+                                                                                      .getAttribute(OAUTH_LOGOUT_ATTRIBUTE)
+                                                                                      .toString();
+  }
+
+  public static boolean isOAuthLogoutInProgress(HttpServletRequest request) {
+    return request.getRemoteUser() != null && StringUtils.isNotBlank(getPortalLogoutURLFromSession(request))
+        && !StringUtils.equals(getPortalLogoutURLFromSession(request), "DONE");
+  }
+}

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/filter/OAuthLogoutFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/filter/OAuthLogoutFilter.java
@@ -1,23 +1,35 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package io.meeds.oauth.filter;
 
-import co.elastic.clients.elasticsearch.nodes.Http;
-import io.meeds.oauth.spi.AccessTokenContext;
 import io.meeds.oauth.spi.OAuthProviderType;
 import io.meeds.oauth.spi.OAuthProviderTypeRegistry;
-import io.meeds.oauth.spi.SocialNetworkService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.UserProfile;
 import org.gatein.sso.agent.filter.api.AbstractSSOInterceptor;
 
 import java.io.IOException;
@@ -37,20 +49,17 @@ public class OAuthLogoutFilter extends AbstractSSOInterceptor {
     HttpServletResponse response = (HttpServletResponse) servletResponse;
     String remoteUser = request.getRemoteUser();
     if (isPortalLogoutInProgress(request) && !StringUtils.isEmpty(remoteUser)) {
-      //if (StringUtils.isBlank(getPortalLogoutURLFromSession(request))) {
-        //request.getSession().setAttribute(OAUTH_LOGOUT_ATTRIBUTE, request.getRequestURI());
-        try {
-          OAuthProviderTypeRegistry oauthRegistry = getService(OAuthProviderTypeRegistry.class);
-          for (OAuthProviderType oAuthProviderType : oauthRegistry.getEnabledOAuthProviders()) {
-            LOG.debug("Logging out from OAuth provider: " + oAuthProviderType.getKey());
-            if (oAuthProviderType.getOauthProviderProcessor().processLogout(request, response, oAuthProviderType)) {
-              return;
-            }
+      try {
+        OAuthProviderTypeRegistry oauthRegistry = getService(OAuthProviderTypeRegistry.class);
+        for (OAuthProviderType oAuthProviderType : oauthRegistry.getEnabledOAuthProviders()) {
+          LOG.debug("Logging out from OAuth provider: " + oAuthProviderType.getKey());
+          if (oAuthProviderType.getOauthProviderProcessor().processLogout(request, response, oAuthProviderType)) {
+            return;
           }
-        } catch (Exception e) {
-          LOG.error("Unable to get OAuthProviderTypeRegistry during logout", e);
         }
-      //}
+      } catch (Exception e) {
+        LOG.error("Unable to get OAuthProviderTypeRegistry during logout", e);
+      }
     }
     filterChain.doFilter(servletRequest, servletResponse);
 

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/openid/OpenIdProcessorImpl.java
@@ -38,11 +38,18 @@ import java.util.SimpleTimeZone;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.meeds.oauth.spi.AccessTokenContext;
+import io.meeds.oauth.spi.OAuthProviderType;
+import io.meeds.oauth.spi.SocialNetworkService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.services.organization.UserProfileHandler;
+import org.exoplatform.web.login.LoginUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -81,6 +88,8 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
 
   private String                      accessTokenURL;
 
+  private String                      endSessionURL;
+
   private String                      userInfoURL;
 
   private final String                clientID;
@@ -105,7 +114,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
 
   private final SecureRandomService   secureRandomService;
 
-
+  private final boolean propagateLogoutToIDP;
 
   private List<String> customClaims;
   private String       customClaimsMultiValuedSeparator;
@@ -151,7 +160,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
                           .collect(Collectors.toList());
     this.customClaimsMultiValuedSeparator = params.getValueParam("customClaimsMultiValueSeparator").getValue();
 
-
+    this.propagateLogoutToIDP = Boolean.parseBoolean(params.getValueParam("propagateLogoutToIDP").getValue());
 
     if (log.isDebugEnabled()) {
       log.debug("configuration: clientId=" + clientID
@@ -163,7 +172,8 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
           ", applicationName=" + applicationName +
           ", chunkLength=" + chunkLength +
           ", customClaims=" + customClaims +
-          ", customClaimsMultivaluedSeparator=" + customClaimsMultiValuedSeparator);
+          ", customClaimsMultivaluedSeparator=" + customClaimsMultiValuedSeparator +
+          ", propagateLogoutToIDP=" + propagateLogoutToIDP);
     }
 
     this.secureRandomService = secureRandomService;
@@ -204,10 +214,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
 
       SimpleDateFormat expireFormat = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss zzz");
       expireFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
-      Date d = new Date();
-      d.setTime(d.getTime() + oidcCookieLifetime * 1000);
-      String cookieLifeTime = expireFormat.format(d);
-      response.setHeader("Set-Cookie", "OPENID_ACCESS_TOKEN="+tokenResponse.getAccessToken()+" ; Path=/; Expires=" + cookieLifeTime + "; HttpOnly;SameSite=Lax");
+      response.setHeader("Set-Cookie", "OPENID_ACCESS_TOKEN="+tokenResponse.getAccessToken()+" ; Path=/; Max-Age=" + oidcCookieLifetime + "; HttpOnly;SameSite=Lax");
       return new InteractionState<>(InteractionState.State.FINISH, accessTokenContext);
     }
 
@@ -389,7 +396,12 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
                                             OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN,
                                             false,
                                             chunkLength);
-
+    String encodedAccessTokenSecret = codec.encodeString(accessToken.accessToken.getRawResponse());
+    OAuthPersistenceUtils.saveLongAttribute(encodedAccessTokenSecret,
+                                            userProfile,
+                                            OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN_SECRET,
+                                            false,
+                                            chunkLength);
   }
 
   @Override
@@ -522,6 +534,9 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
       this.authenticationURL = json.getString("authorization_endpoint");
       this.accessTokenURL = json.getString("token_endpoint");
       this.userInfoURL = json.getString("userinfo_endpoint");
+      if (json.has("end_session_endpoint")) {
+        this.endSessionURL = json.getString("end_session_endpoint");
+      }
       this.issuer = json.getString("issuer");
       this.remoteJwkSigningKeyResolver = new RemoteJwkSigningKeyResolver(this.wellKnownConfigurationUrl);
       this.wellKnownConfigurationLoaded = true;
@@ -555,4 +570,42 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
   public String getCustomClaimsMultiValuedSeparator() {
     return customClaimsMultiValuedSeparator;
   }
+
+
+  @Override
+  public boolean processLogout(HttpServletRequest request, HttpServletResponse response, OAuthProviderType oAuthProviderType) throws IOException {
+    if (request.getRemoteUser() != null) {
+
+
+      String remoteUser = request.getRemoteUser();
+      SocialNetworkService socialNetworkService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(SocialNetworkService.class);
+      AccessTokenContext accessToken = socialNetworkService.getOAuthAccessToken(oAuthProviderType, remoteUser);
+      if (accessToken != null && accessToken instanceof OpenIdAccessTokenContext openIdAccessTokenContext) {
+        for (Cookie cookie : request.getCookies()) {
+          if (cookie.getName().equals("OPENID_ACCESS_TOKEN") && !StringUtils.isEmpty(cookie.getValue())) {
+            log.info("OpenID logout : found OPENID_ACCESS_TOKEN cookie, remove it");
+            response.setHeader("Set-Cookie", "OPENID_ACCESS_TOKEN="+" ; Path=/;  Max-Age=0; HttpOnly;SameSite=Lax");
+            response.sendRedirect(request.getRequestURI());
+            return true;
+          }
+        }
+
+        if (this.endSessionURL==null) {
+          return false;
+        }
+
+        if (!this.propagateLogoutToIDP) {
+          return false;
+        }
+
+        String tokenId = new JSONObject(openIdAccessTokenContext.accessToken.getRawResponse()).get("id_token").toString();
+        String logoutUrl = this.endSessionURL + "?" + "id_token_hint="+tokenId+"&post_logout_redirect_uri="+this.redirectURL.replace("openidAuth","logout");
+        socialNetworkService.removeOAuthAccessToken(oAuthProviderType,remoteUser);
+        response.sendRedirect(logoutUrl);
+        return true;
+      }
+    }
+    return false;
+  }
 }
+

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/spi/OAuthProviderProcessor.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/spi/OAuthProviderProcessor.java
@@ -156,4 +156,15 @@ public interface OAuthProviderProcessor<T extends AccessTokenContext> {
    * @param userProfile from which data will be removed
    */
   void removeAccessTokenFromUserProfile(UserProfile userProfile);
+
+  /**
+   * Logout user from this OAuth provider. Default implementation does nothing.
+   * Concrete OAuth processors may override this method to perform specific
+   * logout operations on OAuth provider side (for example revoke tokens, call
+   * logout endpoints, etc.)
+   */
+  default boolean processLogout(HttpServletRequest request, HttpServletResponse response, OAuthProviderType<T> oAuthProviderType) throws IOException {
+    // Default implementation does nothing
+    return false;
+  }
 }

--- a/component/oauth-auth/src/main/resources/conf/portal/configuration.xml
+++ b/component/oauth-auth/src/main/resources/conf/portal/configuration.xml
@@ -165,6 +165,10 @@
         <name>customClaimsMultiValueSeparator</name>
         <value>${exo.oauth.custom.claims.multivalue.separator:;}</value>
       </value-param>
+      <value-param>
+        <name>propagateLogoutToIDP</name>
+        <value>${exo.oauth.openid.propagate.logout:false}</value>
+      </value-param>
     </init-params>
   </component>
 
@@ -206,6 +210,29 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>io.meeds.oauth.webapi.OAuthFilterIntegrator</target-component>
+    <component-plugin>
+      <name>OAuthLogoutFilter</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.oauth.webapi.OAuthFilterIntegratorPlugin</type>
+      <init-params>
+        <value-param>
+          <name>filterClass</name>
+          <value>io.meeds.oauth.filter.OAuthLogoutFilter</value>
+        </value-param>
+        <!-- It's always enable here but not used if all OAuthProviders (social networks) are disabled. See OAuthFilterIntegratorImpl -->
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>filterMapping</name>
+          <value>/logout</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
   <external-component-plugins>
     <target-component>io.meeds.oauth.webapi.OAuthFilterIntegrator</target-component>
     <component-plugin>

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
@@ -124,7 +124,7 @@
 export default {
   data: () => ({
     settingsUrl: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/settings`,
-    logoutUrl: `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings/?portal:action=Logout&portal:componentId=UIPortal`,
+    logoutUrl: `${eXo.env.portal.context}/logout`,
     profileUri: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile`,
     productName: eXo.env.portal.productName,
     productLink: eXo.env.portal.productLink,


### PR DESCRIPTION
Before this fix, when using OIDC, some IDP provide a endsession_endpoint url, to make a logout on the IDP after being loggued out from the SP, and eXo do not use this url This commit ensure to send the user in this url if existing and if property exo.oauth.openid.propagate.logout is set to true To achieve this modification, this commit create a new handler in the platform to manage the logout : LogoutHandler on /portal/logout. The old logout code (UIPortal.LogoutActionListener) is removed

Resolves meeds-io/meeds#4024

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
