### PR TITLE
Fix: Duplicate link declarations on avatar and text for requests to review in the spaces directory - EXO-87925

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-list-components/components/space-card/menu/SpaceRoleListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list-components/components/space-card/menu/SpaceRoleListItem.vue
@@ -29,6 +29,7 @@
     <exo-user-avatar
       :identity="user"
       :size="30"
+      :url="false"
       extra-class="text-truncate ms-n6 mt-6"
       avatar />
     <v-list-item-content class="py-0 accountTitleLabel text-truncate">


### PR DESCRIPTION
The avatar becomes a non-focusable decorative element, and only the name (the text) remains the clickable/accessible link to the profile.
