### PR TITLE
fix: resolve category links for activities and spaces via the category plugin service - EXO-88497 - eXIP7.3.0.1

### DIFF
--- a/component/core/src/main/java/io/meeds/social/activity/plugin/ActivityCategoryPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/activity/plugin/ActivityCategoryPlugin.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
@@ -30,6 +31,9 @@ import org.exoplatform.social.core.manager.ActivityManager;
 
 import io.meeds.social.category.model.CategoryObject;
 import io.meeds.social.category.plugin.CategoryPlugin;
+import io.meeds.social.category.service.CategoryPluginService;
+
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class ActivityCategoryPlugin implements CategoryPlugin {
@@ -37,10 +41,18 @@ public class ActivityCategoryPlugin implements CategoryPlugin {
   public static final String OBJECT_TYPE            = ExoSocialActivityImpl.DEFAULT_ACTIVITY_METADATA_OBJECT_TYPE;
 
   @Autowired
+  private PortalContainer    container;
+
+  @Autowired
   private ActivityManager    activityManager;
 
   @Autowired
   private UserACL            userAcl;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(CategoryPluginService.class).addPlugin(this);
+  }
 
   @Override
   public String getType() {

--- a/component/core/src/main/java/io/meeds/social/category/listener/CategoryLinkModifiedListener.java
+++ b/component/core/src/main/java/io/meeds/social/category/listener/CategoryLinkModifiedListener.java
@@ -21,6 +21,7 @@ package io.meeds.social.category.listener;
 import static io.meeds.social.category.service.CategoryLinkService.EVENT_CATEGORY_LINK_ADDED;
 import static io.meeds.social.category.service.CategoryLinkService.EVENT_CATEGORY_LINK_REMOVED;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -37,7 +38,6 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 import io.meeds.social.activity.plugin.ActivityCategoryPlugin;
 import io.meeds.social.category.model.CategoryObject;
-import io.meeds.social.category.service.CategoryLinkService;
 import io.meeds.social.space.category.service.SpaceCategoryService;
 import io.meeds.social.space.plugin.SpaceCategoryPlugin;
 
@@ -57,9 +57,6 @@ public class CategoryLinkModifiedListener implements ListenerBase<Long, Category
 
   @Autowired
   private ListenerService      listenerService;
-
-  @Autowired
-  private CategoryLinkService  categoryLinkService;
 
   @PostConstruct
   public void init() {
@@ -87,10 +84,18 @@ public class CategoryLinkModifiedListener implements ListenerBase<Long, Category
       String activityId = object.getId();
       ExoSocialActivity activity = activityManager.getActivity(activityId);
       if (activity != null) {
-        List<Long> categoryIds = categoryLinkService.getLinkedIds(object);
-        if (CollectionUtils.size(activity.getCategoryIds()) != CollectionUtils.size(categoryIds)
-            || (CollectionUtils.size(categoryIds) > 0
-                && !CollectionUtils.isEqualCollection(categoryIds, activity.getCategoryIds()))) {
+        // Update the cached categoryIds incrementally from the event itself instead of
+        // re-querying the storage: the link/unlink that triggered this event may not be
+        // visible yet to a fresh query within the same request/transaction.
+        Long categoryId = event.getSource();
+        List<Long> categoryIds = activity.getCategoryIds() == null ? new ArrayList<>() : new ArrayList<>(activity.getCategoryIds());
+        boolean changed;
+        if (EVENT_CATEGORY_LINK_ADDED.equals(event.getEventName())) {
+          changed = !categoryIds.contains(categoryId) && categoryIds.add(categoryId);
+        } else {
+          changed = categoryIds.remove(categoryId);
+        }
+        if (changed) {
           activity.setCategoryIds(categoryIds);
           activityManager.updateActivity(activity);
         }

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryPluginServiceImpl.java
@@ -50,12 +50,22 @@ public class CategoryPluginServiceImpl implements CategoryPluginService {
 
   @Override
   public CategoryPlugin getCategoryPlugin(String objectType) {
-    return categoryPluginsByType.computeIfAbsent(objectType,
-                                                 t -> categoryPlugins.stream()
-                                                                     .filter(c -> c.getType().equals(t))
-                                                                     .findFirst()
-                                                                     .orElseGet(() -> new DefaultCategoryPlugin(container,
-                                                                                                                objectType)));
+    CategoryPlugin plugin = categoryPluginsByType.get(objectType);
+    if (plugin != null) {
+      return plugin;
+    }
+    // Only cache an actually registered plugin. Plugins self-register asynchronously
+    // (each via its own @PostConstruct), so caching the DefaultCategoryPlugin fallback
+    // here would permanently poison this objectType if it's resolved before its plugin
+    // has registered yet.
+    return categoryPlugins.stream()
+                          .filter(c -> c.getType().equals(objectType))
+                          .findFirst()
+                          .map(p -> {
+                            categoryPluginsByType.put(objectType, p);
+                            return p;
+                          })
+                          .orElseGet(() -> new DefaultCategoryPlugin(container, objectType));
   }
 
   @Override

--- a/component/core/src/main/java/io/meeds/social/space/plugin/SpaceCategoryPlugin.java
+++ b/component/core/src/main/java/io/meeds/social/space/plugin/SpaceCategoryPlugin.java
@@ -23,9 +23,13 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
 import io.meeds.social.category.plugin.CategoryPlugin;
+import io.meeds.social.category.service.CategoryPluginService;
+
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class SpaceCategoryPlugin implements CategoryPlugin {
@@ -33,7 +37,15 @@ public class SpaceCategoryPlugin implements CategoryPlugin {
   public static final String OBJECT_TYPE = SpaceAclPlugin.OBJECT_TYPE;
 
   @Autowired
+  private PortalContainer    container;
+
+  @Autowired
   private SpaceService       spaceService;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(CategoryPluginService.class).addPlugin(this);
+  }
 
   @Override
   public String getType() {

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryPluginServiceImplTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryPluginServiceImplTest.java
@@ -73,8 +73,24 @@ public class CategoryPluginServiceImplTest {
 
     CategoryPlugin defaultPlugin = categoryPluginService.getCategoryPlugin("unregisteredType");
     assertEquals("unregisteredType", defaultPlugin.getType());
-    // Same instance is cached and returned on subsequent calls switch the same objectType
-    assertSame(defaultPlugin, categoryPluginService.getCategoryPlugin("unregisteredType"));
+  }
+
+  @Test
+  public void testDispatchToPluginRegisteredAfterAnInitialLookupMiss() {
+    // Plugins self-register asynchronously (each via its own @PostConstruct), so a lookup
+    // for an objectType can legitimately happen before that type's plugin has registered
+    // yet. The fallback returned in that case must not be cached, otherwise the objectType
+    // stays permanently stuck on the default no-op plugin even once the real one registers.
+    CategoryPluginServiceImpl categoryPluginService = new CategoryPluginServiceImpl();
+
+    CategoryPlugin defaultPlugin = categoryPluginService.getCategoryPlugin(OBJECT_TYPE);
+    assertEquals(OBJECT_TYPE, defaultPlugin.getType());
+
+    CategoryPlugin plugin = mock(CategoryPlugin.class);
+    when(plugin.getType()).thenReturn(OBJECT_TYPE);
+    categoryPluginService.addPlugin(plugin);
+
+    assertSame(plugin, categoryPluginService.getCategoryPlugin(OBJECT_TYPE));
   }
 
 }


### PR DESCRIPTION
Categories linked on an activity (CategoryObject type "activity") are meant to be transformed by CategoryLinkService into the activity's actual metadata object type before being stored, via a dispatch through CategoryPluginService to whichever CategoryPlugin is registered for that type (ActivityCategoryPlugin). But ActivityCategoryPlugin (and SpaceCategoryPlugin) never registered themselves with the service, so the dispatch always fell through to the no-op default plugin, which returns the object unchanged. Categories ended up linked under the raw "activity" object type instead of the type the activity actually represents, so any other object type sharing that same underlying entity could never resolve the categories back through it.