### PR TITLE
fix:if parent and child menu item type is link, sub-items list can't be displayed - MEED-10370 - Meeds-io/meeds#4178

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -213,7 +213,7 @@ export default {
       if (myUri && emitterUri && (myUri.startsWith(emitterUri) || emitterUri.startsWith(myUri))) {
         return;
       }
-      if (!myUri && this.isDescendant(emitter.navigation, this.navigation)) {
+      if ((!myUri || emitter && myUri && !myUri.includes(emitter.baseSiteUri)) && this.isDescendant(emitter.navigation, this.navigation)) {
         return;
       }
       this.showMenu = false;


### PR DESCRIPTION
Before this change, when a new navigation item (ItemX) was added in SpaceX as a link and sub-items were also configured as links, after saving and displaying the ItemX menu, selecting any submenu caused the submenu to close unexpectedly and it could not be displayed properly. To fix this issue, enhanced the sibling menu closing condition in handleCloseSiblingMenus by adding an additional check !myUri.includes(emitter.baseSiteUri) to prevent unintended submenu closure when navigating within the same base site. This prevents unintended submenu closure when navigating through nested menu items.