### PR TITLE
 fix: Link with illustration in short message keep displaying address  path - MEED-10274 - Meeds-io/meeds#3986

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityBody.vue
@@ -54,7 +54,13 @@ export default {
   }),
   computed: {
     bodyElement() {
-      return this.body || '';
+      if (!this.body) {
+        return '';
+      }
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(this.body, 'text/html');
+      doc.querySelectorAll('oembed').forEach(el => el.remove());
+      return doc.body.innerHTML;
     },
     getBody() {
       return this.activityTypeExtension && this.activityTypeExtension.getBody;


### PR DESCRIPTION
Before this change, when passing a link with a preview into an activity and then removing the URL while keeping the illustration, the URL was still displayed. To fix this issue, `<oembed>` tags were removed from `ActivityBody` rendering to prevent duplicate link display. This ensures that when the link text is removed, the preview remains visible without showing the raw URL.