### PR TITLE
fix: user synchronization is incomplete after a space binding - MEED-10275 - Meeds-io/meeds#4059

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/binding/model/UserBindingsQueue.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/binding/model/UserBindingsQueue.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/api/src/main/java/org/exoplatform/social/core/binding/model/UserBindingsQueue.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/binding/model/UserBindingsQueue.java
@@ -25,26 +25,37 @@ import lombok.Data;
  */
 
 @Data
-public class GroupSpaceBindingQueue {
-  /** The id */
-  private long   id;
+public class UserBindingsQueue {
+  /**
+   * The id
+   */
+  private long id;
 
-  /** The GroupSpaceBinding */
-  private GroupSpaceBinding groupSpaceBinding;
-  
-  /** The action. */
+  /**
+   * The UserId
+   */
+  private String userId;
+
+  /**
+   * The action.
+   */
   private String action;
 
   private Long    createdDate;
-  
-  public static String ACTION_CREATE = "create";
-  public static String ACTION_REMOVE = "remove";
 
-  public GroupSpaceBindingQueue() {
+  public static String ACTION_REMOVE_USER_BINDINGS = "removeUserBindings";
+
+  public static String ACTION_CREATE_USER_BINDINGS = "createUserBindings";
+
+
+  public UserBindingsQueue() {
   }
 
-  public GroupSpaceBindingQueue(GroupSpaceBinding groupSpaceBinding, String action) {
-    this.groupSpaceBinding = groupSpaceBinding;
+
+  public UserBindingsQueue(String userId, String action) {
+    this.userId = userId;
     this.action = action;
   }
+
 }
+

--- a/component/api/src/main/java/org/exoplatform/social/core/storage/api/GroupSpaceBindingStorage.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/storage/api/GroupSpaceBindingStorage.java
@@ -37,6 +37,19 @@ public interface GroupSpaceBindingStorage {
   GroupSpaceBindingQueue findFirstGroupSpaceBindingQueue() throws GroupSpaceBindingStorageException;
 
   /**
+   * Get the first GroupSpaceBindingQueueUserBindingsQueue to treat
+   *
+   * @return The GroupSpaceBindingQueueUserBindingsQueue
+   */
+  UserBindingsQueue findFirstUserBindingsQueue() throws GroupSpaceBindingStorageException;
+  /**
+   * Get the list of GroupSpaceBindingQueueUserBindingsQueue by userID ans action
+   *
+   * @return The List of GroupSpaceBindingQueueUserBindingsQueue
+   */
+  List<UserBindingsQueue> findUserBindingsQueueByUserAndAction(String userId, String action);
+
+  /**
    * Get a list containing all the groups binding for a space.
    *
    * @param spaceId The space Id.
@@ -51,6 +64,12 @@ public interface GroupSpaceBindingStorage {
    * @return The list of binding.
    */
   List<GroupSpaceBinding> findGroupSpaceBindingsByGroup(String group) throws GroupSpaceBindingStorageException;
+  /**
+   * Get a list of all groups spaces binding.
+   *
+   * @return The list of binding.
+   */
+  List<GroupSpaceBinding> getAllGroupSpaceBindings() throws GroupSpaceBindingStorageException;
 
   /**
    * Get a list containing all the group binding for a space member.
@@ -93,6 +112,14 @@ public interface GroupSpaceBindingStorage {
    * @throws GroupSpaceBindingStorageException
    */
   GroupSpaceBinding saveGroupSpaceBinding(GroupSpaceBinding binding) throws GroupSpaceBindingStorageException;
+
+  /**
+   * Add a users Bindings Queue to the binding queue
+   *
+   * @param bindingQueue
+   * @throws GroupSpaceBindingStorageException
+   */
+  UserBindingsQueue createUserBindingsQueue(UserBindingsQueue bindingQueue) throws GroupSpaceBindingStorageException;
 
   /**
    * Add a Group Space Binding to the binding queue
@@ -141,6 +168,7 @@ public interface GroupSpaceBindingStorage {
    */
   void deleteGroupBindingReportUser(long id) throws GroupSpaceBindingStorageException;
 
+
   /**
    * Deletes a binding by binding id.
    *
@@ -164,6 +192,16 @@ public interface GroupSpaceBindingStorage {
    * @throws GroupSpaceBindingStorageException
    */
   void deleteAllUserBindings(String userName) throws GroupSpaceBindingStorageException;
+
+
+  /**
+   * Deletes a user bindings Queue by its id.
+   *
+   * @param id
+   * @throws GroupSpaceBindingStorageException
+   */
+  void deleteUserBindingsQueue(long id) throws GroupSpaceBindingStorageException;
+
 
   /**
    * Count user's bindings of the space.
@@ -256,6 +294,7 @@ public interface GroupSpaceBindingStorage {
   
   
   List<GroupSpaceBinding> findAllGroupSpaceBinding();
+  List<UserBindingsQueue> findAllUserBindingsQueue();
   List<UserSpaceBinding> findAllUserSpaceBinding();
   List<GroupSpaceBindingQueue> findAllGroupSpaceBindingQueue();
   List<GroupSpaceBindingReportAction> findAllGroupSpaceBindingReportAction();

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
@@ -223,8 +223,20 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
     }
   
     // Call the delete user binding to also update space membership.
+    int i = 0;
     for (UserSpaceBinding userSpaceBinding : groupSpaceBindingStorage.findUserAllBindingsByGroupBinding(groupSpaceBinding)) {
+      // every 10 users, we check if the binding is not in the queue for creation, if it is the case we stop the process since the binding will be created again and we can have conflicts between the delete and create actions.
+
+
+      if (i==10){
+        if(getGroupSpaceBindingsFromQueueByAction(GroupSpaceBindingQueue.ACTION_CREATE).stream().anyMatch(gSBinding -> groupSpaceBinding.getGroup().equals(gSBinding.getGroup()))){
+          LOG.info("Binding process: Stopped since binding will be created again");
+          break;
+        }
+        i = 0;
+      }
       deleteUserBinding(userSpaceBinding, bindingReportRemoveAction);
+      i++;
     }
     // Finally save the end date for the bindingReportAction.
     bindingReportRemoveAction.setEndDate(new Date());
@@ -386,7 +398,7 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
         bindingReportAddAction=groupSpaceBindingStorage.saveGroupSpaceBindingReport(report);
       }
       do {
-        if(getGroupSpaceBindingsFromQueueByAction(GroupSpaceBindingQueue.ACTION_REMOVE).stream().anyMatch(gSBinding -> groupSpaceBinding.getGroup().equals(gSBinding.getGroup()) && groupSpaceBinding.getId()==gSBinding.getId())){
+        if(getGroupSpaceBindingsFromQueueByAction(GroupSpaceBindingQueue.ACTION_REMOVE).stream().anyMatch(gSBinding -> groupSpaceBinding.getGroup().equals(gSBinding.getGroup()))){
           LOG.info("Binding process: Stopped since binding was removed");
           offset = totalGroupMembersSize;
           break;
@@ -544,45 +556,4 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
   public List<GroupSpaceBindingQueue> getAllFromBindingQueue() {
     return groupSpaceBindingStorage.getAllFromBindingQueue();
   }
-
-  public void checkAndUpdateGroupSpaceBindings()  {
-    for (GroupSpaceBinding groupSpaceBinding : getAllGroupSpaceBindings()){
-      try {
-      Space space = spaceService.getSpaceById(groupSpaceBinding.getSpaceId());
-      String[] members = space.getMembers();
-      ListAccess<User> groupMembersAccess = organizationService.getUserHandler().findUsersByGroupId(groupSpaceBinding.getGroup());
-      int totalGroupMembersSize = groupMembersAccess.getSize();
-      if (totalGroupMembersSize > members.length) {
-        List<String> groupMembers = Arrays.asList(groupMembersAccess.load(0, totalGroupMembersSize)).stream()
-            .map(User::getUserName)
-            .toList();
-        List<String> spaceMembers = Arrays.asList(members);
-        List<String> missingSpaceMembers = groupMembers.stream()
-            .filter(groupMember -> !spaceMembers.contains(groupMember))
-            .toList();
-        GroupSpaceBindingReportAction bindingReportAddSynchronizeAction =
-                findGroupSpaceBindingReportAction(groupSpaceBinding.getId(),
-                        GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
-        if (bindingReportAddSynchronizeAction == null) {
-          GroupSpaceBindingReportAction report =
-                  new GroupSpaceBindingReportAction(groupSpaceBinding.getId(),
-                          Long.parseLong(groupSpaceBinding.getSpaceId()),
-                          groupSpaceBinding.getGroup(),
-                          GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
-          bindingReportAddSynchronizeAction = saveGroupSpaceBindingReport(report);
-        }
-        for (String missingSpaceMember : missingSpaceMembers) {
-          saveUserBinding(missingSpaceMember,
-                  groupSpaceBinding,
-                  space,
-                  bindingReportAddSynchronizeAction);
-        }
-      }
-      } catch (Exception e) {
-        LOG.error("Error when synchronizing group space binding " + groupSpaceBinding.getId() + " for space "
-            + groupSpaceBinding.getSpaceId(), e);
-      }
-    }
-  }
-
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
@@ -31,14 +31,10 @@ import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
-import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingOperationReport;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportUser;
-import org.exoplatform.social.core.binding.model.UserSpaceBinding;
+import org.exoplatform.social.core.binding.model.*;
 import org.exoplatform.social.core.binding.spi.GroupSpaceBindingService;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
@@ -87,6 +83,21 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
     LOG.debug("Retrieving First GroupSpaceBindingQueue to treat");
     return groupSpaceBindingStorage.findFirstGroupSpaceBindingQueue();
   }
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public UserBindingsQueue findFirstUserBindingsQueue() {
+    LOG.debug("Retrieving First UserBindingsQueue to treat");
+    return groupSpaceBindingStorage.findFirstUserBindingsQueue();
+  }
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<UserBindingsQueue> findUserBindingsQueueByUserAndAction(String userId, String action) {
+    return groupSpaceBindingStorage.findUserBindingsQueueByUserAndAction(userId, action);
+  }
 
   /**
    * {@inheritDoc}
@@ -105,6 +116,15 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
   public List<GroupSpaceBinding> findGroupSpaceBindingsByGroup(String group) {
     LOG.debug("Retrieving group/space bindings for group:" + group);
     return groupSpaceBindingStorage.findGroupSpaceBindingsByGroup(group);
+  }
+  /**
+   * {@inheritDoc}
+   */
+
+  @Override
+  public List<GroupSpaceBinding> getAllGroupSpaceBindings() {
+    LOG.debug("Retrieving all group/space ");
+    return groupSpaceBindingStorage.getAllGroupSpaceBindings();
   }
 
   /**
@@ -157,6 +177,11 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
   @Override
   public void createGroupSpaceBindingQueue(GroupSpaceBindingQueue groupSpaceBindingsQueue) {
     groupSpaceBindingStorage.createGroupSpaceBindingQueue(groupSpaceBindingsQueue);
+  }
+
+  @Override
+  public void createUserBindingsQueue(UserBindingsQueue userBindingsQueue) {
+    groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue);
   }
   
   @Override
@@ -372,9 +397,9 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
         users = Arrays.asList(groupMembersAccess.load(offset, limit));
         count = users.size();
         int currentCount = offset;
+        startRequest();
         for (User user : users) {
           currentCount++;
-          startRequest();
           long startTimeUser = System.currentTimeMillis();
 
           String userId = user.getUserName();
@@ -384,8 +409,8 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
           long totalTimeUser = endTimeUser - startTimeUser;
           LOG.debug("Time to treat user " + userId + " (" + currentCount + "/" + totalGroupMembersSize + ") : " + totalTimeUser
               + " ms");
-          endRequest();
         }
+        endRequest();
         offset += count;
         LOG.info("Binding process: Bound Users({})", offset);
         long endBunchTime = System.currentTimeMillis();
@@ -435,6 +460,10 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
   @Override
   public void deleteFromBindingQueue(GroupSpaceBindingQueue bindingQueue) {
     groupSpaceBindingStorage.deleteGroupBindingQueue(bindingQueue.getId());
+  }
+  @Override
+  public void deleteUserBindingsQueue(UserBindingsQueue bindingQueue) {
+    groupSpaceBindingStorage.deleteUserBindingsQueue(bindingQueue.getId());
   }
 
   private void endRequest() {
@@ -487,7 +516,11 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
                                                                                             userId,
                                                                                             GroupSpaceBindingReportUser.ACTION_ADD_USER);
     groupSpaceBindingReportUser.setWasPresentBefore(userSpaceBinding.isMemberBefore());
-    spaceService.addMember(space, userId);
+    try {
+      spaceService.addMember(space, userId);
+    } catch (Exception e) {
+      LOG.error("Error when adding user " + userId + " to space " + space.getPrettyName(), e);
+    }
     groupSpaceBindingStorage.saveUserBinding(userSpaceBinding);
     groupSpaceBindingStorage.saveGroupSpaceBindingReportUser(groupSpaceBindingReportUser);
   }
@@ -510,6 +543,46 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
   @Override
   public List<GroupSpaceBindingQueue> getAllFromBindingQueue() {
     return groupSpaceBindingStorage.getAllFromBindingQueue();
+  }
+
+  public void checkAndUpdateGroupSpaceBindings()  {
+    for (GroupSpaceBinding groupSpaceBinding : getAllGroupSpaceBindings()){
+      try {
+      Space space = spaceService.getSpaceById(groupSpaceBinding.getSpaceId());
+      String[] members = space.getMembers();
+      ListAccess<User> groupMembersAccess = organizationService.getUserHandler().findUsersByGroupId(groupSpaceBinding.getGroup());
+      int totalGroupMembersSize = groupMembersAccess.getSize();
+      if (totalGroupMembersSize > members.length) {
+        List<String> groupMembers = Arrays.asList(groupMembersAccess.load(0, totalGroupMembersSize)).stream()
+            .map(User::getUserName)
+            .toList();
+        List<String> spaceMembers = Arrays.asList(members);
+        List<String> missingSpaceMembers = groupMembers.stream()
+            .filter(groupMember -> !spaceMembers.contains(groupMember))
+            .toList();
+        GroupSpaceBindingReportAction bindingReportAddSynchronizeAction =
+                findGroupSpaceBindingReportAction(groupSpaceBinding.getId(),
+                        GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
+        if (bindingReportAddSynchronizeAction == null) {
+          GroupSpaceBindingReportAction report =
+                  new GroupSpaceBindingReportAction(groupSpaceBinding.getId(),
+                          Long.parseLong(groupSpaceBinding.getSpaceId()),
+                          groupSpaceBinding.getGroup(),
+                          GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
+          bindingReportAddSynchronizeAction = saveGroupSpaceBindingReport(report);
+        }
+        for (String missingSpaceMember : missingSpaceMembers) {
+          saveUserBinding(missingSpaceMember,
+                  groupSpaceBinding,
+                  space,
+                  bindingReportAddSynchronizeAction);
+        }
+      }
+      } catch (Exception e) {
+        LOG.error("Error when synchronizing group space binding " + groupSpaceBinding.getId() + " for space "
+            + groupSpaceBinding.getSpaceId(), e);
+      }
+    }
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
@@ -18,17 +18,26 @@
  */
 package org.exoplatform.social.core.binding.job;
 
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.social.core.binding.model.*;
 import org.exoplatform.social.core.binding.spi.GroupSpaceBindingService;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
 import io.meeds.common.ContainerTransactional;
 
@@ -37,38 +46,36 @@ public class QueueGroupSpaceBindingJob implements Job {
   private static final Log         LOG = ExoLogger.getLogger(QueueGroupSpaceBindingJob.class);
 
   private GroupSpaceBindingService groupSpaceBindingService;
+  private SpaceService spaceService;
 
   @Override
   @ContainerTransactional
   public void execute(JobExecutionContext context) throws JobExecutionException {
     groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
+    spaceService = CommonsUtils.getService(SpaceService.class);
     LOG.info("Start treating GroupSpaceBinding queue");
-    GroupSpaceBindingQueue firstBindingQueue = null;
+    GroupSpaceBindingQueue firstGroupBindingInQueue = groupSpaceBindingService.findFirstGroupSpaceBindingQueue();
+    UserBindingsQueue firstUserBindingsQueue = groupSpaceBindingService.findFirstUserBindingsQueue();
     do {
       try {
-        firstBindingQueue = groupSpaceBindingService.findFirstGroupSpaceBindingQueue();
-        if (firstBindingQueue != null) {
-          // Get first binding from groupSpaceBindingQueue.
-          GroupSpaceBinding firstBindingInBindingQueue = firstBindingQueue.getGroupSpaceBinding();
-          String queueAction = firstBindingQueue.getAction();
-          // Switch the bindingQueue action we proceed.
-          if (queueAction.equals(GroupSpaceBindingQueue.ACTION_CREATE)) {
-            LOG.info("Proceeding binding between space with ID: {} and group: {}",
-                     firstBindingInBindingQueue.getSpaceId(),
-                     firstBindingInBindingQueue.getGroup());
-            // Bind users to space.
-            groupSpaceBindingService.bindUsersFromGroupSpaceBinding(firstBindingInBindingQueue);
-
-            // If totally proceeded remove it from groupSpaceBindingQueue.
-            groupSpaceBindingService.deleteFromBindingQueue(firstBindingQueue);
+        if (firstGroupBindingInQueue != null && firstUserBindingsQueue == null) {
+          proceedGroupSpaceBiding(firstGroupBindingInQueue);
+          firstGroupBindingInQueue = groupSpaceBindingService.findFirstGroupSpaceBindingQueue();
+        } else if (firstUserBindingsQueue != null && firstGroupBindingInQueue == null) {
+          proceedUserBindings(firstUserBindingsQueue);
+          firstUserBindingsQueue = groupSpaceBindingService.findFirstUserBindingsQueue();
+        } else if (firstUserBindingsQueue != null && firstGroupBindingInQueue != null) {
+          // If both queues are not empty, we proceed the one which is the oldest.
+          if (firstGroupBindingInQueue.getCreatedDate() == null || firstGroupBindingInQueue.getCreatedDate() < firstUserBindingsQueue.getCreatedDate()) {
+            proceedGroupSpaceBiding(firstGroupBindingInQueue);
+            firstGroupBindingInQueue = groupSpaceBindingService.findFirstGroupSpaceBindingQueue();
           } else {
-            LOG.info("Proceeding removing binding between space with ID: {} and group: {}",
-                     firstBindingInBindingQueue.getSpaceId(),
-                     firstBindingInBindingQueue.getGroup());
-            // Remove users from space except members before or which has over bindings.
-            // Once the binding deleted it will be removed from groupSpaceBindingQueue.
-            groupSpaceBindingService.deleteGroupSpaceBinding(firstBindingInBindingQueue);
+            proceedUserBindings(firstUserBindingsQueue);
+            firstUserBindingsQueue = groupSpaceBindingService.findFirstUserBindingsQueue();
           }
+        } else {
+          LOG.info("No GroupSpaceBindingQueue or UserBindingsQueue to process");
+          groupSpaceBindingService.checkAndUpdateGroupSpaceBindings();
         }
       } catch (Exception e) {
         LOG.error("Failed to treat GroupSpaceBinding queue", e);
@@ -76,8 +83,156 @@ public class QueueGroupSpaceBindingJob implements Job {
         //else you will continually loop on the same error
         break;
       }
-    } while (firstBindingQueue != null);
+    } while (firstGroupBindingInQueue != null || firstUserBindingsQueue != null);
     LOG.info("End treating GroupSpaceBinding queue");
+  }
+
+  private void proceedGroupSpaceBiding(GroupSpaceBindingQueue groupSpaceBindingQueue) {
+// Get first binding from groupSpaceBindingQueue.
+    GroupSpaceBinding firstBindingInBindingQueue = groupSpaceBindingQueue.getGroupSpaceBinding();
+    String queueAction = groupSpaceBindingQueue.getAction();
+    // Switch the bindingQueue action we proceed.
+    if (queueAction.equals(GroupSpaceBindingQueue.ACTION_CREATE)) {
+      LOG.info("Proceeding binding between space with ID: {} and group: {}",
+              firstBindingInBindingQueue.getSpaceId(),
+              firstBindingInBindingQueue.getGroup());
+      // Bind users to space.
+      groupSpaceBindingService.bindUsersFromGroupSpaceBinding(firstBindingInBindingQueue);
+
+      // If totally proceeded remove it from groupSpaceBindingQueue.
+      groupSpaceBindingService.deleteFromBindingQueue(groupSpaceBindingQueue);
+    } else {
+      LOG.info("Proceeding removing binding between space with ID: {} and group: {}",
+              firstBindingInBindingQueue.getSpaceId(),
+              firstBindingInBindingQueue.getGroup());
+      // Remove users from space except members before or which has over bindings.
+      // Once the binding deleted it will be removed from groupSpaceBindingQueue.
+      groupSpaceBindingService.deleteGroupSpaceBinding(firstBindingInBindingQueue);
+    }
+  }
+
+  private void proceedUserBindings(UserBindingsQueue userBindingsQueue) {
+    if (userBindingsQueue.getAction().equals(UserBindingsQueue.ACTION_REMOVE_USER_BINDINGS)) {
+      if (!groupSpaceBindingService.findUserBindingsQueueByUserAndAction(userBindingsQueue.getUserId(), UserBindingsQueue.ACTION_CREATE_USER_BINDINGS).isEmpty()) {
+        LOG.debug("User {} has already a bindings creation in queue, so we skip the bindings removal for this user", userBindingsQueue.getUserId());
+        groupSpaceBindingService.deleteUserBindingsQueue(userBindingsQueue);
+      } else {
+        RequestLifeCycle.begin(PortalContainer.getInstance());
+        try {
+          // Get all user bindings.
+          List<UserSpaceBinding> userSpaceBindings = groupSpaceBindingService.findUserBindingsByUser(userBindingsQueue.getUserId());
+          // Remove all user's bindings.
+          for (UserSpaceBinding userSpaceBinding : userSpaceBindings) {
+            Space space = spaceService.getSpaceById(userSpaceBinding.getGroupBinding().getSpaceId());
+
+            long startTime = System.currentTimeMillis();
+
+            // Retrieve bindingReportAction of synchronize.
+            GroupSpaceBindingReportAction bindingReportAddSynchronizeAction =
+                    groupSpaceBindingService.findGroupSpaceBindingReportAction(userSpaceBinding.getGroupBinding().getId(),
+                            GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
+            // If bindingReportAction for synchronize is not already created, create it.
+            if (bindingReportAddSynchronizeAction == null) {
+              GroupSpaceBindingReportAction report = new GroupSpaceBindingReportAction(userSpaceBinding.getGroupBinding().getId(),
+                      Long.parseLong(userSpaceBinding.getGroupBinding().getSpaceId()),
+                      userSpaceBinding.getGroupBinding().getGroup(),
+                      GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
+              bindingReportAddSynchronizeAction = groupSpaceBindingService.saveGroupSpaceBindingReport(report);
+            }
+            groupSpaceBindingService.deleteUserBinding(userSpaceBinding, bindingReportAddSynchronizeAction);
+            // Finally save the end date for the bindingReportAction.
+            bindingReportAddSynchronizeAction.setEndDate(new Date());
+            groupSpaceBindingService.updateGroupSpaceBindingReportAction(bindingReportAddSynchronizeAction);
+
+            long totalTime = System.currentTimeMillis() - startTime;
+            LOG.info("service={} operation={} parameters=\"space:{},totalSpaceMembers:{},boundSpaceMembers:{}\" status=ok "
+                            + "duration_ms={}",
+                    GroupSpaceBindingService.LOG_SERVICE_NAME, GroupSpaceBindingService.LOG_UPDATE_OPERATION_NAME,
+                    space.getPrettyName(),
+                    space.getMembers().length,
+                    groupSpaceBindingService.countBoundUsers(space.getId()),
+                    totalTime);
+          }
+          // If totally proceeded remove it from groupSpaceBindingQueue.
+          groupSpaceBindingService.deleteUserBindingsQueue(userBindingsQueue);
+      } catch (Exception e) {
+          LOG.warn("Problem occurred when removing user bindings for user ({}): ", userBindingsQueue.getUserId(), e);
+        } finally {
+          RequestLifeCycle.end();
+        }
+      }
+    } else {
+      if (!groupSpaceBindingService.findUserBindingsQueueByUserAndAction(userBindingsQueue.getUserId(), UserBindingsQueue.ACTION_REMOVE_USER_BINDINGS).isEmpty()) {
+        LOG.debug("User {} has already a bindings remove in queue, so we skip the bindings removal for this user", userBindingsQueue.getUserId());
+        groupSpaceBindingService.deleteUserBindingsQueue(userBindingsQueue);
+      } else {
+        RequestLifeCycle.begin(PortalContainer.getInstance());
+        try {
+          //get all his non space groups
+          //for each check if a groupBinding exists
+          //saveUserBinding for this groupBinding
+          groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
+          spaceService = CommonsUtils.getService(SpaceService.class);
+          OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+          Collection<Group> groups = organizationService.getGroupHandler().findGroupsOfUser(userBindingsQueue.getUserId());
+
+          groups.stream().filter(group -> !isASpaceGroup(group.getGroupName())).forEach(group -> {
+            // Retrieve all bindings of the group.
+            List<GroupSpaceBinding> groupSpaceBindings =
+                    groupSpaceBindingService.findGroupSpaceBindingsByGroup(group.getId());
+            // For each bound space of the group add a user binding to it.
+            for (GroupSpaceBinding groupSpaceBinding : groupSpaceBindings) {
+              Space space = spaceService.getSpaceById(groupSpaceBinding.getSpaceId());
+              long startTime = System.currentTimeMillis();
+
+              // Retrieve bindingReportAction of synchronize.
+              GroupSpaceBindingReportAction bindingReportAddSynchronizeAction =
+                      groupSpaceBindingService.findGroupSpaceBindingReportAction(groupSpaceBinding.getId(),
+                              GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
+              // If bindingReportAction for synchronize is not already created, create it.
+              if (bindingReportAddSynchronizeAction == null) {
+                GroupSpaceBindingReportAction report =
+                        new GroupSpaceBindingReportAction(groupSpaceBinding.getId(),
+                                Long.parseLong(groupSpaceBinding.getSpaceId()),
+                                groupSpaceBinding.getGroup(),
+                                GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
+                bindingReportAddSynchronizeAction = groupSpaceBindingService.saveGroupSpaceBindingReport(report);
+              }
+
+              groupSpaceBindingService.saveUserBinding(userBindingsQueue.getUserId(),
+                      groupSpaceBinding,
+                      space,
+                      bindingReportAddSynchronizeAction);
+
+              // Finally save the end date for the bindingReportAction.
+              bindingReportAddSynchronizeAction.setEndDate(new Date());
+              groupSpaceBindingService.updateGroupSpaceBindingReportAction(bindingReportAddSynchronizeAction);
+
+
+              long totalTime = System.currentTimeMillis() - startTime;
+              LOG.info("service={} operation={} parameters=\"space:{},totalSpaceMembers:{},boundSpaceMembers:{}\" status=ok "
+                              + "duration_ms={}",
+                      GroupSpaceBindingService.LOG_SERVICE_NAME,
+                      GroupSpaceBindingService.LOG_UPDATE_OPERATION_NAME,
+                      space.getPrettyName(),
+                      space.getMembers().length,
+                      groupSpaceBindingService.countBoundUsers(space.getId()),
+                      totalTime);
+            }
+          });
+          // If totally proceeded remove it from groupSpaceBindingQueue.
+          groupSpaceBindingService.deleteUserBindingsQueue(userBindingsQueue);
+        } catch (Exception e) {
+          LOG.warn("Problem occurred when creating user bindings for user ({}): ", userBindingsQueue.getUserId(), e);
+        } finally {
+          RequestLifeCycle.end();
+      }
+      }
+    }
+  }
+
+  private boolean isASpaceGroup(String groupName) {
+    return groupName.startsWith("/spaces");
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
@@ -59,7 +59,7 @@ public class QueueGroupSpaceBindingJob implements Job {
     do {
       try {
         if (firstGroupBindingInQueue != null && firstUserBindingsQueue == null) {
-          proceedGroupSpaceBiding(firstGroupBindingInQueue);
+          proceedGroupSpaceBinding(firstGroupBindingInQueue);
           firstGroupBindingInQueue = groupSpaceBindingService.findFirstGroupSpaceBindingQueue();
         } else if (firstUserBindingsQueue != null && firstGroupBindingInQueue == null) {
           proceedUserBindings(firstUserBindingsQueue);
@@ -67,7 +67,7 @@ public class QueueGroupSpaceBindingJob implements Job {
         } else if (firstUserBindingsQueue != null && firstGroupBindingInQueue != null) {
           // If both queues are not empty, we proceed the one which is the oldest.
           if (firstGroupBindingInQueue.getCreatedDate() == null || firstGroupBindingInQueue.getCreatedDate() < firstUserBindingsQueue.getCreatedDate()) {
-            proceedGroupSpaceBiding(firstGroupBindingInQueue);
+            proceedGroupSpaceBinding(firstGroupBindingInQueue);
             firstGroupBindingInQueue = groupSpaceBindingService.findFirstGroupSpaceBindingQueue();
           } else {
             proceedUserBindings(firstUserBindingsQueue);
@@ -86,7 +86,7 @@ public class QueueGroupSpaceBindingJob implements Job {
     LOG.info("End treating GroupSpaceBinding queue");
   }
 
-  private void proceedGroupSpaceBiding(GroupSpaceBindingQueue groupSpaceBindingQueue) {
+  private void proceedGroupSpaceBinding(GroupSpaceBindingQueue groupSpaceBindingQueue) {
 // Get first binding from groupSpaceBindingQueue.
     GroupSpaceBinding firstBindingInBindingQueue = groupSpaceBindingQueue.getGroupSpaceBinding();
     String queueAction = groupSpaceBindingQueue.getAction();

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/job/QueueGroupSpaceBindingJob.java
@@ -75,7 +75,6 @@ public class QueueGroupSpaceBindingJob implements Job {
           }
         } else {
           LOG.info("No GroupSpaceBindingQueue or UserBindingsQueue to process");
-          groupSpaceBindingService.checkAndUpdateGroupSpaceBindings();
         }
       } catch (Exception e) {
         LOG.error("Failed to treat GroupSpaceBinding queue", e);

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/listener/SpaceBindingUserEventListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/listener/SpaceBindingUserEventListener.java
@@ -18,32 +18,20 @@
  */
 package org.exoplatform.social.core.binding.listener;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.Group;
-import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserEventListener;
-import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
-import org.exoplatform.social.core.binding.model.UserSpaceBinding;
+import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
+import org.exoplatform.social.core.binding.model.UserBindingsQueue;
 import org.exoplatform.social.core.binding.spi.GroupSpaceBindingService;
-import org.exoplatform.social.core.space.model.Space;
-import org.exoplatform.social.core.space.spi.SpaceService;
 
 public class SpaceBindingUserEventListener extends UserEventListener {
   private static final Log         LOG = ExoLogger.getLogger(SpaceBindingUserEventListener.class);
 
   private GroupSpaceBindingService groupSpaceBindingService;
-  private SpaceService spaceService;
-  
+
   @Override
   public void preSetEnabled(User user) throws Exception {
     if(!user.isEnabled()) {
@@ -68,114 +56,14 @@ public class SpaceBindingUserEventListener extends UserEventListener {
   }
   
   private void createAllUserBindings(User user) {
-    RequestLifeCycle.begin(PortalContainer.getInstance());
-    try {
-      //get all his non space groups
-      //for each check if a groupBinding exists
-      //saveUserBinding for this groupBinding
-      groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
-      spaceService = CommonsUtils.getService(SpaceService.class);
-      OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
-      Collection<Group> groups= organizationService.getGroupHandler().findGroupsOfUser(user.getUserName());
-      
-      groups.stream().filter(group -> !isASpaceGroup(group.getGroupName())).forEach(group -> {
-        // Retrieve all bindings of the group.
-        List<GroupSpaceBinding> groupSpaceBindings =
-            groupSpaceBindingService.findGroupSpaceBindingsByGroup(group.getId());
-        // For each bound space of the group add a user binding to it.
-        for (GroupSpaceBinding groupSpaceBinding : groupSpaceBindings) {
-          Space space = spaceService.getSpaceById(groupSpaceBinding.getSpaceId());
-          long startTime = System.currentTimeMillis();
-   
-          // Retrieve bindingReportAction of synchronize.
-          GroupSpaceBindingReportAction bindingReportAddSynchronizeAction =
-              groupSpaceBindingService.findGroupSpaceBindingReportAction(groupSpaceBinding.getId(),
-                                                                         GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
-          // If bindingReportAction for synchronize is not already created, create it.
-          if (bindingReportAddSynchronizeAction == null) {
-            GroupSpaceBindingReportAction report =
-                new GroupSpaceBindingReportAction(groupSpaceBinding.getId(),
-                                                  Long.parseLong(groupSpaceBinding.getSpaceId()),
-                                                  groupSpaceBinding.getGroup(),
-                                                  GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
-            bindingReportAddSynchronizeAction = groupSpaceBindingService.saveGroupSpaceBindingReport(report);
-          }
-  
-          groupSpaceBindingService.saveUserBinding(user.getUserName(),
-                                                   groupSpaceBinding,
-                                                   space,
-                                                   bindingReportAddSynchronizeAction);
-  
-          // Finally save the end date for the bindingReportAction.
-          bindingReportAddSynchronizeAction.setEndDate(new Date());
-          groupSpaceBindingService.updateGroupSpaceBindingReportAction(bindingReportAddSynchronizeAction);
-  
-  
-          long totalTime = System.currentTimeMillis() - startTime;
-          LOG.info("service={} operation={} parameters=\"space:{},totalSpaceMembers:{},boundSpaceMembers:{}\" status=ok "
-                       + "duration_ms={}",
-                   GroupSpaceBindingService.LOG_SERVICE_NAME,
-                   GroupSpaceBindingService.LOG_UPDATE_OPERATION_NAME,
-                   space.getPrettyName(),
-                   space.getMembers().length,
-                   groupSpaceBindingService.countBoundUsers(space.getId()),
-                   totalTime);
-        }
-
-      });
-    } catch (Exception e) {
-      LOG.warn("Problem occurred when creating user bindings for user ({}): ", user.getUserName(), e);
-    } finally {
-      RequestLifeCycle.end();
-    }
+    groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
+    UserBindingsQueue bindingQueue = new UserBindingsQueue(user.getUserName(), UserBindingsQueue.ACTION_CREATE_USER_BINDINGS);
+    groupSpaceBindingService.createUserBindingsQueue(bindingQueue);
   }
   
   private void removeAllUserBindings(User user) {
-    RequestLifeCycle.begin(PortalContainer.getInstance());
-    try {
-      groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
-      spaceService = CommonsUtils.getService(SpaceService.class);
-      // Get all user bindings.
-      List<UserSpaceBinding> userSpaceBindings = groupSpaceBindingService.findUserBindingsByUser(user.getUserName());
-      // Remove all user's bindings.
-      for (UserSpaceBinding userSpaceBinding : userSpaceBindings) {
-        Space space = spaceService.getSpaceById(userSpaceBinding.getGroupBinding().getSpaceId());
-        long startTime=System.currentTimeMillis();
-        
-        // Retrieve bindingReportAction of synchronize.
-        GroupSpaceBindingReportAction bindingReportAddSynchronizeAction =
-            groupSpaceBindingService.findGroupSpaceBindingReportAction(userSpaceBinding.getGroupBinding().getId(),
-                                                                       GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
-        // If bindingReportAction for synchronize is not already created, create it.
-        if (bindingReportAddSynchronizeAction == null) {
-          GroupSpaceBindingReportAction report = new GroupSpaceBindingReportAction(userSpaceBinding.getGroupBinding().getId(),
-                                                                                   Long.parseLong(userSpaceBinding.getGroupBinding().getSpaceId()),
-                                                                                   userSpaceBinding.getGroupBinding().getGroup(),
-                                                                                   GroupSpaceBindingReportAction.SYNCHRONIZE_ACTION);
-          bindingReportAddSynchronizeAction = groupSpaceBindingService.saveGroupSpaceBindingReport(report);
-        }
-        groupSpaceBindingService.deleteUserBinding(userSpaceBinding, bindingReportAddSynchronizeAction);
-        // Finally save the end date for the bindingReportAction.
-        bindingReportAddSynchronizeAction.setEndDate(new Date());
-        groupSpaceBindingService.updateGroupSpaceBindingReportAction(bindingReportAddSynchronizeAction);
-  
-        long totalTime=System.currentTimeMillis() - startTime;
-        LOG.info("service={} operation={} parameters=\"space:{},totalSpaceMembers:{},boundSpaceMembers:{}\" status=ok "
-                     + "duration_ms={}",
-                 GroupSpaceBindingService.LOG_SERVICE_NAME, GroupSpaceBindingService.LOG_UPDATE_OPERATION_NAME,
-                 space.getPrettyName(),
-                 space.getMembers().length,
-                 groupSpaceBindingService.countBoundUsers(space.getId()),
-                 totalTime);
-      }
-    } catch (Exception e) {
-      LOG.warn("Problem occurred when removing user bindings for user ({}): ", user.getUserName(), e);
-    } finally {
-      RequestLifeCycle.end();
-    }
-  }
-  
-  private boolean isASpaceGroup(String groupName) {
-    return groupName.startsWith("/spaces");
+    groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
+    UserBindingsQueue bindingQueue = new UserBindingsQueue(user.getUserName(), UserBindingsQueue.ACTION_REMOVE_USER_BINDINGS);
+    groupSpaceBindingService.createUserBindingsQueue(bindingQueue);
   }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/spi/GroupSpaceBindingService.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/spi/GroupSpaceBindingService.java
@@ -20,12 +20,7 @@ package org.exoplatform.social.core.binding.spi;
 
 import java.util.List;
 
-import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingOperationReport;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportUser;
-import org.exoplatform.social.core.binding.model.UserSpaceBinding;
+import org.exoplatform.social.core.binding.model.*;
 import org.exoplatform.social.core.space.model.Space;
 
 /**
@@ -51,6 +46,23 @@ public interface GroupSpaceBindingService {
   GroupSpaceBindingQueue findFirstGroupSpaceBindingQueue();
 
   /**
+   * Get the first UserBindingsQueue to treat
+   *
+   * @return The firdtbinding.
+   */
+  UserBindingsQueue findFirstUserBindingsQueue();
+
+  /**
+   * Get of UserBindingsQueue by userId and action
+   *
+   * @param userId The user Id.
+   * @param action The action.
+   *
+   * @return The list of UserBindingsQueue.
+   */
+  List<UserBindingsQueue> findUserBindingsQueueByUserAndAction(String userId, String action);
+
+  /**
    * Get a list containing all the groups binding for a space.
    *
    * @param spaceId The space Id.
@@ -65,6 +77,12 @@ public interface GroupSpaceBindingService {
    * @return The list of binding.
    */
   List<GroupSpaceBinding> findGroupSpaceBindingsByGroup(String group);
+  /**
+   * Get a list containing all the groups spaces binding.
+   *
+   * @return The list of binding.
+   */
+  List<GroupSpaceBinding> getAllGroupSpaceBindings();
 
   /**
    * Get a list containing all the groups binding for a space.
@@ -132,6 +150,19 @@ public interface GroupSpaceBindingService {
    * @param groupSpaceBinding The binding to be deleted.
    */
   void deleteGroupSpaceBinding(GroupSpaceBinding groupSpaceBinding);
+  /**
+   * Saves a user bindings queue
+   *
+   * @param userBindingsQueue The user bindings queue to save
+   */
+  void createUserBindingsQueue(UserBindingsQueue userBindingsQueue);
+
+  /**
+   * Delete a user bindings queue.
+   *
+   * @param userBindingsQueue The user bindings to be deleted.
+   */
+  void deleteUserBindingsQueue(UserBindingsQueue userBindingsQueue);
   
   /**
    * Prepare the group binding deletion : create the reportAction, and create the GroupBindingQueue
@@ -263,5 +294,11 @@ public interface GroupSpaceBindingService {
   void updateGroupSpaceBindingReportAction(GroupSpaceBindingReportAction groupSpaceBindingReportAction);
 
   List<GroupSpaceBindingQueue> getAllFromBindingQueue();
+
+  /**
+   * Check and fix  all incompleted group space bindings.
+   *
+   */
+  void checkAndUpdateGroupSpaceBindings();
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/binding/spi/GroupSpaceBindingService.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/spi/GroupSpaceBindingService.java
@@ -294,11 +294,4 @@ public interface GroupSpaceBindingService {
   void updateGroupSpaceBindingReportAction(GroupSpaceBindingReportAction groupSpaceBindingReportAction);
 
   List<GroupSpaceBindingQueue> getAllFromBindingQueue();
-
-  /**
-   * Check and fix  all incompleted group space bindings.
-   *
-   */
-  void checkAndUpdateGroupSpaceBindings();
-
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSGroupSpaceBindingStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSGroupSpaceBindingStorageImpl.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.core.jpa.storage;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -26,24 +27,10 @@ import java.util.stream.Collectors;
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingOperationReport;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportUser;
-import org.exoplatform.social.core.binding.model.UserSpaceBinding;
-import org.exoplatform.social.core.jpa.storage.dao.GroupSpaceBindingDAO;
-import org.exoplatform.social.core.jpa.storage.dao.GroupSpaceBindingQueueDAO;
-import org.exoplatform.social.core.jpa.storage.dao.GroupSpaceBindingReportActionDAO;
-import org.exoplatform.social.core.jpa.storage.dao.GroupSpaceBindingReportUserDAO;
-import org.exoplatform.social.core.jpa.storage.dao.UserSpaceBindingDAO;
+import org.exoplatform.social.core.binding.model.*;
+import org.exoplatform.social.core.jpa.storage.dao.*;
 import org.exoplatform.social.core.jpa.storage.dao.jpa.SpaceDAO;
-import org.exoplatform.social.core.jpa.storage.entity.GroupSpaceBindingEntity;
-import org.exoplatform.social.core.jpa.storage.entity.GroupSpaceBindingQueueEntity;
-import org.exoplatform.social.core.jpa.storage.entity.GroupSpaceBindingReportActionEntity;
-import org.exoplatform.social.core.jpa.storage.entity.GroupSpaceBindingReportUserEntity;
-import org.exoplatform.social.core.jpa.storage.entity.SpaceEntity;
-import org.exoplatform.social.core.jpa.storage.entity.UserSpaceBindingEntity;
+import org.exoplatform.social.core.jpa.storage.entity.*;
 import org.exoplatform.social.core.storage.GroupSpaceBindingStorageException;
 import org.exoplatform.social.core.storage.api.GroupSpaceBindingStorage;
 
@@ -71,18 +58,22 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
 
   private GroupSpaceBindingReportUserDAO   groupSpaceBindingReportUserDAO;
 
+  private UserBindingsQueueDAO             userBindingsQueueDAO;
+
   public RDBMSGroupSpaceBindingStorageImpl(SpaceDAO spaceDAO,
                                            GroupSpaceBindingDAO groupSpaceBindingDAO,
                                            GroupSpaceBindingQueueDAO groupSpaceBindingQueueDAO,
                                            UserSpaceBindingDAO userSpaceBindingDAO,
                                            GroupSpaceBindingReportActionDAO groupSpaceBindingReportActionDAO,
-                                           GroupSpaceBindingReportUserDAO groupSpaceBindingReportUserDAO) {
+                                           GroupSpaceBindingReportUserDAO groupSpaceBindingReportUserDAO,
+                                           UserBindingsQueueDAO   userBindingsQueueDAO) {
     this.spaceDAO = spaceDAO;
     this.groupSpaceBindingDAO = groupSpaceBindingDAO;
     this.groupSpaceBindingQueueDAO = groupSpaceBindingQueueDAO;
     this.userSpaceBindingDAO = userSpaceBindingDAO;
     this.groupSpaceBindingReportActionDAO = groupSpaceBindingReportActionDAO;
     this.groupSpaceBindingReportUserDAO = groupSpaceBindingReportUserDAO;
+    this.userBindingsQueueDAO = userBindingsQueueDAO;
   }
 
   @ExoTransactional
@@ -98,6 +89,11 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
   @ExoTransactional
   public List<GroupSpaceBinding> findGroupSpaceBindingsByGroup(String group) throws GroupSpaceBindingStorageException {
     return buildGroupBindingListFromEntities(groupSpaceBindingDAO.findGroupSpaceBindingsByGroup(group));
+  }
+
+  @ExoTransactional
+  public List<GroupSpaceBinding> getAllGroupSpaceBindings() throws GroupSpaceBindingStorageException {
+    return buildGroupBindingListFromEntities(groupSpaceBindingDAO.findAll());
   }
 
   @ExoTransactional
@@ -123,6 +119,17 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
   }
 
   @ExoTransactional
+  public UserBindingsQueue findFirstUserBindingsQueue() throws GroupSpaceBindingStorageException {
+    UserBindingsQueueEntity entity =userBindingsQueueDAO.findFirstUserBindingsQueue();
+    return fillUserBindingsQueueFromEntity(entity);
+  }
+
+  @ExoTransactional
+  public List<UserBindingsQueue> findUserBindingsQueueByUserAndAction(String userId, String action) {
+    return buildUserBindingsQueueListFromEntities(userBindingsQueueDAO.findUserBindingsQueueByUserAndAction(userId, action));
+  }
+
+  @ExoTransactional
   public GroupSpaceBinding saveGroupSpaceBinding(GroupSpaceBinding binding) throws GroupSpaceBindingStorageException {
     GroupSpaceBindingEntity bindingEntity = buildEntityGroupBindingFrom(binding);
     GroupSpaceBindingEntity entity = groupSpaceBindingDAO.create(bindingEntity);
@@ -133,6 +140,13 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
   public GroupSpaceBindingQueue createGroupSpaceBindingQueue(GroupSpaceBindingQueue bindingQueue) throws GroupSpaceBindingStorageException {
     GroupSpaceBindingQueueEntity entity = groupSpaceBindingQueueDAO.create(buildEntityGroupBindingQueueFrom(bindingQueue));
     return fillGroupBindingQueueFromEntity(entity);
+  }
+
+  @ExoTransactional
+  public UserBindingsQueue createUserBindingsQueue(UserBindingsQueue bindingQueue) throws GroupSpaceBindingStorageException {
+
+    UserBindingsQueueEntity entity = userBindingsQueueDAO.create(buildEntityUserBindingsQueueFrom(bindingQueue));
+    return fillUserBindingsQueueFromEntity(entity);
   }
 
   @ExoTransactional
@@ -184,6 +198,10 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
                                .stream()
                                .map(groupSpaceBindingEntity -> fillGroupBindingFromEntity(groupSpaceBindingEntity))
                                .collect(Collectors.toList());
+  }
+  @Override
+  public List<UserBindingsQueue> findAllUserBindingsQueue() {
+    return buildUserBindingsQueueListFromEntities(userBindingsQueueDAO.findAll());
   }
 
   @Override
@@ -242,6 +260,11 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
   @ExoTransactional
   public void deleteGroupBindingQueue(long id) throws GroupSpaceBindingStorageException {
     groupSpaceBindingQueueDAO.delete(groupSpaceBindingQueueDAO.find(id));
+  }
+
+  @ExoTransactional
+  public void deleteUserBindingsQueue(long id) throws GroupSpaceBindingStorageException {
+    userBindingsQueueDAO.delete(userBindingsQueueDAO.find(id));
   }
 
   @ExoTransactional
@@ -431,6 +454,10 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
     groupSpaceBindingQueue.setId(bindingQueueEntity.getId());
     groupSpaceBindingQueue.setGroupSpaceBinding(fillGroupBindingFromEntity(bindingQueueEntity.getGroupSpaceBindingEntity()));
     groupSpaceBindingQueue.setAction(bindingQueueEntity.getAction());
+    Instant createdDate = bindingQueueEntity.getCreatedDate();
+    if (createdDate != null) {
+      groupSpaceBindingQueue.setCreatedDate(createdDate.toEpochMilli());
+    }
     return groupSpaceBindingQueue;
   }
 
@@ -521,6 +548,7 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
     GroupSpaceBindingQueueEntity groupSpaceBindingQueueEntity = new GroupSpaceBindingQueueEntity();
     groupSpaceBindingQueueEntity.setGroupSpaceBindingEntity(buildEntityGroupBindingFrom(groupSpaceBindingQueue.getGroupSpaceBinding()));
     groupSpaceBindingQueueEntity.setAction(groupSpaceBindingQueue.getAction());
+    groupSpaceBindingQueueEntity.setCreatedDate(Instant.now());
     return groupSpaceBindingQueueEntity;
   }
 
@@ -537,5 +565,54 @@ public class RDBMSGroupSpaceBindingStorageImpl implements GroupSpaceBindingStora
     userSpaceBindingEntity.setGroupSpaceBinding(groupBindingEntity);
     return userSpaceBindingEntity;
   }
+
+  /**
+   * build {@link UserBindingsQueueEntity} from
+   * {@link UserBindingsQueue} object.
+   *
+   * @param userBindingsQueue the UserBindingsQueue object
+   */
+  private UserBindingsQueueEntity buildEntityUserBindingsQueueFrom(UserBindingsQueue userBindingsQueue) {
+    UserBindingsQueueEntity userBindingsQueueEntity = new UserBindingsQueueEntity();
+    userBindingsQueueEntity.setUserId(userBindingsQueue.getUserId());
+    userBindingsQueueEntity.setAction(userBindingsQueue.getAction());
+    userBindingsQueueEntity.setCreatedDate(Instant.now());
+    return userBindingsQueueEntity;
+  }
+
+  /**
+   * Fills {@link UserBindingsQueue}'s properties to
+   * {@link UserBindingsQueueEntity}'s.
+   *
+   * @param bindingQueueEntity the GroupSpaceBinding entity
+   */
+  private UserBindingsQueue fillUserBindingsQueueFromEntity(UserBindingsQueueEntity bindingQueueEntity) {
+    if (bindingQueueEntity == null) {
+      return null;
+    }
+    UserBindingsQueue userBindingsQueue = new UserBindingsQueue();
+    userBindingsQueue.setId(bindingQueueEntity.getId());
+    userBindingsQueue.setUserId(bindingQueueEntity.getUserId());
+    userBindingsQueue.setAction(bindingQueueEntity.getAction());
+    Instant createdDate = bindingQueueEntity.getCreatedDate();
+    if (createdDate != null) {
+      userBindingsQueue.setCreatedDate(createdDate.toEpochMilli());
+    }
+    return userBindingsQueue;
+  }
+
+  /**
+   * build {@link UserBindingsQueue}'s list from {@link UserBindingsQueueEntity}'s
+   * list.
+   *
+   * @param userSpaceBindingEntities
+   * @return
+   */
+  private List<UserBindingsQueue> buildUserBindingsQueueListFromEntities(List<UserBindingsQueueEntity> userSpaceBindingEntities) {
+    List<UserBindingsQueue> userBindingsQueues = new ArrayList<>();
+    userSpaceBindingEntities.stream().forEach(entity -> userBindingsQueues.add(fillUserBindingsQueueFromEntity(entity)));
+    return userBindingsQueues;
+  }
+
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/UserBindingsQueueDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/UserBindingsQueueDAO.java
@@ -1,8 +1,8 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
- *
+ * <p>
  * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
- *
+ * <p>
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -11,40 +11,32 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.exoplatform.social.core.binding.model;
+package org.exoplatform.social.core.jpa.storage.dao;
 
-import lombok.Data;
+import java.util.List;
 
-/**
- * Group Binding Model (between space ang organization group)
- */
+import org.exoplatform.commons.api.persistence.GenericDAO;
+import org.exoplatform.social.core.jpa.storage.entity.UserBindingsQueueEntity;
 
-@Data
-public class GroupSpaceBindingQueue {
-  /** The id */
-  private long   id;
+public interface UserBindingsQueueDAO extends GenericDAO<UserBindingsQueueEntity, Long> {
 
-  /** The GroupSpaceBinding */
-  private GroupSpaceBinding groupSpaceBinding;
-  
-  /** The action. */
-  private String action;
+  /**
+   * Gets first UserBindingsQueue in the queue.
+   *
+   * @return
+   */
+  UserBindingsQueueEntity findFirstUserBindingsQueue();
 
-  private Long    createdDate;
-  
-  public static String ACTION_CREATE = "create";
-  public static String ACTION_REMOVE = "remove";
+  /**
+   * Gets list of UserBindingsQueue by user and action.
+   *
+   * @return
+   */
+  List<UserBindingsQueueEntity> findUserBindingsQueueByUserAndAction(String userId, String action);
 
-  public GroupSpaceBindingQueue() {
-  }
-
-  public GroupSpaceBindingQueue(GroupSpaceBinding groupSpaceBinding, String action) {
-    this.groupSpaceBinding = groupSpaceBinding;
-    this.action = action;
-  }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/UserBindingsQueueDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/UserBindingsQueueDAO.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  * <p>
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  * <p>
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/UserBindingQueuesDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/UserBindingQueuesDAOImpl.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * <p>
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * <p>
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.jpa.storage.dao.jpa;
+
+import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
+import org.exoplatform.social.core.jpa.storage.dao.UserBindingsQueueDAO;
+import org.exoplatform.social.core.jpa.storage.entity.UserBindingsQueueEntity;
+
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
+
+import java.util.List;
+
+public class UserBindingQueuesDAOImpl extends GenericDAOJPAImpl<UserBindingsQueueEntity, Long>
+        implements UserBindingsQueueDAO {
+  @Override
+  public UserBindingsQueueEntity findFirstUserBindingsQueue() {
+    TypedQuery<UserBindingsQueueEntity> query =
+            getEntityManager().createNamedQuery("SocUserBindingsQueue.findFirstUserBindingsQueue",
+                    UserBindingsQueueEntity.class);
+    query.setMaxResults(1);
+    try {
+      return query.getSingleResult();
+    } catch (NoResultException ex) {
+      return null;
+    }
+  }
+
+  @Override
+  public List<UserBindingsQueueEntity> findUserBindingsQueueByUserAndAction(String userId, String action) {
+    TypedQuery<UserBindingsQueueEntity> query =
+            getEntityManager().createNamedQuery("SocUserBindingsQueue.getUserBindingsQueueByUserAndAction",
+                    UserBindingsQueueEntity.class);
+    query.setParameter("userId", userId);
+    query.setParameter("action", action);
+    return query.getResultList();
+  }
+}

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/UserBindingQueuesDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/UserBindingQueuesDAOImpl.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  * <p>
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  * <p>
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/GroupSpaceBindingQueueEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/GroupSpaceBindingQueueEntity.java
@@ -19,18 +19,10 @@
 package org.exoplatform.social.core.jpa.storage.entity;
 
 import java.io.Serializable;
+import java.time.Instant;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQueries;
-import jakarta.persistence.NamedQuery;
-import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.Data;
 
 @Entity(name = "SocGroupSpaceBindingQueue")
 @Table(name = "SOC_GROUP_SPACE_BINDING_QUEUE")
@@ -41,6 +33,7 @@ import jakarta.persistence.Table;
         + " where q.action = :action"),
     @NamedQuery(name = "SocGroupSpaceBindingQueue.getAllFromBindingQueueOrderedById", query = "SELECT q FROM SocGroupSpaceBindingQueue q "
         + " ORDER BY q.id DESC "), })
+@Data
 public class GroupSpaceBindingQueueEntity implements Serializable {
 
   @Id
@@ -56,27 +49,8 @@ public class GroupSpaceBindingQueueEntity implements Serializable {
   @Column(name = "ACTION")
   private String                  action;
 
-  public long getId() {
-    return id;
-  }
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "CREATED_DATE")
+  private Instant createdDate;
 
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public GroupSpaceBindingEntity getGroupSpaceBindingEntity() {
-    return groupSpaceBindingEntity;
-  }
-
-  public void setGroupSpaceBindingEntity(GroupSpaceBindingEntity groupSpaceBindingEntity) {
-    this.groupSpaceBindingEntity = groupSpaceBindingEntity;
-  }
-
-  public String getAction() {
-    return action;
-  }
-
-  public void setAction(String action) {
-    this.action = action;
-  }
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/UserBindingsQueueEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/UserBindingsQueueEntity.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  * <p>
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  * <p>
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/UserBindingsQueueEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/UserBindingsQueueEntity.java
@@ -1,0 +1,56 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * <p>
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * <p>
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.jpa.storage.entity;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity(name = "SocUserBindingsQueue")
+@Table(name = "SOC_USER_BINDINGS_QUEUE")
+@NamedQueries({
+        @NamedQuery(name = "SocUserBindingsQueue.findFirstUserBindingsQueue", query = "SELECT q FROM SocUserBindingsQueue q "
+                + " ORDER BY q.id ASC"),
+        @NamedQuery(name = "SocUserBindingsQueue.getUserBindingsQueueByUserAndAction", query = "SELECT q FROM SocUserBindingsQueue q "
+                + " where q.userId = :userId and q.action = :action "
+                + " ORDER BY q.id DESC ")})
+
+@Data
+public class UserBindingsQueueEntity implements Serializable {
+
+  @Id
+  @SequenceGenerator(name = "SEQ_SOC_USER_BINDINGS_QUEUE_ID", sequenceName = "SEQ_SOC_USER_BINDINGS_QUEUE_ID", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SOC_USER_BINDINGS_QUEUE_ID")
+  @Column(name = "USER_BINDINGS_QUEUE_ID")
+  private long id;
+
+
+  @Column(name = "USER_ID")
+  private String userId;
+
+  @Column(name = "ACTION")
+  private String action;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "CREATED_DATE")
+  private Instant createdDate;
+
+}

--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -1298,4 +1298,27 @@
       <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
     </modifySql>
   </changeSet>
+
+  <changeSet author="social" id="1.0.0-122">
+    <createTable tableName="SOC_USER_BINDINGS_QUEUE">
+      <column name="USER_BINDINGS_QUEUE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
+       <constraints nullable="false" primaryKey="true" primaryKeyName="PK_USER_BINDINGS_QUEUE_ID"/>
+        </column>
+         <column name="USER_ID" type="NVARCHAR(200)">
+           <constraints nullable="false"/>
+         </column>
+         <column name="ACTION" type="NVARCHAR(200)">
+           <constraints nullable="false"/>
+         </column>
+        <column name="CREATED_DATE" type="TIMESTAMP">
+            <constraints nullable="false"/>
+        </column>
+    </createTable>
+    <addColumn tableName="SOC_GROUP_SPACE_BINDING_QUEUE">
+      <column name="CREATED_DATE" type="TIMESTAMP"/>
+    </addColumn>
+   </changeSet>
+   <changeSet author="social" id="1.0.0-123" dbms="hsqldb">
+    <createSequence sequenceName="SEQ_SOC_USER_BINDINGS_QUEUE_ID" startValue="1"/>
+   </changeSet>
 </databaseChangeLog>

--- a/component/core/src/test/java/org/exoplatform/social/core/binding/spi/GroupSpaceBindingServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/binding/spi/GroupSpaceBindingServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.exoplatform.social.core.binding.model.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -38,11 +39,6 @@ import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.idm.UserDAOImpl;
 import org.exoplatform.services.organization.idm.UserImpl;
 import org.exoplatform.social.core.binding.impl.GroupSpaceBindingServiceImpl;
-import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportUser;
-import org.exoplatform.social.core.binding.model.UserSpaceBinding;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.api.GroupSpaceBindingStorage;
@@ -96,6 +92,50 @@ public class GroupSpaceBindingServiceTest extends AbstractCoreTest {
                                                                                          orgService,
                                                                                          spaceService);
     List<GroupSpaceBinding> results = groupSpaceBindingService.findGroupSpaceBindingsBySpace("1");
+    GroupSpaceBinding result1 = results.get(0);
+    GroupSpaceBinding result2 = results.get(1);
+
+    // Then
+    assertEquals(2, results.size());
+
+    assertEquals(1, result1.getId());
+    assertEquals("/platform/administrators", result1.getGroup());
+    assertEquals("1", result1.getSpaceId());
+
+    assertEquals(2, result2.getId());
+    assertEquals("/platform/web-contributors", result2.getGroup());
+    assertEquals("1", result2.getSpaceId());
+  }
+  /**
+   * Test
+   * {@link GroupSpaceBindingService#getAllGroupSpaceBindings()}
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testGetAllGroupSpaceBindings() throws Exception {
+    // Given
+    List<GroupSpaceBinding> groupSpaceBindings = new LinkedList<>();
+    GroupSpaceBinding binding1 = new GroupSpaceBinding();
+    binding1.setId(1);
+    binding1.setGroup("/platform/administrators");
+    binding1.setSpaceId("1");
+    groupSpaceBindings.add(binding1);
+
+    GroupSpaceBinding binding2 = new GroupSpaceBinding();
+    binding2.setId(2);
+    binding2.setGroup("/platform/web-contributors");
+    binding2.setSpaceId("1");
+    groupSpaceBindings.add(binding2);
+
+    Mockito.when(groupSpaceBindingStorage.getAllGroupSpaceBindings()).thenReturn(groupSpaceBindings);
+
+    // When
+    GroupSpaceBindingService groupSpaceBindingService = new GroupSpaceBindingServiceImpl(initParams,
+                                                                                         groupSpaceBindingStorage,
+                                                                                         orgService,
+                                                                                         spaceService);
+    List<GroupSpaceBinding> results = groupSpaceBindingService.getAllGroupSpaceBindings();
     GroupSpaceBinding result1 = results.get(0);
     GroupSpaceBinding result2 = results.get(1);
 
@@ -438,6 +478,48 @@ public class GroupSpaceBindingServiceTest extends AbstractCoreTest {
     Mockito.verify(groupSpaceBindingStorage, Mockito.times(4)).saveGroupSpaceBinding(Mockito.any());
     Mockito.verify(groupSpaceBindingStorage, Mockito.times(4)).createGroupSpaceBindingQueue(Mockito.any());
   
+  }
+  /**
+   * Test {@link GroupSpaceBindingService#createUserBindingsQueue(UserBindingsQueue userBindingsQueue)}
+   * *
+   * @throws Exception
+   */
+  @Test
+  public void testCreateUserBindingsQueue() throws Exception {
+    UserBindingsQueue userBindingsQueue = new UserBindingsQueue("user1", UserBindingsQueue.ACTION_CREATE_USER_BINDINGS);;
+    GroupSpaceBindingService groupSpaceBindingService = new GroupSpaceBindingServiceImpl(initParams,
+                                                                                         groupSpaceBindingStorage,
+                                                                                         orgService,
+                                                                                         spaceService);
+    Mockito.when(groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue)).thenReturn(userBindingsQueue);
+    groupSpaceBindingService.createUserBindingsQueue(userBindingsQueue);
+
+    Mockito.verify(groupSpaceBindingStorage, Mockito.times(1)).createUserBindingsQueue(Mockito.any());
+
+  }
+  /**
+   * Test {@link GroupSpaceBindingService#createUserBindingsQueue(UserBindingsQueue userBindingsQueue)}
+   * *
+   * @throws Exception
+   */
+  @Test
+  public void testDeleteUserBindingsQueue() throws Exception {
+    UserBindingsQueue userBindingsQueue = new UserBindingsQueue("user1", UserBindingsQueue.ACTION_CREATE_USER_BINDINGS);
+    userBindingsQueue.setId(1);
+    GroupSpaceBindingService groupSpaceBindingService = new GroupSpaceBindingServiceImpl(initParams,
+                                                                                         groupSpaceBindingStorage,
+                                                                                         orgService,
+                                                                                         spaceService);
+    groupSpaceBindingService.deleteUserBindingsQueue(userBindingsQueue);
+
+    // Then
+
+
+    ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
+    Mockito.verify(groupSpaceBindingStorage, Mockito.times(1)).deleteUserBindingsQueue(idCaptor.capture());
+    long id = idCaptor.getValue();
+    assertEquals(1, id);
+
   }
   
   /**

--- a/component/core/src/test/java/org/exoplatform/social/core/binding/spi/RDBMSGroupSpaceBindingStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/binding/spi/RDBMSGroupSpaceBindingStorageTest.java
@@ -22,12 +22,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.exoplatform.container.component.RequestLifeCycle;
-import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingOperationReport;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingQueue;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
-import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportUser;
-import org.exoplatform.social.core.binding.model.UserSpaceBinding;
+import org.exoplatform.social.core.binding.model.*;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.jpa.storage.SpaceStorage;
 import org.exoplatform.social.core.space.model.Space;
@@ -79,9 +74,15 @@ public class RDBMSGroupSpaceBindingStorageTest extends AbstractCoreTest {
     identityStorage.saveIdentity(mary);
     identityStorage.saveIdentity(jame);
 
-    Space space = this.getSpaceInstance(1);
-    spaceStorage.saveSpace(space, true);
-    spaceId = spaceStorage.getSpaceByPrettyName("myspacetestbinding1").getId();
+    Space space =  spaceStorage.getSpaceByPrettyName("myspacetestbinding1");
+    if (space == null) {
+      space = this.getSpaceInstance(1);
+      spaceStorage.saveSpace(space, true);
+      spaceId = spaceStorage.getSpaceByPrettyName("myspacetestbinding1").getId();
+    } else {
+        spaceId = space.getId();
+    }
+
     
   }
 
@@ -110,6 +111,9 @@ public class RDBMSGroupSpaceBindingStorageTest extends AbstractCoreTest {
     groupSpaceBindingStorage.findAllGroupSpaceBindingQueue()
                             .stream()
                             .forEach(binding -> groupSpaceBindingStorage.deleteGroupBindingQueue(binding.getId()));
+    groupSpaceBindingStorage.findAllUserBindingsQueue()
+                            .stream()
+                            .forEach(binding -> groupSpaceBindingStorage.deleteUserBindingsQueue(binding.getId()));
     groupSpaceBindingStorage.findAllGroupSpaceBinding()
                             .stream()
                             .forEach(binding -> {
@@ -284,6 +288,39 @@ public class RDBMSGroupSpaceBindingStorageTest extends AbstractCoreTest {
     assertEquals("groupSpaceBindingStorage.findFirstGroupSpaceBindingQueue() must return after creation: " + 1,
                  groupSpaceBindingQueue.getId(),
                  groupSpaceBindingStorage.findFirstGroupSpaceBindingQueue().getId());
+  }
+  /**
+   * Test
+   * {@link org.exoplatform.social.core.storage.api.GroupSpaceBindingStorage#createUserBindingsQueue(UserBindingsQueue)}
+   *
+   * @throws Exception
+   **/
+  public void testCreateUserBindingsQueue() throws Exception {
+    UserBindingsQueue userBindingsQueue = new UserBindingsQueue("john", UserBindingsQueue.ACTION_CREATE_USER_BINDINGS);
+    userBindingsQueue=groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue);
+    assertEquals("groupSpaceBindingStorage.findFirstUserBindingsQueue() must return after creation: " + 1,
+            userBindingsQueue.getId(),
+                 groupSpaceBindingStorage.findFirstUserBindingsQueue().getId());
+  }
+  /**
+   * Test
+   * {@link org.exoplatform.social.core.storage.api.GroupSpaceBindingStorage#findUserBindingsQueueByUserAndAction(String, String)}
+   *
+   * @throws Exception
+   **/
+  public void testFindUserBindingsQueueByUserAndAction() throws Exception {
+    UserBindingsQueue userBindingsQueue = new UserBindingsQueue("john", UserBindingsQueue.ACTION_CREATE_USER_BINDINGS);
+    groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue);
+    userBindingsQueue = new UserBindingsQueue("john", UserBindingsQueue.ACTION_CREATE_USER_BINDINGS);
+    groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue);
+    userBindingsQueue = new UserBindingsQueue("john", UserBindingsQueue.ACTION_CREATE_USER_BINDINGS);
+    groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue);
+    userBindingsQueue = new UserBindingsQueue("john", UserBindingsQueue.ACTION_REMOVE_USER_BINDINGS);
+    groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue);
+    userBindingsQueue = new UserBindingsQueue("john", UserBindingsQueue.ACTION_REMOVE_USER_BINDINGS);
+    groupSpaceBindingStorage.createUserBindingsQueue(userBindingsQueue);
+    assertEquals( 3,  groupSpaceBindingStorage.findUserBindingsQueueByUserAndAction("john", UserBindingsQueue.ACTION_CREATE_USER_BINDINGS).size());
+    assertEquals( 2,  groupSpaceBindingStorage.findUserBindingsQueueByUserAndAction("john", UserBindingsQueue.ACTION_REMOVE_USER_BINDINGS).size());
   }
 
   /**
@@ -501,6 +538,21 @@ public class RDBMSGroupSpaceBindingStorageTest extends AbstractCoreTest {
       groupSpaceBindingStorage.saveGroupSpaceBinding(groupSpaceBinding);
     }
     assertEquals(totalBindings,groupSpaceBindingStorage.findGroupSpaceBindingsByGroup("/platform/administrators").size());
+  }
+  /**
+   * Test
+   * {@link GroupSpaceBindingStorage#getAllGroupSpaceBindings()}
+   *
+   * @throws Exception
+   **/
+  public void testGetAllGroupSpaceBindings() {
+    int totalBindings = 5;
+
+    for (int i = 1; i <= totalBindings; i++) {
+      GroupSpaceBinding groupSpaceBinding = this.getGroupSpaceBindingInstance(spaceId, "/platform/administrators");
+      groupSpaceBindingStorage.saveGroupSpaceBinding(groupSpaceBinding);
+    }
+    assertEquals(totalBindings,groupSpaceBindingStorage.getAllGroupSpaceBindings().size());
   }
   
   /**
@@ -769,7 +821,7 @@ public class RDBMSGroupSpaceBindingStorageTest extends AbstractCoreTest {
         groupSpaceBindingStorage.findGroupSpaceBindingReportAction(groupSpaceBinding.getId(),
                                                                    GroupSpaceBindingReportAction.ADD_ACTION);
     assertEquals(0,resultActionReport.getEndDate().compareTo(endDate));
-    
+
     
   }
 }

--- a/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
+++ b/component/core/src/test/resources/conf/exo.social.component.core-configuration.xml
@@ -420,6 +420,10 @@
     <key>org.exoplatform.social.core.jpa.storage.dao.GroupSpaceBindingQueueDAO</key>
     <type>org.exoplatform.social.core.jpa.storage.dao.jpa.GroupSpaceBindingQueueDAOImpl</type>
   </component>
+  <component>
+    <key>org.exoplatform.social.core.jpa.storage.dao.UserBindingsQueueDAO</key>
+    <type>org.exoplatform.social.core.jpa.storage.dao.jpa.UserBindingQueuesDAOImpl</type>
+  </component>
   
   <component>
     <key>org.exoplatform.social.core.jpa.storage.dao.GroupSpaceBindingReportActionDAO</key>

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -127,6 +127,10 @@
         <type>org.exoplatform.social.core.jpa.storage.dao.jpa.GroupSpaceBindingQueueDAOImpl</type>
     </component>
     <component>
+        <key>org.exoplatform.social.core.jpa.storage.dao.UserBindingsQueueDAO</key>
+        <type>org.exoplatform.social.core.jpa.storage.dao.jpa.UserBindingQueuesDAOImpl</type>
+    </component>
+    <component>
         <key>org.exoplatform.social.core.jpa.storage.dao.GroupSpaceBindingReportActionDAO</key>
         <type>org.exoplatform.social.core.jpa.storage.dao.jpa.GroupSpaceBindingReportActionDAOImpl</type>
     </component>


### PR DESCRIPTION
Prior to this change, user synchronization fails when running space biding then deactivating users, then activating them.
 After this commit, we ensure that deactivating users don't stop synchronization and that their unbiding/bidind to be executed in the biding queue.