### PR TITLE
fix: Enable space setting update button for long descriptions and support larger HTML content - MEED-10229 - Meeds-io/meeds#3976

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -1226,4 +1226,7 @@
     </createIndex>
   </changeSet>
 
+  <changeSet author="social" id="1.0.0-meed-3976">
+    <modifyDataType tableName="SOC_SPACES" columnName="DESCRIPTION" newDataType="CLOB"/>
+  </changeSet>
 </databaseChangeLog>

--- a/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -447,6 +447,10 @@ export default {
             self.inputVal = newData;
           },
           paste: function (evt) {
+            const data = evt.data;
+            if (data.dataValue) {
+              data.dataValue = self.cleanPastedText(data.dataValue);
+            }
             if (!self.disableImageAttachmentPaste && self.$refs?.attachmentsInput && evt.data.dataTransfer.getFilesCount() > 0) {
               const files = [];
               for (let i = 0; i < evt.data.dataTransfer.getFilesCount(); i++ ) {
@@ -463,6 +467,16 @@ export default {
           }
         }
       });
+    },
+    cleanPastedText(text) {
+      if (!text) {
+        return text;
+      }
+      let cleaned = text;
+      cleaned = cleaned.replaceAll(/[\u200B-\u200D\uFEFF]/g, '');
+      cleaned = cleaned.replaceAll(/\u00A0/g, ' ');
+      cleaned = cleaned.replaceAll(/\s+/g, ' ');
+      return cleaned;
     },
     destroyCKEditor: function () {
       this.editor?.destroy?.(true);
@@ -653,7 +667,6 @@ export default {
     updateInput(content) {
       if (this.editorReady) {
         const message = this.getContentToSave(content);
-        this.inputVal = message;
         if (!this.activityId && this.useDraftManagement && this.contextName) {
           localStorage.setItem(`activity-message-${this.contextName}`,  JSON.stringify({'url': this.baseUrl, 'text': this.inputVal}));
         }

--- a/webapp/src/main/webapp/vue-apps/space-settings/components/section/SpaceSettingOverviewSection.vue
+++ b/webapp/src/main/webapp/vue-apps/space-settings/components/section/SpaceSettingOverviewSection.vue
@@ -77,7 +77,8 @@
               tag-enabled
               class="mb-2"
               ck-editor-type="spaceDescription"
-              disable-suggester />
+              disable-suggester
+              @validity-updated="validityUpdated" />
           </div>
           <div class="d-flex flex-column flex-grow-1 flex-shrink-1 col-12 col-sm-6 pa-0 mx-0 mx-sm-2">
             <space-setting-avatar
@@ -124,6 +125,7 @@ export default {
     bannerUploadId: null,
     savingSpace: false,
     maxDescriptionLength: 2000,
+    validDescriptionLength: true,
     cropOptions: {
       aspectRatio: 1,
       viewMode: 1,
@@ -133,7 +135,7 @@ export default {
     saveButtonDisabled() {
       return this.savingSpace
         || !this.displayName
-        || (this.description?.length || 0) > this.maxDescriptionLength;
+        || !this.validDescriptionLength;
     },
     maxUploadSizeInBytes() {
       return Number(this.maxUploadSize) * 1024 *1024;
@@ -147,6 +149,9 @@ export default {
     document.removeEventListener('space-settings-updated', this.reset);
   },
   methods: {
+    validityUpdated(validLength) {
+      this.validDescriptionLength = validLength;
+    },
     reset() {
       this.displayName = this.$root?.space?.displayName;
       this.description = this.$root?.space?.description;


### PR DESCRIPTION
Prior to this change, The Update button in the Identity & Appearance settings was disabled when editing the description field, even if the content length of visibly text chars was below the previous max of 2000 characters. Additionally, saving large HTML content was limited by the DESCRIPTION column type.

This commit:
Updated the save button state logic to depend on the actual HTML content length, allowing the "Update" button to be enabled correctly before reaching the max length. Extended the DESCRIPTION column type to CLOB to support saving larger HTML content.
