### PR TITLE
fix: Count viewers of a post even if no unread notification - MEED-10363 - Meeds-io/meeds#4166

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceWebNotificationServiceImpl.java
@@ -206,8 +206,8 @@ public class SpaceWebNotificationServiceImpl implements SpaceWebNotificationServ
       for (MetadataItem metadataItem : metadataItems) {
         metadataService.deleteMetadataItem(metadataItem.getId(), true);
       }
-      listenerService.broadcast(NOTIFICATION_READ_EVENT_NAME, notificationItem, userIdentityId);
     }
+    listenerService.broadcast(NOTIFICATION_READ_EVENT_NAME, notificationItem, userIdentityId);
   }
 
   @Override

--- a/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -15,7 +15,6 @@
   import org.exoplatform.commons.utils.PropertyManager;
   import org.exoplatform.portal.branding.BrandingService;
   import java.util.Set;
-  import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
 
   def rcontext = _ctx.getRequestContext();
   Space space = SpaceUtils.getSpaceByContext();
@@ -33,12 +32,6 @@
   String ownerIdentityId = Utils.getOwnerIdentityId();
   ProfilePropertyService profilePropertyService = uicomponent.getApplicationComponent(ProfilePropertyService.class);
   ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("manager");
-  UserSettingService userSettingService = uicomponent.getApplicationComponent(UserSettingService.class);
-  boolean spaceWebChannelStatus = (
-    userName != null 
-    && userSettingService.get(userName) != null
-    && userSettingService.get(userName).channelActives != null
-    && userSettingService.get(userName).channelActives.contains("SPACE_WEB_CHANNEL"));
 %>
 <script type="text/javascript" id="socialHeadScripts">
      eXo.env.portal.spaceId = "<%=space == null ? "" : space.getId()%>" ;
@@ -79,5 +72,4 @@
      eXo.env.portal.editorAttachImageEnabled = <%=featureService.isFeatureActiveForUser("EditorAttachImage", userName)%>;
      eXo.env.portal.attachmentObjectTypes = ['<%=StringUtils.join(supportedAttachmentObjectTypes, "', '")%>'];
      eXo.env.portal.customStylesheetEnabled = <%=featureService.isFeatureActiveForUser("customStylesheet", userName)%>;
-     eXo.env.portal.spaceWebChannelStatus = <%=spaceWebChannelStatus%>;
 </script>

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/ActivityStreamActivity.vue
@@ -3,7 +3,8 @@
     :id="id"
     :unread-metadata="unreadMetadata"
     :space-id="spaceId"
-    :display="displayUnreadBadge"
+    :object-id="activityId"
+    object-type="activity"
     class="application-background-color application-border application-border-radius activity-detail flex flex-column"
     @read="markAsRead">
     <div v-if="displayLoading" class="d-flex">
