### PR TITLE
fix: error when requesting access to a hidden space via a referral link - EXO-87778

### DIFF
--- a/component/core/src/main/java/io/meeds/social/space/plugin/SpacePermanentLinkPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/space/plugin/SpacePermanentLinkPlugin.java
@@ -78,11 +78,9 @@ public class SpacePermanentLinkPlugin implements PermanentLinkPlugin {
         throw new ObjectNotFoundException(String.format("Space with id %s not found", object.getObjectId()));
       } else {
         String username = identity.getUserId();
-        return spaceService.isSuperManager(space, username)
-               || spaceService.isInvitedUser(space, username)
-               || spaceService.isMember(space, username)
-               || (!StringUtils.equals(Space.HIDDEN, space.getVisibility())
-                   && !StringUtils.equals(Space.CLOSED, space.getRegistration()));
+        return !StringUtils.equals(Space.CLOSED, space.getRegistration())
+               || spaceService.canViewSpace(space, username)
+               || spaceService.isInvitedUser(space, username);
       }
     }
   }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRest.java
@@ -609,6 +609,7 @@ public class SpaceRest implements ResourceContainer {
       Space space = byId ? spaceService.getSpaceById(id) : spaceService.getSpaceByPrettyName(id);
       if (space == null
           || (Space.HIDDEN.equals(space.getVisibility())
+              && Space.CLOSED.equals(space.getRegistration())
               && !spaceService.canViewSpace(space, authenticatedUser) && !Arrays.asList(space.getInvitedUsers()).contains(authenticatedUser))) {
         return Response.status(Status.NOT_FOUND).build();
       }
@@ -718,6 +719,7 @@ public class SpaceRest implements ResourceContainer {
       Space space = byId ? spaceService.getSpaceById(id) : spaceService.getSpaceByPrettyName(id);
       if (space == null
           || (Space.HIDDEN.equals(space.getVisibility())
+              && Space.CLOSED.equals(space.getRegistration())
               && !spaceService.canViewSpace(space, authenticatedUser))) {
         return Response.status(Status.NOT_FOUND).build();
       }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRest.java
@@ -302,8 +302,7 @@ public class SpaceMembershipRest implements ResourceContainer {
         throw new WebApplicationException(Response.Status.CONFLICT);
       } else if (space.getRegistration().equals(Space.OPEN)) {
         spaceService.addMember(space, user);
-      } else if (space.getVisibility().equals(Space.HIDDEN)
-                 || space.getRegistration().equals(Space.CLOSED)) {
+      } else if (space.getRegistration().equals(Space.CLOSED)) {
         throw new WebApplicationException(Response.Status.UNAUTHORIZED);
       } else {
         spaceService.addPendingUser(space, user);

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesTest.java
@@ -406,6 +406,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
 
     space.setVisibility(Space.HIDDEN);
+    space.setRegistration(Space.CLOSED);
     space = spaceService.updateSpace(space);
     avatarUrl = space.getAvatarUrl().replace("/portal/rest", "");
 
@@ -440,6 +441,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
 
     space.setVisibility(Space.HIDDEN);
+    space.setRegistration(Space.CLOSED);
     space = spaceService.updateSpace(space);
     avatarUrl = space.getAvatarUrl().replace("/portal/rest", "");
 
@@ -529,6 +531,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
 
     space.setVisibility(Space.HIDDEN);
+    space.setRegistration(Space.CLOSED);
     space = spaceService.updateSpace(space);
     restartTransaction();
     space = spaceService.getSpaceById(space.getId());
@@ -563,6 +566,7 @@ public class SpaceRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
 
     space.setVisibility(Space.HIDDEN);
+    space.setRegistration(Space.CLOSED);
     space = spaceService.updateSpace(space);
     restartTransaction();
     space = spaceService.getSpaceById(space.getId());

--- a/component/web/src/main/java/io/meeds/social/handler/ActivityAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/ActivityAccessHandler.java
@@ -93,9 +93,7 @@ public class ActivityAccessHandler extends WebRequestHandler {
         }
         String spaceId = activity.getSpaceId();
         Space space = spaceService.getSpaceById(spaceId);
-        if (space == null || Space.HIDDEN.equals(space.getVisibility())) {
-          return false;
-        } else if (username == null) {
+        if (space == null || username == null) {
           return false;
         } else {
           processSpaceAccess(controllerContext, authenticatedUserIdentity.getUserId(), space);

--- a/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/SpaceAccessHandler.java
@@ -140,14 +140,6 @@ public class SpaceAccessHandler extends WebRequestHandler {
         session.setAttribute(SpaceAccessType.ACCESSED_SPACE_ID_KEY, space.getId());
       }
       return false;
-    } else if (space == null || (Space.HIDDEN.equals(space.getVisibility()) && space.getRegistration()
-                                                                                    .equalsIgnoreCase(Space.CLOSED)
-        && !spaceService.isInvitedUser(space, username))) {
-      controllerContext.getResponse()
-                       .sendRedirect(String.format("%s/%s/page-not-found",
-                                                   controllerContext.getRequest().getContextPath(),
-                                                   getPageNotFoundSite(username)));
-      return true;
     } else if (canAccessSpacePublicSite(space, username)) {
       String redirectUrl = String.format("%s/%s",
                                          controllerContext.getRequest().getContextPath(),


### PR DESCRIPTION
Prior to this change, when attempting to access an unlisted space via a referral link, an Unauthorized exception was thrown when submitting an access request (registration by validation). This change adds a check to allow valid referral/invitation access to hidden spaces, resolving the issue.