### PR TITLE
fix: Reaction drawer doesn't list all activity likes - MEED-10254 - Meeds-io/meeds#4039

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikesList.vue
@@ -4,6 +4,15 @@
       v-for="liker in likers"
       :key="liker.id"
       :liker="liker" />
+    <v-btn
+      v-if="hasMoreLikers"
+      :loading="loading"
+      :disabled="loading"
+      block
+      class="btn pa-0 mt-2"
+      @click="loadMore">
+      {{ $t('Search.button.loadMore') }}
+    </v-btn>
   </div>
 </template>
 <script>
@@ -21,8 +30,15 @@ export default {
   data () {
     return {
       likers: [],
-      limit: 10,
+      limit: 20,
+      likersSize: 0,
+      loading: false
     };
+  },
+  computed: {
+    hasMoreLikers() {
+      return this.likersSize > this.limit;
+    }
   },
   created() {
     this.$root.$on('activity-liked', this.handleActivityLikesUpdate);
@@ -48,14 +64,16 @@ export default {
       }
     },
     retrieveLikers() {
-      return this.$activityService.getActivityLikers(this.activityId, 0)
+      this.loading = true;
+      return this.$activityService.getActivityLikers(this.activityId, 0, this.limit)
         .then(data => {
           this.likers = data.likes;
+          this.likersSize = data.size;
           this.updateLikers();
         })
         .catch((e => {
           console.error('error retrieving activity likers' , e) ;
-        }));
+        })).finally(() => this.loading = false);
     },
     updateLikers() {
       document.dispatchEvent(new CustomEvent('update-reaction-extension', {
@@ -64,6 +82,10 @@ export default {
           type: 'like'
         }
       }));
+    },
+    loadMore() {
+      this.limit = this.limit + 20;
+      this.retrieveLikers();
     }
   },
 };

--- a/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityReactionsDrawer.vue
@@ -38,16 +38,6 @@
         </v-tab-item>
       </v-tabs-items>
     </template>
-    <template v-if="hasMoreLikers" slot="footer">
-      <v-btn
-        :loading="loading"
-        :disabled="loading"
-        block
-        class="btn pa-0"
-        @click="loadMore">
-        {{ $t('Search.button.loadMore') }}
-      </v-btn>
-    </template>
   </exo-drawer>
 </template>
 


### PR DESCRIPTION
Prior to this change, the reaction drawer did not display all activity likers when the number of likes exceeded 50. The issue was caused by fetching likers using the default limit value (50). This update enhances the fetching mechanism by initially fetching 20 likers and adding a `Load Mor`e button when additional results are available