### PR TITLE
fix: Fix public space redirect for non-authenticated users in SpacePermanentLinkHandler - MEED-10312 - Meeds-io/meeds#4113

### DIFF
--- a/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
@@ -82,18 +82,17 @@ public class SpacePermanentLinkHandler extends WebRequestHandler {
     String username = controllerContext.getRequest().getRemoteUser();
     String spaceId = controllerContext.getParameter(REQUEST_SPACE_ID);
     String path = controllerContext.getParameter(REQUEST_PATH);
-    String invitationId = controllerContext.getRequest().getParameter(INVITATION_ID.getName());
     String queryString = controllerContext.getRequest().getQueryString();
     if (StringUtils.isNotEmpty(queryString)) {
       path = path + "?" + queryString;
     }
     Space space = spaceService.getSpaceById(spaceId);
-    if (StringUtils.isBlank(username)) {
+    if (StringUtils.isBlank(username) && space.getPublicSiteId() == 0) {
       String loginPath = getAuthenticationUrl(controllerContext.getRequest().getRequestURI(),
                                               controllerContext.getRequest().getQueryString());
       controllerContext.getResponse().sendRedirect(loginPath);
-    } else if (space == null
-        || (isHiddenSpace(space, username) && !spaceService.isInvitedUser(space, username))) {
+    } else if (space == null || (StringUtils.isNotBlank(username) && isHiddenSpace(space, username)
+        && !spaceService.isInvitedUser(space, username))) {
       String pageNotFoundUrl = "/portal/" + getPageNotFoundSite(username) + "/page-not-found";
       controllerContext.getResponse().sendRedirect(pageNotFoundUrl);
     } else {


### PR DESCRIPTION
Prior to this change, non-authenticated users accessing permanent links of spaces (/portal/s/xxx) were incorrectly redirected to the login page even when the space had a public site.
This caused inconsistent behavior compared to the standard space URLs which displayed the public page without authentication.

This fix updates the handler to:

- Only redirect to login if the user is not connected AND the space does not have a public site.
- Preserve the page-not-found logic for hidden spaces or non-existent spaces for authenticated users.

As a result, permanent links of public spaces now behave consistently with standard space URLs for non-connected users, always displaying the public page when available.
