### PR TITLE
Fix: URL redirection not ok - EXO-88286

### DIFF
--- a/webapp/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/src/main/webapp/js/ExtendedDomPurify.js
@@ -43,7 +43,7 @@
           case 'url' :
             const url = match.getUrl();
             const tag = match.buildTag();
-            tag.setAttr('href', encodeURI(url));
+            tag.setAttr('href', url);
             if (match.getUrl().indexOf('/') === 0 || match.getUrl().indexOf(window.location.origin) === 0) {
               return true;
             } else {


### PR DESCRIPTION
Before this change, when sending a URL in chat or tasks and the link is displayed correctly, then clicking on the link, the URL opened is one that doesn't exist and a 404 page is displayed. To fix this problem, the encodeURI call is removed; the raw URL, already correctly encoded as returned by match.getUrl(), is used, consistent with Utils.js:toLinkUrl, which already works without this additional encoding. After this change, the link opens the correct URL.