### PR TITLE
fix:subitems can't be displayed on hover - MEED-10278 - Meeds-io/meeds#4079

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -210,7 +210,7 @@ export default {
       }
       const myUri = this.navigationNodeUri;
       const emitterUri = emitter.navigationNodeUri;
-      if (myUri && emitterUri && emitterUri.startsWith(myUri)) {
+      if (myUri && emitterUri && (myUri.startsWith(emitterUri) || emitterUri.startsWith(myUri))) {
         return;
       }
       if (!myUri && this.isDescendant(emitter.navigation, this.navigation)) {


### PR DESCRIPTION
Before this change, when a new navigation item (ItemX) was added in SpaceX as a link andsubitems were attached to it, after saving and displaying the ItemX menu, selecting any submenu caused the submenu to close unexpectedly and it could not be displayed properly. To fix this issue, enhanced the sibling menu closing condition in handleCloseSiblingMenus by adding emitterUri.startsWith(myUri). This prevents unintended submenu closure when navigating through nested menu items.
Resolves https://github.com/Meeds-io/meeds/issues/4079