### PR TITLE
fix: Answer with HTTP 404 when searching for not managed content link types - EXO-87639

### DIFF
--- a/component/api/src/main/java/io/meeds/social/cms/service/ContentLinkService.java
+++ b/component/api/src/main/java/io/meeds/social/cms/service/ContentLinkService.java
@@ -86,7 +86,7 @@ public interface ContentLinkService {
                                             String username,
                                             Locale locale,
                                             int offset,
-                                            int limit);
+                                            int limit) throws ObjectNotFoundException;
 
   /**
    * @param contentObject {@link ContentObject}

--- a/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkServiceImpl.java
@@ -75,9 +75,11 @@ public class ContentLinkServiceImpl implements ContentLinkService {
                                                    String username,
                                                    Locale locale,
                                                    int offset,
-                                                   int limit) {
+                                                   int limit) throws ObjectNotFoundException{
     keyword = StringUtils.trim(keyword);
-    if (contentLinkPluginService.isId(objectType, keyword) ) {
+    if (contentLinkPluginService.getPlugin(objectType) == null) {
+      throw new ObjectNotFoundException("Content Link Plugin with type '%s' doesn't exists".formatted(objectType));
+    } else if (contentLinkPluginService.isId(objectType, keyword) ) {
       try {
         ContentLink link = getLink(new ContentLinkIdentifier(objectType, keyword, locale), username);
         return Collections.singletonList(new ContentLinkSearchResult(link));

--- a/component/service/src/main/java/io/meeds/social/cms/rest/ContentLinkRest.java
+++ b/component/service/src/main/java/io/meeds/social/cms/rest/ContentLinkRest.java
@@ -138,12 +138,16 @@ public class ContentLinkRest {
                                                    @Parameter(description = "Search result limit")
                                                    @RequestParam(name = "fieldName", required = false, defaultValue = "10")
                                                    int limit) {
-    return contentLinkService.searchLinks(objectType,
-                                          query,
-                                          request.getRemoteUser(),
-                                          request.getLocale(),
-                                          offset,
-                                          limit);
+    try {
+      return contentLinkService.searchLinks(objectType,
+                                            query,
+                                            request.getRemoteUser(),
+                                            request.getLocale(),
+                                            offset,
+                                            limit);
+    } catch (ObjectNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    }
   }
 
   @PutMapping(value = "{objectType}/{objectId}", consumes = MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
Prior to this change, when attempting to retrieve a content link which isn't managed (unrecognized type), a HTTP 404 is returned instead of adding a log entry in server side.