@@ -216,16 +217,7 @@ export default {
     },
     activityReactionEnabled() {
       return this.activityTypeExtension?.reactionEnabled?.(this.activity) ?? true;
-    },
-    displayUnreadBadge() {
-      return this.isUnreadMetadata && this.spaceWebChannelStatus;
-    },
-    isUnreadMetadata() {
-      return this.activity?.metadatas?.unread?.length && !!this.activity?.metadatas?.unread[0];
-    },
-    spaceWebChannelStatus() {
-      return eXo.env.portal.spaceWebChannelStatus;
-    } 
+    }
   },
   watch: {
     activityLoading() {

--- a/webapp/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
@@ -33,6 +33,14 @@ export default {
       type: Object,
       default: null,
     },
+    objectType: {
+      type: String,
+      default: null,
+    },
+    objectId: {
+      type: String,
+      default: null,
+    },
     spaceId: {
       type: String,
       default: null,
@@ -41,10 +49,6 @@ export default {
       type: Number,
       default: () => 1,
     },
-    display: {
-      type: Boolean,
-      default: () => false,
-    }
   },
   data: () => ({
     textLength: 0,
@@ -55,37 +59,24 @@ export default {
     displayTimeout: false,
     computeTimeout: false,
     isPageHidden: false,
+    isMarkedAsRead: true,
   }),
   computed: {
-    isUnread() {
-      return !!this.unreadMetadata;
-    },
     displayBadge() {
       return this.spaceId && this.isUnread;
     },
     waitTimeToMarkAsRead() {
       return Math.max(parseInt(this.textLength / 100 * 5000) - 1000, 4000);
     },
-    applicationName() {
-      return this.unreadMetadata?.objectType;
-    },
-    applicationId() {
-      return this.unreadMetadata?.objectId;
-    },
   },
   watch: {
-    isUnread() {
-      if (this.isUnread && !this.display) {
-        this.markAsRead('read');
-      } 
-    },
-    displayBadge() {
-      if (this.displayBadge) {
+    isMarkedAsRead() {
+      if (this.isMarkedAsRead) {
+        this.uninstallBodyScrollListener();
+      } else {
         this.countText();
         this.computePagePosition();
         this.installBodyScrollListener();
-      } else {
-        this.uninstallBodyScrollListener();
       }
       this.computeIsReading();
     },
@@ -110,6 +101,7 @@ export default {
     document.addEventListener('notification.unread.item', this.handleUpdatesFromWebSocket);
     document.addEventListener('notification.read.item', this.handleUpdatesFromWebSocket);
     document.addEventListener('notification.read.allItems', this.handleUpdatesFromWebSocket);
+    this.isMarkedAsRead = false;
   },
   beforeDestroy() {
     document.removeEventListener('notification.unread.item', this.handleUpdatesFromWebSocket);
@@ -134,14 +126,14 @@ export default {
       if (spaceWebNotificationItem?.length) {
         spaceWebNotificationItem = JSON.parse(spaceWebNotificationItem);
       }
-      const applicationName = spaceWebNotificationItem?.applicationName;
-      const applicationId = spaceWebNotificationItem?.applicationItemId;
+      const objectType = spaceWebNotificationItem?.applicationName;
+      const objectId = spaceWebNotificationItem?.applicationItemId;
       const spaceId = spaceWebNotificationItem?.spaceId;
       if (Number(this.spaceId) === Number(spaceId)) {
         if (wsEventName === 'notification.read.allItems') {
           this.$emit('read');
         } else {
-          if (applicationName === this.applicationName && applicationId === this.applicationId) {
+          if (objectType === this.objectType && objectId === this.objectId) {
             if (wsEventName === 'notification.unread.item') {
               this.$emit('unread');
             } else if (wsEventName === 'notification.read.item') {
@@ -152,12 +144,12 @@ export default {
       }
     },
     countText() {
-      if (this.displayBadge) {
+      if (!this.isMarkedAsRead) {
         this.textLength = this.$el?.innerText.replace(/[\n\r\t ]/g, '').length || 0;
       }
     },
     computePagePosition() {
-      if (this.displayBadge && !this.computeTimeout) {
+      if (!this.isMarkedAsRead && !this.computeTimeout) {
         this.computeTimeout = window.setTimeout(() => {
           this.textPosition = this.$el?.getBoundingClientRect();
           if (!this.streamHeight) {
@@ -170,7 +162,7 @@ export default {
       }
     },
     computeIsReading() {
-      this.isReading = this.displayBadge && this.textPosition && !this.isPageHidden
+      this.isReading = !this.isMarkedAsRead && this.textPosition && !this.isPageHidden
         && ((this.textPosition.top >= 200 && this.textPosition.top <= this.streamHeight)
           || (this.textPosition.bottom >= 200 && this.textPosition.bottom <= this.streamHeight)
           || (this.textPosition.top <= 200 && this.textPosition.bottom >= this.streamHeight)
@@ -181,8 +173,9 @@ export default {
       this.isPageHidden = document.hidden || document.msHidden || document.webkitHidden || document.mozHidden;
     },
     markAsRead(event) {
-      if (this.spaceId && this.isUnread) {
-        this.$spaceService.markAsRead(this.spaceId, this.applicationName, this.applicationId, event?.type && 'click' || 'read');
+      if (!this.isMarkedAsRead) {
+        this.isMarkedAsRead = true;
+        this.$spaceService.markAsRead(this.spaceId, this.objectType, this.objectId, event?.type && 'click' || 'read');
       }
     },
   }

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/SidebarButton.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/SidebarButton.vue
@@ -41,13 +41,9 @@ export default {
   computed: {
     showBadge() {
       return this.$root.unreadPerSpace
-        && this.spaceWebChannelStatus
         && this.$root.hidden
         && Object.values(this.$root.unreadPerSpace).reduce((sum, v) => sum += v, 0) > 0;
     },
-    spaceWebChannelStatus() {
-      return eXo.env.portal.spaceWebChannelStatus;
-    }
   },
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -120,7 +120,7 @@
           height="auto">
       </v-list-item-avatar>
       <v-card
-        v-if="spaceWebChannelStatus && spaceUnreadCount && $root.icon && !$root.expand"
+        v-if="spaceUnreadCount && $root.icon && !$root.expand"
         :class="$vuetify.rtl && 'l-0' || 'r-0'"
         class="hamburger-unread-badge border-radius-circle error-color-background position-absolute t-0 me-4 mt-0"
         width="12"
@@ -170,7 +170,7 @@
         </v-btn>
       </v-list-item-action>
       <space-unread-badge
-        v-if="spaceWebChannelStatus && isSpace"
+        v-if="isSpace"
         v-show="!toggleArrow"
         :space-id="spaceId"
         :unread-badge="spaceUnreadCount"
@@ -363,9 +363,6 @@ export default {
     avatar() {
       return this.item.avatar || this.iconUrl;
     },
-    spaceWebChannelStatus() {
-      return eXo.env.portal.spaceWebChannelStatus;
-    }
   },
   watch: {
     hover() {

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/space/SpaceNavigationItem.vue
@@ -40,7 +40,7 @@
       <v-list-item-title v-text="spaceDisplayName" class="menu-text-color" />
     </v-list-item-content>
     <v-list-item-action
-      v-if="spaceUnreadCount && spaceWebChannelStatus"
+      v-if="spaceUnreadCount"
       class="me-2 my-auto align-center">
       <v-chip
         color="error-color-background"
@@ -91,7 +91,7 @@
         </ripple-hover-button>
       </v-list-item-action>
       <v-list-item-action
-        v-if="!toggleArrow && spaceUnreadCount && spaceWebChannelStatus"
+        v-if="!toggleArrow && spaceUnreadCount"
         class="me-2 my-auto align-center">
         <v-chip
           v-if="spaceUnreadCount"
@@ -169,9 +169,6 @@ export default {
     arrowIconRight() {
       return this.$vuetify.rtl && 'fa-arrow-left' || 'fa-arrow-right';
     },
-    spaceWebChannelStatus() {
-      return eXo.env.portal.spaceWebChannelStatus;
-    }
   },
   watch: {
     space: {

--- a/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationTree.vue
+++ b/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationTree.vue
@@ -34,7 +34,7 @@
       <site-navigation-item
         :navigation="item"
         :enable-change-home="enableChangeHome"
-        :enable-unread="firstNavigationId === item.id && spaceWebChannelStatus"
+        :enable-unread="firstNavigationId === item.id"
         :aria-current="isActive(item) && 'true'"
         :aria-selected="isActive(item) && 'true'" />
     </template>
@@ -109,9 +109,6 @@ export default {
       }
       return [this.selectedNodeUri];
     },
-    spaceWebChannelStatus() {
-      return eXo.env.portal.spaceWebChannelStatus;
-    }
   },
   methods: {
     filterNodes(navigations) {


### PR DESCRIPTION
Before this change, when access the space after the post has been added and unread notif channel has been deactivated then reading the post does not count in the views number, it could make the views number not equal to the factual number of readers. To fix this problem, update in the addActivityViewer method the set viewerIds of type Long to type String. After this change, the number of views will match the actual number of readers.