### PR TITLE
fix: Safari not considering click when using v-hover on iOS - EXO-87666 - EXO-87667

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListItem.vue
@@ -26,10 +26,10 @@
       :item="item" />
   </div>
   <div v-else-if="isSpaces || isSpaceTemplate || isSpaceCategory">
-    <v-hover
+    <component
+      :is="$root.displaySequentially ? 'v-hover' : 'div'"
       v-model="hover"
-      v-if="displaySpacesList"
-      :disabled="!$root.displaySequentially">
+      v-if="displaySpacesList">
       <v-list-item
         :title="spacesTooltip"
         :class="$root.iconCollapse && 'mx-0'"
@@ -74,15 +74,16 @@
           </ripple-hover-button>
         </v-list-item-action>
       </v-list-item>
-    </v-hover>
+    </component>
     <v-expand-transition v-if="displayItemsInMobile">
       <sidebar-list-sub-list
         v-show="!collapsedSpaces || !$root.displaySequentially"
         :item="item" />
     </v-expand-transition>
   </div>
-  <v-hover
+  <component
     v-else-if="item.url"
+    :is="$root.displaySequentially ? 'v-hover' : 'div'"
     v-model="hover">
     <v-list-item
       v-bind="itemAttributes"
@@ -176,7 +177,7 @@
         :unread-badge="spaceUnreadCount"
         @refresh="retrieveSpace(true)" />
     </v-list-item>
-  </v-hover>
+  </component>
 </template>
 <script>
 export default {

--- a/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationItem.vue
+++ b/webapp/src/main/webapp/vue-apps/site-details/components/SiteNavigationItem.vue
@@ -17,13 +17,15 @@
 
 <template>
   <a
+    v-on="!isMobile && {
+      mouseover: () => showAction = true,
+      mouseleave: () => showAction = false,
+    }"
     :href="uri"
     :target="target"
     :rel="rel"
     :ripple="false"
-    class="d-flex px-0"
-    @mouseover="showAction = true"
-    @mouseleave="showAction = false">
+    class="d-flex px-0">
     <v-list-item-avatar
       v-if="iconUrl"
       class="d-flex align-center justify-center my-auto ms-0 me-3"
@@ -77,7 +79,6 @@
     </v-list-item-action>
   </a>
 </template>
-
 <script>
 export default {
   props: {
@@ -99,6 +100,9 @@ export default {
     showAction: false,
   }),
   computed: {
+    isMobile() {
+      return this.$vuetify.breakpoint.width < this.$vuetify.breakpoint.thresholds.md;
+    },
     baseSiteUri() {
       if (this.navigation.siteKey.type === 'GROUP') {
         return `${eXo.env.portal.context}/g/${this.navigation.siteKey.name.replace?.(/\//g, ':')}/`;


### PR DESCRIPTION
Prior to this change, the 'v-hover' is used even in Mobile in order to display a selection state of a menu. This change hides the v-hover to use a simple 'div' knowing that there is no hover effect needed in Mobile. By changing this, the Safari will not need double tap to trigger the click event on menu.