### PR TITLE
feat: expose an extensible way to browse content linked to a category across object types - EXO-88138 - eXIP7.3.0.1

### DIFF
--- a/component/api/src/main/java/io/meeds/social/category/model/CategoryEntryItem.java
+++ b/component/api/src/main/java/io/meeds/social/category/model/CategoryEntryItem.java
@@ -1,0 +1,81 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.category.model;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A generic, object-type agnostic preview of an entry linked to a Category,
+ * supplied by the {@link io.meeds.social.category.plugin.CategoryPlugin}
+ * managing the designated objectType.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryEntryItem {
+
+  /**
+   * Object technical identifier
+   */
+  private String     id;
+
+  /**
+   * Object type
+   */
+  private String     objectType;
+
+  /**
+   * Fontawesome Icon identifier used switch a corner badge to identify the
+   * entry type. Supplied by the owning plugin, never guessed switch the
+   * objectType value.
+   */
+  private String     icon;
+
+  private String     title;
+
+  private String     summary;
+
+  private String     illustrationUrl;
+
+  private String     url;
+
+  private String     authorDisplayName;
+
+  private String     authorAvatarUrl;
+
+  private String     spaceDisplayName;
+
+  private String     spaceAvatarUrl;
+
+  private Date       date;
+
+  private long       likesCount;
+
+  private long       commentsCount;
+
+  private long       viewsCount;
+
+  private List<Long> categoryIds;
+
+}

--- a/component/api/src/main/java/io/meeds/social/category/model/CategoryEntryList.java
+++ b/component/api/src/main/java/io/meeds/social/category/model/CategoryEntryList.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.category.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryEntryList {
+
+  private List<CategoryEntryItem> items;
+
+  private long                      offset;
+
+  private long                      limit;
+
+  private boolean                   hasMore;
+
+}

--- a/component/api/src/main/java/io/meeds/social/category/plugin/CategoryPlugin.java
+++ b/component/api/src/main/java/io/meeds/social/category/plugin/CategoryPlugin.java
@@ -21,6 +21,7 @@ package io.meeds.social.category.plugin;
 import java.util.List;
 
 import io.meeds.social.category.model.Category;
