### PR TITLE
fix: Enhance post content see more button display - MEED-10267 - Meeds-io/meeds#4063

### DIFF
--- a/component/service/src/main/resources/locale/social/Webui_en.properties
+++ b/component/service/src/main/resources/locale/social/Webui_en.properties
@@ -123,7 +123,7 @@ UIActivity.input.Add_your_comment=Add your comment...
 UIActivity.label.Show_All_Comments=View all {0} comments.
 UIActivity.label.Hide_All_Comments=Hide all {0} comments.
 UIActivity.label.Show_Previous_Comments=View previous comments.
-UIActivity.label.seeMore=...see more
+UIActivity.label.seeMore=see more
 
 
 

--- a/component/service/src/main/resources/locale/social/Webui_fr.properties
+++ b/component/service/src/main/resources/locale/social/Webui_fr.properties
@@ -123,7 +123,7 @@ UIActivity.input.Add_your_comment=Ajoutez votre commentaire...
 UIActivity.label.Show_All_Comments=Voir tous les  {0} commentaires.
 UIActivity.label.Hide_All_Comments=Masquer tous {0} les commentaires.
 UIActivity.label.Show_Previous_Comments=Voir les commentaires précédents.
-UIActivity.label.seeMore=... voir plus
+UIActivity.label.seeMore=voir plus
 
 
 

--- a/webapp/src/main/webapp/skin/less/portlet/ActivityStream/Style.less
+++ b/webapp/src/main/webapp/skin/less/portlet/ActivityStream/Style.less
@@ -41,7 +41,7 @@
     }
   }
   .postContent {
-    font-family: NoLineClamp, NoLineClampHelvetica, NoLineClampArial, NoLineClampSansSerif, NoLineClampRoboto, Helvetica, Arial, sans-serif;
+    font-family: NoLineClampHelvetica, NoLineClampArial, NoLineClampSansSerif, NoLineClampRoboto, Helvetica, Arial, sans-serif;
   }
 
   .pinnedActivity {

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -7,13 +7,13 @@
       :html="bodyElement"
       :element="element"
       :class="bodyClass"
-      class="reset-style-box rich-editor-content text-break"
+      class="reset-style-box rich-editor-content text-break mb-0"
       dir="auto" />
     <v-btn
       v-if="collapsed && !fullContent && readMore"
       :aria-label="$t('UIActivity.label.seeMore')"
       :class="!isComment && 'linear-gradient-app-background' || 'linear-gradient-comment-background'"
-      class="d-flex ms-auto mb-0 pb-2px pl-2 pr-0 height-auto position-absolute text-light-color r-0 b-0 hover-underline hover-blue-color"
+      class="d-flex ms-auto mb-0 pb-2px pl-2 pr-0 height-auto text-light-color r-0 b-0 hover-underline hover-blue-color"
       text
       plain
       @click="displayFullContent">

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityLink.vue
@@ -109,12 +109,12 @@
           v-if="summary"
           :child="summaryElement"
           :class="bodyClass"
-          class="text-wrap text-break reset-style-box rich-editor-content text-color"
+          class="text-wrap text-break reset-style-box rich-editor-content text-color mb-0"
           dir="auto" />
         <v-btn
           v-if="showReadMore"
           :aria-label="$t('UIActivity.label.seeMore')"
-          class="d-flex ms-auto pb-2px mb-0 pl-2 pr-0 height-auto position-absolute r-0 b-0 text-light-color linear-gradient-white-background hover-underline hover-blue-color"
+          class="d-flex ms-auto pb-2px mb-0 pl-2 pr-0 height-auto r-0 b-0 text-light-color linear-gradient-white-background hover-underline hover-blue-color"
           text
           plain
           @click="displayFullContent">


### PR DESCRIPTION
Prior to this change, for posts with long content, the `see more` button was displayed at the end of the text, making it hard to read and sometimes invisible when the background changed. This update improves the display by moving the `see more` button to the next line