### PR TITLE
fix: disable Like activity button tooltip on mobile view - EXO-87368

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
@@ -3,7 +3,7 @@
     :class="cssClass"
     class="d-inline-flex">
     <!-- Added for mobile -->
-    <v-tooltip bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           :id="`LikeLink${activityId}`"


### PR DESCRIPTION
Prior to this change, in mobile view, long-pressing the like activity button would trigger the tooltip, which remained visible even while scrolling the screen. Like other activity reaction actions, this change disables the tooltip in mobile view.