### PR TITLE
fix: Fix the value search is ko when field id has points - MEED-10429 - Meeds-io/meeds#4225

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -577,6 +577,7 @@ public class ProfileSearchConnector {
                 } else {
                   searchedText = removeAccents(splittedValues[i]);
                 }
+                key = normalizeESFieldName(key);
                 expression.append(" ").append(key.replace(" ", "\\\\ ")).append(isEmailProfileProperty(key) ? ":" : ".whitespace:").append(searchedText);
               }
             }
@@ -593,6 +594,7 @@ public class ProfileSearchConnector {
                                                               + StorageUtils.ASTERISK_STR
                                                           : removeAccents(value);
             String propertyName = property.getPropertyName();
+            propertyName = normalizeESFieldName(propertyName);
             String filedName = isEmailProfileProperty(propertyName) ? propertyName : "%s.whitespace".formatted(propertyName);
             query.append("""
                   {
@@ -639,5 +641,8 @@ public class ProfileSearchConnector {
   }
   private boolean isEmailProfileProperty(String propertyName) {
     return propertyName.equals("email");
+  }
+  private String normalizeESFieldName(String fieldName) {
+    return fieldName.replace(".", "_");
   }
 }


### PR DESCRIPTION
Before this change, when a profile field identifier contained dots in its value, the search on this field returned no results because Elasticsearch interpreted dots as object path separators. To fix this problem, normalized profile field identifiers by replacing dots with underscores before building the Elasticsearch query. After this change, advanced profile search works correctly for profile fields whose identifiers contain dots.