### PR TITLE
fix: support emoji characters in SOC_SPACES.DESCRIPTION column for MySQL - Meeds-io/meeds#3976

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -1268,4 +1268,13 @@
   <changeSet author="social" id="1.0.0-meed-3976">
     <modifyDataType tableName="SOC_SPACES" columnName="DESCRIPTION" newDataType="CLOB"/>
   </changeSet>
+
+  <changeSet author="social" id="1.0.0-meed-3976-fix" dbms="mysql">
+    <sql>
+        ALTER TABLE SOC_SPACES
+        MODIFY COLUMN DESCRIPTION LONGTEXT
+        CHARACTER SET utf8mb4
+        COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
The DESCRIPTION column in SOC_SPACES was converted to CLOB via Liquibase's modifyDataType, which caused MySQL to lose the utf8mb4 charset and fall back to utf8 (3-byte only). This resulted in a SQLException when inserting data containing 4-byte UTF-8 characters such as emojis.

Fix: Added a MySQL-specific Liquibase changeset that explicitly alters the DESCRIPTION column to LONGTEXT with CHARACTER SET utf8mb4 and COLLATE utf8mb4_unicode_ci, ensuring full Unicode support.
