### PR TITLE
fix: Not possible to disable manager attribute - MEED-10413 - Meeds-io/meeds#4221

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profileproperty/ProfilePropertyServiceImpl.java
@@ -369,7 +369,7 @@ public class ProfilePropertyServiceImpl implements ProfilePropertyService, Start
     String existingType = existingProperty.getPropertyType();
     String updatedType = updatedProperty.getPropertyType();
 
-    if (!existingType.equals(updatedType) && USER_TYPE.equals(existingType) || USER_TYPE.equals(updatedType)) {
+    if (!existingType.equals(updatedType) && (USER_TYPE.equals(existingType) || USER_TYPE.equals(updatedType))) {
       throw new IllegalArgumentException("Changing profile property type to or from USER type is not allowed.");
     }
   }


### PR DESCRIPTION
Before this change, when go to profile attribute management in admin app and disable Manager profile, It is no longer possible to disable manager profile attribute. To fix this problem, correct the validatePropertySettingType condition. After this change, manager attribute disbaled and org chart no longer available in profile attributes/cards.