### PR TITLE
fix: Fix the count of the manager's subordinates - EXO-87491  (#5793)

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -564,6 +564,7 @@ public class EntityBuilder {
     ProfileFilter filter = new ProfileFilter();
     filter.setEnabled(true);
     filter.setUserType("internal");
+    filter.setWildcardSearch(false);
     filter.setProfileSettings(Map.of(MANAGER, userEntity.getUsername()));
     ListAccess<Identity> managedUsers = getIdentityManager().getIdentitiesByProfileFilter(OrganizationIdentityProvider.NAME,
                                                                                           filter,


### PR DESCRIPTION
This change will fix the count of the manager's subordinates by setting wildCardSearch to false to filter by exact value match.

(cherry picked from commit 0431ff379424f17f55699878f54cff0146f0ec3d)
