### PR TITLE
fix: Search and tag filter fields haven't labels - EXO-88602

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -703,7 +703,8 @@ GroupsManagement.error.invalidField=The "{0}" field must start with a character 
 #####################################################################################
 #                                    Search                                         #
 #####################################################################################
-Search.label.inputPlaceHolder=Search for content...
+Search.label.inputPlaceHolder=Start searching content...
+Search.label.ariaLabel=Search for content
 Search.label.inProgress=Search in progress
 Search.button.tooltip=Search
 Search.button.tooltip.shortcut=(Ctrl + Shift + f)
@@ -794,6 +795,7 @@ Favorite.tooltip.ErrorDeletingFavorite=An error occurred while deleting the {0} 
 Tag.tooltip.startSearch=Start a search based on this tag
 Tag.search.button=Tags
 Tag.search.placeholder=Start typing to search a Tag
+Tag.search.ariaLabel=Filter by tag name
 Tag.last.added=Last tags added
 
 #####################################################################################

--- a/webapp/src/main/webapp/vue-apps/search/components/SearchToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/search/components/SearchToolbar.vue
@@ -5,6 +5,8 @@
       id="searchInput"
       v-model="term"
       :placeholder="searchInputPlaceholder"
+      :aria-label="searchInputAriaLabel"
+      :title="searchInputAriaLabel"
       rounded
       clearable
       clear-icon="fas fa-times fa-1x"
@@ -54,6 +56,9 @@ export default {
   computed: {
     searchInputPlaceholder() {
       return this.$t('Search.label.inputPlaceHolder', {0: eXo.env?.portal?.companyName});
+    },
+    searchInputAriaLabel() {
+      return this.$t('Search.label.ariaLabel');
     }
   },
   watch: {

--- a/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchTagList.vue
+++ b/webapp/src/main/webapp/vue-apps/search/components/searchOptions/SearchTagList.vue
@@ -30,6 +30,8 @@
         v-model="query"
         autofocus
         :placeholder="$t('Tag.search.placeholder')"
+        :aria-label="$t('Tag.search.ariaLabel')"
+        :title="$t('Tag.search.ariaLabel')"
         class="px-4" />
       <div class="pa-3">
         <span v-if="!searching" class="font-weight-bold pl-1">{{ $t('Tag.last.added') }}</span>


### PR DESCRIPTION
Before this change, when access to note application and click on the fiter button, the filter field hasn't a label. After this change, add aria-label/title=`Search for content to the search field` and update its placeholder to `Start searching content...`, and add aria-label/title=`Filter by tag name to the tag filter field`.