### PR TITLE
fix: Synchronize mapped LDAP attributes with social profile, including absent attributes - MEED-10199 - Meeds-io/meeds#3736

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SynchronizedUserProfileListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SynchronizedUserProfileListener.java
@@ -55,7 +55,8 @@ public class SynchronizedUserProfileListener extends Listener<IDMExternalStoreIm
       boolean isModified = false;
       Set<String> externalUserProfileAttributes = externalUserProperties.keySet();
       for (String externalUserProfileAttribute : externalUserProfileAttributes) {
-        if (!internalUserProperties.containsKey(externalUserProfileAttribute)
+        Object externalPropertyValue = externalUserProperties.getOrDefault(externalUserProfileAttribute, null);
+        if ((!internalUserProperties.containsKey(externalUserProfileAttribute) && externalPropertyValue != null)
             || !Objects.equals(externalUserProperties.get(externalUserProfileAttribute),
                                internalUserProperties.get(externalUserProfileAttribute))) {
           // set the newly or modified property


### PR DESCRIPTION
This change adds a condition to skip updating the profile in case external properties are null and already removed from internal profile, avoiding unnecessary writes and broadcasts while preserving correct synchronization behavior for actual new or modified attributes.
