### PR TITLE
fix: Search by email doesn't display any results - MEED-10284 - Meeds-io/meeds#4096

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -577,7 +577,7 @@ public class ProfileSearchConnector {
                 } else {
                   searchedText = removeAccents(splittedValues[i]);
                 }
-                expression.append(" ").append(key.replace(" ", "\\\\ ")).append(".whitespace").append(":").append(searchedText);
+                expression.append(" ").append(key.replace(" ", "\\\\ ")).append(isEmailProfileProperty(key) ? ":" : ".whitespace:").append(searchedText);
               }
             }
             query.append("""
@@ -592,13 +592,15 @@ public class ProfileSearchConnector {
                                                           ? StorageUtils.ASTERISK_STR + removeAccents(value)
                                                               + StorageUtils.ASTERISK_STR
                                                           : removeAccents(value);
+            String propertyName = property.getPropertyName();
+            String filedName = isEmailProfileProperty(propertyName) ? propertyName : "%s.whitespace".formatted(propertyName);
             query.append("""
                   {
                     "query_string": {
-                      "query": "%s.whitespace:%s"
+                      "query": "%s:%s"
                     }
                  }
-                """.formatted(property.getPropertyName().replace(" ", "\\\\ "), searchedTex));
+                """.formatted(filedName.replace(" ", "\\\\ "), searchedTex));
           }
           index++;
         }
@@ -634,5 +636,8 @@ public class ProfileSearchConnector {
     query.append("        }\n");
     query.append("      }");
     return query.toString();
+  }
+  private boolean isEmailProfileProperty(String propertyName) {
+    return propertyName.equals("email");
   }
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -448,7 +448,7 @@ public class ProfileSearchConnectorTest {
     }
 
     @Test
-    public void testSearchWithProfileSetting() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    public void testSearchWithProfileSetting() {
         ElasticSearchingClient elasticSearchClient = Mockito.mock(ElasticSearchingClient.class);
         profileSearchConnector = new ProfileSearchConnector(getInitParams(), elasticSearchClient, profilePropertyService);
         IdentityManagerImpl identityManager = Mockito.mock(IdentityManagerImpl.class);


### PR DESCRIPTION
Prior to this change, the profile advanced search using the email field returned no results. The issue was caused by the query using the `whitespace` field, while the email field is not analyzed with this type. This change updates the search query to avoid using the `whitespace` field when filtering by the email property.