### PR TITLE
fix: Fix reset people card list after resetting advanced search filter - MEED-10285 - Meeds-io/meeds#4097

### DIFF
--- a/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -204,7 +204,10 @@ export default {
     document.addEventListener('user-extension-updated', this.refreshUserExtensions);
     document.addEventListener('people-list-refresh', this.searchPeopleNoFilters);
 
-    this.$root.$on('reset-advanced-filter', this.searchPeople);
+    this.$root.$on('reset-advanced-filter', () => {
+      this.advancedFilterSettings = null;
+      this.searchPeople();
+    });
     this.$root.$on('advanced-filter', profileSettings => this.searchPeople(profileSettings));
 
     this.refreshExtensions();


### PR DESCRIPTION
Prior to this change, when resetting people card advanced search filter after having search results, the people card list still the same and not reset. After this commit, we will ensure to reset the people list card after resetting advanced search filter by setting this.advancedFilterSettings to null.

Resolves Meeds-io/meeds#4097