### PR TITLE
fix: Fix access to unlisted spaces for invited users - MEED-10295 - Meeds-io/meeds#4104

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.text.StringEscapeUtils;
 
+import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
@@ -326,6 +327,15 @@ public class LinkProvider {
    */
   public static String getActivityUriForSpace(final String remoteId, final String groupId) {
     return String.format("/%s/g/:spaces:%s/%s", getPortalName(null), groupId, remoteId);
+  }
+
+  /**
+   * Gets space Link
+   * @param spaceId target spaceId
+   * @return space link
+   */
+  public static String getSpaceLink(String spaceId) throws ObjectNotFoundException {
+    return CommonsUtils.getService(PermanentLinkService.class).getLink(new PermanentLinkObject("space", spaceId));
   }
 
   /**

--- a/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
+++ b/component/service/src/main/java/org/exoplatform/social/service/rest/NotificationsRestService.java
@@ -198,7 +198,7 @@ public class NotificationsRestService implements ResourceContainer {
     if (Arrays.asList(space.getInvitedUsers()).contains(userId)) {
       getSpaceService().addMember(space, userId);
     }
-    String targetURL = Util.getBaseUrl() + LinkProvider.getActivityUriForSpace(space.getPrettyName(), space.getGroupId().replace("/spaces/", ""));
+    String targetURL = Util.getBaseUrl() + LinkProvider.getSpaceLink(spaceId);
 
     // redirect to target page
     return Response.seeOther(URI.create(targetURL)).build();
@@ -323,7 +323,7 @@ public class NotificationsRestService implements ResourceContainer {
     }
     
     String baseUrl = Util.getBaseUrl();
-    String spaceHomeUrl = LinkProvider.getActivityUriForSpace(space.getPrettyName(), space.getGroupId().replace("/spaces/", ""));
+    String spaceHomeUrl = LinkProvider.getSpaceLink(spaceId);
     StringBuilder targetURL = new StringBuilder().append(baseUrl).append(spaceHomeUrl).append("/members?feedbackMessage=");
     if (getSpaceService().isMember(space, userId)) {
       targetURL.append("SpaceRequestAlreadyMember&spaceId=").append(spaceId).append("&userName=").append(userId);

--- a/component/service/src/test/java/org/exoplatform/social/service/rest/NotificationsRestServiceTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/rest/NotificationsRestServiceTest.java
@@ -18,9 +18,12 @@
  */
 package org.exoplatform.social.service.rest;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 
+import io.meeds.portal.permlink.service.PermanentLinkService;
+import io.meeds.social.space.plugin.SpacePermanentLinkPlugin;
 import org.exoplatform.services.rest.impl.ContainerResponse;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
@@ -35,7 +38,8 @@ public class NotificationsRestServiceTest extends AbstractResourceTest {
 
   private ActivityManagerImpl activityManager;
   private SpaceService spaceService;
-  
+  private PermanentLinkService permanentLinkService;
+
   private Identity rootIdentity;
   private Identity johnIdentity;
   private Identity maryIdentity;
@@ -47,7 +51,14 @@ public class NotificationsRestServiceTest extends AbstractResourceTest {
     IdentityStorage identityStorage = getContainer().getComponentInstanceOfType(IdentityStorage.class);
     activityManager = getContainer().getComponentInstanceOfType(ActivityManagerImpl.class);
     spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
-    
+
+    permanentLinkService = getContainer().getComponentInstanceOfType(PermanentLinkService.class);
+    SpacePermanentLinkPlugin spacePermanentLinkPlugin = new SpacePermanentLinkPlugin();
+    Field field = SpacePermanentLinkPlugin.class.getDeclaredField("spaceService");
+    field.setAccessible(true);
+    field.set(spacePermanentLinkPlugin, spaceService);
+    permanentLinkService.addPlugin(spacePermanentLinkPlugin);
+
     rootIdentity = new Identity("organization", "root");
     johnIdentity = new Identity("organization", "john");
     maryIdentity = new Identity("organization", "mary");

--- a/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
@@ -108,7 +108,8 @@ public class SpaceAccessHandler extends WebRequestHandler {
       return false;
     }
     Space space = spaceService.getSpaceByGroupId(requestSiteName);
-    if (StringUtils.isBlank(username) && canAccessSpacePublicSite(space, username)) {
+    if (StringUtils.isBlank(username) && space.getPublicSiteId() != 0
+        && canAccessSpacePublicSite(space, username)) {
       controllerContext.getResponse()
                        .sendRedirect(String.format("%s/%s",
                                                    controllerContext.getRequest().getContextPath(),
@@ -129,7 +130,8 @@ public class SpaceAccessHandler extends WebRequestHandler {
         session.setAttribute(SpaceAccessType.ACCESSED_SPACE_ID_KEY, space.getId());
       }
       return false;
-    } else if (space == null || Space.HIDDEN.equals(space.getVisibility())) {
+    } else if (space == null || (Space.HIDDEN.equals(space.getVisibility())
+        && !spaceService.isInvitedUser(space, username))) {
       controllerContext.getResponse()
                        .sendRedirect(String.format("%s/%s/page-not-found",
                                                    controllerContext.getRequest().getContextPath(),

--- a/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
@@ -89,7 +89,7 @@ public class SpacePermanentLinkHandler extends WebRequestHandler {
       String loginPath = getAuthenticationUrl(controllerContext.getRequest().getRequestURI());
       controllerContext.getResponse().sendRedirect(loginPath);
     } else if (space == null
-        || isHiddenSpace(space, username)) {
+        || (isHiddenSpace(space, username) && !spaceService.isInvitedUser(space, username))) {
       String pageNotFoundUrl = "/portal/" + getPageNotFoundSite(username) + "/page-not-found";
       controllerContext.getResponse().sendRedirect(pageNotFoundUrl);
     } else {


### PR DESCRIPTION
Previously, when a space was unlisted, the access checks in SpacePermanentLinkHandler and SpaceAccessHandler treated invited users as unauthorized and redirected them to the not-found page. 
This fix ensures that invited users can be redirected to the space access page correctly to accept or refuse invitation,
