### PR TITLE
fix: remove the caption class from the activity liker subtitle - EXO-87167

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-reactions/components/ActivityLikerItem.vue
@@ -8,7 +8,7 @@
       popover
       bold-title>
       <template slot="subTitle">
-        <span v-if="!sameUser" class="caption text-bold">
+        <span v-if="!sameUser">
           {{ inCommonConnections }} {{ $t('UIActivity.label.Reactions_in_Common') }}
         </span>
       </template>


### PR DESCRIPTION
This change is going to remove the caption class from the activity liker subtitle.