### PR TITLE
fix: Avoid Missing Method in Navigation Tree UI

### DIFF
--- a/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationTree.vue
+++ b/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationTree.vue
@@ -34,9 +34,7 @@
       <site-navigation-item
         :navigation="item"
         :enable-change-home="enableChangeHome"
-        :enable-unread="firstNavigationId === item.id"
-        :aria-current="isActive(item) && 'true'"
-        :aria-selected="isActive(item) && 'true'" />
+        :enable-unread="firstNavigationId === item.id" />
     </template>
   </v-treeview>
 </template>


### PR DESCRIPTION
This change will rollback a modification made on Site Navigation Tree without defining the method.