### PR TITLE
fix: when login with openid, with a user is deactivated in eXo, the error message is not correct - MEED-10341 - meeds-io/meeds#4151

### DIFF
--- a/component/oauth-auth/src/main/java/io/meeds/oauth/data/SocialNetworkServiceImpl.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/data/SocialNetworkServiceImpl.java
@@ -166,7 +166,7 @@ public class SocialNetworkServiceImpl implements SocialNetworkService, OAuthCode
       UserHandler userHandler = organizationService.getUserHandler();
       Query queryByEmail = new Query();
       queryByEmail.setEmail(email);
-      ListAccess<User> users = userHandler.findUsersByQuery(queryByEmail);
+      ListAccess<User> users = userHandler.findUsersByQuery(queryByEmail,UserStatus.ANY);
       if (users == null || users.getSize() == 0 || users.getSize() > 1) {
         return null;
       } else if (users.getSize() == 1) {

--- a/component/oauth-auth/src/main/java/io/meeds/oauth/web/OAuthAuthenticationFilter.java
+++ b/component/oauth-auth/src/main/java/io/meeds/oauth/web/OAuthAuthenticationFilter.java
@@ -197,12 +197,18 @@ public class OAuthAuthenticationFilter extends AbstractSSOInterceptor {
       socialNetworkService.updateOAuthAccessToken(principal.getOauthProviderType(),
                                                   portalUser.getUserName(),
                                                   principal.getAccessToken());
+      // Now Facebook/Google authentication handshake is finished and credentials
+      // are in session. We can redirect to JAAS authenticatio
+      String loginRedirectURL = httpResponse.encodeRedirectURL(getLoginRedirectUrl(httpRequest, portalUser.getUserName()));
+      httpResponse.sendRedirect(loginRedirectURL);
+    } else {
+      String loginRedirectURL = "/portal/login?error=SigninFail";
+      cleanAuthenticationContext(httpRequest);
+      httpResponse.setHeader("Set-Cookie", "OPENID_ACCESS_TOKEN="+" ; Path=/;  Max-Age=0; HttpOnly;SameSite=Lax");
+      httpResponse.sendRedirect(loginRedirectURL);
     }
 
-    // Now Facebook/Google authentication handshake is finished and credentials
-    // are in session. We can redirect to JAAS authentication
-    String loginRedirectURL = httpResponse.encodeRedirectURL(getLoginRedirectUrl(httpRequest, portalUser.getUserName()));
-    httpResponse.sendRedirect(loginRedirectURL);
+
   }
 
   protected String getLoginRedirectUrl(HttpServletRequest req, String username) {


### PR DESCRIPTION
Before this fix, if the user is deactivated in eXo, the page displayed is the page to link the account. It should display the login form with the classic error message when the user is deactivated

Resolves meeds-io/meeds#4151

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
