### PR TITLE
feat: load the user properties for the profile header - EXO-76410 - meeds-io/MIP#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeader.vue
@@ -255,7 +255,7 @@ export default {
         });
     },
     refresh() {
-      return this.$userService.getUser(eXo.env.portal.profileOwner, 'relationshipStatus')
+      return this.$userService.getUser(eXo.env.portal.profileOwner, 'relationshipStatus,settings')
         .then(user => {
           this.user = user;
           this.setPageTitle();


### PR DESCRIPTION
The user matrix ID is stored in the profile properties, to display the chat button , we need to load the user properties by adding the parameter **settings** to the expand URL param

(This change cherry-pick the commit https://github.com/Meeds-io/social/commit/fb07fdf7c5b7fdad84f19155083ca819c9cf0ea8 that was exiting develop-exo and not in develop)