+import io.meeds.social.category.model.CategoryEntryItem;
 import io.meeds.social.category.model.CategoryObject;
 
 public interface CategoryPlugin {
@@ -86,6 +87,21 @@ public interface CategoryPlugin {
 
   default CategoryObject getObject(CategoryObject metadataObject) {
     return metadataObject;
+  }
+
+  /**
+   * Resolves a generic, object-type agnostic preview (title, summary, image,
+   * author, date, url ...) of the designated object, so that it can be
+   * displayed in a Category entries listing (browse entries by Category)
+   * without the caller having to know anything specific to this objectType.
+   *
+   * @param objectId Object technical identifier
+   * @param username User technical name (login identifier)
+   * @return {@link CategoryEntryItem} or null when this objectType isn't
+   *         meant to be browsable as an entry (Space, Activity ...)
+   */
+  default CategoryEntryItem getEntryItem(String objectId, String username) {
+    return null;
   }
 
 }

--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
@@ -47,6 +47,17 @@ public interface CategoryLinkService {
 
   /**
    * @param categoryId {@link Category} identifier
+   * @param objectTypes {@link List} of {@link CategoryObject} types to filter
+   *          switch
+   * @param offset offset of objects to retrieve
+   * @param limit limit of objects to retrieve
+   * @return {@link List} of {@link CategoryObject} linked to the category,
+   *         ordered by last modification date descending
+   */
+  List<CategoryObject> getLinkedObjects(long categoryId, List<String> objectTypes, int offset, int limit);
+
+  /**
+   * @param categoryId {@link Category} identifier
    * @param object {@link CategoryObject} using type/id to designate any object
    *          in the platform (Space, Activity ...)
    * @return true if the object is linked to the category

--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryPluginService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryPluginService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.exoplatform.social.core.space.model.Space;
 
 import io.meeds.social.category.model.Category;
+import io.meeds.social.category.model.CategoryEntryItem;
 import io.meeds.social.category.model.CategoryObject;
 import io.meeds.social.category.plugin.CategoryPlugin;
 
@@ -47,6 +48,25 @@ public interface CategoryPluginService {
    *         else false
    */
   boolean canEdit(String objectType, String objectId, String username);
+
+  /**
+   * @param objectType {@link CategoryObject} type
+   * @param objectId {@link CategoryObject} id
+   * @param username User technical name (login identifier)
+   * @return true if user can access the object identified by its id and type,
+   *         else false
+   */
+  boolean canAccess(String objectType, String objectId, String username);
+
+  /**
+   * @param objectType {@link CategoryObject} type
+   * @param objectId {@link CategoryObject} id
+   * @param username User technical name (login identifier)
+   * @return {@link CategoryEntryItem} preview of the object identified by
+   *         its id and type, or null when this objectType isn't meant to be
+   *         browsable as an entry
+   */
+  CategoryEntryItem getEntryItem(String objectType, String objectId, String username);
 
   /**
    * @param objectType {@link CategoryObject} type

--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryService.java
@@ -26,6 +26,7 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.social.core.identity.model.Identity;
 
 import io.meeds.social.category.model.Category;
+import io.meeds.social.category.model.CategoryEntryList;
 import io.meeds.social.category.model.CategoryFilter;
 import io.meeds.social.category.model.CategorySearchFilter;
 import io.meeds.social.category.model.CategorySearchResult;
@@ -218,5 +219,20 @@ public interface CategoryService {
    * @return true if can link an object to the category, else false
    */
   boolean canManageLink(long categoryId, String username);
+
+  /**
+   * Retrieves the entries linked to a Category, de-duplicated (when the same
+   * entry is available switch several objectTypes, only the most specific
+   * one is kept), filtered switch the accessibility of each item to the
+   * designated user, ordered by last modification date descending.
+   *
+   * @param categoryId {@link Category} identifier
+   * @param objectTypes {@link List} of objectTypes to browse
+   * @param username User name/login
+   * @param offset Request offset
+   * @param limit Request limit
+   * @return {@link CategoryEntryList} switch used filter
+   */
+  CategoryEntryList getCategoryEntries(long categoryId, List<String> objectTypes, String username, long offset, long limit);
 
 }

--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -774,4 +774,22 @@ public interface MetadataService {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Retrieves the list of Metadata items attached to a {@link Metadata}
+   * identified by its technical identifier, filtered by a list of object
+   * types, ordered by last modification date descending.
+   *
+   * @param metadataId {@link Metadata} technical identifier
+   * @param objectTypes {@link List} of {@link MetadataItem} objectTypes
+   * @param offset offset of items to retrieve
+   * @param limit limit of items to retrieve
+   * @return {@link List} of linked {@link MetadataItem}
+   */
+  default List<MetadataItem> getMetadataItemsByMetadataIdAndObjectTypes(long metadataId,
+                                                                        List<String> objectTypes,
+                                                                        int offset,
+                                                                        int limit) {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/component/core/src/main/java/io/meeds/social/category/listener/CategoryLinkModifiedListener.java
+++ b/component/core/src/main/java/io/meeds/social/category/listener/CategoryLinkModifiedListener.java
@@ -87,7 +87,7 @@ public class CategoryLinkModifiedListener implements ListenerBase<Long, Category
       String activityId = object.getId();
       ExoSocialActivity activity = activityManager.getActivity(activityId);
       if (activity != null) {
-        List<Long> categoryIds = categoryLinkService.getLinkedIds(new CategoryObject(activity.getMetadataObject()));
+        List<Long> categoryIds = categoryLinkService.getLinkedIds(object);
         if (CollectionUtils.size(activity.getCategoryIds()) != CollectionUtils.size(categoryIds)
             || (CollectionUtils.size(categoryIds) > 0
                 && !CollectionUtils.isEqualCollection(categoryIds, activity.getCategoryIds()))) {

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryLinkServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryLinkServiceImpl.java
@@ -68,6 +68,11 @@ public class CategoryLinkServiceImpl implements CategoryLinkService {
   }
 
   @Override
+  public List<CategoryObject> getLinkedObjects(long categoryId, List<String> objectTypes, int offset, int limit) {
+    return categoryStorage.getLinkedItems(categoryId, objectTypes, offset, limit);
+  }
+
+  @Override
   public boolean isLinked(long categoryId, CategoryObject object) {
     return categoryStorage.isLinked(categoryId, getObject(object));
   }

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import org.exoplatform.container.PortalContainer;
 
+import io.meeds.social.category.model.CategoryEntryItem;
 import io.meeds.social.category.model.CategoryObject;
 import io.meeds.social.category.plugin.CategoryPlugin;
 import io.meeds.social.category.plugin.DefaultCategoryPlugin;
@@ -64,6 +65,16 @@ public class CategoryPluginServiceImpl implements CategoryPluginService {
   @Override
   public boolean canEdit(String objectType, String objectId, String username) {
     return getCategoryPlugin(objectType).canEdit(objectId, username);
+  }
+
+  @Override
+  public boolean canAccess(String objectType, String objectId, String username) {
+    return getCategoryPlugin(objectType).canAccess(objectId, username);
+  }
+
+  @Override
+  public CategoryEntryItem getEntryItem(String objectType, String objectId, String username) {
+    return getCategoryPlugin(objectType).getEntryItem(objectId, username);
   }
 
   @Override

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
@@ -22,8 +22,10 @@ import static io.meeds.social.category.utils.Utils.isManagerOf;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,7 +48,10 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
 import io.meeds.social.category.model.Category;
+import io.meeds.social.category.model.CategoryEntryItem;
+import io.meeds.social.category.model.CategoryEntryList;
 import io.meeds.social.category.model.CategoryFilter;
+import io.meeds.social.category.model.CategoryObject;
 import io.meeds.social.category.model.CategoryRootTree;
 import io.meeds.social.category.model.CategorySearchFilter;
 import io.meeds.social.category.model.CategorySearchResult;
@@ -299,6 +304,31 @@ public class CategoryServiceImpl implements CategoryService {
       org.exoplatform.services.security.Identity identity = StringUtils.isBlank(username) ? null : userAcl.getUserIdentity(username);
       return userAcl.isMemberOf(identity, StringUtils.join(category.getLinkPermissions(), ","));
     }
+  }
+
+  @Override
+  public CategoryEntryList getCategoryEntries(long categoryId, List<String> objectTypes, String username, long offset, long limit) {
+    long fetchLimit = limit * 3;
+    List<CategoryObject> linkedObjects = categoryStorage.getLinkedItems(categoryId, objectTypes, (int) offset, (int) fetchLimit);
+    // De-duplicate: when the same entry is linked switch several objectTypes, keep only the occurrence
+    // whose objectType comes first in the caller-supplied list.
+    Map<String, CategoryObject> deduplicated = new LinkedHashMap<>();
+    linkedObjects.forEach(object -> {
+      CategoryObject existing = deduplicated.get(object.getId());
+      if (existing == null || objectTypes.indexOf(object.getType()) < objectTypes.indexOf(existing.getType())) {
+        deduplicated.put(object.getId(), object);
+      }
+    });
+    List<CategoryEntryItem> items = deduplicated.values()
+                                                .stream()
+                                                .filter(object -> categoryPluginService.canAccess(object.getType(), object.getId(), username))
+                                                .map(object -> categoryPluginService.getEntryItem(object.getType(), object.getId(), username))
+                                                .filter(Objects::nonNull)
+                                                .toList();
+    boolean hasMoreCandidates = linkedObjects.size() == fetchLimit;
+    boolean truncated = items.size() > limit;
+    List<CategoryEntryItem> page = truncated ? items.subList(0, (int) limit) : items;
+    return new CategoryEntryList(page, offset, limit, truncated || hasMoreCandidates);
   }
 
   private long getAdminGroupIdentityId() {

--- a/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
@@ -172,6 +172,14 @@ public class CategoryStorage {
                                               .collect(Collectors.toSet()));
   }
 
+  public List<CategoryObject> getLinkedItems(long categoryId, List<String> objectTypes, int offset, int limit) {
+    List<MetadataItem> items = metadataService.getMetadataItemsByMetadataIdAndObjectTypes(categoryId, objectTypes, offset, limit);
+    return items == null ? Collections.emptyList() :
+                         items.stream()
+                              .map(item -> new CategoryObject(item.getObjectType(), item.getObjectId(), item.getSpaceId()))
+                              .toList();
+  }
+
   public boolean isLinked(long categoryId, CategoryObject object) {
     return getMetadataItem(categoryId, object) != null;
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -74,6 +74,8 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
 
   private static final String OBJECT_TYPE          = OBJECT_TYPE_PARAM;
 
+  private static final String OBJECT_TYPES         = "objectTypes";
+
   private static final String CREATOR_ID           = "creatorId";
 
   private static final String AUDIENCE_ID          = "audienceId";
@@ -233,6 +235,24 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     }
     if (limit > 0) {
       query.setMaxResults((int) limit);
+    }
+    return query.getResultList();
+  }
+
+  public List<MetadataItemEntity> getMetadataItemsByMetadataIdAndObjectTypes(long metadataId,
+                                                                             List<String> objectTypes,
+                                                                             int offset,
+                                                                             int limit) {
+    TypedQuery<MetadataItemEntity> query =
+                                         getEntityManager().createNamedQuery("SocMetadataItemEntity.getMetadataItemsByMetadataIdAndObjectTypes",
+                                                                             MetadataItemEntity.class);
+    query.setParameter(METADATA_ID, metadataId);
+    query.setParameter(OBJECT_TYPES, objectTypes);
+    if (offset > 0) {
+      query.setFirstResult(offset);
+    }
+    if (limit > 0) {
+      query.setMaxResults(limit);
     }
     return query.getResultList();
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -87,6 +87,14 @@ import jakarta.persistence.Table;
         + " mi.createdDate DESC, mi.id DESC"
 )
 @NamedQuery(
+    name = "SocMetadataItemEntity.getMetadataItemsByMetadataIdAndObjectTypes",
+    query = "SELECT mi FROM SocMetadataItemEntity mi WHERE "
+        + " mi.metadata.id = :metadataId AND"
+        + " mi.objectType IN (:objectTypes)"
+        + " ORDER BY COALESCE(mi.updatedDate, mi.createdDate) DESC,"
+        + " mi.createdDate DESC, mi.id DESC"
+)
+@NamedQuery(
     name = "SocMetadataItemEntity.getMetadataObjectIds",
     query = "SELECT mi.objectId, mi.createdDate, mi.id FROM SocMetadataItemEntity mi WHERE "
         + " mi.metadata.type = :metadataType AND"

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -583,6 +583,14 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   }
 
   @Override
+  public List<MetadataItem> getMetadataItemsByMetadataIdAndObjectTypes(long metadataId,
+                                                                       List<String> objectTypes,
+                                                                       int offset,
+                                                                       int limit) {
+    return this.metadataStorage.getMetadataItemsByMetadataIdAndObjectTypes(metadataId, objectTypes, offset, limit);
+  }
+
+  @Override
   public void addMetadataTypePlugin(MetadataTypePlugin metadataTypePlugin) {
     if (metadataTypePlugins.values()
                            .stream()

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
@@ -432,6 +432,20 @@ public class MetadataStorage {
     return metadataDAO.findMetadataNamesByUserAndQuery(term, metadataTypeId, creatorId, audienceIds, limit);
   }
 
+  public List<MetadataItem> getMetadataItemsByMetadataIdAndObjectTypes(long metadataId,
+                                                                       List<String> objectTypes,
+                                                                       int offset,
+                                                                       int limit) {
+    List<MetadataItemEntity> metadataItemEntities = metadataItemDAO.getMetadataItemsByMetadataIdAndObjectTypes(metadataId,
+                                                                                                                objectTypes,
+                                                                                                                offset,
+                                                                                                                limit);
+    if (CollectionUtils.isEmpty(metadataItemEntities)) {
+      return Collections.emptyList();
+    }
+    return metadataItemEntities.stream().map(this::fromEntity).toList();
+  }
+
   public List<MetadataItem> getMetadataItemsByMetadataAndObject(long metadataId, MetadataObject object) {
     List<MetadataItemEntity> metadataItemEntities = metadataItemDAO.getMetadataItemsByMetadataAndObject(metadataId,
                                                                                                         object.getType(),

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
@@ -18,11 +18,13 @@
  */
 package io.meeds.social.category.service;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -127,6 +129,45 @@ public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
     spaceService.setManager(space, MARY_USER, true);
     categoryLinkService.unlink(rootCategory.getId(), object, MARY_USER);
     assertFalse(categoryLinkService.isLinked(rootCategory.getId(), object));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetLinkedObjects() {
+    Category rootCategory = categoryService.getRootCategory(getAdminGroupIdentityId());
+
+    Space space1 = new Space();
+    space1.setRegistration(Space.OPEN);
+    space1.setVisibility(Space.PUBLIC);
+    space1 = spaceService.createSpace(space1, ROOT_USER);
+    CategoryObject object1 = new CategoryObject(SpaceCategoryPlugin.OBJECT_TYPE, space1.getId(), space1.getSpaceId());
+
+    Space space2 = new Space();
+    space2.setRegistration(Space.OPEN);
+    space2.setVisibility(Space.PUBLIC);
+    space2 = spaceService.createSpace(space2, ROOT_USER);
+    CategoryObject object2 = new CategoryObject(SpaceCategoryPlugin.OBJECT_TYPE, space2.getId(), space2.getSpaceId());
+
+    List<CategoryObject> linkedObjects = categoryLinkService.getLinkedObjects(rootCategory.getId(),
+                                                                              Collections.singletonList(SpaceCategoryPlugin.OBJECT_TYPE),
+                                                                              0,
+                                                                              10);
+    assertTrue(linkedObjects.isEmpty());
+
+    categoryLinkService.link(rootCategory.getId(), object1, ROOT_USER);
+    categoryLinkService.link(rootCategory.getId(), object2, ROOT_USER);
+
+    linkedObjects = categoryLinkService.getLinkedObjects(rootCategory.getId(),
+                                                         Collections.singletonList(SpaceCategoryPlugin.OBJECT_TYPE),
+                                                         0,
+                                                         10);
+    assertEquals(2, linkedObjects.size());
+
+    linkedObjects = categoryLinkService.getLinkedObjects(rootCategory.getId(),
+                                                         Collections.singletonList("notMatchingType"),
+                                                         0,
+                                                         10);
+    assertTrue(linkedObjects.isEmpty());
   }
 
 }

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryPluginServiceImplTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryPluginServiceImplTest.java
@@ -1,0 +1,80 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.category.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import io.meeds.social.category.model.CategoryEntryItem;
+import io.meeds.social.category.model.CategoryObject;
+import io.meeds.social.category.plugin.CategoryPlugin;
+
+public class CategoryPluginServiceImplTest {
+
+  private static final String OBJECT_TYPE = "typeA";
+
+  private static final String OBJECT_ID   = "1";
+
+  private static final String TEST_USER   = "testuser";
+
+  @Test
+  public void testDispatchToRegisteredPlugin() {
+    CategoryPluginServiceImpl categoryPluginService = new CategoryPluginServiceImpl();
+    CategoryPlugin plugin = mock(CategoryPlugin.class);
+    when(plugin.getType()).thenReturn(OBJECT_TYPE);
+    when(plugin.canEdit(OBJECT_ID, TEST_USER)).thenReturn(true);
+    when(plugin.canAccess(OBJECT_ID, TEST_USER)).thenReturn(true);
+    CategoryEntryItem entryItem = mock(CategoryEntryItem.class);
+    when(plugin.getEntryItem(OBJECT_ID, TEST_USER)).thenReturn(entryItem);
+    when(plugin.getCategoryIds(0l, TEST_USER)).thenReturn(Collections.singletonList(5l));
+
+    categoryPluginService.addPlugin(plugin);
+
+    assertSame(plugin, categoryPluginService.getCategoryPlugin(OBJECT_TYPE));
+    assertTrue(categoryPluginService.canEdit(OBJECT_TYPE, OBJECT_ID, TEST_USER));
+    assertTrue(categoryPluginService.canAccess(OBJECT_TYPE, OBJECT_ID, TEST_USER));
+    assertSame(entryItem, categoryPluginService.getEntryItem(OBJECT_TYPE, OBJECT_ID, TEST_USER));
+    assertEquals(Collections.singletonList(5l), categoryPluginService.getCategoryIds(OBJECT_TYPE, 0l, TEST_USER));
+
+    CategoryObject object = new CategoryObject(OBJECT_TYPE, OBJECT_ID, 0l);
+    when(plugin.getObject(object)).thenReturn(object);
+    assertSame(object, categoryPluginService.getObject(object));
+  }
+
+  @Test
+  public void testDispatchToDefaultPluginWhenNoneRegistered() {
+    CategoryPluginServiceImpl categoryPluginService = new CategoryPluginServiceImpl();
+    CategoryPlugin plugin = mock(CategoryPlugin.class);
+    when(plugin.getType()).thenReturn(OBJECT_TYPE);
+    categoryPluginService.addPlugin(plugin);
+
+    CategoryPlugin defaultPlugin = categoryPluginService.getCategoryPlugin("unregisteredType");
+    assertEquals("unregisteredType", defaultPlugin.getType());
+    // Same instance is cached and returned on subsequent calls switch the same objectType
+    assertSame(defaultPlugin, categoryPluginService.getCategoryPlugin("unregisteredType"));
+  }
+
+}

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryServiceUnitTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryServiceUnitTest.java
@@ -19,7 +19,9 @@
 package io.meeds.social.category.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +45,9 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
 import io.meeds.social.category.model.Category;
+import io.meeds.social.category.model.CategoryEntryItem;
+import io.meeds.social.category.model.CategoryEntryList;
+import io.meeds.social.category.model.CategoryObject;
 import io.meeds.social.category.model.CategorySearchFilter;
 import io.meeds.social.category.model.CategorySearchResult;
 import io.meeds.social.category.storage.CategoryStorage;
@@ -85,6 +90,10 @@ public class CategoryServiceUnitTest {
   private static final String   TERM                    = "term";
 
   private static final String   TEST_USER               = "testuser";
+
+  private static final String   TYPE_A                  = "typeA";
+
+  private static final String   TYPE_B                  = "typeB";
 
   @MockBean
   private IdentityManager       identityManager;
@@ -176,6 +185,40 @@ public class CategoryServiceUnitTest {
     assertNotNull(categories);
     assertEquals(1, categories.size());
     assertEquals(Collections.singletonList(PARENT_ID), categories.get(0).getAncestorIds());
+  }
+
+  @Test
+  public void testGetCategoryEntries() {
+    List<String> objectTypes = Arrays.asList(TYPE_A, TYPE_B);
+    List<CategoryObject> linkedObjects = Arrays.asList(new CategoryObject(TYPE_A, "1", 0l),
+                                                       new CategoryObject(TYPE_B, "1", 0l),
+                                                       new CategoryObject(TYPE_A, "2", 0l),
+                                                       new CategoryObject(TYPE_B, "3", 0l),
+                                                       new CategoryObject(TYPE_A, "4", 0l));
+    when(categoryStorage.getLinkedItems(CATEGORY_ID, objectTypes, 0, 6)).thenReturn(linkedObjects);
+
+    when(categoryPluginService.canAccess(TYPE_A, "1", TEST_USER)).thenReturn(true);
+    when(categoryPluginService.canAccess(TYPE_B, "1", TEST_USER)).thenReturn(true);
+    when(categoryPluginService.canAccess(TYPE_A, "2", TEST_USER)).thenReturn(false);
+    when(categoryPluginService.canAccess(TYPE_B, "3", TEST_USER)).thenReturn(true);
+    when(categoryPluginService.canAccess(TYPE_A, "4", TEST_USER)).thenReturn(true);
+
+    CategoryEntryItem item1 = mock(CategoryEntryItem.class);
+    CategoryEntryItem item4 = mock(CategoryEntryItem.class);
+    when(categoryPluginService.getEntryItem(TYPE_A, "1", TEST_USER)).thenReturn(item1);
+    when(categoryPluginService.getEntryItem(TYPE_B, "3", TEST_USER)).thenReturn(null);
+    when(categoryPluginService.getEntryItem(TYPE_A, "4", TEST_USER)).thenReturn(item4);
+
+    CategoryEntryList result = categoryService.getCategoryEntries(CATEGORY_ID, objectTypes, TEST_USER, 0, 2);
+    assertNotNull(result);
+    // Duplicate entry (typeB/1) dropped in favor of typeA/1, entry typeA/2 dropped (no access),
+    // entry typeB/3 dropped (no resolved preview): only typeA/1 and typeA/4 remain.
+    assertEquals(2, result.getItems().size());
+    assertTrue(result.getItems().contains(item1));
+    assertTrue(result.getItems().contains(item4));
+    assertEquals(0, result.getOffset());
+    assertEquals(2, result.getLimit());
+    assertFalse(result.isHasMore());
   }
 
 }

--- a/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/metadata/MetadataServiceTest.java
@@ -733,6 +733,47 @@ public class MetadataServiceTest extends AbstractCoreTest {
     assertEquals(1, metadataItems.size());
   }
 
+  public void testGetMetadataItemsByMetadataIdAndObjectTypes() throws Exception {
+    long creatorId = Long.parseLong(johnIdentity.getId());
+    long audienceId = creatorId;
+    String objectId1 = "objectIdTestEntry1";
+    String objectId2 = "objectIdTestEntry2";
+    String objectType1 = "objectTypeTestEntry1";
+    String objectType2 = "objectTypeTestEntry2";
+    String name = "testMetadataEntry";
+    String type = userMetadataType.getName();
+    MetadataKey metadataKey = new MetadataKey(type, name, audienceId);
+    MetadataObject metadataObject1 = newMetadataObjectInstance(objectType1, objectId1, null);
+    MetadataObject metadataObject2 = newMetadataObjectInstance(objectType2, objectId2, null);
+
+    MetadataItem metadataItem1 = metadataService.createMetadataItem(metadataObject1, metadataKey, creatorId);
+    metadataService.createMetadataItem(metadataObject2, metadataKey, creatorId);
+    long metadataId = metadataItem1.getMetadata().getId();
+
+    List<MetadataItem> metadataItems = metadataService.getMetadataItemsByMetadataIdAndObjectTypes(metadataId,
+                                                                                                   Arrays.asList(objectType1,
+                                                                                                                objectType2),
+                                                                                                   0,
+                                                                                                   10);
+    assertNotNull(metadataItems);
+    assertEquals(2, metadataItems.size());
+
+    metadataItems = metadataService.getMetadataItemsByMetadataIdAndObjectTypes(metadataId,
+                                                                               Collections.singletonList(objectType1),
+                                                                               0,
+                                                                               10);
+    assertNotNull(metadataItems);
+    assertEquals(1, metadataItems.size());
+    assertEquals(objectType1, metadataItems.get(0).getObjectType());
+
+    metadataItems = metadataService.getMetadataItemsByMetadataIdAndObjectTypes(metadataId,
+                                                                               Collections.singletonList("notMatchingType"),
+                                                                               0,
+                                                                               10);
+    assertNotNull(metadataItems);
+    assertEquals(0, metadataItems.size());
+  }
+
   public void testGetMetadataNamesByMetadataTypeAndObject() {
     long creatorId = Long.parseLong(johnIdentity.getId());
     long audienceId = creatorId;

--- a/component/service/src/main/java/io/meeds/social/category/rest/CategoryRest.java
+++ b/component/service/src/main/java/io/meeds/social/category/rest/CategoryRest.java
@@ -40,6 +40,7 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.social.rest.api.RestUtils;
 
 import io.meeds.social.category.model.Category;
+import io.meeds.social.category.model.CategoryEntryList;
 import io.meeds.social.category.model.CategoryFilter;
 import io.meeds.social.category.model.CategorySearchFilter;
 import io.meeds.social.category.model.CategorySearchResult;
@@ -153,6 +154,28 @@ public class CategoryRest {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
     return categoryTree;
+  }
+
+  @GetMapping("{id}/entries")
+  @Operation(summary = "Retrieves the entries linked to a Category", method = "GET", description = "This retrieves the entries linked to a category switch the designated objectTypes, de-duplicated and ordered switch last modification date descending")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+  })
+  @Secured("users")
+  public CategoryEntryList getCategoryEntries(HttpServletRequest request,
+                                              @Parameter(description = "Category Identifier")
+                                              @PathVariable(name = "id", required = true)
+                                              long id,
+                                              @Parameter(description = "Comma separated list of objectTypes to browse")
+                                              @RequestParam(name = "types", required = true)
+                                              List<String> types,
+                                              @Parameter(description = "Request offset")
+                                              @RequestParam(name = "offset", required = false, defaultValue = "0")
+                                              long offset,
+                                              @Parameter(description = "Request limit")
+                                              @RequestParam(name = "limit", required = false, defaultValue = "20")
+                                              long limit) {
+    return categoryService.getCategoryEntries(id, types, request.getRemoteUser(), offset, limit);
   }
 
   @GetMapping("search")

--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -1184,6 +1184,8 @@ categories.all=All
 categories.seeAll=See All
 categories.remainingCount=+{0}
 categories.drawer.select.title=Select a category
+categoryEntry.drawer.title=Content List
+categoryEntry.drawer.loadMore=Load More...
 
 publicWidgetHidden.tooltipPart1=Platform Access Restricted. The widget is hidden.
 publicWidgetHidden.tooltipPart2=Adjust in admin settings.

--- a/webapp/src/main/webapp/vue-apps/category-components/components/drawer/EntryListDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/drawer/EntryListDrawer.vue
@@ -1,0 +1,131 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <exo-drawer
+    id="EntryListDrawer"
+    ref="drawer"
+    v-model="drawer"
+    right>
+    <template #title>
+      {{ $t('categoryEntry.drawer.title') }}
+    </template>
+    <template v-if="drawer" #content>
+      <div class="d-flex flex-column">
+        <categories-breadcrumb
+          v-if="breadcrumb"
+          :breadcrumb="breadcrumb"
+          :selected-id="categoryId"
+          class="pa-4"
+          @select="selectBreadcrumb" />
+        <div class="d-flex flex-column px-4">
+          <category-entry-list-item
+            v-for="item in items"
+            :key="`${item.objectType}-${item.id}`"
+            :item="item" />
+        </div>
+        <div
+          v-if="hasMore"
+          class="d-flex justify-center pa-4">
+          <v-btn
+            :loading="loadingMore"
+            text
+            @click="loadMore">
+            {{ $t('categoryEntry.drawer.loadMore') }}
+          </v-btn>
+        </div>
+      </div>
+    </template>
+  </exo-drawer>
+</template>
+<script>
+export default {
+  data: () => ({
+    drawer: false,
+    categoryId: null,
+    objectTypes: [],
+    breadcrumb: null,
+    items: [],
+    offset: 0,
+    limit: 20,
+    hasMore: false,
+    loading: false,
+    loadingMore: false,
+  }),
+  methods: {
+    async open(categoryId, objectTypes) {
+      this.categoryId = categoryId;
+      this.objectTypes = objectTypes?.length && objectTypes || ['news', 'notes'];
+      this.items = [];
+      this.offset = 0;
+      this.hasMore = false;
+      this.breadcrumb = null;
+      this.$refs.drawer.open();
+      await Promise.all([
+        this.loadBreadcrumb(),
+        this.loadEntries(),
+      ]);
+    },
+    close() {
+      this.$refs.drawer.close();
+    },
+    async loadBreadcrumb() {
+      const [category, ancestorIds] = await Promise.all([
+        this.$categoryService.getCategory(this.categoryId),
+        this.$categoryService.getAncestorIds(this.categoryId),
+      ]);
+      const ancestors = await Promise.all((ancestorIds || []).map(id => this.$categoryService.getCategory(id)));
+      this.breadcrumb = [...ancestors.reverse(), category].filter(cat => cat);
+    },
+    async loadEntries() {
+      this.loading = true;
+      try {
+        const data = await this.$categoryService.getCategoryEntries({
+          categoryId: this.categoryId,
+          types: this.objectTypes,
+          offset: this.offset,
+          limit: this.limit,
+        });
+        this.items = [...this.items, ...(data?.items || [])];
+        this.hasMore = !!data?.hasMore;
+      } finally {
+        this.loading = false;
+      }
+    },
+    async loadMore() {
+      this.loadingMore = true;
+      this.offset += this.limit;
+      try {
+        await this.loadEntries();
+      } finally {
+        this.loadingMore = false;
+      }
+    },
+    selectBreadcrumb(category) {
+      if (category) {
+        this.open(category.id, this.objectTypes);
+      } else {
+        this.close();
+      }
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/category-components/components/drawer/EntryListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/drawer/EntryListItem.vue
@@ -1,0 +1,136 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-hover v-slot="{ hover }">
+    <a
+      :class="{'background-grey-primary': hover}"
+      :href="item.url"
+      class="entry-list-item-link position-relative d-flex full-width py-2 text-decoration-none"
+      target="_self">
+      <div
+        style="position: relative; overflow: hidden; height: 80px; min-width: 80px;"
+        class="flex-shrink-0 application-border-radius background-grey-primary d-flex align-center justify-center">
+        <img
+          v-if="item.illustrationUrl"
+          :src="item.illustrationUrl"
+          :alt="item.title"
+          style="position: absolute; top: 0; left: 0;"
+          width="80"
+          height="80"
+          class="application-border-radius object-fit-cover full-width full-height d-block">
+        <v-icon
+          v-else-if="item.icon"
+          size="32"
+          color="tertiary">
+          {{ item.icon }}
+        </v-icon>
+      </div>
+      <div
+        style="margin-inline-start: 15px;"
+        class="d-flex flex-column align-stretch flex-grow-1 no-min-width overflow-hidden">
+        <div class="d-flex align-center text-subtitle mb-1">
+          <date-format
+            v-if="item.date"
+            :value="new Date(item.date)"
+            :format="dateFormat" />
+          <v-spacer v-if="firstCategory" />
+          <category-chip
+            v-if="firstCategory"
+            :category="firstCategory"
+            small />
+        </div>
+        <span class="text-body text-truncate-2">{{ item.title }}</span>
+        <span
+          v-if="item.summary"
+          class="text-subtitle text-truncate-2">
+          {{ item.summary }}
+        </span>
+        <div class="d-flex align-center text-subtitle mt-1 mt-auto">
+          <v-img
+            v-if="item.spaceAvatarUrl"
+            class="my-auto rounded flex-grow-0"
+            :src="item.spaceAvatarUrl"
+            width="20"
+            height="20"
+            alt="" />
+          <v-icon
+            v-if="item.spaceAvatarUrl && item.authorDisplayName"
+            class="mx-1"
+            small>
+            mdi-chevron-right
+          </v-icon>
+          <v-avatar
+            v-if="!item.spaceAvatarUrl && item.authorAvatarUrl"
+            size="20"
+            class="flex-shrink-0 me-1">
+            <img :src="item.authorAvatarUrl" :alt="item.authorDisplayName">
+          </v-avatar>
+          <span
+            v-if="item.authorDisplayName"
+            class="text-truncate">
+            {{ item.authorDisplayName }}
+          </span>
+        </div>
+      </div>
+      <v-icon
+        v-if="item.icon"
+        :title="item.objectType"
+        size="16"
+        class="entry-list-item-type-icon icon-default-color position-absolute t-0 r-0 mt-1 me-1">
+        {{ item.icon }}
+      </v-icon>
+    </a>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+  },
+  data: () => ({
+    dateFormat: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    },
+    firstCategory: null,
+  }),
+  watch: {
+    item: {
+      immediate: true,
+      handler() {
+        const categoryId = this.item?.categoryIds?.[0];
+        if (categoryId) {
+          this.$categoryService.getCategory(categoryId)
+            .then(category => this.firstCategory = category)
+            .catch(() => this.firstCategory = null);
+        } else {
+          this.firstCategory = null;
+        }
+      },
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/category-components/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/category-components/initComponents.js
@@ -24,6 +24,8 @@ import BulkCategoriesDrawer from './components/drawer/BulkCategoriesDrawer.vue';
 import CategoryFormDrawer from './components/drawer/CategoryFormDrawer.vue';
 import CategoryListDrawer from './components/drawer/CategoryListDrawer.vue';
 import CategoryInputDrawer from './components/drawer/CategoryInputDrawer.vue';
+import EntryListDrawer from './components/drawer/EntryListDrawer.vue';
+import EntryListItem from './components/drawer/EntryListItem.vue';
 
 import CategoriesFilter from './components/CategoriesFilter.vue';
 import CategoriesBreadcrumb from './components/filter/CategoriesBreadcrumb.vue';
@@ -40,6 +42,8 @@ const components = {
   'categories-bulk-edit-drawer': BulkCategoriesDrawer,
   'category-form-drawer': CategoryFormDrawer,
   'categories-list-drawer': CategoryListDrawer,
+  'category-entry-drawer': EntryListDrawer,
+  'category-entry-list-item': EntryListItem,
 
   'category-suggester': CategorySuggester,
   'categories-filter': CategoriesFilter,

--- a/webapp/src/main/webapp/vue-apps/category-components/js/CategoryService.js
+++ b/webapp/src/main/webapp/vue-apps/category-components/js/CategoryService.js
@@ -73,6 +73,28 @@ export function getCategory(id) {
   });
 }
 
+export function getCategoryEntries(options) {
+  const formData = new FormData();
+  formData.append('types', (options.types || []).join(','));
+  if (options.offset) {
+    formData.append('offset', options.offset);
+  }
+  if (options.limit) {
+    formData.append('limit', options.limit);
+  }
+  const urlParams = new URLSearchParams(formData).toString();
+  return fetch(`/social/rest/categories/${options.categoryId}/entries?${urlParams}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (resp?.ok) {
+      return resp.json();
+    } else {
+      throw new Error('Error when retrieving the category entries');
+    }
+  });
+}
+
 export function getAncestorIds(id) {
   return fetch(`/social/rest/categories/${id}/ancestors`, {
     method: 'GET',


### PR DESCRIPTION
This change will add a reverse lookup (category -> linked objects) at the Metadata layer, and extend the CategoryPlugin SPI with an optional entry resolver so any object type can supply a generic preview of its content, without the social module knowing about specific types.
 