### PR TITLE
fix: user synchronization is incomplete after a space binding - MEED-10275 - Meeds-io/meeds#4059

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/impl/GroupSpaceBindingServiceImpl.java
@@ -412,9 +412,9 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
         users = Arrays.asList(groupMembersAccess.load(offset, limit));
         count = users.size();
         int currentCount = offset;
-        startRequest();
         for (User user : users) {
           currentCount++;
+          startRequest();
           long startTimeUser = System.currentTimeMillis();
 
           String userId = user.getUserName();
@@ -424,8 +424,8 @@ public class GroupSpaceBindingServiceImpl implements GroupSpaceBindingService {
           long totalTimeUser = endTimeUser - startTimeUser;
           LOG.debug("Time to treat user " + userId + " (" + currentCount + "/" + totalGroupMembersSize + ") : " + totalTimeUser
               + " ms");
+          endRequest();
         }
-        endRequest();
         offset += count;
         LOG.info("Binding process: Bound Users({})", offset);
         long endBunchTime = System.currentTimeMillis();


### PR DESCRIPTION
Prior to this change, user synchronization fails when running space binding, then deactivating users, then activating them.
 After this commit, we ensure that deactivating users won't stop synchronization and that their unbidding/binding to be executed in the binding queue.