### PR TITLE
fix: Tooltip displayed on feed after scroll - EXO-87368

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadTime.vue
@@ -8,7 +8,7 @@
       x-small>
       far fa-clock
     </v-icon>
-    <v-tooltip bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           :href="activityLink"

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -69,8 +69,8 @@
             </v-tooltip>
             <v-tooltip
               v-if="$root.canEdit"
-              bottom
-              :disabled="isMobile">
+              :disabled="isMobile"
+              bottom>
               <template #activator="{ on, attrs }">
                 <v-btn
                   v-bind="attrs"

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityStreamToolbar.vue
@@ -67,7 +67,10 @@
                 {{ $t('activity.filter.button.markAllAsRead') }}
               </span>
             </v-tooltip>
-            <v-tooltip v-if="$root.canEdit" bottom>
+            <v-tooltip
+              v-if="$root.canEdit"
+              bottom
+              :disabled="isMobile">
               <template #activator="{ on, attrs }">
                 <v-btn
                   v-bind="attrs"
@@ -96,7 +99,7 @@
               name="ActivityToolbarButton"
               type="activity-toolbar-button"
               class="hidden-xs-only d-flex align-center" />
-            <v-tooltip bottom>
+            <v-tooltip :disabled="isMobile" bottom>
               <template #activator="{ on, attrs }">
                 <v-btn
                   v-if="streamFilterEnabled"


### PR DESCRIPTION
Prior to this change, in mobile view, long-pressing the feed action buttons would trigger the tooltip, which remained visible even while scrolling the screen. , this change disables the tooltip in mobile view.