### PR TITLE
fix: new DB changelogs are blocked due to emojies in space desciptions - MEED-10415 - Meeds-io/meeds#4222

### DIFF
--- a/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/component/core/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -1269,10 +1269,14 @@
   <changeSet author="social" id="1.0.0-meed-3976" dbms="!mysql" runOnChange="true">
     <modifyDataType tableName="SOC_SPACES" columnName="DESCRIPTION" newDataType="CLOB"/>
   </changeSet>
-
-  <changeSet author="social" id="1.0.0-meed-3976-fix" dbms="mysql">
-    <modifyDataType tableName="SOC_SPACES" columnName="DESCRIPTION" newDataType="LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"/>
-  </changeSet>
+    <changeSet author="social" id="1.0.0-meed-4222-fix" dbms="mysql">
+        <sql>
+            ALTER TABLE SOC_SPACES
+                MODIFY `DESCRIPTION` LONGTEXT
+                    CHARACTER SET utf8mb4
+                    COLLATE utf8mb4_unicode_ci;
+        </sql>
+    </changeSet>
 
   <changeSet author="social" id="1.0.0-mip-244-01" dbms="oracle,postgresql,hsqldb">
     <createSequence sequenceName="SEQ_SOC_SPACE_INVITATION_LINK_ID" startValue="1"/>


### PR DESCRIPTION
prior to this fix, having emjies in space description would cause an issue when creating new tables in DB.
This fix would update the Liquibase changelog to handle broader character support in order to accommodate emojis or special international characters in SOC_SPACES table.