### PR TITLE
fix: Parent space selection step is missing when creating a subspace from the sidebar - MEED-10256 - Meeds-io/meeds#4054

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -654,8 +654,8 @@ export default {
           this.templates = this.$root.spaceTemplates;
         }
       }
-      if (!this.subspaceTemplateIds) {
-        if (!this.$root.subspaceTemplateIds) {
+      if (!this.subspaceTemplateIds?.length) {
+        if (!this.$root?.subspaceTemplateIds) {
           try {
             this.$root.subspaceTemplateIds = await this.$spaceTemplateService.getSubspaceTemplateIds();
           } catch (e) {


### PR DESCRIPTION
Prior to this change, when attempting to create a subspace from the sidebar, the space form drawer was displayed without prompting the user to select a parent space. As a result, an exception was thrown.
The issue was caused by the uninitialized subspaceTemplateIds list, which is used to determine whether a template is a sub-template.
This change properly initializes subspaceTemplateIds, resolving the issue.