### PR TITLE
fix: Content Link Tags Parsing - EXO-87630

### DIFF
--- a/component/core/src/main/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPlugin.java
@@ -40,9 +40,7 @@ import jakarta.annotation.PostConstruct;
 public class ContentLinkHtmlProcessorPlugin implements HtmlProcessorPlugin {
 
   private static final String CONTENT_LINK_TAG       =
-                                               """
-                                                   <content-link contenteditable="false" style="display: none;">/%s</content-link>
-                                                   """;
+                                               "<content-link contenteditable=\"false\" style=\"display: none;\">/%s</content-link>";
 
   private static final String CONTENT_LINK_START_TAG = "<content-link";
 
@@ -80,66 +78,92 @@ public class ContentLinkHtmlProcessorPlugin implements HtmlProcessorPlugin {
   private List<ContentLinkIdentifier> getContentLinkFromTag(String html, HtmlProcessorContext context) {
     List<ContentLinkIdentifier> links = new ArrayList<>();
     int fromIndex = 0;
-    while (html.indexOf(CONTENT_LINK_START_TAG, fromIndex) > -1) {
-      String contentLinkTag = getContentLinkTag(html, fromIndex);
+    int contentLinkIndex;
+    while ((contentLinkIndex = html.indexOf(CONTENT_LINK_START_TAG, fromIndex)) > -1) {
+      String contentLinkTag = getContentLinkTag(html, contentLinkIndex);
+      if (StringUtils.isBlank(contentLinkTag)) {
+        fromIndex = contentLinkIndex + CONTENT_LINK_START_TAG.length();
+        continue;
+      }
       ContentLinkIdentifier contentLinkIdentifier = getContentLinkIdentifier(contentLinkTag, context);
       if (contentLinkIdentifier != null) {
         links.add(contentLinkIdentifier);
       }
-      fromIndex += CONTENT_LINK_START_TAG.length();
+      fromIndex = contentLinkIndex + contentLinkTag.length();
     }
     return links;
   }
 
   private ContentLinkIdentifier getContentLinkIdentifier(String contentLinkTag, HtmlProcessorContext context) {
     int startIndex = contentLinkTag.indexOf(">");
-    int endIndex = contentLinkTag.indexOf("<", startIndex);
-    if (endIndex < 0) {
-      endIndex = contentLinkTag.indexOf("'", startIndex);
-    }
-    String contentLinkObject = contentLinkTag.substring(startIndex + 2, endIndex);
-    if (contentLinkObject.contains(":")) {
-      String[] parts = contentLinkObject.trim().replace("/", "").trim().split(":");
-      return new ContentLinkIdentifier(parts[0], parts[1], context.getFieldName(), context.getLocale());
-    } else {
+    if (startIndex < 0 || startIndex + 1 >= contentLinkTag.length()) {
       return null;
     }
+    int endIndex = contentLinkTag.indexOf("<", startIndex + 1);
+    if (endIndex < 0) {
+      endIndex = contentLinkTag.indexOf("'", startIndex + 1);
+    }
+    if (endIndex <= startIndex + 1) {
+      return null;
+    }
+    String contentLinkObject = contentLinkTag.substring(startIndex + 1, endIndex).trim().replaceFirst("^/", "");
+    if (contentLinkObject.contains(":")) {
+      String[] parts = contentLinkObject.split(":", 2);
+      if (parts.length == 2 && StringUtils.isNoneBlank(parts[0], parts[1])) {
+        return new ContentLinkIdentifier(parts[0], parts[1], context.getFieldName(), context.getLocale());
+      }
+    }
+    return null;
   }
 
   private String getContentLinkTag(String html, int fromIndex) {
     int startIndex = html.indexOf(CONTENT_LINK_START_TAG, fromIndex);
+    if (startIndex < 0) {
+      return null;
+    }
     int endIndex = html.indexOf(CONTENT_LINK_END_TAG, startIndex);
+    if (endIndex < 0) {
+      return null;
+    }
     return html.substring(startIndex, endIndex + CONTENT_LINK_END_TAG.length());
   }
 
   private String replaceDataObjectTag(String html) {
     int fromIndex = 0;
-    while (html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex) > -1) {
-      String dataObjectTag = getDataObjectTag(html, fromIndex);
-      int newFromIndex;
-      if (StringUtils.isNotBlank(dataObjectTag)) {
-        newFromIndex = html.indexOf(dataObjectTag);
-        String dataObjectAttribute = getDataObjectAttribute(dataObjectTag);
-        if (dataObjectAttribute != null) {
-          html = html.replace(dataObjectTag,
-                              String.format(CONTENT_LINK_TAG, dataObjectAttribute));
-        }
-      } else {
-        newFromIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex) + 1;
+    int attributeIndex;
+    while ((attributeIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex)) > -1) {
+      String dataObjectTag = getDataObjectTag(html, attributeIndex);
+      if (StringUtils.isBlank(dataObjectTag)) {
+        fromIndex = attributeIndex + DATA_OBJECT_ATTRIBUTE.length();
+        continue;
       }
-      fromIndex = newFromIndex;
+      String dataObjectAttribute = getDataObjectAttribute(dataObjectTag);
+      if (dataObjectAttribute == null) {
+        fromIndex = attributeIndex + DATA_OBJECT_ATTRIBUTE.length();
+        continue;
+      }
+      int tagIndex = html.lastIndexOf(DATA_OBJECT_START_TAG, attributeIndex);
+      String replacement = String.format(CONTENT_LINK_TAG, dataObjectAttribute.trim());
+      html = html.substring(0, tagIndex) + replacement + html.substring(tagIndex + dataObjectTag.length());
+      fromIndex = tagIndex + replacement.length();
     }
     return html;
   }
 
   private String getDataObjectTag(String html, int fromIndex) {
-    int attributeIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex);
-    int startIndex = html.substring(fromIndex, attributeIndex).lastIndexOf(DATA_OBJECT_START_TAG);
-    if (startIndex > -1 && !html.substring(startIndex + 1, attributeIndex).contains("<")) {
-      int endIndex = html.indexOf(DATA_OBJECT_END_TAG, attributeIndex);
-      return html.substring(fromIndex + startIndex, endIndex + DATA_OBJECT_END_TAG.length());
+    int attributeIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, Math.max(0, fromIndex));
+    if (attributeIndex < 0) {
+      return null;
     }
-    return null;
+    int startIndex = html.lastIndexOf(DATA_OBJECT_START_TAG, attributeIndex);
+    if (startIndex < 0 || html.substring(startIndex + 1, attributeIndex).contains("<")) {
+      return null;
+    }
+    int endIndex = html.indexOf(DATA_OBJECT_END_TAG, attributeIndex);
+    if (endIndex < 0) {
+      return null;
+    }
+    return html.substring(startIndex, endIndex + DATA_OBJECT_END_TAG.length());
   }
 
   private String getDataObjectAttribute(String dataObjectTag) {

--- a/component/core/src/main/java/io/meeds/social/cms/plugin/ContentLinkHtmlTransformerPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/cms/plugin/ContentLinkHtmlTransformerPlugin.java
@@ -18,7 +18,6 @@
  */
 package io.meeds.social.cms.plugin;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -27,7 +26,6 @@ import java.util.ResourceBundle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.meeds.social.cms.model.ContentLinkExtension;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +38,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
 
 import io.meeds.social.cms.model.ContentLink;
+import io.meeds.social.cms.model.ContentLinkExtension;
 import io.meeds.social.cms.model.ContentLinkIdentifier;
 import io.meeds.social.cms.service.ContentLinkPluginService;
 import io.meeds.social.cms.service.ContentLinkService;
@@ -65,9 +64,7 @@ public class ContentLinkHtmlTransformerPlugin implements HtmlTransformerPlugin {
   private static final String      NOT_FOUND_LABEL                 = "(Content has been deleted)";
 
   private static final String      CONTENT_LINK_TAG                =
-                                                    """
-                                                        <content-link contenteditable="false" style="display: none;">/%s</content-link>
-                                                        """;
+                                                    "<content-link contenteditable=\"false\" style=\"display: none;\">/%s</content-link>";
 
   private static final String      CONTENT_LINK_START_TAG          = "<content-link";
 
@@ -120,8 +117,13 @@ public class ContentLinkHtmlTransformerPlugin implements HtmlTransformerPlugin {
   }
 
   private String replaceContentLinkTag(String html, HtmlTransformerContext context) { // NOSONAR
-    while (html.contains(CONTENT_LINK_START_TAG)) {
-      String contentLinkTag = getContentLinkTag(html);
+    int contentLinkIndex;
+    while ((contentLinkIndex = html.indexOf(CONTENT_LINK_START_TAG)) > -1) {
+      String contentLinkTag = getContentLinkTag(html, contentLinkIndex);
+      if (StringUtils.isBlank(contentLinkTag)) {
+        html = html.substring(0, contentLinkIndex) + html.substring(contentLinkIndex + CONTENT_LINK_START_TAG.length());
+        continue;
+      }
       ContentLinkIdentifier contentLinkIdentifier = getContentLinkIdentifier(contentLinkTag, context.getLocale());
       if (contentLinkIdentifier == null) {
         html = html.replace(contentLinkTag, "");
@@ -170,16 +172,22 @@ public class ContentLinkHtmlTransformerPlugin implements HtmlTransformerPlugin {
 
   private String replaceDataObjectTag(String html) {
     int fromIndex = 0;
-    while (html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex) > -1) {
-      String dataObjectTag = getDataObjectTag(html, fromIndex);
-      if (StringUtils.isNotBlank(dataObjectTag)) {
-        String dataObjectAttribute = getDataObjectAttribute(dataObjectTag);
-        if (dataObjectAttribute != null) {
-          html = html.replace(dataObjectTag,
-                              String.format(CONTENT_LINK_TAG, dataObjectAttribute.trim()));
-        }
+    int attributeIndex;
+    while ((attributeIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex)) > -1) {
+      String dataObjectTag = getDataObjectTag(html, attributeIndex);
+      if (StringUtils.isBlank(dataObjectTag)) {
+        fromIndex = attributeIndex + DATA_OBJECT_ATTRIBUTE.length();
+        continue;
       }
-      fromIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex + DATA_OBJECT_ATTRIBUTE.length());
+      String dataObjectAttribute = getDataObjectAttribute(dataObjectTag);
+      if (dataObjectAttribute == null) {
+        fromIndex = attributeIndex + DATA_OBJECT_ATTRIBUTE.length();
+        continue;
+      }
+      int tagIndex = html.lastIndexOf(DATA_OBJECT_START_TAG, attributeIndex);
+      String replacement = String.format(CONTENT_LINK_TAG, dataObjectAttribute.trim());
+      html = html.substring(0, tagIndex) + replacement + html.substring(tagIndex + dataObjectTag.length());
+      fromIndex = tagIndex + replacement.length();
     }
     return html;
   }
@@ -217,33 +225,52 @@ public class ContentLinkHtmlTransformerPlugin implements HtmlTransformerPlugin {
 
   private ContentLinkIdentifier getContentLinkIdentifier(String contentLinkTag, Locale locale) {
     int startIndex = contentLinkTag.indexOf(">");
-    int endIndex = contentLinkTag.indexOf("<", startIndex);
-    if (endIndex < 0) {
-      endIndex = contentLinkTag.indexOf("'", startIndex);
-    }
-    String contentLinkObject = contentLinkTag.substring(startIndex + 2, endIndex);
-    if (contentLinkObject.contains(":")) {
-      String[] parts = contentLinkObject.trim().replace("/", "").trim().split(":");
-      return new ContentLinkIdentifier(parts[0], parts[1], null, locale);
-    } else {
+    if (startIndex < 0 || startIndex + 1 >= contentLinkTag.length()) {
       return null;
     }
+    int endIndex = contentLinkTag.indexOf("<", startIndex + 1);
+    if (endIndex < 0) {
+      endIndex = contentLinkTag.indexOf("'", startIndex + 1);
+    }
+    if (endIndex <= startIndex + 1) {
+      return null;
+    }
+    String contentLinkObject = contentLinkTag.substring(startIndex + 1, endIndex).trim().replaceFirst("^/", "");
+    if (contentLinkObject.contains(":")) {
+      String[] parts = contentLinkObject.split(":", 2);
+      if (parts.length == 2 && StringUtils.isNoneBlank(parts[0], parts[1])) {
+        return new ContentLinkIdentifier(parts[0], parts[1], null, locale);
+      }
+    }
+    return null;
   }
 
-  private String getContentLinkTag(String html) {
-    int startIndex = html.indexOf(CONTENT_LINK_START_TAG);
+  private String getContentLinkTag(String html, int fromIndex) {
+    int startIndex = html.indexOf(CONTENT_LINK_START_TAG, fromIndex);
+    if (startIndex < 0) {
+      return null;
+    }
     int endIndex = html.indexOf(CONTENT_LINK_END_TAG, startIndex);
+    if (endIndex < 0) {
+      return null;
+    }
     return html.substring(startIndex, endIndex + CONTENT_LINK_END_TAG.length());
   }
 
   private String getDataObjectTag(String html, int fromIndex) {
-    int attributeIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, fromIndex);
-    int startIndex = html.substring(fromIndex, attributeIndex).lastIndexOf(DATA_OBJECT_START_TAG);
-    if (startIndex > -1 && !html.substring(startIndex + 1, attributeIndex).contains("<")) {
-      int endIndex = html.indexOf(DATA_OBJECT_END_TAG, attributeIndex);
-      return html.substring(fromIndex + startIndex, endIndex + DATA_OBJECT_END_TAG.length());
+    int attributeIndex = html.indexOf(DATA_OBJECT_ATTRIBUTE, Math.max(0, fromIndex));
+    if (attributeIndex < 0) {
+      return null;
     }
-    return null;
+    int startIndex = html.lastIndexOf(DATA_OBJECT_START_TAG, attributeIndex);
+    if (startIndex < 0 || html.substring(startIndex + 1, attributeIndex).contains("<")) {
+      return null;
+    }
+    int endIndex = html.indexOf(DATA_OBJECT_END_TAG, attributeIndex);
+    if (endIndex < 0) {
+      return null;
+    }
+    return html.substring(startIndex, endIndex + DATA_OBJECT_END_TAG.length());
   }
 
   private String getDataObjectAttribute(String dataObjectTag) {

--- a/component/core/src/test/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPluginTest.java
@@ -194,6 +194,39 @@ public class ContentLinkHtmlProcessorPluginTest extends AbstractSpringConfigurat
     }
   }
 
+
+  @Test
+  @SneakyThrows
+  public void testContentLinkPluginFromSeveralATagsFollowedByExternalLink() {
+    String html = """
+        <div>Random publication checklist 927</div><div><a class="content-link" contenteditable="false" data-object="testContentLink:5874" href="/portal/s/215/notes/5874">Randomized note reference</a></div><div><a href="https://example.org/portal/g/:spaces:knowledge/tasks/taskDetail/64823" rel="nofollow">https://example.org/portal/g/:spaces:knowledge/tasks/taskDetail/64823</a></div>
+        """.replace("\n", "").trim();
+
+    assertEquals(html, HtmlUtils.process(html, CONTENT_OBJECT_CONTEXT));
+
+    List<ContentLink> links = contentLinkService.getLinks(CONTENT_OBJECT,
+                                                          Locale.ENGLISH,
+                                                          userAcl.getSuperUser());
+    assertNotNull(links);
+    assertEquals(1, links.size());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testContentLinkPluginSkipsMalformedDataObjectOccurrences() {
+    String html = """
+        <div>Free text marker data-object="testContentLink:5874" should not break processing 531</div><div><span data-object="testContentLink:5874">Unexpected marker</span></div><div><a class="content-link" contenteditable="false" data-object="testContentLink:5874" href="/portal/s/316/notes/5874">Valid randomized reference</a></div>
+        """.replace("\n", "").trim();
+
+    assertEquals(html, HtmlUtils.process(html, CONTENT_OBJECT_CONTEXT));
+
+    List<ContentLink> links = contentLinkService.getLinks(CONTENT_OBJECT,
+                                                          Locale.ENGLISH,
+                                                          userAcl.getSuperUser());
+    assertNotNull(links);
+    assertEquals(1, links.size());
+  }
+
   private void addAclPlugin(String objectType) {
     userAcl.addAclPlugin(new AclPlugin() {
       @Override

--- a/component/core/src/test/java/io/meeds/social/cms/plugin/ContentLinkHtmlTransformerPluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/plugin/ContentLinkHtmlTransformerPluginTest.java
@@ -158,6 +158,41 @@ public class ContentLinkHtmlTransformerPluginTest extends AbstractSpringConfigur
     assertEquals(CONTENT_LINK_RESULT.trim(), HtmlUtils.transform(CONTENT_LINK_OLD, CONTENT_LINK_CONTEXT).trim());
   }
 
+
+  @Test
+  @SneakyThrows
+  public void testContentLinkPluginWhenSeveralDataObjectLinksAreFollowedByExternalLink() {
+    String externalLink = """
+        <a href="https://example.org/portal/g/:spaces:knowledge/tasks/taskDetail/73190" rel="nofollow">https://example.org/portal/g/:spaces:knowledge/tasks/taskDetail/73190</a>
+        """.replace("\n", "").trim();
+    String html = """
+        <div>Generated draft block 814</div><div><a class="content-link" contenteditable="false" data-object="testContentLink:5874" href="/portal/s/842/notes/5874">First randomized note</a></div><div>Intermediate text 263</div><div><a class="content-link" contenteditable="false" data-object="testContentLink:5874" href="/portal/s/843/notes/5874" target="_blank">Second randomized note</a></div><div>Reference task %s</div>
+        """.formatted(externalLink).replace("\n", "").trim();
+
+    String expectedContentLink = """
+        <a href="linkToContent" data-object="testContentLink:5874" contenteditable="false" class="content-link"><i aria-hidden="true" class="pluginIcon v-icon notranslate theme--light icon-default-color" style="font-size: 16px; margin: 0 4px;"></i>contentTitle</a>
+        """.replace("\n", "").trim();
+    String expected = """
+        <div>Generated draft block 814</div><div>%s</div><div>Intermediate text 263</div><div>%s</div><div>Reference task %s</div>
+        """.formatted(expectedContentLink, expectedContentLink, externalLink).replace("\n", "").trim();
+
+    assertEquals(expected, HtmlUtils.transform(html, CONTENT_LINK_CONTEXT).trim());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testContentLinkPluginIgnoresMalformedDataObjectOccurrences() {
+    String html = """
+        <div>Data object marker outside an anchor data-object="testContentLink:5874" should stay untouched 419</div><div><span data-object="testContentLink:5874">Unexpected span marker</span></div><div><a href="/portal/s/842/notes/5874" data-object="testContentLink:5874">Recoverable randomized link</a></div>
+        """.replace("\n", "").trim();
+
+    String expected = """
+        <div>Data object marker outside an anchor data-object="testContentLink:5874" should stay untouched 419</div><div><span data-object="testContentLink:5874">Unexpected span marker</span></div><div><a href="linkToContent" data-object="testContentLink:5874" contenteditable="false" class="content-link"><i aria-hidden="true" class="pluginIcon v-icon notranslate theme--light icon-default-color" style="font-size: 16px; margin: 0 4px;"></i>contentTitle</a></div>
+        """.replace("\n", "").trim();
+
+    assertEquals(expected, HtmlUtils.transform(html, CONTENT_LINK_CONTEXT).trim());
+  }
+
   private void addAclPlugin(String objectType) {
     userAcl.addAclPlugin(new AclPlugin() {
       @Override


### PR DESCRIPTION
Prior to this change, the HTML Content Link Tags parsing wasn't sufficiently efficient to detect malformed contents. This change will consider malformed links to not throw an Index Out of Bound Errors.