### PR TITLE
fix: externalTag is not displayed in user popover - MEED-10232 - meeds-io/meeds#4043

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -411,7 +411,7 @@ export default {
       }
     },
     isExternal() {
-      return this.userIdentity?.external === 'true';
+      return this.userIdentity?.external === 'true' || this.userIdentity?.external === true;
     },
     externalTag() {
       return `( ${this.$t('userAvatar.external.label')} )`;


### PR DESCRIPTION
Before this fix, the externalTag is not displayed in user popover. This is because, when testing if the user is external in the object userIdentity, the external property is sometime a boolean, sometimes the string "true". This commit ensure to check both type, so that the external is correctly displayed

Resolves meeds-io/meeds#4043

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
