### PR TITLE
fix: add sanitization to portlets' JSP files to prevent XSS attacks -EXO-87658

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/activityStream.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/activityStream.jsp
@@ -1,7 +1,7 @@
-<%@page import="org.apache.commons.text.StringEscapeUtils"%>
 <%@taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 <%@page import="org.exoplatform.social.core.manager.IdentityManager"%>
 <%@page import="org.exoplatform.container.ExoContainerContext"%>
+<%@ page import="java.net.URLEncoder" %>
 <portlet:defineObjects/>
 <portlet:actionURL var="saveSettingsUrl" />
 <%
@@ -36,11 +36,11 @@
         <div class="v-progress-circular__info"></div>
       </div>
     </div>
-    <textarea id="<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : StringEscapeUtils.escapeJava((String) settings).replace("\\\"", "\"").replace("\\\\\"", "\\\"")%></textarea>
+    <textarea id="<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : URLEncoder.encode(settings.toString().replace(" ", "._.")).replace("._.", " ").replace("\\\"", "\"").replace("\\\\\"", "\\\"")%></textarea>
     <script type="text/javascript">
       require(['SHARED/ActivityStream'], app => app.init({
         appId: '<%=domId%>',
-        settings: JSON.parse(document.getElementById('<%=valueDomId%>').value),
+        settings: JSON.parse(decodeURIComponent(document.getElementById('<%=valueDomId%>').value)),
         saveSettingsUrl: '<%=saveSettingsUrl%>',
         canEdit: <%=canEdit%>,
         maxUploadSize: <%=maxUploadSize%>,

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/parentSpaceListing.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/parentSpaceListing.jsp
@@ -2,7 +2,7 @@
 <%@ page import="org.exoplatform.social.core.space.model.Space" %>
 <%@ page import="org.exoplatform.social.core.space.spi.SpaceService" %>
 <%@ page import="org.exoplatform.commons.utils.CommonsUtils" %>
-<%@page import="org.apache.commons.text.StringEscapeUtils"%>
+<%@ page import="java.net.URLEncoder" %>
 <%@taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 <portlet:defineObjects />
 <portlet:actionURL var="saveSettingsUrl" />
@@ -30,10 +30,10 @@
   <div data-app="true"
        class="v-application v-application--is-ltr theme--light"
        id="<%=domId%>">
-    <textarea id="<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : StringEscapeUtils.escapeJava(settings).replace("\\\"", "\"").replace("\\\\\"", "\\\"").replace("\\n", "") %></textarea>
+    <textarea id="<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : URLEncoder.encode(settings.toString().replace(" ", "._.")).replace("._.", " ").replace("\\\"", "\"").replace("\\\\\"", "\\\"").replace("\\n", "") %></textarea>
     <script type="text/javascript">
         require(['PORTLET/social/ParentSpaceListing'],
-            app => app.init('<%=domId%>', '<%=parentSpaceId%>', <%=isManager%>, JSON.parse(document.getElementById('<%=valueDomId%>').value), '<%=saveSettingsUrl%>')
+            app => app.init('<%=domId%>', '<%=parentSpaceId%>', <%=isManager%>, JSON.parse(decodeURIComponent(document.getElementById('<%=valueDomId%>').value)), '<%=saveSettingsUrl%>')
         );
     </script>
   </div>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/spaceAccess.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/spaceAccess.jsp
@@ -21,6 +21,10 @@
 <%@page import="org.exoplatform.portal.application.PortalRequestContext"%>
 <%@page import="org.exoplatform.web.application.RequestContext"%>
 <%@page import="org.exoplatform.social.core.space.SpaceAccessType"%>
+<%@ page import="io.meeds.social.util.JsonUtils" %>
+<%@ page import="java.util.HashMap" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.net.URLEncoder" %>
 <%
   PortalRequestContext portalRequestContext = RequestContext.getCurrentInstance();
   HttpSession portalSession = portalRequestContext.getRequest().getSession();
@@ -33,24 +37,32 @@
   String spacePrettyName = (String) portalSession.getAttribute(SpaceAccessType.ACCESSED_SPACE_PRETTY_NAME_KEY);
   String spaceDisplayName = (String) portalSession.getAttribute(SpaceAccessType.ACCESSED_SPACE_DISPLAY_NAME_KEY);
   String originalUri = (String) portalSession.getAttribute(SpaceAccessType.ACCESSED_SPACE_REQUEST_PATH_KEY);
+
+  Map<String, Object> data = new HashMap<>();
+  data.put("spaceId", spaceId);
+  data.put("spaceAccessTypeLabel", spaceAccessTypeLabel);
+  data.put("spacePrettyName", spacePrettyName);
+  data.put("spaceDisplayName", spaceDisplayName);
+  data.put("originalUri", originalUri);
+
+  String valueDomId = "SpaceAccessData";
+  String dataJson = JsonUtils.toJsonString(data);
 %>
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application v-application--is-ltr theme--light"
     id="SpaceAccess">
-    <textarea id="SpaceAccessData" rows="0" class="d-none">{
-      "spaceId": "<%=spaceId%>",
-      "spaceAccessTypeLabel": "<%=spaceAccessTypeLabel%>",
-      "spacePrettyName": "<%=spacePrettyName%>",
-      "spaceDisplayName": "<%=spaceDisplayName%>",
-      "originalUri": "<%=originalUri%>"
-    }</textarea>
+    <textarea id="<%=valueDomId%>" rows="0" class="d-none"> <%=URLEncoder.encode(dataJson.replace(" ", "._."))
+                                                                         .replace("._.", " ")
+                                                                         .replace("\\\"", "\"")
+                                                                         .replace("\\\\\"", "\\\"")
+                                                                         .replace("\\n", "")%></textarea>
     <script type="text/javascript">
       const queryString = window.location.search;
       const urlParams = new URLSearchParams(queryString);
       const spaceInvitationToken = urlParams.get('invitation_id') || '';
       const data = JSON.parse(
-        document.getElementById('SpaceAccessData').value.replace(/\n/g, '')
+        decodeURIComponent(document.getElementById('<%=valueDomId%>').value)
       );
       if (urlParams.has('isParentSpaceMember')) {
         data.isParentSpaceMember = urlParams.get('isParentSpaceMember') === 'true';

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/spaceCreation.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/spaceCreation.jsp
@@ -11,6 +11,7 @@
 <%@page import="java.util.Map" %>
 <%@page import="javax.portlet.PortletPreferences" %>
 <%@page import="org.apache.commons.text.StringEscapeUtils"%>
+<%@ page import="java.net.URLEncoder" %>
 <%@taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 <portlet:defineObjects />
 <portlet:actionURL var="saveSettingsUrl" />
@@ -37,10 +38,10 @@ String valueDomId = "spaceCreationApplicationSettingsValue" + portletId;
     <div data-app="true"
       class="v-application v-application--is-ltr theme--light"
       id="<%=domId%>">
-      <textarea id="spaceCreationSettings<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : StringEscapeUtils.escapeJava(settings).replace("\\\"", "\"").replace("\\\\\"", "\\\"").replace("\\n", "") %></textarea>
-      <textarea id="spaceCreationTemplate<%=valueDomId%>" style="display:none;"><%=StringEscapeUtils.escapeJava(spaceTemplatesJson).replace("\\\"", "\"").replace("\\\\\"", "\\\"").replace("\\\\n", "").replace("\\n", "") %></textarea>
+      <textarea id="spaceCreationSettings<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : URLEncoder.encode(settings.replace(" ", "._.")).replace("._.", " ").replace("\\\"", "\"").replace("\\\\\"", "\\\"").replace("\\n", "") %></textarea>
+      <textarea id="spaceCreationTemplate<%=valueDomId%>" style="display:none;"><%=URLEncoder.encode(spaceTemplatesJson.replace(" ", "._.")).replace("._.", " ").replace("\\\"", "\"").replace("\\\\\"", "\\\"").replace("\\\\n", "").replace("\\n", "") %></textarea>
       <script type="text/javascript">
