### PR TITLE
fix : Removes unecessary filterByPermissions in SiteRest.getSites - EXO-86349 - meeds-io/si#16

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -2241,26 +2241,21 @@ public class EntityBuilder {
                                                    boolean excludeEmptyNavigationSites,
                                                    boolean temporalCheck,
                                                    boolean excludeGroupNodesWithoutPageChildNodes,
-                                                   boolean filterByPermission,
                                                    boolean sortByDisplayOrder,
                                                    Locale locale) throws Exception {
-    List<PortalConfig> filteredByPermissionSites = sites;
-    if (filterByPermission) {
-      filteredByPermissionSites = sites.stream()
-                                       .filter(portalConfig -> getUserACL().hasAccessPermission(portalConfig,
-                                                                                                getCurrentUserIdentity()))
-                                       .toList();
-    }
     List<SiteEntity> siteEntities = new ArrayList<>();
-    for (PortalConfig site : filteredByPermissionSites) {
-      siteEntities.add(buildSiteEntity(site,
-                                       request,
-                                       expandNavigations,
-                                       visibilityNames,
-                                       excludeEmptyNavigationSites,
-                                       temporalCheck,
-                                       excludeGroupNodesWithoutPageChildNodes,
-                                       locale));
+    for (PortalConfig site : sites) {
+      if (getUserACL().hasAccessPermission(site,
+                                           getCurrentUserIdentity())) {
+        siteEntities.add(buildSiteEntity(site,
+                                         request,
+                                         expandNavigations,
+                                         visibilityNames,
+                                         excludeEmptyNavigationSites,
+                                         temporalCheck,
+                                         excludeGroupNodesWithoutPageChildNodes,
+                                         locale));
+      }
     }
     siteEntities = siteEntities.stream().filter(Objects::nonNull).toList();
     return sortByDisplayOrder ? siteEntities :

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/site/SiteRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/site/SiteRest.java
@@ -154,10 +154,6 @@ public class SiteRest implements ResourceContainer {
                            @DefaultValue("false")
                            @QueryParam("displayed")
                            boolean displayed,
-                           @Parameter(description = "to filter sites by view/edit permissions")
-                           @DefaultValue("false")
-                           @QueryParam("filterByPermissions")
-                           boolean filterByPermission,
                            @Parameter(description = "Offset of results to retrieve")
                            @QueryParam("offset")
                            @DefaultValue("0")
@@ -196,7 +192,6 @@ public class SiteRest implements ResourceContainer {
                                                                       excludeEmptyNavigationSites,
                                                                       temporalCheck,
                                                                       excludeGroupNodesWithoutPageChildNodes,
-                                                                      filterByPermission,
                                                                       sortByDisplayOrder,
                                                                       getLocale(httpServletRequest, lang));
       EntityTag eTag = new EntityTag(String.valueOf(Objects.hash(siteEntities,
@@ -206,7 +201,6 @@ public class SiteRest implements ResourceContainer {
                                                                  excludeEmptyNavigationSites,
                                                                  temporalCheck,
                                                                  excludeGroupNodesWithoutPageChildNodes,
-                                                                 filterByPermission,
                                                                  sortByDisplayOrder,
                                                                  getLocale(httpServletRequest, lang))));
       Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);

--- a/webapp/src/main/webapp/vue-apps/common/js/SiteService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/SiteService.js
@@ -18,7 +18,7 @@
  */
 
 
-export function getSites(siteType, excludedSiteType, excludedSiteName, excludeEmptyNavigationSites, excludeSpaceSites, expandNavigations, filterByDisplayed, sortByDisplayOrder, displayed, filterByPermissions, excludeGroupNodesWithoutPageChildNodes, temporalCheck, visibility) {
+export function getSites(siteType, excludedSiteType, excludedSiteName, excludeEmptyNavigationSites, excludeSpaceSites, expandNavigations, filterByDisplayed, sortByDisplayOrder, displayed, excludeGroupNodesWithoutPageChildNodes, temporalCheck, visibility) {
   return getSitesByFilter({
     siteType,
     excludedSiteType,
@@ -29,7 +29,6 @@ export function getSites(siteType, excludedSiteType, excludedSiteName, excludeEm
     filterByDisplayed,
     sortByDisplayOrder,
     displayed,
-    filterByPermissions,
     excludeGroupNodesWithoutPageChildNodes,
     temporalCheck,
     visibility
@@ -46,7 +45,6 @@ export function getSitesByFilter({
   filterByDisplayed,
   sortByDisplayOrder,
   displayed,
-  filterByPermissions,
   excludeGroupNodesWithoutPageChildNodes,
   temporalCheck,
   visibility,
@@ -82,7 +80,6 @@ export function getSitesByFilter({
   if (expand) {
     formData.append('expand', expand);
   }
-  formData.append('filterByPermissions', filterByPermissions || false);
   const params = new URLSearchParams(formData).toString();
 
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/sites?${params}`, {

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/preview/SiteBrandingPreview.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/preview/SiteBrandingPreview.vue
@@ -83,7 +83,7 @@ export default {
   },
   methods: {
     init() {
-      return this.$siteService.getSites('PORTAL', null, 'global', true, true, false, true, true, true, true, true, true, ['displayed', 'temporal'])
+      return this.$siteService.getSites('PORTAL', null, 'global', true, true, false, true, true, true, true, true, ['displayed', 'temporal'])
         .then(data => this.sites = data || [])
         .then(this.computeWidth)
         .finally(() => this.initialized = true);

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/navigation/sidebar/drawer/NavigationSettingsAddSidebarSiteDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/navigation/sidebar/drawer/NavigationSettingsAddSidebarSiteDrawer.vue
@@ -274,7 +274,6 @@ export default {
             this.filterByDisplayed,
             this.sortByDisplayOrder,
             this.displayed,
-            this.filterByPermissions,
             this.excludeGroupNodesWithoutPageChildNodes,
             this.temporalCheck
           );

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -431,7 +431,7 @@ export default {
       }
     },
     async retrieveSites() {
-      this.$root.sites = await this.$siteService.getSites('PORTAL', null, 'global', true, true, true, true, true, true, true, true, true, ['displayed', 'temporal']);
+      this.$root.sites = await this.$siteService.getSites('PORTAL', null, 'global', true, true, true, true, true, true, true, true, ['displayed', 'temporal']);
     },
     async retrieveSpace(refresh) {
       this.space = await this.$spaceService.getSpaceById(this.spaceId, 'member,managers,favorite,unread,muted', refresh);


### PR DESCRIPTION
Before this fix, the endpoint to get sites and groups navigation have a field filterByPermissions with default value to false So, anonymous users where able to read all groups and sites navigations. This field is no more necessary as navigation must be served always respecting permissions This commit removes the fields

Resolves meeds-io/si#16

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
