### PR TITLE
fix: Race Condition when creating the same Metadata - EXO-88237

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -31,6 +31,7 @@ import org.picocontainer.Startable;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -48,6 +49,8 @@ import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataKey;
 import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.metadata.model.MetadataType;
+
+import lombok.Synchronized;
 
 @SuppressWarnings("removal")
 public class MetadataServiceImpl implements MetadataService, Startable {
@@ -707,12 +710,22 @@ public class MetadataServiceImpl implements MetadataService, Startable {
     return metadata;
   }
 
+  @Synchronized
   private Metadata createMetadataAndBroadcast(Metadata metadata, long userIdentityId) {
     try {
+      // Need to commit previous changes in order to not rollback the entire
+      // transaction if an error happens
+      RequestLifeCycle.restartTransaction();
       Metadata createdMetadata = metadataStorage.createMetadata(metadata);
+      // Need to commit changes in order to propagate changes through JPA
+      // Sessions
+      RequestLifeCycle.restartTransaction();
       this.listenerService.broadcast("social.metadata.created", userIdentityId, createdMetadata);
       return createdMetadata;
     } catch (Exception e) {
+      // Need to restart a clean transaction knowing that the previous one will
+      // be roolbacked
+      RequestLifeCycle.restartTransaction();
       Metadata createdMetadata = metadataStorage.getMetadataByKey(new MetadataKey(metadata.getType().getName(),
                                                                                   metadata.getName(),
                                                                                   metadata.getAudienceId()));


### PR DESCRIPTION
Prior to this change, creating the same Metadata asynchronously from multiple threads could still lead to a race condition. This was particularly noticeable during highly concurrent operations, such as asynchronously creating translation labels at server startup through the `TranslationService`.

This change adds the `@Synchronized` annotation to the Metadata creation operation. Since Metadata creation is an infrequent operation, the impact on Metadata item creation performance should be negligible. The priority here is to ensure data consistency rather than optimize performance for a rarely executed operation.