### PR TITLE
fix: Dropdown value attributes not displaying for Quick search - MEED-10434 - Meeds-io/meeds#4245

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-contact-information/components/QuickSearchUsersListDrawer.vue
@@ -259,7 +259,7 @@ export default {
       this.abortController = new AbortController();
       this.offset = this.users.length || 0;
       this.limit = this.limit || this.pageSize;
-      this.$userService.getUsersByAdvancedFilter(this.profileSetting, this.offset, this.limit + 1, this.fieldsToRetrieve,'all', this.keyword, false, this.abortController.signal, 'false').then(data => {
+      this.$userService.getUsersByAdvancedFilter(this.profileSetting, this.offset, this.limit + 1, this.fieldsToRetrieve,'all', this.keyword, false, this.abortController.signal, 'true').then(data => {
         this.users.push(...data.users);
         this.hasMore = data.users?.length > this.limit;
       }).finally(() => {


### PR DESCRIPTION
Before this change, when open user profile and click on user filed value, drop down values ​​not displaying quick search and analytics data. To fix this problem, change the value of wildCardSearch to true. After this change, quick search drawer display all users having this value of their user field.