### PR TITLE
fix: Space directory filter field hasn't a label - EXO-88604

### DIFF
--- a/webapp/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
@@ -128,28 +128,22 @@
             :max-width="rightTextFilter.maxWidth"
             :class="expandFilter && 'flex-grow-1'"
             flat>
-            <v-tooltip :value="showTextTooltip" bottom>
-              <template #activator="{on}">
-                <v-text-field
-                  id="applicationToolbarFilterInput"
-                  ref="applicationToolbarFilterInput"
-                  v-model="term"
-                  :placeholder="rightTextFilter.placeholder"
-                  :aria-label="rightTextFilter.ariaLabel || rightTextFilter.placeholder"
-                  :title="rightTextFilter.ariaLabel || rightTextFilter.placeholder"
-                  :disabled="rightTextFilter.disabled"
-                  :autofocus="autofocusTextFilter"
-                  :height="isCompact && 24 || 36"
-                  :prepend-inner-icon="term && 'fa-filter primary--text' || 'fa-filter icon-default-color'"
-                  class="flex-grow-1 full-height pa-0 ms-4"
-                  clear-icon="fa-times fa-1x primary--text position-absolute absolute-vertical-center"
-                  autocomplete="off"
-                  hide-details
-                  clearable
-                  v-on="on" />
-              </template>
-              <span>{{ rightTextFilter.tooltip }}</span>
-            </v-tooltip>
+            <v-text-field
+              id="applicationToolbarFilterInput"
+              ref="applicationToolbarFilterInput"
+              v-model="term"
+              :placeholder="rightTextFilter.placeholder"
+              :aria-label="rightTextFilter.ariaLabel || rightTextFilter.placeholder"
+              :title="rightTextFilter.ariaLabel || rightTextFilter.placeholder"
+              :disabled="rightTextFilter.disabled"
+              :autofocus="autofocusTextFilter"
+              :height="isCompact && 24 || 36"
+              :prepend-inner-icon="term && 'fa-filter primary--text' || 'fa-filter icon-default-color'"
+              class="flex-grow-1 full-height pa-0 ms-4"
+              clear-icon="fa-times fa-1x primary--text position-absolute absolute-vertical-center"
+              autocomplete="off"
+              hide-details
+              clearable />
           </v-card>
           <select
             v-if="showSelectBoxFilter"
@@ -271,7 +265,6 @@ export default {
         minCharacters: 3,
         placeholder: 'example',
         ariaLabel: 'Item',
-        tooltip: 'Item',
       }),
     },
     rightSelectBox: { // Select box field attributes
@@ -403,9 +396,6 @@ export default {
       return !this.term?.length
           || !this.rightTextFilter.minCharcters
           || this.term.length >= this.rightTextFilter.minCharcters;
-    },
-    showTextTooltip() {
-      return this.rightTextFilter?.tooltip && !this.isTermValid;
     },
     autofocusTextFilter() {
       return this.showTextFilter && (this.isCompact || this.expandFilter);

--- a/webapp/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
@@ -25,8 +25,7 @@
     :right-text-filter="{
       minCharacters: 3,
       placeholder: $t('peopleList.label.filterPeople.placeholder'),
-      ariaLabel: $t('peopleList.label.filterPeople'),
-      tooltip: $t('peopleList.label.filterPeople')
+      ariaLabel: $t('peopleList.label.filterPeople')
     }"
     :right-filter-button="{
       hide: hideRightFilterButton,

--- a/webapp/src/main/webapp/vue-apps/spaces-list-components/components/toolbar/SpacesToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list-components/components/toolbar/SpacesToolbar.vue
@@ -24,8 +24,7 @@
     :right-text-filter="{
       minCharacters: 3,
       placeholder: $t('spacesList.label.filterSpaces.placeholder'),
-      ariaLabel: $t('spacesList.label.filterSpaces'),
-      tooltip: $t('spacesList.label.filterSpaces')
+      ariaLabel: $t('spacesList.label.filterSpaces')
     }"
     :right-filter-button="displayRightFilter && {
       text: $t('spaceList.advanced.filter.button.title'),


### PR DESCRIPTION
Before this change, the filter field showed a custom Vuetify tooltip in addition to the native title attribute already added for accessibility. To fix this, the custom tooltip has been removed from the shared toolbar component, along with its now-unused configuration. After this change, the filter field relies solely on the native tooltip.