### PR TITLE
fix: Label not translated in Self Registration page - EXO-87170 (#5769)

### DIFF
--- a/webapp/src/main/webapp/vue-apps/login-external-onboarding/components/ExternalOnboardingCreateUserForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-external-onboarding/components/ExternalOnboardingCreateUserForm.vue
@@ -303,7 +303,7 @@ export default {
                 this.error = data.error;
                 this.errorField = data.errorField;
                 if (!this.errorField) {
-                  this.$root.$emit('alert-message', this.error, 'error');
+                  this.$root.$emit('alert-message', this.$t(this.error), 'error');
                 }
                 this.loading = false;
               });


### PR DESCRIPTION
Prior to this change, when attempting to self-register, the translation key was displayed when the captcha was invalid. This change ensures that the translated value is shown as the error message, resolving the issue.
