### PR TITLE
fix: prevent category chips nested in a link from being separate tab stops - EXO-88501 - eXIP7.3.0.1

### DIFF
--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
@@ -39,16 +39,12 @@ public class CategoryPluginServiceImpl implements CategoryPluginService {
   @Autowired
   private PortalContainer             container;
 
-  @Autowired(required = false)
-  private List<CategoryPlugin>        categoryPlugins;
+  private List<CategoryPlugin>        categoryPlugins = new ArrayList<>();
 
   private Map<String, CategoryPlugin> categoryPluginsByType = new ConcurrentHashMap<>();
 
   @Override
   public void addPlugin(CategoryPlugin categoryPlugin) {
-    if (!(categoryPlugins instanceof ArrayList)) {
-      categoryPlugins = categoryPlugins == null ? new ArrayList<>() : new ArrayList<>(categoryPlugins);
-    }
     categoryPlugins.add(categoryPlugin);
   }
 

--- a/webapp/src/main/webapp/vue-apps/category-components/components/drawer/EntryListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/drawer/EntryListItem.vue
@@ -56,6 +56,7 @@
           <category-chip
             v-if="firstCategory"
             :category="firstCategory"
+            tabindex="-1"
             small />
         </div>
         <span class="text-body text-truncate-2">{{ item.title }}</span>

--- a/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryChip.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryChip.vue
@@ -44,7 +44,7 @@
         :class="[chipClass, small && 'text-subtitle-font-size' || '', !visible && 'invisible' || '']"
         :color="selected && 'primary'"
         :small="small"
-        tabindex="0"
+        :tabindex="tabindex"
         class="text-truncate border-box-sizing"
         @focus="menu = true">
         <v-card
@@ -98,7 +98,7 @@
     :class="[chipClass, small && 'text-subtitle-font-size' || '', !visible && 'invisible' || '']"
     :color="selected && 'primary'"
     :small="small"
-    tabindex="0"
+    :tabindex="tabindex"
     class="text-truncate border-box-sizing"
     @click.prevent.stop="openCategory(category)"
     @keydown.enter.stop.prevent="openCategory(category)">
@@ -150,6 +150,10 @@ export default {
     small: {
       type: Boolean,
       default: false,
+    },
+    tabindex: {
+      type: [String, Number],
+      default: 0,
     },
   },
   data: () => ({


### PR DESCRIPTION
Add a tabindex prop to CategoryChip (default 0, unchanged everywhere it's the primary interactive element) so it can be excluded from keyboard tab order when displayed as a decorative label inside a larger clickable link, and set it on the category chip shown in the entry list drawer's content preview.