### PR TITLE
fix: incorrect styling of the create space CTA in the Space List - MEED-10367 - Meeds-io/meeds#4174

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-list-components/components/common/SpaceCreationButton.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list-components/components/common/SpaceCreationButton.vue
@@ -35,11 +35,15 @@
         :small="!icon && isMobile"
         :color="color"
         :icon="icon"
+        :outlined="outlined"
         :elevation="elevation"
         v-bind="attrs"
         v-on="on">
-        <v-icon :size="iconSize">fa-plus</v-icon>
-        <span v-if="displayLabel" class="ms-2 hidden-xs-only">
+        <v-icon v-if="displaySpaceCreationIcon" :size="iconSize">fa-plus</v-icon>
+        <span
+          v-if="displayLabel"
+          :class="{ 'ms-2': displaySpaceCreationIcon }"
+          class="hidden-xs-only">
           {{ $t('spacesList.button.add') }}
         </span>
       </v-btn>
@@ -80,7 +84,7 @@
     v-on="on"
     @click="addNewSpace">
     <v-icon
-      v-if="displayIcon || isMobile"
+      v-if="displaySpaceCreationIcon"
       :size="iconSize"
       class="me-2">
       fa-plus
@@ -149,6 +153,9 @@ export default {
     },
     isMobile() {
       return this.$vuetify?.breakpoint?.mobile;
+    },
+    displaySpaceCreationIcon() {
+      return this.displayIcon || this.isMobile;
     }
   },
   watch: {
@@ -164,8 +171,8 @@ export default {
       }
     },
   },
-  created() {
-    this.init();
+  async created() {
+    await this.init();
   },
   methods: {
     async init() {


### PR DESCRIPTION
Prior to this change, when no spaces were available in the Spaces List, the CTA to add new space was not match the expected design.
This change fixes the CTA styling to ensure it is consistently displayed as an outlined button with a “+” icon and “Add” label