### PR TITLE
fix: default page background lacks alpha support - EXO-88511

### DIFF
--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/drawers/PageStylingDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/drawers/PageStylingDrawer.vue
@@ -121,7 +121,7 @@ export default {
     drawer: false,
     backgroundProperties: null,
     defaultCustomPageWidth: '1320',
-    defaultPageBackground: '#F0F0F0',
+    defaultPageBackground: '#F0F0F0FF',
     pageWidth: null,
     borderRadius: null,
     defaultPageStylingProperties: null,
@@ -164,7 +164,7 @@ export default {
   methods: {
     init() {
       this.backgroundProperties = {
-        backgroundColor: this.pageStylingProperties?.pageBackgroundColor || this.defaultPageBackground,
+        backgroundColor: this.normalizeBackgroundColor(this.pageStylingProperties?.pageBackgroundColor) || this.defaultPageBackground,
         backgroundPosition: this.pageStylingProperties?.pageBackgroundPosition || null,
         background: this.pageStylingProperties?.pageBackground || null,
         backgroundRepeat: this.pageStylingProperties?.pageBackgroundRepeat || null,
@@ -204,6 +204,12 @@ export default {
     close() {
       this.reset();
       this.$refs.drawer.close();
+    },
+    normalizeBackgroundColor(color) {
+      if (!color) {
+        return color;
+      }
+      return color.length === 7 ? `${color}FF` : color;
     },
     getPageBackgroundEffect() {
       const effect = this.pageStylingProperties?.pageBackgroundEffect;

--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/BackgroundInput.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/form/BackgroundInput.vue
@@ -225,7 +225,7 @@ export default {
           this.backgroundGradientFrom = null;
           this.backgroundGradientTo = null;
         } else if (this.choice === 'gradient') {
-          if (this.branding.backgroundEffect) {
+          if (this.branding.backgroundEffect && this.branding.backgroundEffect.startsWith('linear-gradient(')) {
             this.backgroundGradientFrom = this.branding.backgroundEffect.replace('linear-gradient(', '').split(',')[0].trim();
             this.backgroundGradientTo = this.branding.backgroundEffect.replace('linear-gradient(', '').split(',')[1].replace(/\)$/g, '').trim();
           } else {
@@ -253,7 +253,7 @@ export default {
         this.backgroundImageStyle = this.branding.backgroundRepeat;
       }
     }
-    if (this.branding.backgroundEffect) {
+    if (this.branding.backgroundEffect && this.branding.backgroundEffect.startsWith('linear-gradient(')) {
       this.choice = 'gradient';
       this.backgroundGradientFrom = this.branding.backgroundEffect.replace('linear-gradient(', '').split(',')[0].trim();
       this.backgroundGradientTo = this.branding.backgroundEffect.replace('linear-gradient(', '').split(',')[1].replace(/\)$/g, '').trim();


### PR DESCRIPTION
The Theme management page's default page background color (used both as the picker's placeholder and normalized when reading an already persisted 6-digit value) had no alpha channel, so the color picker silently dropped its transparency slider. Also stop the gradient from/to parser from garbling non-linear-gradient values (e.g. conic gradients set elsewhere) instead of falling back to solid color.
