### PR TITLE
fix: Allow publisher without redactor role to add content (post, content, note) when content restriction is ON - MEED-10360 - Meeds-io/meeds#4164 

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
@@ -568,7 +568,9 @@ public interface SpaceService {
     } else if (isMember(space, username)
                && (!hasRedactor(space)
                    || isRedactor(space, username)
-                   || isManager(space, username))) {
+                   || isManager(space, username)
+                   || isPublisher(space, username))
+               ) {
       return true;
     } else {
       return isSuperManager(space, username);

--- a/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/space/spi/SpaceServiceTest.java
@@ -849,8 +849,8 @@ public class SpaceServiceTest extends AbstractCoreTest {
     assertTrue(spaceService.canRedactOnSpace(space, demoACLIdentity));
     // Redactor can redact
     assertTrue(spaceService.canRedactOnSpace(space, jamesACLIdentity));
-    // space publisher can't redact
-    assertFalse(spaceService.canRedactOnSpace(space, maryACLIdentity));
+    // space publisher can redact
+    assertTrue(spaceService.canRedactOnSpace(space, maryACLIdentity));
     // space members can't redact
     assertFalse(spaceService.canRedactOnSpace(space, raulACLIdentity));
   }
@@ -1394,7 +1394,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
 
   public void testCreateSpaceWithInvalidSpaceName() {
     Space space = new Space();
-    String spaceDisplayName = "%zzz:^!/<>😁";
+    String spaceDisplayName = "%zzz:^!/<>ðŸ˜�";
     space.setDisplayName(spaceDisplayName);
     String creator = ROOT_NAME;
     String shortName = "zzz";
@@ -1413,7 +1413,7 @@ public class SpaceServiceTest extends AbstractCoreTest {
     assertFalse(space.getPrettyName().contains("/"));
     assertFalse(space.getPrettyName().contains("<"));
     assertFalse(space.getPrettyName().contains(">"));
-    assertFalse(space.getPrettyName().contains("😁"));
+    assertFalse(space.getPrettyName().contains("ðŸ˜�"));
   }
 
   public void testCreateSpaceNoUser() {


### PR DESCRIPTION
Prior to this change, when content restriction is ON, a simple publisher without redactor role was not able to add contents such as a post, a content or a note. After this commit, we ensure that publishers can add contents such as a post, a content or a note even if content restriction is ON by updating spaceService.canRedactOnSpace method.

Resolves https://github.com/Meeds-io/meeds/issues/4164