### PR TITLE
fix: Remove aria-label of disabled actions on scheduled post - EXO-88474

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityCommentAction.vue
@@ -8,7 +8,7 @@
           :disabled="isScheduled"
           :class="[commentTextColorClass, isScheduled && 'opacity-5']"
           class="pa-0 mt-0"
-          :aria-label="commentAriaLabel"
+          :aria-label="isScheduled ? null : (hasCommented ? $t('UIActivity.aria.Comment') : $t('UIActivity.label.Comment'))"
           text
           link
           small
@@ -67,12 +67,6 @@ export default {
     },
     commentTextColorClass() {
       return this.hasCommented && 'primary--text' || '';
-    },
-    commentAriaLabel() {
-      const label = this.hasCommented && this.$t('UIActivity.aria.Comment') || this.$t('UIActivity.label.Comment');
-      // Expose in the accessible label the disabled reason shown by the
-      // tooltip
-      return this.isScheduled && `${label}. ${this.$t('activityStream.scheduledActionsDisabled')}` || label;
     },
   },
   watch: {

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityFavoriteAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityFavoriteAction.vue
@@ -18,7 +18,6 @@
             :template-params="templateParams"
             :type-label="extensionName"
             :disabled="isScheduled"
-            :disabled-label="isScheduled && $t('activityStream.scheduledActionsDisabled') || null"
             @removed="removed"
             @remove-error="removeError"
             @added="added"

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityLikeAction.vue
@@ -10,7 +10,7 @@
           :loading="changingLike"
           :disabled="isScheduled"
           :class="[likeTextColorClass, isScheduled && 'opacity-5']"
-          :aria-label="likeAriaLabel"
+          :aria-label="isScheduled ? null : (hasLiked ? $t('UIActivity.aria.Like') : $t('UIActivity.msg.LikeActivity'))"
           class="pa-0 mt-0"
           text
           link
@@ -71,12 +71,6 @@ export default {
     },
     likeButtonTitle() {
       return this.hasLiked && this.$t('UIActivity.msg.UnlikeActivity') || this.$t('UIActivity.msg.LikeActivity');
-    },
-    likeAriaLabel() {
-      const label = this.hasLiked && this.$t('UIActivity.aria.Like') || this.$t('UIActivity.msg.LikeActivity');
-      // Expose in the accessible label the disabled reason shown by the
-      // tooltip
-      return this.isScheduled && `${label}. ${this.$t('activityStream.scheduledActionsDisabled')}` || label;
     },
     cssClass() {
       return (this.$vuetify.breakpoint.width >= this.$vuetify.breakpoint.thresholds.xl && !this.$root.reducedWidth) ? 'ms-4'

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/actions/ActivityShareAction.vue
@@ -8,7 +8,7 @@
           :id="`ShareActivity${activityId}`"
           :disabled="isScheduled"
           :class="[shareTextColorClass, isScheduled && 'opacity-5']"
-          :aria-label="shareAriaLabel"
+          :aria-label="isScheduled ? null : (hasShared ? $t('UIActivity.aria.Share') : $t('UIActivity.share'))"
           class="pa-0 mt-0"
           text
           link
@@ -81,12 +81,6 @@ export default {
     },
     shareIconColorClass() {
       return this.hasShared && 'primary--text' || 'disabled--text';
-    },
-    shareAriaLabel() {
-      const label = this.hasShared && this.$t('UIActivity.aria.Share') || this.$t('UIActivity.share');
-      // Expose in the accessible label the disabled reason shown by the
-      // tooltip
-      return this.isScheduled && `${label}. ${this.$t('activityStream.scheduledActionsDisabled')}` || label;
     },
   },
   created() {

--- a/webapp/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/FavoriteButton.vue
@@ -8,7 +8,7 @@
           :loading="loading"
           :disabled="loading || disabled"
           :class="disabled && 'opacity-5'"
-          :aria-label="buttonAriaLabel"
+          :aria-label="disabled ? null : favoriteTooltip"
           class="pa-0 mt-0"
           icon
           :small="small"
@@ -114,10 +114,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    disabledLabel: {
-      type: String,
-      default: null,
-    },
   },
   data: () => ({
     isFavorite: false,
@@ -136,14 +132,6 @@ export default {
     },
     favoriteTooltip() {
       return this.isFavorite && this.$t('Favorite.tooltip.DeleteFavorite') || this.$t('Favorite.tooltip.AddAsFavorite');
-    },
-    buttonAriaLabel() {
-      // Expose in the accessible label the disabled reason shown by the
-      // tooltip
-      if (this.disabled && this.disabledLabel) {
-        return `${this.favoriteTooltip}. ${this.disabledLabel}`;
-      }
-      return this.favoriteTooltip;
     },
     favoriteIconColor() {
       return this.isFavorite && 'yellow--text text--darken-2 ma-n2px' || 'icon-default-color';


### PR DESCRIPTION
Remove the aria-label of the like, comment, share and bookmark actions when they are disabled on a scheduled post, instead of enriching it with the disabled reason. The whole actions bar keeps its tooltip and group aria-label announcing that the actions are disabled.
