### PR TITLE
feat: bookmark a page from the unified search results - EXO-88572

### DIFF
--- a/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnector.java
+++ b/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnector.java
@@ -52,6 +52,9 @@ import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.ResourceBundleManager;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.metadata.favorite.FavoriteService;
+import org.exoplatform.social.metadata.favorite.model.Favorite;
 
 import io.meeds.social.search.model.PageSearchResult;
 
@@ -81,6 +84,10 @@ public class PageContentSearchConnector {
 
   private final ResourceBundleManager resourceBundleManager;
 
+  private final FavoriteService      favoriteService;
+
+  private final IdentityManager      identityManager;
+
   private final String               queryFilePath;
 
   private String                     query;
@@ -89,11 +96,15 @@ public class PageContentSearchConnector {
                                     ElasticSearchingClient client,
                                     LayoutService layoutService,
                                     ResourceBundleManager resourceBundleManager,
+                                    FavoriteService favoriteService,
+                                    IdentityManager identityManager,
                                     InitParams initParams) {
     this.configurationManager = configurationManager;
     this.client = client;
     this.layoutService = layoutService;
     this.resourceBundleManager = resourceBundleManager;
+    this.favoriteService = favoriteService;
+    this.identityManager = identityManager;
     ValueParam queryFileParam = initParams.getValueParam("query.file.path");
     this.queryFilePath = queryFileParam.getValue();
     this.query = retrieveQueryFromFile();
@@ -109,6 +120,90 @@ public class PageContentSearchConnector {
                                     .replace(LIMIT_REPLACEMENT, String.valueOf(limit < 1 ? 20 : limit));
     String jsonResponse = client.sendRequest(esQuery, INDEX);
     return buildResults(jsonResponse, locale == null ? Locale.getDefault() : locale);
+  }
+
+  /**
+   * Fetches a single previously-indexed page by its storage id, regardless
+   * of whether any term matches it — used to hydrate a page that a user
+   * already bookmarked for display in their favorites list. Unlike
+   * {@link #search}, there is no query term to highlight against, so the
+   * excerpt is a plain (non-highlighted) snippet of the user's own
+   * language content, falling back to the default content.
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public PageSearchResult getById(String id, Locale locale) {
+    if (StringUtils.isBlank(id)) {
+      throw new IllegalArgumentException("Id is mandatory");
+    }
+    Locale effectiveLocale = locale == null ? Locale.getDefault() : locale;
+    String esQuery = """
+        {
+          "query": {
+            "terms": {"_id": ["%s"]}
+          }
+        }
+        """.formatted(id);
+    String jsonResponse = client.sendRequest(esQuery, INDEX);
+    JSONObject jsonHit = firstHit(jsonResponse);
+    return jsonHit == null ? null : buildFavoriteResult(jsonHit, effectiveLocale);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private JSONObject firstHit(String jsonResponse) {
+    JSONParser parser = new JSONParser();
+    Map json;
+    try {
+      json = (Map) parser.parse(jsonResponse);
+    } catch (ParseException e) {
+      throw new ElasticSearchException("Unable to parse JSON response", e);
+    }
+    JSONObject jsonResult = (JSONObject) json.get("hits");
+    if (jsonResult == null) {
+      return null;
+    }
+    JSONArray jsonHits = (JSONArray) jsonResult.get("hits");
+    return jsonHits == null || jsonHits.isEmpty() ? null : (JSONObject) jsonHits.get(0);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private PageSearchResult buildFavoriteResult(JSONObject jsonHit, Locale locale) {
+    String id = (String) jsonHit.get("_id");
+    JSONObject source = (JSONObject) jsonHit.get("_source");
+    String langField = PageContentIndexingConnector.contentFieldName(locale.toLanguageTag());
+    String content = source == null ? null : (String) source.get(langField);
+    if (StringUtils.isBlank(content)) {
+      content = source == null ? null : (String) source.get("content");
+    }
+    List<String> excerpts = StringUtils.isBlank(content) ? Collections.emptyList()
+                                                          : List.of(StringUtils.abbreviate(content, 150));
+    Object dateValue = source == null ? null : source.get("lastUpdatedDate");
+    String siteType = source == null ? null : (String) source.get("siteType");
+    String siteName = source == null ? null : (String) source.get("siteName");
+    return new PageSearchResult(id,
+                                resolveSiteLabel(siteType, siteName, locale),
+                                source == null ? null : (String) source.get("pageName"),
+                                source == null ? null : (String) source.get("pageTitle"),
+                                source == null ? null : (String) source.get("pagePath"),
+                                source == null ? null : (String) source.get("author"),
+                                dateValue == null ? 0L : ((Number) dateValue).longValue(),
+                                excerpts,
+                                isFavorite(id));
+  }
+
+  private boolean isFavorite(String id) {
+    ConversationState conversationState = ConversationState.getCurrent();
+    if (conversationState == null || conversationState.getIdentity() == null) {
+      return false;
+    }
+    String username = conversationState.getIdentity().getUserId();
+    org.exoplatform.social.core.identity.model.Identity socialIdentity = identityManager.getOrCreateUserIdentity(username);
+    if (socialIdentity == null) {
+      return false;
+    }
+    return favoriteService.isFavorite(new Favorite(PageContentIndexingConnector.TYPE,
+                                                    id,
+                                                    null,
+                                                    Long.parseLong(socialIdentity.getId())));
   }
 
   private String retrieveQuery() {
@@ -232,7 +327,8 @@ public class PageContentSearchConnector {
                                 source == null ? null : (String) source.get("pagePath"),
                                 source == null ? null : (String) source.get("author"),
                                 dateValue == null ? 0L : ((Number) dateValue).longValue(),
-                                excerpts);
+                                excerpts,
+                                isFavorite(id));
   }
 
   /**

--- a/component/core/src/main/java/io/meeds/social/search/model/PageSearchResult.java
+++ b/component/core/src/main/java/io/meeds/social/search/model/PageSearchResult.java
@@ -49,4 +49,6 @@ public class PageSearchResult {
 
   private List<String> excerpts;
 
+  private boolean       favorite;
+
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/plugin/PageFavoriteACLPlugin.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/plugin/PageFavoriteACLPlugin.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.plugin;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.metadata.FavoriteACLPlugin;
+
+public class PageFavoriteACLPlugin extends FavoriteACLPlugin {
+
+  private static final String PAGE_FAVORITE_TYPE     = "page";
+
+  private static final String PAGE_STORAGE_ID_PREFIX  = "page_";
+
+  private final LayoutService layoutService;
+
+  private final UserACL       userACL;
+
+  public PageFavoriteACLPlugin(LayoutService layoutService, UserACL userACL) {
+    this.layoutService = layoutService;
+    this.userACL = userACL;
+  }
+
+  @Override
+  public String getEntityType() {
+    return PAGE_FAVORITE_TYPE;
+  }
+
+  @Override
+  public boolean canCreateFavorite(Identity userIdentity, String objectId) {
+    Page page = layoutService.getPage(parseStorageId(objectId));
+    return page != null && userACL.hasAccessPermission(page, userIdentity);
+  }
+
+  private long parseStorageId(String storageId) {
+    return Long.parseLong(StringUtils.removeStart(storageId, PAGE_STORAGE_ID_PREFIX));
+  }
+
+}

--- a/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnectorTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnectorTest.java
@@ -52,6 +52,9 @@ import org.exoplatform.services.resources.ResourceBundleManager;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.metadata.favorite.FavoriteService;
+import org.exoplatform.social.metadata.favorite.model.Favorite;
 
 import io.meeds.social.search.model.PageSearchResult;
 
@@ -73,6 +76,12 @@ public class PageContentSearchConnectorTest {
   @Mock
   private ResourceBundleManager      resourceBundleManager;
 
+  @Mock
+  private FavoriteService            favoriteService;
+
+  @Mock
+  private IdentityManager            identityManager;
+
   private PageContentSearchConnector connector;
 
   @Before
@@ -83,7 +92,13 @@ public class PageContentSearchConnectorTest {
     queryFileParam.setName("query.file.path");
     queryFileParam.setValue("query.json");
     params.addParameter(queryFileParam);
-    connector = new PageContentSearchConnector(configurationManager, client, layoutService, resourceBundleManager, params);
+    connector = new PageContentSearchConnector(configurationManager,
+                                               client,
+                                               layoutService,
+                                               resourceBundleManager,
+                                               favoriteService,
+                                               identityManager,
+                                               params);
   }
 
   @After
@@ -400,6 +415,108 @@ public class PageContentSearchConnectorTest {
     List<PageSearchResult> results = connector.search("world", 0, 10, Locale.ENGLISH);
 
     assertEquals("unknown", results.get(0).getSiteName());
+  }
+
+  @Test
+  public void shouldMarkResultAsFavoriteWhenAlreadyFavorited() {
+    Identity identity = new Identity("john", Arrays.asList());
+    ConversationState.setCurrent(new ConversationState(identity));
+    org.exoplatform.social.core.identity.model.Identity socialIdentity =
+                                                                        mock(org.exoplatform.social.core.identity.model.Identity.class);
+    when(socialIdentity.getId()).thenReturn("42");
+    when(identityManager.getOrCreateUserIdentity("john")).thenReturn(socialIdentity);
+    when(favoriteService.isFavorite(new Favorite("page", "page_139", null, 42L))).thenReturn(true);
+
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "pageTitle": "test",
+                  "content": "hello world"
+                },
+                "highlight": {
+                  "content": ["hello <span>world</span>"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("world", 0, 10, Locale.ENGLISH);
+
+    assertTrue(results.get(0).isFavorite());
+  }
+
+  @Test
+  public void shouldMarkResultAsNotFavoriteWhenNoCurrentIdentity() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "pageTitle": "test",
+                  "content": "hello world"
+                },
+                "highlight": {
+                  "content": ["hello <span>world</span>"]
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    List<PageSearchResult> results = connector.search("world", 0, 10, Locale.ENGLISH);
+
+    assertTrue(!results.get(0).isFavorite());
+  }
+
+  @Test
+  public void shouldGetByIdWithPlainSnippetInUserLanguage() {
+    String response = """
+        {
+          "hits": {
+            "hits": [
+              {
+                "_id": "page_139",
+                "_source": {
+                  "siteName": "site",
+                  "pageName": "page",
+                  "pageTitle": "My Page",
+                  "pagePath": "/portal/site/page",
+                  "author": "john",
+                  "lastUpdatedDate": 1234567890,
+                  "content": "default content",
+                  "content-fr": "contenu francais"
+                }
+              }
+            ]
+          }
+        }
+        """;
+    when(client.sendRequest(any(), any())).thenReturn(response);
+
+    PageSearchResult result = connector.getById("page_139", Locale.FRENCH);
+
+    assertEquals("page_139", result.getId());
+    assertEquals("My Page", result.getPageTitle());
+    assertEquals(1, result.getExcerpts().size());
+    assertEquals("contenu francais", result.getExcerpts().get(0));
+  }
+
+  @Test
+  public void shouldGetByIdReturnNullWhenNotFound() {
+    when(client.sendRequest(any(), any())).thenReturn(emptyResponse());
+
+    assertEquals(null, connector.getById("page_139", Locale.ENGLISH));
   }
 
   private String emptyResponse() {

--- a/component/core/src/test/java/org/exoplatform/social/core/plugin/PageFavoriteACLPluginTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/plugin/PageFavoriteACLPluginTest.java
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.plugin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.security.Identity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PageFavoriteACLPluginTest {
+
+  private static final String     STORAGE_ID = "page_139";
+
+  @Mock
+  private LayoutService           layoutService;
+
+  @Mock
+  private UserACL                 userACL;
+
+  @InjectMocks
+  private PageFavoriteACLPlugin   plugin;
+
+  private Identity                userIdentity;
+
+  @Before
+  public void setup() {
+    userIdentity = mock(Identity.class);
+  }
+
+  @Test
+  public void shouldExposePageEntityType() {
+    assertEquals("page", plugin.getEntityType());
+  }
+
+  @Test
+  public void shouldReturnFalseWhenPageNotFound() {
+    when(layoutService.getPage(139L)).thenReturn(null);
+
+    assertFalse(plugin.canCreateFavorite(userIdentity, STORAGE_ID));
+  }
+
+  @Test
+  public void shouldReturnTrueWhenUserHasAccessToPage() {
+    Page page = mock(Page.class);
+    when(layoutService.getPage(139L)).thenReturn(page);
+    when(userACL.hasAccessPermission(page, userIdentity)).thenReturn(true);
+
+    assertTrue(plugin.canCreateFavorite(userIdentity, STORAGE_ID));
+  }
+
+  @Test
+  public void shouldReturnFalseWhenUserHasNoAccessToPage() {
+    Page page = mock(Page.class);
+    when(layoutService.getPage(139L)).thenReturn(page);
+    when(userACL.hasAccessPermission(page, userIdentity)).thenReturn(false);
+
+    assertFalse(plugin.canCreateFavorite(userIdentity, STORAGE_ID));
+  }
+
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
@@ -23,6 +23,7 @@ import io.meeds.social.cms.service.PageContentBlockPluginServiceImplTest;
 import io.meeds.social.cms.service.PageUrlResolverServiceImplTest;
 import io.meeds.social.cms.storage.elasticsearch.PageContentIndexingConnectorTest;
 import io.meeds.social.cms.storage.elasticsearch.PageContentSearchConnectorTest;
+import org.exoplatform.social.core.plugin.PageFavoriteACLPluginTest;
 import io.meeds.social.space.invitation.storage.SpaceInvitationLinkLinkStorageTest;
 import io.meeds.social.space.listener.SpaceGroupCacheListenerTest;
 import io.meeds.social.space.listener.SpaceInvitationLinkLinkJoinListenerTest;
@@ -113,7 +114,8 @@ import io.meeds.social.user.plugin.UserAclPluginTest;
     PageUrlResolverServiceImplTest.class,
     PageContentBlockIndexingListenerTest.class,
     PageContentIndexingConnectorTest.class,
-    PageContentSearchConnectorTest.class
+    PageContentSearchConnectorTest.class,
+    PageFavoriteACLPluginTest.class
 })
 public class NoContainerTestSuite {
 

--- a/component/service/src/main/java/io/meeds/social/cms/rest/PageSearchRest.java
+++ b/component/service/src/main/java/io/meeds/social/cms/rest/PageSearchRest.java
@@ -21,11 +21,14 @@ package io.meeds.social.cms.rest;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import io.meeds.social.cms.storage.elasticsearch.PageContentSearchConnector;
 import io.meeds.social.search.model.PageSearchResult;
@@ -61,6 +64,23 @@ public class PageSearchRest {
                                        @RequestParam(name = "limit", required = false, defaultValue = "20")
                                        int limit) {
     return pageContentSearchConnector.search(term, offset, limit, request.getLocale());
+  }
+
+  @GetMapping(value = "{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Retrieves a single indexed page by its storage id", method = "GET")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Not found"),
+  })
+  public PageSearchResult getById(HttpServletRequest request,
+                                  @Parameter(description = "Page storage id")
+                                  @PathVariable(name = "id")
+                                  String id) {
+    PageSearchResult result = pageContentSearchConnector.getById(id, request.getLocale());
+    if (result == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Page not found");
+    }
+    return result;
   }
 
 }

--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -803,12 +803,14 @@ Tag.last.added=Last tags added
 UITopBarFavoritesPortlet.title.recentFavorites=Recent Favorites
 UITopBarFavoritesPortlet.label.activity=Activity
 UITopBarFavoritesPortlet.label.space=Space
+UITopBarFavoritesPortlet.label.page=Page
 UITopBarFavoritesPortlet.label.seeAll=See all
 UITopBarFavoritesPortlet.label.iconTooltip=Check your recent favorites
 UITopBarFavoritesPortlet.types=Types
 UITopBarFavoritesPortlet.types.all=All
 UITopBarFavoritesPortlet.types.space=Spaces
 UITopBarFavoritesPortlet.types.activity=Discussions
+UITopBarFavoritesPortlet.types.page=Pages
 UITopBarFavoritesPortlet.NoFavorites=No favorite yet
 UITopBarFavoritesPortlet.NoTypedFavorites=No {0} marked as favorite yet
 

--- a/webapp/src/main/resources/locale/portlet/Portlets_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_fr.properties
@@ -803,12 +803,14 @@ Tag.last.added=Derniers tags ajoutés
 UITopBarFavoritesPortlet.title.recentFavorites=Favoris récents
 UITopBarFavoritesPortlet.label.activity=Activité
 UITopBarFavoritesPortlet.label.space=Espace
+UITopBarFavoritesPortlet.label.page=Page
 UITopBarFavoritesPortlet.label.seeAll=Voir tout
 UITopBarFavoritesPortlet.label.iconTooltip=Accèdez rapidement à vos favoris
 UITopBarFavoritesPortlet.types=Types
 UITopBarFavoritesPortlet.types.all=Tous
 UITopBarFavoritesPortlet.types.space=Espaces
 UITopBarFavoritesPortlet.types.activity=Discussions
+UITopBarFavoritesPortlet.types.page=Pages
 UITopBarFavoritesPortlet.NoFavorites=Pas encore de favori
 UITopBarFavoritesPortlet.NoTypedFavorites=Aucun {0} n'a encore été marqué comme favori
 

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
@@ -159,6 +159,15 @@
   </external-component-plugins>
 
   <external-component-plugins>
+    <target-component>org.exoplatform.social.metadata.favorite.FavoriteService</target-component>
+    <component-plugin>
+      <name>PageFavoriteACLPlugin</name>
+      <set-method>addFavoriteACLPlugin</set-method>
+      <type>org.exoplatform.social.core.plugin.PageFavoriteACLPlugin</type>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
     <target-component>org.exoplatform.social.attachment.AttachmentService</target-component>
     <component-plugin>
       <name>ActivityAttachmentPlugin</name>

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/search-configuration.xml
@@ -250,6 +250,9 @@
             <field name="spaceFilterEnabled">
               <boolean>true</boolean>
             </field>
+            <field name="favoritesEnabled">
+              <boolean>${search.page.favorites.enabled:true}</boolean>
+            </field>
           </object>
         </object-param>
       </init-params>

--- a/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
+++ b/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
@@ -37,6 +37,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
               v-sanitized-html="excerptHtml">
             </v-list-item-subtitle>
           </v-list-item-content>
+          <v-list-item-action v-if="result && result.id">
+            <favorite-button
+              :id="result.id"
+              :favorite="result.favorite"
+              type="page"
+              @removed="$emit('refresh-favorite')"
+              @added="$emit('refresh-favorite')" />
+          </v-list-item-action>
         </v-list-item>
       </v-list>
     </v-card>

--- a/webapp/src/main/webapp/vue-apps/top-bar-favorites/components/PageFavoriteItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-favorites/components/PageFavoriteItem.vue
@@ -1,0 +1,120 @@
+<!--
+This file is part of the Meeds project (https://meeds.io/).
+Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+-->
+<template>
+  <v-list-item
+    v-if="page"
+    :href="pageUrl"
+    @keydown.enter="setAsViewed"
+    @auxclick="setAsViewed"
+    @click="setAsViewed">
+    <v-list-item-icon class="me-3 my-auto">
+      <v-icon :size="iconSize">
+        fas fa-file-alt
+      </v-icon>
+    </v-list-item-icon>
+
+    <v-list-item-content>
+      <v-list-item-title class="text-truncate">
+        {{ pageTitleText }}
+      </v-list-item-title>
+      <v-list-item-subtitle v-if="expanded && excerpt" class="pt-2px text-truncate-2">
+        {{ excerpt }}
+      </v-list-item-subtitle>
+    </v-list-item-content>
+
+    <v-list-item-action>
+      <favorite-button
+        :id="id"
+        :favorite="isFavorite"
+        type="page"
+        @removed="removed"
+        @remove-error="removeError" />
+    </v-list-item-action>
+  </v-list-item>
+</template>
+<script>
+export default {
+  props: {
+    id: {
+      type: String,
+      default: () => null,
+    },
+    expanded: {
+      type: Boolean,
+      default: false,
+    },
+    clickCallback: {
+      type: Function,
+      default: null,
+    },
+  },
+  data: () => ({
+    page: null,
+    pageUrl: '#',
+    isFavorite: true,
+  }),
+  computed: {
+    iconSize() {
+      return this.expanded ? 34 : 24;
+    },
+    pageTitle() {
+      const name = this.page?.pageTitle || this.page?.pageName || '';
+      const site = this.page?.siteName || '';
+      return site && name && `${name} - ${site}` || name || site;
+    },
+    pageTitleText() {
+      return this.pageTitle || this.$t('UITopBarFavoritesPortlet.label.page');
+    },
+    excerpt() {
+      return this.page?.excerpts?.length && this.page.excerpts[0] || '';
+    },
+  },
+  async created() {
+    try {
+      const resp = await fetch(`/social/rest/pages/${this.id}`, {
+        credentials: 'include',
+      });
+      if (resp?.ok) {
+        this.page = await resp.json();
+        this.pageUrl = this.page?.pagePath || '#';
+      } else {
+        this.$root.$emit('favorite-removed', 'page', this.id);
+      }
+    } catch {
+      this.$root.$emit('favorite-removed', 'page', this.id);
+    }
+  },
+  methods: {
+    removed() {
+      this.isFavorite = !this.isFavorite;
+      this.displayAlert(this.$t('Favorite.tooltip.SuccessfullyDeletedFavorite', {0: this.$t('UITopBarFavoritesPortlet.label.page')}));
+      this.$emit('removed');
+      this.$root.$emit('refresh-favorite-list');
+    },
+    removeError() {
+      this.displayAlert(this.$t('Favorite.tooltip.ErrorDeletingFavorite', {0: this.$t('UITopBarFavoritesPortlet.label.page')}), 'error');
+    },
+    displayAlert(message, type) {
+      this.$root.$emit('alert-message', message, type || 'success');
+    },
+    setAsViewed(event) {
+      if (event.which === 1 || event.which === 2) {
+        this.clickCallback('page', this.id);
+      }
+    },
+  }
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/top-bar-favorites/extensions.js
+++ b/webapp/src/main/webapp/vue-apps/top-bar-favorites/extensions.js
@@ -18,5 +18,16 @@ extensionRegistry.registerExtension('favorite', 'favorite-type', {
 extensionRegistry.registerComponent('favorite-space', 'favorite-drawer-item', {
   id: 'space',
   vueComponent: Vue.options.components['space-favorite-item'],
-}); 
+});
+
+extensionRegistry.registerExtension('favorite', 'favorite-type', {
+  rank: 30,
+  id: 'page',
+  icon: 'fa-file-alt',
+});
+
+extensionRegistry.registerComponent('favorite-page', 'favorite-drawer-item', {
+  id: 'page',
+  vueComponent: Vue.options.components['page-favorite-item'],
+});
 

--- a/webapp/src/main/webapp/vue-apps/top-bar-favorites/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/top-bar-favorites/initComponents.js
@@ -4,6 +4,7 @@ import TopBarFavoritesDrawer from './components/TopBarFavoritesDrawer.vue';
 import TopBarFavoritesButton from './components/TopBarFavoritesButton.vue';
 import ActivityFavoriteItem from './components/ActivityFavoriteItem.vue';
 import SpaceFavoriteItem from './components/SpaceFavoriteItem.vue';
+import PageFavoriteItem from './components/PageFavoriteItem.vue';
 import FavoriteTypes from './components/FavoriteTypes.vue';
 import FavoriteType from './components/FavoriteType.vue';
 import FavoritePlaceholder from './components/FavoritePlaceholder.vue';
@@ -20,6 +21,7 @@ const components = {
   'favorite-placeholder': FavoritePlaceholder,
   'activity-favorite-item': ActivityFavoriteItem,
   'space-favorite-item': SpaceFavoriteItem,
+  'page-favorite-item': PageFavoriteItem,
   'favorite-space-avatar': FavoriteSpaceAvatar,
   'favorite-user-avatar': FavoriteUserAvatar,
 };


### PR DESCRIPTION
- FavoriteButton wired on the "Pages" search result card and a new PageFavoriteItem in the favorites drawer (compact + expanded view), backed by the generic FavoriteService and a new PageFavoriteACLPlugin.
- New GET /social/rest/pages/{id} endpoint to hydrate a favorited page.