### PR TITLE
 fix: Users card options alignment issue - EXO-80968

### DIFF
--- a/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserMenuItem.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserMenuItem.vue
@@ -72,7 +72,7 @@ export default {
     initExtension() {
       if (this.$refs.container?.$el) {
         this.$refs.container.$el.innerHTML = '';
-        this.extension.init(this.$refs.container?.$el, this.user.username);
+        this.extension.init(this.$refs.container?.$el, this.user.username, { isMenu: true });
       }
     }
   }


### PR DESCRIPTION
Before this change, when using the Unified Search user results view, opening the options menu on a user card could cause the video call icon and label to become misaligned when multiple external video conferencing providers were available and configured by the user. As a result, the display was not rendered as expected. To fix this problem, the dropdown component was replaced with v-menu. After this change, the video call icon and label are properly aligned, and the list of available video conferencing options is displayed correctly.