### PR TITLE
feat: Do not allow to use a subspace template as a parent one - MEED-10257 - Meeds-io/meeds#4058

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/template/plugin/decorator/SpaceTemplateGroupDecoratorPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/plugin/decorator/SpaceTemplateGroupDecoratorPlugin.java
@@ -86,6 +86,7 @@ public class SpaceTemplateGroupDecoratorPlugin extends BaseComponentPlugin imple
                                                                 .collect(Collectors.toSet());
 
       group.setEnclosingMemberships(templateEnclosingMembership);
+      group.setLabel(spaceTemplate.getName());
       return group;
     } catch (Exception e) {
       LOG.error("Failed to decorate space template group {}. Group will be returned without decoration.", group.getId(), e);

--- a/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/service/SpaceTemplateService.java
@@ -420,7 +420,9 @@ public class SpaceTemplateService {
   }
 
   public SpaceTemplate getSpaceTemplateByGroupId(String groupId) {
-    return spaceTemplateStorage.getSpaceTemplateByGroupId(groupId);
+    SpaceTemplate spaceTemplate = spaceTemplateStorage.getSpaceTemplateByGroupId(groupId);
+    computeSpaceTemplateAttributes(spaceTemplate, getDefaultLocale());
+    return spaceTemplate;
   }
 
   private void createSpaceTemplateGroupIfNotExist(long templateId) throws ObjectNotFoundException {

--- a/webapp/src/main/resources/locale/portlet/SpaceTemplatesManagement_en.properties
+++ b/webapp/src/main/resources/locale/portlet/SpaceTemplatesManagement_en.properties
@@ -159,3 +159,4 @@ spaceTemplate.parentSpaceTemplate.type.label=Parent
 spaceTemplate.subspaceTemplate.type.label=Subspace
 spaceTemplate.enclosingMembership.title=Associate space members to a group
 spaceTemplate.enclosingMembership.label=Select the group for space members using this template
+spaceTemplate.subspaces.disable.message=You cannot set this one as a parent space template. Indeed, it is already used as a subspace for this parent space template: {0}

--- a/webapp/src/main/webapp/vue-apps/space-templates-management/components/drawer/SpaceTemplateCharacteristicsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-templates-management/components/drawer/SpaceTemplateCharacteristicsDrawer.vue
@@ -283,9 +283,11 @@
                   v-model="canHaveSubspaces"
                   :aria-label="canHaveSubspaces && $t('spaceTemplate.subspacesConfigurationStepCanHaveSubspaces') || $t('spaceTemplate.subspacesConfigurationStepCannotHaveSubspaces')"
                   :aria-checked="canHaveSubspaces ? 'true' : 'false'"
+                  :disabled="isSubspaceTemplate"
                   class="mb-0 mt-1 me-2 pa-0 r-0 absolute-vertical-center" />
               </div>
             </div>
+            <span v-if="isSubspaceTemplate" class="text-subtitle px-2">{{ subspaceDisableMessage }}</span>
           </div>
           <template v-if="canHaveSubspaces">
             <div class="d-flex flex-column">
@@ -517,6 +519,26 @@ export default {
         noDataLabel: this.$t('spaceTemplate.templateSuggester.noDataLabel'),
       };
     },
+    isSubspaceTemplate() {
+      return this.$root?.subspacesTemplateIds?.includes(this.spaceTemplate?.id) || false;
+    },
+    parentSpaceTemplateName() {
+      const parent = this.$root.spaceTemplates.find(template =>
+        Array.isArray(template.allowedSubspaceTemplates) &&
+          template.allowedSubspaceTemplates.some(subspaceId =>
+            Number(subspaceId.split(':')[0]) === this.spaceTemplate.id
+          )
+      );
+      return parent?.name || '';
+    },
+    subspaceDisableMessage() {
+      if (!this.isSubspaceTemplate) {
+        return '';
+      }
+      return this.$t('spaceTemplate.subspaces.disable.message', {
+        0: this.parentSpaceTemplateName,
+      });
+    }
   },
   watch: {
     description() {


### PR DESCRIPTION
Prior to this change, it was possible to use a subspace template as a parent space template, which could create a circular dependency. This change prevents using a subspace template as a parent.

In addition, this change decorates the space template group label with the default space template label to ensure the group label remains consistent when it is modified from the group management.