### PR TITLE
fix: Topbar navigation menu items inaccessible when exceeding screen height - EXO-87513

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -26,6 +26,7 @@
     :content-class="`topBar-navigation-drop-menu ${isTopBarElement && 'layout-top-bar' || ''}`"
     :left="$vuetify.rtl"
     :open-on-hover="isOpenedOnHover"
+    :max-height="menuMaxHeight"
     bottom
     offset-y
     eager>
@@ -100,6 +101,7 @@ export default {
     return {
       showMenu: false,
       isOpenedOnHover: true,
+      menuMaxHeight: '100vh'
     };
   },
   computed: {


### PR DESCRIPTION
Prior to this change, when the topbar navigation menu contained many items and exceeded the screen height, some of the items were not accessible. This change adds a maximum height to the menu which enables scrolling, resolving the issue.