### PR TITLE
fix: Suggest subspace creation when space list widget is in a parent space - MEED-10368 - Meeds-io/meeds#4175

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -54,6 +54,8 @@ import javax.ws.rs.core.UriInfo;
 
 import io.meeds.social.html.model.HtmlTransformerContext;
 import io.meeds.social.html.utils.HtmlUtils;
+import io.meeds.social.space.template.model.SpaceTemplate;
+import io.meeds.social.space.template.service.SpaceTemplateService;
 import io.meeds.social.translation.service.TranslationService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -955,6 +957,7 @@ public class EntityBuilder {
       spaceEntity.setInvitedUsersCount(space.getInvitedUsers() == null ? 0 : countUsers(space.getInvitedUsers()));
     }
     spaceEntity.setParentSpaceId(space.getParentSpaceId());
+    spaceEntity.setIsParentSpace(isParentSpace(space));
 
     return spaceEntity;
   }
@@ -2558,6 +2561,15 @@ public class EntityBuilder {
     if (StringUtils.isNotBlank(defaultTitle)) {
       activityEntity.getTemplateParams().put(COMMENT_PARAM, HtmlUtils.transform(comment, htmlContext));
     }
+  }
+
+  private static boolean isParentSpace(Space space) {
+    if (space.getParentSpaceId() != null && space.getParentSpaceId() > 0) {
+      return false;
+    }
+    SpaceTemplate spaceTemplate = ExoContainerContext.getService(SpaceTemplateService.class)
+                                                     .getSpaceTemplate(space.getTemplateId());
+    return spaceTemplate != null && CollectionUtils.isNotEmpty(spaceTemplate.getAllowedSubspaceTemplates());
   }
 
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/entity/SpaceEntity.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/entity/SpaceEntity.java
@@ -250,6 +250,15 @@ public class SpaceEntity extends BaseEntity {
     return (Boolean) getProperty("isPublisher");
   }
 
+  public SpaceEntity setIsParentSpace(boolean isParentSpace) {
+    setProperty("isParentSpace", isParentSpace);
+    return this;
+  }
+
+  public Boolean getIsParentSpace() {
+    return (Boolean) getProperty("isParentSpace");
+  }
+
   public SpaceEntity setCreatedTime(String creationTime) {
     setProperty("createdTime", creationTime);
     return this;

--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -476,6 +476,12 @@ export default {
       if (this.parentSpaceId) {
         const parentSpace = await this.$spaceService.getSpaceById(parentSpaceId);
         await this.selectParentSpace(parentSpace);
+        if (!spaceTemplates) {
+          this.templates = await this.$spaceTemplateService.getAllowedSubspaceTemplates(parentSpace?.templateId);
+          if (this.templates?.length === 1) {
+            this.templateId = this.templates[0].id;
+          }
+        }
         this.$refs.spaceFormDrawer.open();
         return;
       }

--- a/webapp/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
+++ b/webapp/src/main/webapp/vue-apps/space-settings/components/SpaceSettings.vue
@@ -56,7 +56,7 @@ export default {
       return !this.$root.activeSection;
     },
     isParentSpace() {
-      return !this.$root.space?.parentSpaceId;
+      return this.$root.space?.isParentSpace;
     }
   },
 };

--- a/webapp/src/main/webapp/vue-apps/spaces-list-components/components/common/SpaceCreationButton.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list-components/components/common/SpaceCreationButton.vue
@@ -83,7 +83,7 @@
     :min-width="!icon && 'auto'"
     v-bind="attrs"
     v-on="on"
-    @click="addNewSpace">
+    @click="addSpace">
     <v-icon
       v-if="displaySpaceCreationIcon"
       :size="iconSize">
@@ -140,6 +140,10 @@ export default {
     displayIcon: {
       type: Boolean,
       default: true
+    },
+    parentSpaceId: {
+      type: String,
+      default: null
     }
   },
   data: () => ({
@@ -160,7 +164,7 @@ export default {
       return this.displayIcon || this.isMobile;
     },
     displaySpaceCreationMenu() {
-      return !!(this.isMemberInParentSpace && this.subspaceTemplateIds?.length > 0 && !this.$root.openedSpaceTemplateId);
+      return !!(!this.parentSpaceId && this.isMemberInParentSpace && this.subspaceTemplateIds?.length > 0 && !this.$root.openedSpaceTemplateId);
     }
   },
   watch: {
@@ -181,13 +185,15 @@ export default {
   },
   methods: {
     async init() {
-      const result = await this.$spaceService.getSpacesByFilter({
-        offset: 0,
-        limit: 1,
-        filter: 'accessible',
-        onlyParentSpaces: true,
-      });
-      this.isMemberInParentSpace = result?.size > 0;
+      if (!this.parentSpaceId) {
+        const result = await this.$spaceService.getSpacesByFilter({
+          offset: 0,
+          limit: 1,
+          filter: 'accessible',
+          onlyParentSpaces: true,
+        });
+        this.isMemberInParentSpace = result?.size > 0;
+      }
       if (!this.$root.spaceTemplates) {
         this.$root.spaceTemplates = await this.$spaceTemplateService.getSpaceTemplates();
       }
@@ -210,6 +216,20 @@ export default {
         window.require(['SHARED/spaceForm'], drawer => drawer.open(this.$root.openedSpaceTemplateId, null, null, true));
       } else {
         this.$root.$emit('addNewSpace', this.$root.openedSpaceTemplateId, null, null, true);
+      }
+    },
+    addNewSubSpaceWithSelectedParent() {
+      if (this.requireFormDrawer) {
+        window.require(['SHARED/spaceForm'], drawer => drawer.open(null, null, this.parentSpaceId, false));
+      } else {
+        this.$root.$emit('addNewSpace', null, null, this.parentSpaceId, false);
+      }
+    },
+    addSpace() {
+      if (this.parentSpaceId) {
+        this.addNewSubSpaceWithSelectedParent();
+      } else {
+        this.addNewSpace();
       }
     },
     closeMenu(event) {


### PR DESCRIPTION
Prior to this change, when the space list widget was added to a parent space layout, users could create either a main space or a subspace. This change updates the space creation button component to restrict creation to subspaces only when a parent space is provided as a prop.