### PR TITLE
fix: Avoid using Promise.try which is too recent for Safari - EXO-87679

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/js/Utils.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/Utils.js
@@ -39,7 +39,8 @@ export function includeExtensions(suffix) {
       window.require([module], app => {
         const previousLoadingResult = window.requireJsLoadedExtension[module];
         if (!previousLoadingResult) {
-          window.requireJsLoadedExtension[module] = Promise.try(() => app?.init?.()) // NOSONAR
+          window.requireJsLoadedExtension[module] = Promise.resolve()
+            .then(() => app?.init?.()) // NOSONAR
             .then(() => { // NOSONAR
               window.requireJsLoadedExtension[module] = true;
               resolve();


### PR DESCRIPTION
Prior to this change, the Promise.try JS method was used while its support has been added since iOS 18 only.