-        require(['PORTLET/social/SpaceCreation'], app => app.init('<%=domId%>', JSON.parse(document.getElementById('spaceCreationSettings<%=valueDomId%>').value), <%=isAdministrator%>, '<%=saveSettingsUrl%>', JSON.parse(document.getElementById('spaceCreationTemplate<%=valueDomId%>').value)));
+        require(['PORTLET/social/SpaceCreation'], app => app.init('<%=domId%>', JSON.parse(decodeURIComponent(document.getElementById('spaceCreationSettings<%=valueDomId%>').value)), <%=isAdministrator%>, '<%=saveSettingsUrl%>', JSON.parse(decodeURIComponent(document.getElementById('spaceCreationTemplate<%=valueDomId%>').value))));
       </script>
     </div>
   </div>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/spacesList.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/spacesList.jsp
@@ -5,6 +5,7 @@
 <%@ page import="org.exoplatform.social.rest.api.RestUtils" %>
 <%@ page import="io.meeds.portal.security.service.SecuritySettingService" %>
 <%@ page import="io.meeds.portal.security.constant.UserRegistrationType" %>
+<%@ page import="java.net.URLEncoder" %>
 <%@taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 <portlet:defineObjects />
 <portlet:actionURL var="saveSettingsUrl" />
@@ -50,10 +51,10 @@
   <div data-app="true"
        class="v-application transparent v-application--is-ltr theme--light"
        id="<%=domId%>">
