### PR TITLE
fix: the home page isn't displayed - EXO-88361

### DIFF
--- a/webapp/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
+++ b/webapp/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
@@ -50,7 +50,7 @@
 export default {
   computed: {
     defaultLink() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}`;
+      return eXo.env.portal.homeLink || `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}`;
     },
   },
   mounted() {


### PR DESCRIPTION
Before this change, when userA make spaceX notes page as him own home page and USerA user an url that generates page-not-found then userA clicks on Back Home button, /dw page is displayed. To fix this problem, change the default link to home link in the PageNotFound. After this change, the home page is displayed.