### PR TITLE
fix: clean zero-width characters on paste to prevent incorrect char counter - MEED-10229 - Meeds-io/meeds#3976

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -544,6 +544,10 @@ export default {
             self.inputVal = newData;
           },
           paste: function (evt) {
+            const data = evt.data;
+            if (data.dataValue) {
+              data.dataValue = self.cleanPastedText(data.dataValue);
+            }
             if (!self.disableImageAttachmentPaste && self.$refs?.attachmentsInput && evt.data.dataTransfer.getFilesCount() > 0) {
               const files = [];
               for (let i = 0; i < evt.data.dataTransfer.getFilesCount(); i++ ) {
@@ -560,6 +564,18 @@ export default {
           }
         }
       });
+    },
+    methods: {
+      cleanPastedText(text) {
+        if (!text) {
+          return text;
+        }
+        let cleaned = text;
+        cleaned = cleaned.replaceAll(/[\u200B-\u200D\uFEFF]/g, '');
+        cleaned = cleaned.replaceAll(/\u00A0/g, ' ');
+        cleaned = cleaned.replaceAll(/\s+/g, ' ');
+        return cleaned;
+      }
     },
     destroyCKEditor: function () {
       this.editor?.destroy?.(true);


### PR DESCRIPTION
Prior to this change, invisible zero-width and non-breaking space characters were preserved when pasting content into the space description field.

As a result, each time the space description was saved, the character counter changed because those hidden characters were progressively removed during processing, causing inconsistent and confusing behavior.

This fix introduces a paste cleanup function that removes zero-width and non-breaking space characters before inserting the content into CKEditor, ensuring the character counter remains stable across saves.
