### PR TITLE
fix: sanitize rich editor content on initialization to prevent XSS attacks - EXO-87658

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/RichEditor.vue
@@ -350,13 +350,13 @@ export default {
         this.initCKEditor(true, storageMessageText);
         this.updateInput(this.inputVal);
       } else {
-        this.initCKEditor(true, this.value);
+        this.initCKEditor(true, DOMPurify.sanitize(this.value));
       }
     },
     initCKEditor(reset, textValue) {
       const self = this;
       window.require(['SHARED/commons-editor', 'SHARED/suggester', 'SHARED/tagSuggester'], function() {
-        self.initCKEditorInstance(reset, textValue || self.value);
+        self.initCKEditorInstance(reset, textValue || DOMPurify.sanitize(self.value));
       });
     },
     async initCKEditorInstance(reset, textValue) {


### PR DESCRIPTION
Prior to this change, the content passed to the editor was loaded directly without sanitization during initialization. This could allow XSS attacks. This change ensures that editor content is sanitized during initialization.

