### PR TITLE
fix: Inconsistent display of a user's profile avatar across the profile page, comments, and unified search- EXO-87924

### DIFF
--- a/webapp/src/main/webapp/vue-apps/search-activity/components/SearchActivityCard.vue
+++ b/webapp/src/main/webapp/vue-apps/search-activity/components/SearchActivityCard.vue
@@ -9,15 +9,12 @@
         <v-list-item>
           <v-list-item-icon class="me-2 pt-1">
             <span class="d-flex align-center justify-center pt-2px">
-              <v-avatar
-                size="32"
-                class="flex-shrink-0">
-                <img
-                  :src="posterAvatar"
-                  class="object-fit-cover ma-auto"
-                  loading="lazy"
-                  alt="">
-              </v-avatar>
+              <exo-user-avatar
+                :identity="posterIdentity"
+                :size="32"
+                :extra-class="'object-fit-cover ma-auto'" 
+                popover
+                avatar />
             </span>
           </v-list-item-icon>
 
@@ -25,9 +22,13 @@
             <v-list-item-title class="d-flex flex-row full-width align-center">
               <div class="d-flex flex-row align-center flex-grow-1 text-truncate">
                 <span
-                  class="title pt-1 mb-0 ps-0 my-auto text-start text-truncate primary--text"
+                  class="d-inline-flex title pt-1 mb-0 ps-0 my-auto text-start text-truncate primary--text"
                   :aria-label="activityTitleText">
-                  {{ posterName }}
+                  <exo-user-avatar
+                    :identity="posterIdentity"
+                    fullname
+                    popover
+                    link-style />
                   <span v-if="isSpaceStreamOwner">
                     <v-icon class="icon-default-color ms-1" size="14">
                       fas fa-chevron-right
@@ -141,6 +142,9 @@ export default {
     },
     poster() {
       return this.activity?.poster?.profile;
+    },
+    posterIdentity() {
+      return this.activity?.poster?.profile?.dataEntity;
     },
     posterAvatar() {
       return this.poster?.avatar;


### PR DESCRIPTION
Before this change, after disabling a user, searching for their comments or profile via unified search still displayed their normal active avatar without the greyed-out style or the disabled icon — even though activity and article comment views already showed the correct disabled avatar. To fix this issue, the raw <v-avatar> and {{ posterName }} usages in the unified search result component have been replaced with <exo-user-avatar />, which natively handles the disabled user state rendering. After this change, the disabled user's greyed avatar and disabled icon are consistently displayed in unified search results, matching the behavior already present in activity and article comment views.