### PR TITLE
fix: admins should be able to view hidden & non-editable properties - MEED-10253 (#5613)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -466,7 +466,7 @@ public class EntityBuilder {
       }
     }
     if (expandAttributes.contains(SETTINGS)) {
-      userEntity.setProperties(buildProperties(profile, canViewProperties));
+      userEntity.setProperties(buildProperties(profile, isCurrentUser, isAdmin));
     }
     if (expandAttributes.contains(MANAGER) && profile.getProperty(MANAGER) != null) {
       buildListManagers(userEntity, profile, restPath);
@@ -605,7 +605,7 @@ public class EntityBuilder {
     return profilePropertyService;
   }
 
-  public static List<ProfilePropertySettingEntity> buildProperties(Profile profile, boolean canViewProperties) {
+  public static List<ProfilePropertySettingEntity> buildProperties(Profile profile, boolean isCurrentUser, boolean isAdmin) {
     ProfilePropertyService profilePropertyService = getProfilePropertyService();
     List<Long> hiddenProfileProperties = profilePropertyService.getHiddenProfilePropertyIds(Long.parseLong(profile.getIdentity()
                                                                                                                   .getId()));
@@ -614,7 +614,8 @@ public class EntityBuilder {
     List<ProfilePropertySetting> settings = profilePropertyService.getPropertySettings()
                                                                   .stream()
                                                                   .filter(prop -> prop.isVisible()
-                                                                                  || (prop.isEditable() && canViewProperties))
+                                                                                  || (prop.isEditable() && isCurrentUser)
+                                                                                  || isAdmin)
                                                                   .toList();
     List<ProfilePropertySetting> subProperties = new ArrayList<>();
     List<Long> parents = new ArrayList<>();
@@ -636,7 +637,7 @@ public class EntityBuilder {
                                                                                                       profilePropertyService,
                                                                                                       ProfilePropertyService.LABELS_OBJECT_TYPE);
         boolean isHidden = hiddenProfileProperties.contains(profilePropertySettingEntity.getId());
-        if (isHidden && !canViewProperties) {
+        if (isHidden && !isCurrentUser && !isAdmin) {
           continue;
         }
         profilePropertySettingEntity.setHidden(isHidden);
@@ -676,7 +677,7 @@ public class EntityBuilder {
                                                                                         profilePropertyService,
                                                                                         ProfilePropertyService.LABELS_OBJECT_TYPE);
                       isHidden = hiddenProfileProperties.contains(profilePropertySettingEntity.getId());
-                      if (isHidden && !canViewProperties) {
+                      if (isHidden && !isCurrentUser && !isAdmin) {
                         continue;
                       }
                       subProfilePropertySettingEntity.setHidden(hiddenProfileProperties.contains(subProfilePropertySettingEntity.getId()));


### PR DESCRIPTION
Allow admin users to view the hidden & non editable fields.

(cherry picked from commit 1bf20e366d3241c3015195ae72c1d7a57ffe8b62)