### PR TITLE
feat: cancel a scheduled message - EXO-88481

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -293,6 +293,9 @@ activity.filter.empty_unread_spaces_stream.msg=No unread activities from your sp
 activity.filter.empty_unread_spaces_stream.switchMessage=You're up-to-date! You've seen all the latest activities.
 activity.filter.empty_scheduled_stream.msg=No scheduled post. Start writing a new one
 activityStream.scheduledActionsDisabled=Scheduled post. Hence, actions are disabled
+activityStream.scheduledPost.cancelScheduling=Cancel Scheduling
+activityStream.scheduledPost.cancelSchedulingMessage=Your post will no more be sent at the expected date and hour and it will be completely deleted. Do you confirm?
+activityStream.scheduledPost.cancelSchedulingConfirm=Confirm
 
 activity.filter.button.markAllAsRead=Mark all activities as read
 activity.filter.button.resetFilter=Reset

--- a/webapp/src/main/resources/locale/portlet/Portlets_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_fr.properties
@@ -293,6 +293,9 @@ activity.filter.empty_unread_spaces_stream.msg=Aucune activité non lue depuis v
 activity.filter.empty_unread_spaces_stream.switchMessage=Vous êtes à jour ! Vous avez passé en revue toutes les dernières activités
 activity.filter.empty_scheduled_stream.msg=Aucune publication programmée. Commencez à en rédiger une nouvelle
 activityStream.scheduledActionsDisabled=Publication programmée. Les actions sont donc désactivées
+activityStream.scheduledPost.cancelScheduling=Annuler la programmation
+activityStream.scheduledPost.cancelSchedulingMessage=Votre publication ne sera plus envoyée à la date et à l'heure prévues et elle sera définitivement supprimée. Confirmez-vous ?
+activityStream.scheduledPost.cancelSchedulingConfirm=Confirmer
 
 activity.filter.button.markAllAsRead=Marquer toutes les activités comme lues
 activity.filter.button.resetFilter=Réinitialiser

--- a/webapp/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -246,7 +246,7 @@ extensionRegistry.registerExtension('activity', 'action', {
   confirmOkKey: 'UIActivity.label.Confirm_Delete_Activity-Button',
   confirmCancelKey: 'UIActivity.label.Cancel_Delete_Activity-Button',
   isEnabled: (activity, activityTypeExtension) => {
-    if (activityTypeExtension.canDelete && !activityTypeExtension.canDelete(activity)) {
+    if (activity.publicationStartTime || (activityTypeExtension.canDelete && !activityTypeExtension.canDelete(activity))) {
       return false;
     }
     return activity.canDelete === 'true';
@@ -261,6 +261,30 @@ extensionRegistry.registerExtension('activity', 'action', {
           document.dispatchEvent(new CustomEvent('activity-deleted', {detail: activity.id}));
         }
       })
+      .finally(() => document.dispatchEvent(new CustomEvent('hideTopBarLoading')));
+  },
+});
+
+extensionRegistry.registerExtension('activity', 'action', {
+  id: 'cancelScheduling',
+  rank: 100,
+  labelKey: 'UIActivity.label.Delete',
+  icon: 'fa-trash-alt',
+  confirmDialog: true,
+  confirmMessageKey: 'activityStream.scheduledPost.cancelSchedulingMessage',
+  confirmTitleKey: 'activityStream.scheduledPost.cancelScheduling',
+  confirmOkKey: 'activityStream.scheduledPost.cancelSchedulingConfirm',
+  confirmCancelKey: 'UIActivity.label.Cancel_Delete_Activity-Button',
+  isEnabled: (activity, activityTypeExtension) => {
+    if (!activity.publicationStartTime || (activityTypeExtension.canDelete && !activityTypeExtension.canDelete(activity))) {
+      return false;
+    }
+    return activity.canDelete === 'true';
+  },
+  click: (activity) => {
+    document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
+    return Vue.prototype.$activityService.deleteActivity(activity.id)
+      .then(() => document.dispatchEvent(new CustomEvent('activity-deleted', {detail: activity.id})))
       .finally(() => document.dispatchEvent(new CustomEvent('hideTopBarLoading')));
   },
 });


### PR DESCRIPTION
Show a dedicated 'Cancel Scheduling' confirmation dialog when deleting a still scheduled post, warning that it will no more be sent at the expected date and hour and will be completely deleted. The regular delete confirmation stays used for posted activities, each action extension declaring its own applicability.
