### PR TITLE
fix: Display space description as plain text in the muted spaces list  - EXO-97380

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationMuteSpacesDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationMuteSpacesDrawer.vue
@@ -75,7 +75,7 @@
               </v-list-item-title>
               <v-list-item-subtitle
                 v-if="space.description"
-                v-sanitized-html="space.description"
+                v-sanitized-html="getSpaceDescriptionText(space.description)"
                 class="caption text-truncate" />
             </v-list-item-content>
             <v-list-item-action class="pa-0 my-auto">
@@ -198,6 +198,9 @@ export default {
         })
         .catch(() => this.$root.$emit('alert-message', this.$t('Notification.alert.errorChangingSpaceMutingStatus'), 'error'))
         .finally(() => this.loading = false);
+    },
+    getSpaceDescriptionText(description) {
+      return this.$utils.htmlToText(description);
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationMuteSpacesDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationMuteSpacesDrawer.vue
@@ -75,8 +75,9 @@
               </v-list-item-title>
               <v-list-item-subtitle
                 v-if="space.description"
-                v-sanitized-html="getSpaceDescriptionText(space.description)"
-                class="caption text-truncate" />
+                class="caption text-truncate">
+                {{ getSpaceDescriptionText(space.description) }}
+              </v-list-item-subtitle>
             </v-list-item-content>
             <v-list-item-action class="pa-0 my-auto">
               <v-tooltip


### PR DESCRIPTION
Prior to this change, when a space description contained HTML, it was displayed as HTML in the muted spaces list drawer. This change ensures that the space description is displayed as plain text.