### PR TITLE
fix: User directory filter field hasn't a label - EXO-88603

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
@@ -33,6 +33,7 @@ peopleList.title.spacesCount=Spaces
 peopleList.title.usersToInvite=Invite users
 peopleList.label.peopleCount=Showing {0} results
 peopleList.label.filterPeople=Filter by name
+peopleList.label.filterPeople.placeholder=Search for a user
 peopleList.label.filter=Filter
 peopleList.label.filter.all=Everyone
 peopleList.label.filter.connections=My Network

--- a/webapp/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
@@ -24,7 +24,8 @@
     id="peopleListApplication"
     :right-text-filter="{
       minCharacters: 3,
-      placeholder: $t('peopleList.label.filterPeople'),
+      placeholder: $t('peopleList.label.filterPeople.placeholder'),
+      ariaLabel: $t('peopleList.label.filterPeople'),
       tooltip: $t('peopleList.label.filterPeople')
     }"
     :right-filter-button="{


### PR DESCRIPTION
Before this change, when accessing the user directory and clicking the filter button, the filter field had no aria-label/title, making it inaccessible to screen readers. To fix this problem, add aria-label/title=`Filter by name to the filter field` and update its placeholder to `Search for a user`. After this change, the filter field is properly labeled for accessibility.