### PR TITLE
fix: Redirect to space-access page if unlisted page is not closed - MEED-10337 - Meeds-io/meeds#4143 (#5663)

### DIFF
--- a/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
@@ -138,7 +138,8 @@ public class SpaceAccessHandler extends WebRequestHandler {
         session.setAttribute(SpaceAccessType.ACCESSED_SPACE_ID_KEY, space.getId());
       }
       return false;
-    } else if (space == null || (Space.HIDDEN.equals(space.getVisibility())
+    } else if (space == null || (Space.HIDDEN.equals(space.getVisibility()) && space.getRegistration()
+                                                                                    .equalsIgnoreCase(Space.CLOSED)
         && !spaceService.isInvitedUser(space, username))) {
       controllerContext.getResponse()
                        .sendRedirect(String.format("%s/%s/page-not-found",

--- a/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpacePermanentLinkHandler.java
@@ -92,7 +92,7 @@ public class SpacePermanentLinkHandler extends WebRequestHandler {
                                               controllerContext.getRequest().getQueryString());
       controllerContext.getResponse().sendRedirect(loginPath);
     } else if (space == null || (StringUtils.isNotBlank(username) && isHiddenSpace(space, username)
-        && !spaceService.isInvitedUser(space, username))) {
+        && space.getRegistration().equalsIgnoreCase(Space.CLOSED) && !spaceService.isInvitedUser(space, username))) {
       String pageNotFoundUrl = "/portal/" + getPageNotFoundSite(username) + "/page-not-found";
       controllerContext.getResponse().sendRedirect(pageNotFoundUrl);
     } else {


### PR DESCRIPTION
Prior to this change, when access to unlisted space via its url, it redirects to not-found page ,
This PR ensures to redirect to space-access page if unlisted page is not closed

(cherry picked from commit 709f525c82e0b8829b99e020bd7d9a3ff7f5afcb)