### PR TITLE
feat: display pages carrying a content block in the unified search - EXO-88571

### DIFF
--- a/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
+++ b/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
@@ -82,7 +82,6 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
           "pageTitle" : {"type" : "keyword"},
           "pagePath" : {"type" : "keyword"},
           "author" : {"type" : "keyword"},
-          "date" : {"type" : "date", "format": "epoch_millis"},
           "permissions" : {"type" : "keyword"},
           @content_mappings@
         }

--- a/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnector.java
+++ b/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnector.java
@@ -1,0 +1,307 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.cms.storage.elasticsearch;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import org.exoplatform.commons.search.es.ElasticSearchException;
+import org.exoplatform.commons.search.es.client.ElasticSearchingClient;
+import org.exoplatform.commons.utils.ExpressionUtil;
+import org.exoplatform.commons.utils.IOUtil;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.configuration.ConfigurationManager;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.resources.LocaleContextInfo;
+import org.exoplatform.services.resources.ResourceBundleManager;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.MembershipEntry;
+
+import io.meeds.social.search.model.PageSearchResult;
+
+/**
+ * Searches pages previously indexed by {@link PageContentIndexingConnector}
+ * (index alias {@code page_content_alias}) for the unified search bar.
+ */
+public class PageContentSearchConnector {
+
+  private static final String        INDEX                     = "page_content_alias";
+
+  private static final Log           LOG                       = ExoLogger.getLogger(PageContentSearchConnector.class);
+
+  private static final String        TERM_REPLACEMENT          = "@term@";
+
+  private static final String        OFFSET_REPLACEMENT        = "@offset@";
+
+  private static final String        LIMIT_REPLACEMENT         = "@limit@";
+
+  private static final String        PERMISSIONS_REPLACEMENT   = "@permissions_filter@";
+
+  private final ConfigurationManager configurationManager;
+
+  private final ElasticSearchingClient client;
+
+  private final LayoutService        layoutService;
+
+  private final ResourceBundleManager resourceBundleManager;
+
+  private final String               queryFilePath;
+
+  private String                     query;
+
+  public PageContentSearchConnector(ConfigurationManager configurationManager,
+                                    ElasticSearchingClient client,
+                                    LayoutService layoutService,
+                                    ResourceBundleManager resourceBundleManager,
+                                    InitParams initParams) {
+    this.configurationManager = configurationManager;
+    this.client = client;
+    this.layoutService = layoutService;
+    this.resourceBundleManager = resourceBundleManager;
+    ValueParam queryFileParam = initParams.getValueParam("query.file.path");
+    this.queryFilePath = queryFileParam.getValue();
+    this.query = retrieveQueryFromFile();
+  }
+
+  public List<PageSearchResult> search(String term, int offset, int limit, Locale locale) {
+    if (StringUtils.isBlank(term)) {
+      throw new IllegalArgumentException("Term is mandatory");
+    }
+    String esQuery = retrieveQuery().replace(TERM_REPLACEMENT, escape(term))
+                                    .replace(PERMISSIONS_REPLACEMENT, buildPermissionFilter())
+                                    .replace(OFFSET_REPLACEMENT, String.valueOf(Math.max(offset, 0)))
+                                    .replace(LIMIT_REPLACEMENT, String.valueOf(limit < 1 ? 20 : limit));
+    String jsonResponse = client.sendRequest(esQuery, INDEX);
+    return buildResults(jsonResponse, locale == null ? Locale.getDefault() : locale);
+  }
+
+  private String retrieveQuery() {
+    if (StringUtils.isBlank(query) || PropertyManager.isDevelopping()) {
+      query = retrieveQueryFromFile();
+    }
+    return query;
+  }
+
+  private String retrieveQueryFromFile() {
+    try {
+      InputStream inputStream = configurationManager.getInputStream(queryFilePath);
+      return IOUtil.getStreamContentAsString(inputStream);
+    } catch (Exception e) {
+      throw new IllegalStateException("Error retrieving search query from file: " + queryFilePath, e);
+    }
+  }
+
+  private String escape(String term) {
+    return term.replaceAll("([\\Q+-!():^[]\"{}~*?|&/\\E])", " ").trim();
+  }
+
+  /**
+   * A page is visible to the current user when its {@code permissions} field
+   * (raw {@code Page#getAccessPermissions()} ACL expressions) contains
+   * either the current username, the {@link UserACL#EVERYONE} sentinel, or a
+   * membership the user holds.
+   */
+  private String buildPermissionFilter() {
+    ConversationState conversationState = ConversationState.getCurrent();
+    if (conversationState == null || conversationState.getIdentity() == null) {
+      return """
+          {"term": {"permissions": "%s"}}
+          """.formatted(UserACL.EVERYONE);
+    }
+    String username = conversationState.getIdentity().getUserId();
+    Set<String> memberships = getUserMemberships(conversationState);
+    List<String> should = new ArrayList<>();
+    should.add("""
+        {"term": {"permissions": "%s"}}
+        """.formatted(username));
+    should.add("""
+        {"term": {"permissions": "%s"}}
+        """.formatted(UserACL.EVERYONE));
+    if (!memberships.isEmpty()) {
+      should.add("""
+          {"regexp": {"permissions": "%s"}}
+          """.formatted(StringUtils.join(memberships, "|")));
+    }
+    return "{\"bool\": {\"should\": [" + StringUtils.join(should, ",") + "], \"minimum_should_match\": 1}}";
+  }
+
+  private Set<String> getUserMemberships(ConversationState conversationState) {
+    if (conversationState.getIdentity().getMemberships() == null) {
+      return Collections.emptySet();
+    }
+    Set<String> entries = new HashSet<>();
+    for (MembershipEntry entry : conversationState.getIdentity().getMemberships()) {
+      if (entry.getMembershipType().equals(MembershipEntry.ANY_TYPE)) {
+        entries.add(entry.toString().replace("*", ".*"));
+      } else {
+        entries.add(entry.toString());
+        entries.add("*:" + entry.getGroup());
+      }
+    }
+    return entries;
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private List<PageSearchResult> buildResults(String jsonResponse, Locale locale) {
+    JSONParser parser = new JSONParser();
+    Map json;
+    try {
+      json = (Map) parser.parse(jsonResponse);
+    } catch (ParseException e) {
+      throw new ElasticSearchException("Unable to parse JSON response", e);
+    }
+    JSONObject jsonResult = (JSONObject) json.get("hits");
+    if (jsonResult == null) {
+      return Collections.emptyList();
+    }
+    List<PageSearchResult> results = new ArrayList<>();
+    JSONArray jsonHits = (JSONArray) jsonResult.get("hits");
+    for (Object jsonHit : jsonHits) {
+      try {
+        PageSearchResult result = buildResult((JSONObject) jsonHit, locale);
+        if (result != null) {
+          results.add(result);
+        }
+      } catch (Exception e) {
+        LOG.warn("Error processing page search result item, ignore it from results", e);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * @return the built result, or {@code null} when the page only matched
+   *         through content in a language that shouldn't be shown to this
+   *         user (see {@link #extractExcerpts}) — such a page isn't a valid
+   *         result for this user at all, it isn't merely missing an
+   *         excerpt. A page matching through its title/name/site instead is
+   *         still a valid result even without any content excerpt.
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private PageSearchResult buildResult(JSONObject jsonHit, Locale locale) {
+    String id = (String) jsonHit.get("_id");
+    JSONObject source = (JSONObject) jsonHit.get("_source");
+    JSONObject highlight = (JSONObject) jsonHit.get("highlight");
+    List<String> excerpts = extractExcerpts(source, highlight, locale);
+    if (excerpts.isEmpty() && matchedContentInAnyLanguage(highlight)) {
+      return null;
+    }
+    Object dateValue = source == null ? null : source.get("lastUpdatedDate");
+    String siteType = source == null ? null : (String) source.get("siteType");
+    String siteName = source == null ? null : (String) source.get("siteName");
+    return new PageSearchResult(id,
+                                resolveSiteLabel(siteType, siteName, locale),
+                                source == null ? null : (String) source.get("pageName"),
+                                source == null ? null : (String) source.get("pageTitle"),
+                                source == null ? null : (String) source.get("pagePath"),
+                                source == null ? null : (String) source.get("author"),
+                                dateValue == null ? 0L : ((Number) dateValue).longValue(),
+                                excerpts);
+  }
+
+  /**
+   * A page's content is indexed once per configured language (
+   * {@code content}/{@code content-<lang>}). An excerpt is only ever shown
+   * when the search term actually matched the searching user's own
+   * language (or, when the page has no translation for it, the default
+   * no-language content) — a match that only exists in some other language
+   * (be it the default content when a translation exists, or an unrelated
+   * language when it doesn't) never surfaces any excerpt at all.
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private List<String> extractExcerpts(JSONObject source, JSONObject highlight, Locale locale) {
+    String langField = PageContentIndexingConnector.contentFieldName(locale == null ? null : locale.toLanguageTag());
+    boolean hasTranslation = source != null && source.get(langField) != null;
+    String fieldToUse = hasTranslation ? langField : "content";
+
+    JSONArray fragments = highlight == null ? null : (JSONArray) highlight.get(fieldToUse);
+    if (fragments == null) {
+      return Collections.emptyList();
+    }
+    List<String> excerpts = new ArrayList<>();
+    fragments.forEach(fragment -> excerpts.add((String) fragment));
+    return excerpts;
+  }
+
+  /**
+   * @return whether the term matched a {@code content}/{@code content-<lang>}
+   *         field at all, in any language. Used to tell apart "no excerpt
+   *         because the page matched through its title/name/site" (still a
+   *         valid result) from "no excerpt because the only content match
+   *         was in a language we won't show this user" (not a valid result
+   *         for this user at all).
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private boolean matchedContentInAnyLanguage(JSONObject highlight) {
+    if (highlight == null) {
+      return false;
+    }
+    return highlight.keySet().stream().anyMatch(key -> StringUtils.startsWith((String) key, "content"));
+  }
+
+  /**
+   * Resolves the site's display label in the searching user's locale. The
+   * raw site label ({@link PortalConfig#getLabel()}) is only indexed as-is
+   * ({@code siteName}) — resolving it earlier, at index time, would freeze
+   * it in one locale for every searching user.
+   */
+  private String resolveSiteLabel(String siteType, String siteName, Locale locale) {
+    if (StringUtils.isAnyBlank(siteType, siteName)) {
+      return siteName;
+    }
+    try {
+      PortalConfig portalConfig = layoutService.getPortalConfig(new SiteKey(siteType, siteName));
+      String label = portalConfig == null ? null : portalConfig.getLabel();
+      if (StringUtils.isBlank(label)) {
+        return siteName;
+      } else if (!ExpressionUtil.isResourceBindingExpression(label)) {
+        return label;
+      }
+      ResourceBundle bundle = resourceBundleManager.getNavigationResourceBundle(LocaleContextInfo.getLocaleAsString(locale),
+                                                                                siteType,
+                                                                                siteName);
+      String resolved = bundle == null ? null : ExpressionUtil.getExpressionValue(bundle, label);
+      return StringUtils.isNotBlank(resolved) ? resolved : siteName;
+    } catch (Exception e) {
+      LOG.debug("Cannot resolve site label for site {}:{}", siteType, siteName, e);
+      return siteName;
+    }
+  }
+
+}

--- a/component/core/src/main/java/io/meeds/social/search/model/PageSearchResult.java
+++ b/component/core/src/main/java/io/meeds/social/search/model/PageSearchResult.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.search.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A page carrying an indexed content block, as displayed in the unified
+ * search result list.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class PageSearchResult {
+
+  private String       id;
+
+  private String       siteName;
+
+  private String       pageName;
+
+  private String       pageTitle;
+
+  private String       pagePath;
+
+  private String       author;
+
+  private long          date;
+
+  private List<String> excerpts;
+
+}

--- a/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnectorTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnectorTest.java
@@ -1,0 +1,413 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.cms.storage.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.search.es.client.ElasticSearchingClient;
+import org.exoplatform.container.configuration.ConfigurationManager;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.resources.ResourceBundleManager;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.MembershipEntry;
+
+import io.meeds.social.search.model.PageSearchResult;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PageContentSearchConnectorTest {
+
+  private static final String        QUERY_TEMPLATE = "{\"q\":\"@term@\",\"filter\":@permissions_filter@,"
+      + "\"from\":\"@offset@\",\"size\":\"@limit@\"}";
+
+  @Mock
+  private ConfigurationManager       configurationManager;
+
+  @Mock
+  private ElasticSearchingClient     client;
+
+  @Mock
+  private LayoutService              layoutService;
+
+  @Mock
+  private ResourceBundleManager      resourceBundleManager;
+
+  private PageContentSearchConnector connector;
+
+  @Before
+  public void setup() throws Exception {
+    when(configurationManager.getInputStream(anyString())).thenAnswer(invocation -> toStream(QUERY_TEMPLATE));
+    InitParams params = new InitParams();
+    ValueParam queryFileParam = new ValueParam();
+    queryFileParam.setName("query.file.path");
+    queryFileParam.setValue("query.json");
+    params.addParameter(queryFileParam);
+    connector = new PageContentSearchConnector(configurationManager, client, layoutService, resourceBundleManager, params);
+  }
+
+  @After
+  public void tearDown() {
+    ConversationState.setCurrent(null);
+  }
+
+  @Test
+  public void shouldThrowWhenTermIsBlank() {
+    try {
+      connector.search("", 0, 10, Locale.ENGLISH);
+      fail("IllegalArgumentException should be thrown");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void shouldOnlyFilterOnEveryoneWhenNoCurrentIdentity() {
+    when(client.sendRequest(any(), any())).thenAnswer(invocation -> {
+      String query = invocation.getArgument(0);
+      assertTrue(query.contains("\"term\": {\"permissions\": \"Everyone\"}"));
+      return emptyResponse();
+    });
+
+    connector.search("term", 0, 10, Locale.ENGLISH);
+  }
+
+  @Test
+  public void shouldFilterOnUsernameEveryoneAndMembershipsWhenIdentityPresent() {
+    Identity identity = new Identity("john", Arrays.asList(new MembershipEntry("/spaces/x", "manager")));
+    ConversationState.setCurrent(new ConversationState(identity));
+
+    when(client.sendRequest(any(), any())).thenAnswer(invocation -> {
+      String query = invocation.getArgument(0);
+      assertTrue(query.contains("\"term\": {\"permissions\": \"john\"}"));
+      assertTrue(query.contains("\"term\": {\"permissions\": \"Everyone\"}"));
+      assertTrue(query.contains("\"regexp\": {\"permissions\": \"manager:/spaces/x|*:/spaces/x\"}"));
+      return emptyResponse();
+    });
+
+    connector.search("term", 0, 10, Locale.ENGLISH);
+  }
+
+  @Test
+  public void shouldReplaceOffsetAndLimitAndEscapedTerm() {
+    when(client.sendRequest(any(), any())).thenAnswer(invocation -> {
+      String query = invocation.getArgument(0);
+      assertTrue(query.contains("\"from\":\"5\""));
+      assertTrue(query.contains("\"size\":\"15\""));
+      assertTrue(query.contains("\"q\":\"my term\""));
+      return emptyResponse();
+    });
+
+    connector.search("my+term", 5, 15, Locale.ENGLISH);
+  }
+
+  @Test
+  public void shouldParseHitsIntoPageSearchResults() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "siteName": "site",
+                  "pageName": "page",
+                  "pageTitle": "My Page",
+                  "pagePath": "/portal/site/page",
+                  "author": "john",
+                  "lastUpdatedDate": 1234567890
+                },
+                "highlight": {
+                  "content": ["Hello <span class='searchMatchExcerpt'>world</span>"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("world", 0, 10, Locale.ENGLISH);
+
+    assertEquals(1, results.size());
+    PageSearchResult result = results.get(0);
+    assertEquals("page_139", result.getId());
+    assertEquals("site", result.getSiteName());
+    assertEquals("page", result.getPageName());
+    assertEquals("My Page", result.getPageTitle());
+    assertEquals("/portal/site/page", result.getPagePath());
+    assertEquals("john", result.getAuthor());
+    assertEquals(1234567890L, result.getDate());
+    assertEquals(1, result.getExcerpts().size());
+    assertTrue(result.getExcerpts().get(0).contains("world"));
+  }
+
+  @Test
+  public void shouldOnlyReturnExcerptInSearchingUserLanguage() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "content": "default language content",
+                  "content-fr": "contenu en francais"
+                },
+                "highlight": {
+                  "content": ["default language excerpt"],
+                  "content-fr": ["extrait en francais"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("term", 0, 10, Locale.FRENCH);
+
+    assertEquals(1, results.get(0).getExcerpts().size());
+    assertEquals("extrait en francais", results.get(0).getExcerpts().get(0));
+  }
+
+  @Test
+  public void shouldExcludeResultWhenTranslationExistsButOnlyDefaultContentMatched() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "content": "default content",
+                  "content-fr": "fr content"
+                },
+                "highlight": {
+                  "content": ["<span>default</span> content"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("default", 0, 10, Locale.FRENCH);
+
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void shouldKeepResultWithoutExcerptWhenMatchedThroughTitleOnly() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "pageTitle": "Default meeting notes",
+                  "content": "default content",
+                  "content-fr": "fr content"
+                },
+                "highlight": {
+                  "pageTitle": ["<span>Default</span> meeting notes"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("default", 0, 10, Locale.FRENCH);
+
+    assertEquals(1, results.size());
+    assertTrue(results.get(0).getExcerpts().isEmpty());
+  }
+
+  @Test
+  public void shouldExcludeResultWhenOnlyAnUnrelatedLanguageMatchedAndNoTranslationForUser() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "content": "the original english content",
+                  "content-de": "der deutsche inhalt mit dem begriff"
+                },
+                "highlight": {
+                  "content-de": ["der deutsche inhalt mit dem <span>begriff</span>"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("begriff", 0, 10, Locale.FRENCH);
+
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void shouldFallBackToDefaultLanguageExcerptWhenNoTranslationForUserLanguage() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {},
+                "highlight": {
+                  "content": ["default language excerpt"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("term", 0, 10, Locale.FRENCH);
+
+    assertEquals(1, results.get(0).getExcerpts().size());
+    assertEquals("default language excerpt", results.get(0).getExcerpts().get(0));
+  }
+
+  @Test
+  public void shouldReturnPlainSiteLabelWhenNotAnExpression() {
+    PortalConfig portalConfig = mock(PortalConfig.class);
+    when(portalConfig.getLabel()).thenReturn("My Workspace");
+    when(layoutService.getPortalConfig(new SiteKey("portal", "myworkspace"))).thenReturn(portalConfig);
+
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "siteType": "portal",
+                  "siteName": "myworkspace"
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("world", 0, 10, Locale.ENGLISH);
+
+    assertEquals("My Workspace", results.get(0).getSiteName());
+  }
+
+  @Test
+  public void shouldResolveExpressionBoundSiteLabelInSearchingUserLocale() {
+    PortalConfig portalConfig = mock(PortalConfig.class);
+    when(portalConfig.getLabel()).thenReturn("#{portal.myworkspace.name}");
+    when(layoutService.getPortalConfig(new SiteKey("portal", "myworkspace"))).thenReturn(portalConfig);
+    ResourceBundle bundle = mock(ResourceBundle.class);
+    when(bundle.getString("portal.myworkspace.name")).thenReturn("My Workspace FR");
+    when(resourceBundleManager.getNavigationResourceBundle("fr", "portal", "myworkspace")).thenReturn(bundle);
+
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "siteType": "portal",
+                  "siteName": "myworkspace"
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("world", 0, 10, Locale.FRENCH);
+
+    assertEquals("My Workspace FR", results.get(0).getSiteName());
+  }
+
+  @Test
+  public void shouldFallBackToRawSiteNameWhenSiteNotFound() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "siteType": "portal",
+                  "siteName": "unknown"
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("world", 0, 10, Locale.ENGLISH);
+
+    assertEquals("unknown", results.get(0).getSiteName());
+  }
+
+  private String emptyResponse() {
+    return "{\"hits\": {\"hits\": []}}";
+  }
+
+  private InputStream toStream(String content) {
+    return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+  }
+
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
@@ -22,6 +22,7 @@ import io.meeds.social.cms.listener.PageContentBlockIndexingListenerTest;
 import io.meeds.social.cms.service.PageContentBlockPluginServiceImplTest;
 import io.meeds.social.cms.service.PageUrlResolverServiceImplTest;
 import io.meeds.social.cms.storage.elasticsearch.PageContentIndexingConnectorTest;
+import io.meeds.social.cms.storage.elasticsearch.PageContentSearchConnectorTest;
 import io.meeds.social.space.invitation.storage.SpaceInvitationLinkLinkStorageTest;
 import io.meeds.social.space.listener.SpaceGroupCacheListenerTest;
 import io.meeds.social.space.listener.SpaceInvitationLinkLinkJoinListenerTest;
@@ -111,7 +112,8 @@ import io.meeds.social.user.plugin.UserAclPluginTest;
     PageContentBlockPluginServiceImplTest.class,
     PageUrlResolverServiceImplTest.class,
     PageContentBlockIndexingListenerTest.class,
-    PageContentIndexingConnectorTest.class
+    PageContentIndexingConnectorTest.class,
+    PageContentSearchConnectorTest.class
 })
 public class NoContainerTestSuite {
 

--- a/component/service/src/main/java/io/meeds/social/cms/rest/PageSearchRest.java
+++ b/component/service/src/main/java/io/meeds/social/cms/rest/PageSearchRest.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.cms.rest;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.meeds.social.cms.storage.elasticsearch.PageContentSearchConnector;
+import io.meeds.social.search.model.PageSearchResult;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/pages")
+@Tag(name = "/social/rest/pages", description = "Searches pages carrying an indexed content block")
+public class PageSearchRest {
+
+  @Autowired
+  private PageContentSearchConnector pageContentSearchConnector;
+
+  @GetMapping(value = "search", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Searches pages carrying an indexed content block", method = "GET")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+  })
+  public List<PageSearchResult> search(HttpServletRequest request,
+                                       @Parameter(description = "Search term")
+                                       @RequestParam("q")
+                                       String term,
+                                       @Parameter(description = "Search result offset")
+                                       @RequestParam(name = "offset", required = false, defaultValue = "0")
+                                       int offset,
+                                       @Parameter(description = "Search result limit")
+                                       @RequestParam(name = "limit", required = false, defaultValue = "20")
+                                       int limit) {
+    return pageContentSearchConnector.search(term, offset, limit, request.getLocale());
+  }
+
+}

--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -712,6 +712,7 @@ Search.button.loadMore=Load more
 Search.button.close.label=Close search
 Search.activity.inComment=In comments
 search.connector.label.activities=Activity
+search.connector.label.pages=Pages
 search.connector.label.all=All
 search.connector.label.favorites=Favorites
 search.connector.option.type.ariaLabel=Start searching content of this type: {0}

--- a/webapp/src/main/resources/locale/portlet/Portlets_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_fr.properties
@@ -712,6 +712,7 @@ Search.button.loadMore=Charger plus
 Search.button.close.label=Abandonner la recherche
 Search.activity.inComment=En commentaire
 search.connector.label.activities=Activité
+search.connector.label.pages=Pages
 search.connector.label.all=Tous
 search.connector.label.favorites=Favoris
 search.connector.option.type.ariaLabel=Commencer la recherche de contenu de ce type : {0}

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
@@ -63,6 +63,16 @@
     </init-params>
   </component>
 
+  <component>
+    <type>io.meeds.social.cms.storage.elasticsearch.PageContentSearchConnector</type>
+    <init-params>
+      <value-param>
+        <name>query.file.path</name>
+        <value>${social.pages.es.query.path:war:/conf/social-extension/social/search/page-search-query.json}</value>
+      </value-param>
+    </init-params>
+  </component>
+
   <external-component-plugins>
     <target-component>org.exoplatform.social.core.search.SearchService</target-component>
     <component-plugin>
@@ -198,6 +208,44 @@
             </field>
             <field name="icon">
               <string>fas fa-stream</string>
+            </field>
+            <field name="spaceFilterEnabled">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>PageSearchConnector</name>
+      <set-method>addConnector</set-method>
+      <type>org.exoplatform.social.core.search.SearchConnectorPlugin</type>
+      <description>Page Search connector</description>
+      <init-params>
+        <object-param>
+          <name>PageSearchConnector</name>
+          <description>Search connector for pages carrying an indexed content block</description>
+          <object type="org.exoplatform.social.core.search.SearchConnector">
+            <field name="name">
+              <string>pages</string>
+            </field>
+            <field name="contentType">
+              <string>page</string>
+            </field>
+            <field name="uri">
+              <string><![CDATA[/social/rest/pages/search?q={keyword}&limit={limit}]]></string>
+            </field>
+            <field name="enabled">
+              <boolean>${search.page.enabled:true}</boolean>
+            </field>
+            <field name="jsModule">
+              <string>SHARED/PageSearchResultCard</string>
+            </field>
+            <field name="uiComponent">
+              <string>page-search-result-card</string>
+            </field>
+            <field name="icon">
+              <string>fas fa-file-alt</string>
             </field>
             <field name="spaceFilterEnabled">
               <boolean>true</boolean>

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/search/page-search-query.json
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/search/page-search-query.json
@@ -1,0 +1,30 @@
+{
+  "from": "@offset@",
+  "size": "@limit@",
+  "query": {
+    "bool": {
+      "must": {
+        "query_string": {
+          "fields": ["pageTitle", "pageName", "siteName", "content*"],
+          "default_operator": "AND",
+          "query": "@term@"
+        }
+      },
+      "filter": [
+        @permissions_filter@
+      ]
+    }
+  },
+  "highlight": {
+    "number_of_fragments": 2,
+    "fragment_size": 150,
+    "no_match_size": 0,
+    "order": "score",
+    "fields": {
+      "content*": {
+        "pre_tags": ["<span class='searchMatchExcerpt'>"],
+        "post_tags": ["</span>"]
+      }
+    }
+  }
+}

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -2615,6 +2615,33 @@
   </module>
 
   <module>
+    <name>PageSearchResultCard</name>
+    <script>
+      <minify>false</minify>
+      <path>/js/pageSearchResultCard.bundle.js</path>
+    </script>
+    <depends>
+      <module>commonVueComponents</module>
+    </depends>
+    <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+    <depends>
+      <module>jquery</module>
+      <as>$</as>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
+
+  <module>
     <name>ActivityReactions</name>
     <load-group>ActivityStreamGRP</load-group>
     <script>

--- a/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
+++ b/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
@@ -1,0 +1,74 @@
+<!--
+This file is part of the Meeds project (https://meeds.io/).
+Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+-->
+<template>
+  <v-hover v-slot="{ hover }">
+    <v-card
+      flat
+      class="pa-0"
+      :aria-label="$t('search.access.to.result', {0: excerptText})"
+      :href="link">
+      <v-list class="pa-0" :class="hover && 'light-grey-background-color no-border-radius' || ''">
+        <v-list-item>
+          <v-list-item-icon class="me-2 pt-1">
+            <v-icon size="24" class="icon-default-color">
+              fas fa-file-alt
+            </v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title class="text-truncate primary--text">
+              {{ title }}
+            </v-list-item-title>
+            <v-list-item-subtitle
+              v-if="excerptHtml"
+              class="pt-1 text-wrap text-body-2 text-color text-break text-truncate-3"
+              v-sanitized-html="excerptHtml">
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    term: {
+      type: String,
+      default: null,
+    },
+    result: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    title() {
+      const name = this.result?.pageTitle || this.result?.pageName || '';
+      const site = this.result?.siteName || '';
+      return site && name && `${name} - ${site}` || name || site;
+    },
+    link() {
+      return this.result?.pagePath || null;
+    },
+    excerptHtml() {
+      return this.result?.excerpts?.length && this.result.excerpts.join('\r\n...') || '';
+    },
+    excerptText() {
+      return this.$utils.htmlToText(this.excerptHtml);
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/search-page/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/search-page/initComponents.js
@@ -1,0 +1,9 @@
+import SearchPageCard from './components/SearchPageCard.vue';
+
+const components = {
+  'page-search-result-card': SearchPageCard,
+};
+
+for (const key in components) {
+  Vue.component(key, components[key]);
+}

--- a/webapp/src/main/webapp/vue-apps/search-page/main.js
+++ b/webapp/src/main/webapp/vue-apps/search-page/main.js
@@ -1,0 +1,15 @@
+import './initComponents.js';
+
+// get overrided components if exists
+if (extensionRegistry) {
+  const components = extensionRegistry.loadComponents('SearchPageCard');
+  if (components && components.length > 0) {
+    components.forEach(cmp => {
+      Vue.component(cmp.componentName, cmp.componentOptions);
+    });
+  }
+}
+
+export function formatSearchResult(result) {
+  return result;
+}

--- a/webapp/webpack.common.js
+++ b/webapp/webpack.common.js
@@ -71,6 +71,7 @@ let config = {
     peopleSearchResultCard: './src/main/webapp/vue-apps/search-people/main.js',
     spaceSearchResultCard: './src/main/webapp/vue-apps/search-space/main.js',
     activitySearchResultCard: './src/main/webapp/vue-apps/search-activity/main.js',
+    pageSearchResultCard: './src/main/webapp/vue-apps/search-page/main.js',
     activityReactions: './src/main/webapp/vue-apps/activity-reactions/main.js',
     activityStream: './src/main/webapp/vue-apps/activity-stream/main.js',
     topBarLogo: './src/main/webapp/vue-apps/top-bar-logo/main.js',


### PR DESCRIPTION
- Query-time search connector on the page_content index, with permission filtering and per-language excerpt selection.
- New "Pages" unified search connector (REST + Vue card).