### PR TITLE
feat: Make UserSettingSecurity JS Module as Group to allow extensibility

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
@@ -43,6 +43,7 @@ UserSettings.button.save=Save
 UserSettings.button.confirm=Confirm
 UserSettings.button.tooltip.disabled=You cannot change your password. Please contact the support services
 UserSettings.button.tooltip.enabled=Edit password
+UserSettings.passwordChange.sso.enabled=Your authentication method doesn't allow to use a password
 UserSettings.title.muteSpacesNotifications=Muted spaces
 UserSettings.subtitle.muteSpacesNotifications=Muting a space stops notifications unless you are mentioned
 UserSettings.drawer.title.muteSpacesNotifications=Muted spaces

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1154,6 +1154,7 @@
   <portlet>
     <name>UserSettingSecurity</name>
     <module>
+      <load-group>UserSettingSecurityGRP</load-group>
       <script>
         <minify>false</minify>
         <path>/js/userSettingSecurity.bundle.js</path>

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
@@ -53,7 +53,7 @@
             </v-tooltip>  
           </v-list-item-action>
         </v-list-item>
-        <v-list-item v-if="!$root.ssoEnabled" dense>
+        <v-list-item dense>
           <v-list-item-content>
             <v-list-item-title>
               {{ $t('UserSettings.security.passwordChange.title') }}
@@ -79,6 +79,12 @@
             </v-tooltip>  
           </v-list-item-action>
         </v-list-item>
+        <extension-registry-components
+          name="UserSettingsSecurity"
+          type="user-settings-security"
+          parent-element="div"
+          element="div"
+          class=" d-flex flex-column" />
       </v-list>
     </v-card>
     <user-setting-security-email-drawer
@@ -96,7 +102,11 @@ export default {
   }),
   computed: {
     passwordChangeTooltip() {
-      return this.allowedToChangePassword ? this.$t('UserSettings.button.tooltip.enabled') : this.$t('UserSettings.button.tooltip.disabled');
+      if (this.$root.ssoEnabled) {
+        return this.$t('UserSettings.passwordChange.sso.enabled');
+      } else {
+        return this.allowedToChangePassword ? this.$t('UserSettings.button.tooltip.enabled') : this.$t('UserSettings.button.tooltip.disabled');
+      }
     },
     emailChangeTooltip() {
       return this.$t('UserSettings.security.emailChange.tooltip');
@@ -122,7 +132,7 @@ export default {
   methods: {
     async init() {
       const data = await this.$userService.isSynchronizedUserAllowedToChangePassword();
-      this.allowedToChangePassword = data?.isSynchronizedUserAllowedToChangePassword === 'true';
+      this.allowedToChangePassword = !this.$root.ssoEnabled && data?.isSynchronizedUserAllowedToChangePassword === 'true';
     },
     showApp() {
       this.displayed = true;

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/main.js
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/main.js
@@ -42,14 +42,12 @@ const appId = 'UserSettingSecurity';
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
 export function init(ssoEnabled, isEmailEditable) {
-  if (!isEmailEditable && ssoEnabled) {
-    Vue.prototype.$updateApplicationVisibility(false, document.querySelector(`#${appId}`));
-  } else {
-    exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+  exoi18n.loadLanguageAsync(lang, url)
+    .then(i18n => {
       const appElement = document.createElement('div');
       appElement.id = appId;
-  
-      Vue.createApp({
+
+      return Vue.createApp({
         data: {
           ssoEnabled,
           isEmailEditable,
@@ -61,6 +59,6 @@ export function init(ssoEnabled, isEmailEditable) {
         i18n,
         vuetify: Vue.prototype.vuetifyOptions,
       }, appElement, 'User Settings Security');
-    });
-  }
+    })
+    .then(() => Vue.prototype.$utils.includeExtensions('UserSecuritySetting'));
 }


### PR DESCRIPTION
This change will allow to use `extensionRegistry` to display additional sections in User Settings Security UI.