### PR TITLE
fix: when session expires and user want to join a url of a hidden space, a page not found is displayed - MEED-10292 - meeds-io/meeds#4111

### DIFF
--- a/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
@@ -22,11 +22,14 @@ import static org.exoplatform.portal.application.PortalRequestHandler.REQUEST_SI
 import static org.exoplatform.portal.application.PortalRequestHandler.REQUEST_SITE_TYPE;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.UserPortalConfigService;
@@ -46,6 +49,7 @@ import org.exoplatform.web.WebRequestHandler;
 import org.exoplatform.web.url.URLFactoryService;
 import org.exoplatform.web.url.navigation.NavigationResource;
 import org.exoplatform.web.url.navigation.NodeURL;
+import org.exoplatform.web.security.sso.SSOHelper;
 
 import io.meeds.social.space.service.SpaceLayoutService;
 
@@ -104,7 +108,17 @@ public class SpaceAccessHandler extends WebRequestHandler {
       return false;
     }
     Space space = spaceService.getSpaceByGroupId(requestSiteName);
-    if (canAccessSpace(space, username)) {
+    if (StringUtils.isBlank(username) && canAccessSpacePublicSite(space, username)) {
+      controllerContext.getResponse()
+                       .sendRedirect(String.format("%s/%s",
+                                                   controllerContext.getRequest().getContextPath(),
+                                                   spaceLayoutService.getSpacePublicSiteName(space)));
+      return true;
+    } else if (StringUtils.isBlank(username)) {
+      String loginPath = getAuthenticationUrl(controllerContext.getRequest().getRequestURI());
+      controllerContext.getResponse().sendRedirect(loginPath);
+      return true;
+    } else if (canAccessSpace(space, username)) {
       if (spaceService.isMember(space, username)) {
         HttpSession session = controllerContext.getRequest().getSession();
         String lastAccessedSpaceId = (String) session.getAttribute(SpaceAccessType.ACCESSED_SPACE_ID_KEY);
@@ -127,8 +141,6 @@ public class SpaceAccessHandler extends WebRequestHandler {
                                                    controllerContext.getRequest().getContextPath(),
                                                    spaceLayoutService.getSpacePublicSiteName(space)));
       return true;
-    } else if (username == null) {
-      return false;
     } else {
       processSpaceAccess(controllerContext, username, space);
       return true;
@@ -216,6 +228,20 @@ public class SpaceAccessHandler extends WebRequestHandler {
 
   private String getPageNotFoundSite(String username) {
     return StringUtils.isBlank(username) ? "public" : userPortalConfigService.getMetaPortal();
+  }
+
+  private String getAuthenticationUrl(String permanentLink) {
+    StringBuilder loginPath = new StringBuilder();
+
+    // . Check SSO Enable
+    SSOHelper ssoHelper = ExoContainerContext.getService(SSOHelper.class);
+    if (ssoHelper != null && ssoHelper.isSSOEnabled() && ssoHelper.skipJSPRedirection()) {
+      loginPath.append("/portal").append(ssoHelper.getSSORedirectURLSuffix());
+    } else {
+      loginPath.append("/portal/login");
+    }
+    loginPath.append("?initialURI=").append(URLEncoder.encode(permanentLink, StandardCharsets.UTF_8));
+    return loginPath.toString();
   }
 
 }


### PR DESCRIPTION
Before  this fix, in SpaceAccessHandler, we firstly check if the user have access to the space, even if he is not connected. For specially hidden space, we return a page not found, because we dont want to expose the hidden space, and then user see a page not found, even if he is member of the space This commit ensure to require a user login if necessary, and then check if the user have access to the space. If not, the space is not exposed and a page not found is returned

Resolves meeds-io/meeds#4111

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
