### PR TITLE
fix: When a text content is domPurify, mailto is incorrectly displayed as 2 links - EXO-88030

### DIFF
--- a/webapp/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/src/main/webapp/js/ExtendedDomPurify.js
@@ -34,6 +34,7 @@
     content = decodeEntitiesInUrls(content);
     content = content.replace(/<div> <\/div>/g, '<div><br><\/div>');
     content = content.trim().replace(/>[ \n]+</g, '> <').replace(/  /g, '&nbsp;&nbsp;');
+    content = content.replace(/\b[a-zA-Z][a-zA-Z0-9+\-.]*:\/?\/?[^\s<>"'@&]+(?:@|&#64;)[^\s<>"'<>]+/gi, url => `<a href="${url}">${url}</a>`);
     const pureHtml = DOMPurify.sanitize(Autolinker.link(content, {
       email: false,
       replaceFn : function (match) {

--- a/webapp/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/src/main/webapp/js/ExtendedDomPurify.js
@@ -34,6 +34,7 @@
     content = decodeEntitiesInUrls(content);
     content = content.replace(/<div> <\/div>/g, '<div><br><\/div>');
     content = content.trim().replace(/>[ \n]+</g, '> <').replace(/  /g, '&nbsp;&nbsp;');
+    // FIXME a workaround for https://github.com/Meeds-io/social/pull/github.com/gregjacobs/Autolinker.js/issues/393
     content = content.replace(/\b[a-zA-Z][a-zA-Z0-9+\-.]*:\/?\/?[^\s<>"'@&]+(?:@|&#64;)[^\s<>"'<>]+/gi, url => `<a href="${url}">${url}</a>`);
     const pureHtml = DOMPurify.sanitize(Autolinker.link(content, {
       email: false,


### PR DESCRIPTION
Before this fix, the domPurify does not generates a correct link for mailto link (or any protocol different from mailto with email after) It generates currently 2 links : one before the @, one after, instead of a single link for all the protocol

The commit ensure to manage theses links in DomPurify

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
