### PR TITLE
fix: Search result displays searched term + null - EXO-87954

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ActivityIndexingServiceConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/ActivityIndexingServiceConnector.java
@@ -181,7 +181,10 @@ public class ActivityIndexingServiceConnector extends ElasticIndexingServiceConn
     // in field 'description'
     if (activity.getTemplateParams() != null && activity.getTemplateParams().containsKey("description")) {
       body += '\n';
-      body += activity.getTemplateParams().get("description");
+      String description = activity.getTemplateParams().get("description");
+      if (StringUtils.isNotBlank(description)) {
+        body += description;
+      }
     }
 
     // Ensure to index text only without html tags


### PR DESCRIPTION
Before this change, a comment body indexed in Elasticsearch could contain a spurious null suffix when the description template param key existed with a null value. To fix this issue, the description value is now checked with StringUtils.isNotBlank() before being appended to the indexed body. After this change, search results display the exact comment text without any spurious null suffix.