### PR TITLE
fix: CSV user import issue if attribute isn't the exact value - MEED-10196 - Meeds-io/meeds#4002

### DIFF
--- a/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
+++ b/component/core/src/main/java/io/meeds/social/core/identity/service/UserImportService.java
@@ -553,6 +553,9 @@ public class UserImportService {
       if (!STANDARD_FIELDS.contains(field)) {
         if (!field.contains(".")) {
           ProfilePropertySetting propertySetting = profilePropertyService.getProfileSettingByName(field);
+          if (propertySetting != null && !propertySetting.getPropertyName().equals(field)) {
+            propertySetting = null;
+          }
           if (propertySetting == null) {
             userImportResult.addWarnMessage("ALL", "PROFILE_PROPERTY_DOES_NOT_EXIST:" + field);
             unauthorizedFields.add(field);
@@ -566,6 +569,9 @@ public class UserImportService {
         } else {
           String[] fieldNames = field.split("\\.");
           ProfilePropertySetting parentProperty = profilePropertyService.getProfileSettingByName(fieldNames[0]);
+          if (parentProperty != null && !parentProperty.getPropertyName().equals(fieldNames[0])) {
+            parentProperty = null;
+          }
           if (fieldNames.length > 2) {
             userImportResult.addWarnMessage("ALL", "PROPERTY_HAS_MORE_THAN_ONE_PARENT:" + field);
             unauthorizedFields.add(field);


### PR DESCRIPTION
Before this change, create attribute filed which ID is Phone and import csv having téléphone attribute, user attribute never displayed on user profile and the Téléphone attribute can never be reimported again. To fix this problem, ensured that profile property validation is performed in a strictly case-sensitive way at the application level, independently of the database collation. Now, the system verifies that the imported field name exactly matches the attribute ID before allowing it. After this change, attribute will not be imported if it doesn't exactly match the attribute ID.
Resolves https://github.com/Meeds-io/meeds/issues/4002