### PR TITLE
fix: Execute save content links asynchronously - EXO-87310

### DIFF
--- a/component/api/src/main/java/io/meeds/social/cms/service/ContentLinkService.java
+++ b/component/api/src/main/java/io/meeds/social/cms/service/ContentLinkService.java
@@ -52,6 +52,15 @@ public interface ContentLinkService {
    */
   void saveLinks(ContentObject contentObject,
                  List<? extends ContentObjectIdentifier> links);
+  
+  /**
+   * Saves the {@link List} of Links attached to the designated Object asyncronously
+   * 
+   * @param contentObject {@link ContentObject}
+   * @param links {@link List} of {@link ContentObjectIdentifier} to attach
+   */
+  void saveLinksAsync(ContentObject contentObject,
+                      List<? extends ContentObjectIdentifier> links);
 
   /**
    * Delete the {@link List} of Links attached to the designated Object

--- a/component/core/src/main/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPlugin.java
@@ -67,7 +67,7 @@ public class ContentLinkHtmlProcessorPlugin implements HtmlProcessorPlugin {
   public String process(String html, HtmlProcessorContext context) {
     String formattedHtml = replaceDataObjectTag(html);
     List<ContentLinkIdentifier> links = getContentLinkFromTag(formattedHtml, context);
-    contentLinkService.saveLinks(new ContentObject(context.getObjectType(),
+    contentLinkService.saveLinksAsync(new ContentObject(context.getObjectType(),
                                                    context.getObjectId(),
                                                    context.getFieldName(),
                                                    context.getLocale()),

--- a/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/cms/service/ContentLinkServiceImpl.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
@@ -29,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.portal.config.UserACL;
 
+import io.meeds.common.ContainerTransactional;
 import io.meeds.social.cms.model.ContentLink;
 import io.meeds.social.cms.model.ContentLinkExtension;
 import io.meeds.social.cms.model.ContentLinkIdentifier;
@@ -36,18 +39,33 @@ import io.meeds.social.cms.model.ContentLinkSearchResult;
 import io.meeds.social.cms.model.ContentObject;
 import io.meeds.social.cms.model.ContentObjectIdentifier;
 import io.meeds.social.cms.storage.ContentLinkStorage;
-
-import lombok.AllArgsConstructor;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class ContentLinkServiceImpl implements ContentLinkService {
 
-  private ContentLinkPluginService contentLinkPluginService;
+  private final ContentLinkPluginService contentLinkPluginService;
 
-  private UserACL                  userAcl;
+  private final UserACL                  userAcl;
 
-  private ContentLinkStorage       contentLinkStorage;
+  private final ContentLinkStorage       contentLinkStorage;
+  
+  private ExecutorService                executorService;
+
+  @PostConstruct
+  public void init() {
+    executorService = Executors.newCachedThreadPool();
+  }
+
+  @PreDestroy
+  public void stop() {
+    if (executorService != null) {
+      executorService.shutdown();
+    }
+  }
 
   @Override
   public List<ContentLinkExtension> getExtensions() {
@@ -118,6 +136,11 @@ public class ContentLinkServiceImpl implements ContentLinkService {
   public void saveLinks(ContentObject contentObject, List<? extends ContentObjectIdentifier> links) {
     contentLinkStorage.saveLinks(contentObject, links);
   }
+  
+  @Override
+  public void saveLinksAsync(ContentObject contentObject, List<? extends ContentObjectIdentifier> links) {
+    executorService.execute(() -> saveLinksTransactional(contentObject, links));
+  }
 
   @Override
   public void deleteLinks(ContentObjectIdentifier contentObject) {
@@ -163,6 +186,11 @@ public class ContentLinkServiceImpl implements ContentLinkService {
     return userAcl.hasEditPermission(contentObject.getObjectType(),
                                      contentObject.getObjectId(),
                                      username);
+  }
+
+  @ContainerTransactional
+  protected void saveLinksTransactional(ContentObject contentObject, List<? extends ContentObjectIdentifier> links) {
+    saveLinks(contentObject, links);
   }
 
 }

--- a/component/core/src/test/java/io/meeds/social/activity/plugin/ActivityContentLinkPluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/activity/plugin/ActivityContentLinkPluginTest.java
@@ -105,7 +105,7 @@ public class ActivityContentLinkPluginTest extends AbstractSpringConfigurationTe
                                               identity);
     assertNotNull(activity);
     assertNotNull(activity.getId());
-
+    Thread.sleep(150);
     List<ContentLink> links = contentLinkService.getLinks(new ContentObject(ActivityContentLinkPlugin.OBJECT_TYPE,
                                                                             activity.getId()),
                                                           null,

--- a/component/core/src/test/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/plugin/ContentLinkHtmlProcessorPluginTest.java
@@ -159,6 +159,7 @@ public class ContentLinkHtmlProcessorPluginTest extends AbstractSpringConfigurat
 
     for (int i = 0; i < 5; i++) {
       assertEquals(CONTENT_LINK, HtmlUtils.process(CONTENT_LINK, CONTENT_OBJECT_CONTEXT));
+      Thread.sleep(150);
       links = contentLinkService.getLinks(CONTENT_OBJECT,
                                           Locale.ENGLISH,
                                           userAcl.getSuperUser());
@@ -167,7 +168,7 @@ public class ContentLinkHtmlProcessorPluginTest extends AbstractSpringConfigurat
     }
 
     assertEquals(CONTENT_LINK_NOT_FOUND, HtmlUtils.process(CONTENT_LINK_NOT_FOUND, CONTENT_OBJECT_CONTEXT));
-
+    Thread.sleep(150);
     links = contentLinkService.getLinks(CONTENT_OBJECT,
                                         Locale.ENGLISH,
                                         userAcl.getSuperUser());
@@ -186,6 +187,7 @@ public class ContentLinkHtmlProcessorPluginTest extends AbstractSpringConfigurat
 
     for (int i = 0; i < 5; i++) {
       assertEquals(CONTENT_LINK_RESULT, HtmlUtils.process(CONTENT_LINK_RESULT, CONTENT_OBJECT_CONTEXT));
+      Thread.sleep(150);
       links = contentLinkService.getLinks(CONTENT_OBJECT,
                                           Locale.ENGLISH,
                                           userAcl.getSuperUser());
@@ -203,7 +205,7 @@ public class ContentLinkHtmlProcessorPluginTest extends AbstractSpringConfigurat
         """.replace("\n", "").trim();
 
     assertEquals(html, HtmlUtils.process(html, CONTENT_OBJECT_CONTEXT));
-
+    Thread.sleep(150);
     List<ContentLink> links = contentLinkService.getLinks(CONTENT_OBJECT,
                                                           Locale.ENGLISH,
                                                           userAcl.getSuperUser());
@@ -219,7 +221,7 @@ public class ContentLinkHtmlProcessorPluginTest extends AbstractSpringConfigurat
         """.replace("\n", "").trim();
 
     assertEquals(html, HtmlUtils.process(html, CONTENT_OBJECT_CONTEXT));
-
+    Thread.sleep(150);
     List<ContentLink> links = contentLinkService.getLinks(CONTENT_OBJECT,
                                                           Locale.ENGLISH,
                                                           userAcl.getSuperUser());


### PR DESCRIPTION
Prior to this change, saving content links was performed synchronously, causing significant performance degradation when saving objects such as activities, notes, or contents with numerous content links. This commit introduces asynchronous processing for saving content links, significantly reducing latency and improving overall object persistence performance.