### PR TITLE
fix: Count viewers of a post even if no unread notification - MEED-10363 - Meeds-io/meeds#4166

### DIFF
--- a/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -15,6 +15,7 @@
   import org.exoplatform.commons.utils.PropertyManager;
   import org.exoplatform.portal.branding.BrandingService;
   import java.util.Set;
+  import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
 
   def rcontext = _ctx.getRequestContext();
   Space space = SpaceUtils.getSpaceByContext();
@@ -32,6 +33,12 @@
   String ownerIdentityId = Utils.getOwnerIdentityId();
   ProfilePropertyService profilePropertyService = uicomponent.getApplicationComponent(ProfilePropertyService.class);
   ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("manager");
+  UserSettingService userSettingService = uicomponent.getApplicationComponent(UserSettingService.class);
+  boolean spaceWebChannelStatus = (
+    userName != null 
+    && userSettingService.get(userName) != null
+    && userSettingService.get(userName).channelActives != null
+    && userSettingService.get(userName).channelActives.contains("SPACE_WEB_CHANNEL"));
 %>
 <script type="text/javascript" id="socialHeadScripts">
      eXo.env.portal.spaceId = "<%=space == null ? "" : space.getId()%>" ;
@@ -72,4 +79,5 @@
      eXo.env.portal.editorAttachImageEnabled = <%=featureService.isFeatureActiveForUser("EditorAttachImage", userName)%>;
      eXo.env.portal.attachmentObjectTypes = ['<%=StringUtils.join(supportedAttachmentObjectTypes, "', '")%>'];
      eXo.env.portal.customStylesheetEnabled = <%=featureService.isFeatureActiveForUser("customStylesheet", userName)%>;
+     eXo.env.portal.spaceWebChannelStatus = <%=spaceWebChannelStatus%>;
 </script>

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -3,6 +3,7 @@
     :id="id"
     :unread-metadata="unreadMetadata"
     :space-id="spaceId"
+    :display="displayUnreadBadge"
     class="application-background-color application-border application-border-radius activity-detail flex flex-column"
     @read="markAsRead">
     <div v-if="displayLoading" class="d-flex">
@@ -215,7 +216,16 @@ export default {
     },
     activityReactionEnabled() {
       return this.activityTypeExtension?.reactionEnabled?.(this.activity) ?? true;
-    }
+    },
+    displayUnreadBadge() {
+      return this.isUnreadMetadata && this.spaceWebChannelStatus;
+    },
+    isUnreadMetadata() {
+      return this.activity?.metadatas?.unread?.length && !!this.activity?.metadatas?.unread[0];
+    },
+    spaceWebChannelStatus() {
+      return eXo.env.portal.spaceWebChannelStatus;
+    } 
   },
   watch: {
     activityLoading() {

--- a/webapp/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
@@ -41,6 +41,10 @@ export default {
       type: Number,
       default: () => 1,
     },
+    display: {
+      type: Boolean,
+      default: () => false,
+    }
   },
   data: () => ({
     textLength: 0,
@@ -70,6 +74,11 @@ export default {
     },
   },
   watch: {
+    isUnread() {
+      if (this.isUnread && !this.display) {
+        this.markAsRead('read');
+      } 
+    },
     displayBadge() {
       if (this.displayBadge) {
         this.countText();
@@ -172,7 +181,7 @@ export default {
       this.isPageHidden = document.hidden || document.msHidden || document.webkitHidden || document.mozHidden;
     },
     markAsRead(event) {
-      if (this.displayBadge) {
+      if (this.spaceId && this.isUnread) {
         this.$spaceService.markAsRead(this.spaceId, this.applicationName, this.applicationId, event?.type && 'click' || 'read');
       }
     },

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/SidebarButton.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/SidebarButton.vue
@@ -41,9 +41,13 @@ export default {
   computed: {
     showBadge() {
       return this.$root.unreadPerSpace
+        && this.spaceWebChannelStatus
         && this.$root.hidden
         && Object.values(this.$root.unreadPerSpace).reduce((sum, v) => sum += v, 0) > 0;
     },
+    spaceWebChannelStatus() {
+      return eXo.env.portal.spaceWebChannelStatus;
+    }
   },
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -120,7 +120,7 @@
           height="auto">
       </v-list-item-avatar>
       <v-card
-        v-if="spaceUnreadCount && $root.icon && !$root.expand"
+        v-if="spaceWebChannelStatus && spaceUnreadCount && $root.icon && !$root.expand"
         :class="$vuetify.rtl && 'l-0' || 'r-0'"
         class="hamburger-unread-badge border-radius-circle error-color-background position-absolute t-0 me-4 mt-0"
         width="12"
@@ -170,7 +170,7 @@
         </v-btn>
       </v-list-item-action>
       <space-unread-badge
-        v-if="isSpace"
+        v-if="spaceWebChannelStatus && isSpace"
         v-show="!toggleArrow"
         :space-id="spaceId"
         :unread-badge="spaceUnreadCount"
@@ -363,6 +363,9 @@ export default {
     avatar() {
       return this.item.avatar || this.iconUrl;
     },
+    spaceWebChannelStatus() {
+      return eXo.env.portal.spaceWebChannelStatus;
+    }
   },
   watch: {
     hover() {

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
@@ -40,7 +40,7 @@
       <v-list-item-title v-text="spaceDisplayName" class="menu-text-color" />
     </v-list-item-content>
     <v-list-item-action
-      v-if="spaceUnreadCount"
+      v-if="spaceUnreadCount && spaceWebChannelStatus"
       class="me-2 my-auto align-center">
       <v-chip
         color="error-color-background"
@@ -91,7 +91,7 @@
         </ripple-hover-button>
       </v-list-item-action>
       <v-list-item-action
-        v-if="!toggleArrow && spaceUnreadCount"
+        v-if="!toggleArrow && spaceUnreadCount && spaceWebChannelStatus"
         class="me-2 my-auto align-center">
         <v-chip
           v-if="spaceUnreadCount"
@@ -169,6 +169,9 @@ export default {
     arrowIconRight() {
       return this.$vuetify.rtl && 'fa-arrow-left' || 'fa-arrow-right';
     },
+    spaceWebChannelStatus() {
+      return eXo.env.portal.spaceWebChannelStatus;
+    }
   },
   watch: {
     space: {

--- a/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationTree.vue
+++ b/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationTree.vue
@@ -34,7 +34,7 @@
       <site-navigation-item
         :navigation="item"
         :enable-change-home="enableChangeHome"
-        :enable-unread="firstNavigationId === item.id"
+        :enable-unread="firstNavigationId === item.id && spaceWebChannelStatus"
         :aria-current="isActive(item) && 'true'"
         :aria-selected="isActive(item) && 'true'" />
     </template>
@@ -109,6 +109,9 @@ export default {
       }
       return [this.selectedNodeUri];
     },
+    spaceWebChannelStatus() {
+      return eXo.env.portal.spaceWebChannelStatus;
+    }
   },
   methods: {
     filterNodes(navigations) {


### PR DESCRIPTION
Before this change, when access the space after the post has been added and unread notif channel has been deactivated then reading the post does not count in the views number, it could make the views number not equal to the factual number of readers. To fix this problem, correct the validatePropertySettingType condition. After this change, the activity stream will retrieve unread activity metadata even if the spaceWebChannelStatus notification is disabled. However, the unread activity badge will not be displayed as long as spaceWebChannelStatus is set to false, which has already been added to the eXo.env.portal.spaceWebChannelStatus property. Additionally, the unread activity badge is marked as read when eXo.env.portal.spaceWebChannelStatus is false and isUnread is true.