### PR TITLE
fix: Review size of deactivated user icon - EXO-87168 - Meeds-io/meeds#4257

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -46,7 +46,8 @@
           :title="$t('label.disabled')"
           class="muted font-weight-regular">
           <v-icon
-            class="primary--text mb-1">
+            class="primary--text mb-1"
+            small>
             fas fa-user-slash
           </v-icon>
         </span>
@@ -91,7 +92,8 @@
             :title="$t('label.disabled')"
             class="muted font-weight-regular">
             <v-icon
-              class="primary--text mb-1">
+              class="primary--text mb-1"
+              small>
               fas fa-user-slash
             </v-icon>
           </span>
@@ -155,7 +157,8 @@
           :title="$t('label.disabled')"
           class="muted font-weight-regular">
           <v-icon
-            class="primary--text mb-1">
+            class="primary--text mb-1"
+            small>
             fas fa-user-slash
           </v-icon>
         </span>
@@ -215,7 +218,8 @@
             :title="$t('label.disabled')"
             class="muted font-weight-regular">
             <v-icon
-              class="primary--text mb-1">
+              class="primary--text mb-1"
+              small>
               fas fa-user-slash
             </v-icon>
           </span>


### PR DESCRIPTION
Prior to this change, the icon used to indicate that a user is deactivated had the default size. This change updates it to use the small icon size.
Resolves https://github.com/Meeds-io/meeds/issues/4257 