### PR TITLE
fix:Handle space group decoration when no template is applied - MEED-10314 - Meeds-io/meeds#4131

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/plugin/SpaceGroupDecoratorPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/space/plugin/SpaceGroupDecoratorPlugin.java
@@ -72,7 +72,7 @@ public class SpaceGroupDecoratorPlugin extends BaseComponentPlugin implements Gr
     }
     try {
       Space space = spaceService.getSpaceByGroupId(group.getId());
-      if (space == null) {
+      if (space == null || space.getTemplateId() <= 0) {
         return group;
       }
       String templateGroupId = spaceTemplateService.getOrCreateSpaceTemplateGroupId(space.getTemplateId());


### PR DESCRIPTION
Prior to this change, if no space template is applied to an existing space (e.g., during migration from 6.5.x to 7.2.x), an exception is thrown when decorating the space group using the spaceGroupDecorator. This occurs because the space has a templateId = 0. This change handles this exception.