### PR TITLE
fix: Avoid NPE when Group doesn't exist anymore - EXO-87637

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
@@ -404,7 +404,7 @@ public class IdentityManagerImpl implements IdentityManager {
 
         // case of create new space or user, an event will be called only in
         // case of create user
-        if (result.isUser()) {
+        if (result != null && result.isUser()) {
           profileLifeCycle.createProfile(result.getProfile());
         }
       } else {

--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -627,7 +627,9 @@ public class SpaceUtils {
         Space space = spaceService.getSpaceByGroupId(groupId);
         if (space != null) {
           Identity identity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
-          groupIdentityIds.add(identity.getId());
+          if (identity != null) {
+            groupIdentityIds.add(identity.getId());
+          }
         }
       } else {
         Identity identity = identityManager.getOrCreateGroupIdentity(groupId);


### PR DESCRIPTION
Prior to this change, when retrieving the User Identity permissions, an NPE is thrown due to missing Group Identity. This change avoids such error by testing on Identity nullability.