### PR TITLE
fix: muted space list displays empty when it includes an inaccessible space - EXO-87584

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationMuteSpacesDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingNotificationMuteSpacesDrawer.vue
@@ -167,15 +167,18 @@ export default {
     },
     retrieveSpaces() {
       this.loading = true;
-      return Promise.all(this.mutedSpaceIds.map(id => this.$spaceService.getSpaceById(id)))
-        .then(spaces => {
-          const mutedSpaces = spaces || [];
-          mutedSpaces.forEach(space => {
-            space.url = `${eXo.env.portal.context}/s/${space.id}`;
-          });
-          this.mutedSpaces = mutedSpaces;
-        })
-        .finally(() => this.loading = false);
+      return Promise.allSettled(
+        this.mutedSpaceIds.map(id => this.$spaceService.getSpaceById(id))).then(results => {
+        // rejected promises has no value
+        const mutedSpaces = results.filter(result => result?.value).map(result => result.value);
+        mutedSpaces.forEach(space => {
+          space.url = `${eXo.env.portal.context}/s/${space.id}`;
+        });
+        this.mutedSpaces = mutedSpaces;
+      })
+        .finally(() => {
+          this.loading = false;
+        });
     },
     muteSpace(space, unmute) {
       this.loading = true;


### PR DESCRIPTION
Prior to this change, when a user muted a space and later left it, and the space was marked as hidden, the muted spaces list in user settings was displayed as empty.
This issue was caused by a rejected promise when a space was not accessible, which caused Promise.all to fail for all requests.
This change replaces Promise.all with Promise.allSettled, filters only fulfilled results, and ensures that inaccessible spaces do not block the display of other muted spaces.