### PR TITLE
feat: Upgrade to Spring 3.5.14 - EXO-86212

### DIFF
--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -77,7 +77,7 @@
           <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>6.6.33.Final</version>
+            <version>6.6.49.Final</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
This change will align Hibernate  `jpamodelgen` artifact version to Spring Boot 3.5.14 Hibernate referenced version.