### PR TITLE
fix: Remove usage of sessionId in javascript - EXO-84888 - meeds-io/si#10

### DIFF
--- a/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -50,7 +50,6 @@
      eXo.env.portal.cometdToken = "<%=cometdToken%>";
      eXo.env.portal.cometdContext = "<%=cometdContext%>";
      eXo.env.portal.isOrganizationalChartEnabled = <%=profilePropertySetting != null && profilePropertySetting.isActive()%>;
-     eXo.env.server.sessionId = "<%=rcontext.getRequest().getSession(true).getId()%>";
      eXo.env.portal.vuetifyPreset = {
        dark: true,
        silent: !eXo.developing,

--- a/webapp/src/main/webapp/vue-apps/common/js/UserService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/UserService.js
@@ -166,7 +166,7 @@ export function getPending(offset, limit, expand) {
 }
 
 export function getUserSuggestions() {
-  const cachedSuggestions = sessionStorage && sessionStorage.getItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+  const cachedSuggestions = sessionStorage && sessionStorage.getItem(`Suggestions_Users_${eXo.env.portal.userName}`);
   if (cachedSuggestions) {
     return Promise.resolve(JSON.parse(cachedSuggestions));
   }
@@ -183,7 +183,7 @@ export function getUserSuggestions() {
   }).then(data => {
     if (sessionStorage && data) {
       try {
-        sessionStorage.setItem(`Suggestions_Users_${eXo.env.server.sessionId}`, JSON.stringify(data));
+        sessionStorage.setItem(`Suggestions_Users_${eXo.env.portal.userName}`, JSON.stringify(data));
       } catch (e) {
         // Expected when Quota Error is thrown 
       }
@@ -194,7 +194,7 @@ export function getUserSuggestions() {
 
 export function connect(userId) {
   if (sessionStorage) {
-    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.portal.userName}`);
   }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/relationships?expand=sender`, {
     method: 'POST',
@@ -219,7 +219,7 @@ export function connect(userId) {
 
 export function confirm(userId) {
   if (sessionStorage) {
-    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.portal.userName}`);
   }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/relationships?expand=sender`, {
     method: 'PUT',
@@ -244,7 +244,7 @@ export function confirm(userId) {
 
 export function ignore(receiver) {
   if (sessionStorage) {
-    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.portal.userName}`);
   }
   const sender = eXo.env.portal.userName;
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/relationships?expand=sender`, {
@@ -272,7 +272,7 @@ export function ignore(receiver) {
 
 export function deleteRelationship(userId) {
   if (sessionStorage) {
-    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.server.sessionId}`);
+    sessionStorage.removeItem(`Suggestions_Users_${eXo.env.portal.userName}`);
   }
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/relationships`, {
     method: 'DELETE',


### PR DESCRIPTION
Before this fix, the sessionId is exposed as javascript object. This could allow Session hijacking, user impersonation or Account takeover This commit remove the sessionId and use the username for the session storage of suggestions instead of sessionId.

Resolves meeds-io/si#10

(cherry picked from commit 6c5ca610a3f71432502ab427a94a852c5857626f)