### PR TITLE
fix: Display space template description as plain text in the space form drawer - EXO-87549

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-form/components/SpaceFormDrawer.vue
@@ -74,9 +74,10 @@
                       {{ item.name }}
                     </div>
                     <div
-                      v-sanitized-html="item.description || ''"
-                      :title="item.description"
-                      class="text-subtitle white--text full-width text-truncate-5"></div>
+                      :title="getTemplateDescriptionText(item.description)"
+                      class="text-subtitle white--text full-width text-truncate-5">
+                      {{ getTemplateDescriptionText(item.description) }}
+                    </div>
                   </div>
                 </v-expand-transition>
               </div>
@@ -676,7 +677,10 @@ export default {
       if (!this.parentSpaceId) {
         this.selectedParentSpace = null;
       }
-    }
+    },
+    getTemplateDescriptionText(description) {
+      return this.$utils.htmlToText(description);
+    },
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change the space template description was displayed as html tag in the space form drawer, this change prevents space template description from being displayed as HTML in the space form drawer.