### PR TITLE
fix: Fix advanced profile filter to support partial single-word matching - MEED-10273 - Meeds-io/meeds#3970

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -588,14 +588,17 @@ public class ProfileSearchConnector {
                        }
                       """.formatted(expression.toString()));
           } else {
-            String searchedText = removeAccents(value);
+            String searchedTex = filter.isWildcardSearch()
+                                                          ? StorageUtils.ASTERISK_STR + removeAccents(value)
+                                                              + StorageUtils.ASTERISK_STR
+                                                          : removeAccents(value);
             query.append("""
-                    {
-                      "match_phrase": {
-                        "%s": "%s"
-                      }
-                   }
-                  """.formatted(property.getPropertyName().replace(" ", "\\\\ "), searchedText));
+                  {
+                    "query_string": {
+                      "query": "%s.whitespace:%s"
+                    }
+                 }
+                """.formatted(property.getPropertyName().replace(" ", "\\\\ "), searchedTex));
           }
           index++;
         }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -553,8 +553,8 @@ public class ProfileSearchConnectorTest {
                 }
           ,
             {
-              "match_phrase": {
-                "testProperty": "valueProperty"
+              "query_string": {
+                "query": "testProperty.whitespace:*valueProperty*"
               }
            }
                 ]


### PR DESCRIPTION
Prior to this change, searching for a profile using the advanced profile filter required an exact match. This change updates the profile filter search query to support partial single-word matching.