### PR TITLE
fix: Fix confirmation popup message XSS vulnerability - EXO-86231 

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/ConfirmDialog.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/ConfirmDialog.vue
@@ -16,7 +16,7 @@
         <span class="ignore-vuetify-classes text-title" v-html="title"></span>
       </div>
       <!-- eslint-disable-next-line vue/no-v-html -->
-      <v-card-text v-html="message" />
+      <v-card-text v-sanitized-html="message" />
       <v-card-actions v-if="!hideActions">
         <v-spacer />
         <button


### PR DESCRIPTION
Prior to this change, a JavaScript payload injected into the confirmation popup message could be executed when the popup was displayed, leading to an XSS vulnerability.
After this commit, the confirmation popup message is sanitized using the v-sanitize-html directive instead of v-html, preventing the XSS vulnerability.

Resolves https://github.com/Meeds-io/si/issues/11