### PR TITLE
fix: disable Like activity button tooltip on mobile view - EXO-87368

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
@@ -49,10 +49,6 @@ export default {
       type: Object,
       default: null,
     },
-    isMobile: {
-      type: Boolean,
-      default: () => false
-    },
   },
   data: () => ({
     changingLike: false,
@@ -74,7 +70,10 @@ export default {
     cssClass() {
       return (this.$vuetify.breakpoint.width >= this.$vuetify.breakpoint.thresholds.xl && !this.$root.reducedWidth) ? 'ms-4'
         : ((this.$vuetify.breakpoint.width >= this.$vuetify.breakpoint.thresholds.lg && !this.$root.reducedWidth) ? ' ms-3' :'');
-    }
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'sm';
+    },
   },
   created() {
     this.computeLikes();


### PR DESCRIPTION
Prior to this change, in mobile view, long-pressing the like activity button would trigger the tooltip, which remained visible even while scrolling the screen. Like other activity reaction actions, this change disables the tooltip in mobile view.