### PR TITLE
fix: Avoid NPE when accessing a deleted Space URL - EXO-87201

### DIFF
--- a/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
@@ -106,7 +106,7 @@ public class SpaceAccessHandler extends WebRequestHandler {
   }
 
   @Override
-  public boolean execute(ControllerContext controllerContext) throws Exception {
+  public boolean execute(ControllerContext controllerContext) throws Exception { // NOSONAR
     String username = controllerContext.getRequest().getRemoteUser();
     String requestSiteType = controllerContext.getParameter(REQUEST_SITE_TYPE);
     String requestSiteName = controllerContext.getParameter(REQUEST_SITE_NAME);
@@ -116,7 +116,9 @@ public class SpaceAccessHandler extends WebRequestHandler {
       return false;
     }
     Space space = spaceService.getSpaceByGroupId(requestSiteName);
-    if (StringUtils.isBlank(username) && space.getPublicSiteId() != 0
+    if (StringUtils.isBlank(username)
+        && space != null
+        && space.getPublicSiteId() != 0
         && canAccessSpacePublicSite(space, username)) {
       controllerContext.getResponse()
                        .sendRedirect(String.format("%s/%s",


### PR DESCRIPTION
Prior to this change, when accessing a deleted space URL, a blank page is displayed rather than a Page Not found page. This change avoids an NPE and redirects the user to the correct page.