### PR TITLE
fix: inherit the member role following the assignment of any other role - MEED-10304 - Meeds-io/meeds#4083

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialMembershipListenerImpl.java
@@ -138,12 +138,15 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
       // , except 'validator', ...so on.
       SpaceService spaceService = ExoContainerContext.getService(SpaceService.class);
       Space space = spaceService.getSpaceByGroupId(m.getGroupId());
+      String userName = m.getUserName();
       if (space != null) {
         ConversationState state = ConversationState.getCurrent();
         if (state != null && state.getIdentity() != null && space.getEditor() == null) {
+          if (!spaceService.isMember(space, userName)) {
+            spaceService.addMember(space, userName);
+          }
           space.setEditor(state.getIdentity().getUserId());
         }
-        String userName = m.getUserName();
         clearOwnerGlobalStreamCache(userName);
         if (acl.getAdminMSType().equalsIgnoreCase(m.getMembershipType()) ||
             MembershipTypeHandler.ANY_MEMBERSHIP_TYPE.equalsIgnoreCase(m.getMembershipType())) {
@@ -165,10 +168,16 @@ public class SocialMembershipListenerImpl extends MembershipEventListener {
           if (spaceService.isRedactor(space, userName)) {
             return;
           }
+          if (!spaceService.isMember(space, userName)) {
+            spaceService.addMember(space, userName);
+          }
           spaceService.addRedactor(space, userName);
         } else if (SpaceUtils.PUBLISHER.equalsIgnoreCase(m.getMembershipType())) {
           if (spaceService.isPublisher(space, userName)) {
             return;
+          }
+          if (!spaceService.isMember(space, userName)) {
+            spaceService.addMember(space, userName);
           }
           spaceService.addPublisher(space, userName);
         }


### PR DESCRIPTION
Before this change, when a user was assigned a role such as publisher or content writer in a space without being granted the member role, they could not access the related space. To fix this issue, the postSave method in the SocialMembershipListenerImpl class has been updated to automatically add the user as a member if they are not already a member of the space whenever a role is assigned. After this change, assigning any role will automatically grant the member role to the user, ensuring proper access to the space.