### PR TITLE
fix: Fix subordinates display when the username is email - EXO-87148  Meeds-io/meeds#4248 (#5771)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnector.java
@@ -561,7 +561,7 @@ public class ProfileSearchConnector {
           query.append(",");
         }
         String value = settings.get(key);
-        value = removeESReservedChars(value);
+        value = escapeESReservedChars(value);
         if (StringUtils.isNotBlank(value)) {
           StringBuilder expression = new StringBuilder();
           String[] splittedValues = value.split(" ");
@@ -616,10 +616,10 @@ public class ProfileSearchConnector {
     return string;
   }
 
-  public static String removeESReservedChars(String string) {
+  public static String escapeESReservedChars(String string) {
     String [] ES_RESERVED_CHARS = new String []{"+","-","=","&&","||",">","<","!","(",")","{","}","[","]","^","\"","~","*","?",":","\\","/"};
     for(String c : ES_RESERVED_CHARS) {
-      string = string.replace(c, " ");
+      string = string.replace(c, "\\" + c);
     }
     return string;
   }

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/search/ProfileSearchConnectorTest.java
@@ -722,7 +722,7 @@ public class ProfileSearchConnectorTest {
         Identity identity2 = new Identity("test2","test2");
         excludedIdentityList.add(identity1);
         excludedIdentityList.add(identity2);
-        profileSettings.put("testProperty","value+ -=&&||of><!(){} test[]^\"~*? Property:\\/");
+        profileSettings.put("testProperty","value+ -=&&||of><!(){} test[]^\"~*? Property:");
         filter.setSearchEmail(false);
         filter.setSearchUserName(false);
         filter.setName("\\\"te-s t\\\"");
@@ -819,7 +819,7 @@ public class ProfileSearchConnectorTest {
           ,
             {
               "query_string": {
-                "query": " testProperty.whitespace:*value* AND  testProperty.whitespace:*of* AND  testProperty.whitespace:*test* AND  testProperty.whitespace:*Property*"
+                "query": " testProperty.whitespace:*value\\\\+* AND  testProperty.whitespace:*\\\\-\\\\=\\\\&&\\\\||of\\\\>\\\\<\\\\!\\\\(\\\\)\\\\{\\\\}* AND  testProperty.whitespace:*test\\\\[\\\\]\\\\^\\\\"\\\\~\\\\*\\\\?* AND  testProperty.whitespace:*Property\\\\:*"
               }
            }
                 ]


### PR DESCRIPTION
Prior to this change, usernames that contained special characters were not correctly handled in Elasticsearch queries. As a result, managers with such usernames did not display their subordinates. This change will ensure that usernames are processed safely by escaping reserved characters when building queries.

(cherry picked from commit 4716007c64f7f4b9b6a7672e282b3f6a98241570)