### PR TITLE
feat: Undecorate Space and Space Template Group Entities before persisting - EXO-87220

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/plugin/SpaceGroupDecoratorPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/space/plugin/SpaceGroupDecoratorPlugin.java
@@ -89,4 +89,13 @@ public class SpaceGroupDecoratorPlugin extends BaseComponentPlugin implements Gr
       return group;
     }
   }
+
+  @Override
+  public Group undecorate(Group group) {
+    if (group != null && group.getId().startsWith(SPACES_ROOT)) {
+      group.setDescription("");
+    }
+    return group;
+  }
+
 }

--- a/component/core/src/main/java/io/meeds/social/space/template/plugin/decorator/SpaceTemplateGroupDecoratorPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/space/template/plugin/decorator/SpaceTemplateGroupDecoratorPlugin.java
@@ -94,6 +94,14 @@ public class SpaceTemplateGroupDecoratorPlugin extends BaseComponentPlugin imple
     }
   }
 
+  @Override
+  public Group undecorate(Group group) {
+    if (group != null && group.getId().startsWith(SPACE_TEMPLATES_ROOT)) {
+      group.setDescription("");
+    }
+    return group;
+  }
+
   private static boolean isValidEnclosingExpression(String expression) {
     if (expression == null) {
       return false;


### PR DESCRIPTION
Prior to this change, when persisting a Space or Space Template Group,
the Space Description is used inside IDM Group entity which is limited
in term of Number of characters. This change ensures to make the Group
Description volatile and computed each retrieval instead of persisting
it while it's ignored by decorator.
