### PR TITLE
fix: Ensure to display Unread Badge in Unread Activities - EXO-87143

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UnreadBadge.vue
@@ -62,6 +62,9 @@ export default {
     isMarkedAsRead: true,
   }),
   computed: {
+    isUnread() {
+      return !!this.unreadMetadata;
+    },
     displayBadge() {
       return this.spaceId && this.isUnread;
     },


### PR DESCRIPTION
Prior to this change, the Activity Badge wasn't displayed when it's unread. This change will bring back a computed property which is necessary to display the Activity Badge.