### PR TITLE
fix: Category drawer preferences aren't applied - MEED-10335 - Meeds-io/meeds#4142

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-administration/components/bulk-action/SpacesAdministrationBulkEditCategories.vue
+++ b/webapp/src/main/webapp/vue-apps/space-administration/components/bulk-action/SpacesAdministrationBulkEditCategories.vue
@@ -42,8 +42,8 @@ export default {
             objectType: 'space',
             objectId: space.id,
             spaceId: space.id,
-            oldCategoryIds: oldCategoryIds.slice(),
-            newCategoryIds: newCategoryIds.slice(),
+            oldCategories: oldCategoryIds.slice(),
+            newCategories: newCategoryIds.slice(),
             dropExisting: params.dropExisting
           });
           const categoryIds = newCategoryIds.slice();


### PR DESCRIPTION
Before this change, when go to spaces admin app then select one or many spaces and update category from dedicated button and save, preferences aren't applied. To resolve this issue, in method saveCategories change in the object the properties names oldCategoryIds and newCategoryIds by oldCategories and newCategories. As a result, category preferences is applied and saved.
Resolves https://github.com/Meeds-io/meeds/issues/4142