### PR TITLE
fix: Fix MIME type detection for cropped image uploads - EXO-87793

### DIFF
--- a/webapp/src/main/webapp/vue-apps/component-image-crop/components/ImageCropDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/component-image-crop/components/ImageCropDrawer.vue
@@ -627,7 +627,9 @@ export default {
               this.sendingImage = false;
               return;
             }
-            this.$uploadService.upload(blob)
+            const extension = this.mimetype.split('/')[1];
+            const file = new File([blob], `cropped.${extension}`, { type: this.mimetype });
+            this.$uploadService.upload(file)
               .then(uploadId => {
                 if (uploadId) {
                   const reader = new FileReader();


### PR DESCRIPTION
Prior to this change, cropped images were uploaded as Blob objects with the default filename blob, causing the backend to fall back to the default MIME type. This change uploads cropped images as File objects with the appropriate file extension, allowing the backend to detect the correct MIME type.