### PR TITLE
fix: prevent category autocomplete search issues after selection - EXO-87144 - Meeds-io/meeds#3563

### DIFF
--- a/webapp/src/main/webapp/vue-apps/category-components/components/CategorySuggester.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/CategorySuggester.vue
@@ -124,8 +124,10 @@ export default {
       } else {
         this.category = null;
         this.categories = [];
+        await this.$nextTick();
         if (this.$refs?.autocomplete) {
           this.$refs.autocomplete.isFocused = false;
+          this.$refs.autocomplete?.blur();
         }
       }
     },


### PR DESCRIPTION
Prior to this change, the category suggester remained focused after selecting a category, which caused issues when searching for a new category. This happened because Vuetify could not properly reconcile the selected category when updating the items list, resulting in the items being cleared. This change blurs the autocomplete after selection, resolving the issue.
Resolves https://github.com/Meeds-io/meeds/issues/3563