### PR TITLE
fix: Fix access to unlisted spaces for invited users - MEED-10295 - Meeds-io/meeds#4104

### DIFF
--- a/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
@@ -129,7 +129,8 @@ public class SpaceAccessHandler extends WebRequestHandler {
         session.setAttribute(SpaceAccessType.ACCESSED_SPACE_ID_KEY, space.getId());
       }
       return false;
-    } else if (space == null || Space.HIDDEN.equals(space.getVisibility())) {
+    } else if (space == null || (Space.HIDDEN.equals(space.getVisibility())
+        && !spaceService.isInvitedUser(space, username))) {
       controllerContext.getResponse()
                        .sendRedirect(String.format("%s/%s/page-not-found",
                                                    controllerContext.getRequest().getContextPath(),

--- a/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
@@ -89,7 +89,7 @@ public class SpacePermanentLinkHandler extends WebRequestHandler {
       String loginPath = getAuthenticationUrl(controllerContext.getRequest().getRequestURI());
       controllerContext.getResponse().sendRedirect(loginPath);
     } else if (space == null
-        || isHiddenSpace(space, username)) {
+        || (isHiddenSpace(space, username) && !spaceService.isInvitedUser(space, username))) {
       String pageNotFoundUrl = "/portal/" + getPageNotFoundSite(username) + "/page-not-found";
       controllerContext.getResponse().sendRedirect(pageNotFoundUrl);
     } else {


### PR DESCRIPTION
Previously, when a space was unlisted, the access checks in SpacePermanentLinkHandler and SpaceAccessHandler treated invited users as unauthorized and redirected them to the not-found page.
This fix ensures that invited users can be redirected to the space access page correctly to accept or refuse invitation,