-    <textarea id="<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : settings%></textarea>
+    <textarea id="<%=valueDomId%>" style="display:none;"><%=settings == null ? "{}" : URLEncoder.encode(settings.toString().replace(" ", "._.")).replace("._.", " ").replace("\\\"", "\"").replace("\\\\\"", "\\\"")%></textarea>
     <script type="text/javascript">
       require(['PORTLET/social/SpacesList'],
-          app => app.init('<%=domId%>', '<%=filter%>', <%=canCreateSpace%>, <%=isExternalFeatureEnabled%>, <%=canEdit%>, JSON.parse(document.getElementById('<%=valueDomId%>').value), '<%=saveSettingsUrl%>', '<%=getSettingNameUrl%>', '<%=settingName == null ? "" : settingName%>', '<%=registrationType%>', <%=isAdministrator%>, <%=isPublicPage%>)
+          app => app.init('<%=domId%>', '<%=filter%>', <%=canCreateSpace%>, <%=isExternalFeatureEnabled%>, <%=canEdit%>, JSON.parse(decodeURIComponent(document.getElementById('<%=valueDomId%>').value)), '<%=saveSettingsUrl%>', '<%=getSettingNameUrl%>', '<%=settingName == null ? "" : settingName%>', '<%=registrationType%>', <%=isAdministrator%>, <%=isPublicPage%>)
       );
     </script>
   <% } else { %>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/whoIsOnline.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/whoIsOnline.jsp
@@ -14,6 +14,7 @@
 <%@page import="java.util.List"%>
 <%@page import="org.exoplatform.social.core.space.model.Space"%>
 <%@page import="org.exoplatform.social.core.space.SpaceUtils"%>
+<%@ page import="java.net.URLEncoder" %>
 <%
   Identity viewerIdentity = Utils.getViewerIdentity();
   if (viewerIdentity != null && !viewerIdentity.isExternal()) {
@@ -50,7 +51,7 @@
   <div data-app="true"
     class="v-application hiddenable-widget v-application--is-ltr theme--light"
     id="OnlinePortlet">
-    <textarea id="whoIsOnlineDefaultValue" class="hidden"><%=usersOnlineString%></textarea>
+    <textarea id="whoIsOnlineDefaultValue" class="hidden"><%=URLEncoder.encode(usersOnlineString.replace(" ", "._.")).replace("._.", " ").replace("\\\"", "\"").replace("\\\\\"", "\\\"").replace("\\n", "")%></textarea>
     <script type="text/javascript">
       require(['PORTLET/social/WhoIsOnLinePortlet'], app => app.init());
     </script>

--- a/webapp/src/main/webapp/vue-apps/who-is-online-app/main.js
+++ b/webapp/src/main/webapp/vue-apps/who-is-online-app/main.js
@@ -27,7 +27,7 @@ export function init() {
   }}));
   exoi18n.loadLanguageAsync(lang, url)
     .then(() => {
-      const onlineUsers = JSON.parse(document.getElementById('whoIsOnlineDefaultValue').value);
+      const onlineUsers = JSON.parse(decodeURIComponent(document.getElementById('whoIsOnlineDefaultValue').value));
       if (!onlineUsers.length) {
         Vue.prototype.$updateApplicationVisibility(false, document.querySelector('#OnlinePortlet'));
       }


### PR DESCRIPTION
Prior to this change, JSP files using hidden <textarea> to pass data to JavaScript were vulnerable to XSS attacks by injecting scripts through unescaped content.
This change adds sanitization to portlet JSP files to prevent XSS attacks and ensure safe data handling