### PR TITLE
fix: Add bottom  bar to site vertical menu portlet - EXO-88532 - eXIP7.3.0.9

### DIFF
--- a/webapp/src/main/resources/locale/portal/HamburgerMenu_en.properties
+++ b/webapp/src/main/resources/locale/portal/HamburgerMenu_en.properties
@@ -28,6 +28,7 @@ menu.spaces.joinSpace=Join a space
 menu.spaces.exploreSpaces=Explore Spaces
 menu.spaces.noSpacesFound=No spaces found
 menu.productName.seeProduct=See More
+menu.goBackToMainPortal=Go back to main portal
 menu.settings=Access User Settings
 menu.logout=Log out
 menu.spaces.openSpaceAdvancedActions=See other options

--- a/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuApp.vue
+++ b/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuApp.vue
@@ -20,8 +20,10 @@
       <v-card
         min-height="var(--100vh, 100vh)"
         color="transparent"
+        class="d-flex flex-column"
         flat>
-        <vertical-menu-content :extra-class="extraClass" />
+        <vertical-menu-content :extra-class="extraClass" class="flex-grow-1 flex-shrink-1" />
+        <vertical-menu-bottom-bar class="flex-grow-0 flex-shrink-0" />
         <template v-if="$root.isMobile">
           <vertical-menu-button />
           <vertical-menu-drawer />

--- a/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuBottomBar.vue
+++ b/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuBottomBar.vue
@@ -1,0 +1,73 @@
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2026 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <v-card
+    class="d-flex verticalMenuBottomBar border-box-sizing"
+    height="48"
+    flat>
+    <v-list-item class="my-auto" dense>
+      <v-list-item-action class="me-auto font-weight-bold">
+        <v-tooltip top>
+          <template #activator="{ on, attrs }">
+            <a
+              :href="productLink"
+              :aria-label="$t('menu.productName.seeProduct')"
+              target="_blank"
+              class="text-body font-weight-bold my-auto"
+              v-bind="attrs"
+              v-on="on">
+              {{ productName }}
+            </a>
+          </template>
+          <span>
+            {{ $t('menu.productName.seeProduct') }}
+          </span>
+        </v-tooltip>
+      </v-list-item-action>
+      <v-spacer />
+      <v-list-item-action class="my-auto">
+        <v-tooltip top>
+          <template #activator="{ on, attrs }">
+            <v-btn
+              v-bind="attrs"
+              v-on="on"
+              :href="mainPortalLink"
+              :title="$t('menu.goBackToMainPortal')"
+              :aria-label="$t('menu.goBackToMainPortal')"
+              class="goBackToMainPortalLink me-n2 my-auto"
+              target="_blank"
+              icon>
+              <v-icon size="20">fa-home</v-icon>
+            </v-btn>
+          </template>
+          <span>
+            {{ $t('menu.goBackToMainPortal') }}
+          </span>
+        </v-tooltip>
+      </v-list-item-action>
+    </v-list-item>
+  </v-card>
+</template>
+<script>
+export default {
+  data: () => ({
+    productName: eXo.env.portal.productName,
+    productLink: eXo.env.portal.productLink,
+    mainPortalLink: eXo.env.portal.context,
+  }),
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/vertical-menu/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/vertical-menu/initComponents.js
@@ -21,12 +21,14 @@ import VerticalMenuApp from './components/VerticalMenuApp.vue';
 import VerticalMenuDrawer from './components/VerticalMenuDrawer.vue';
 import VerticalMenuContent from './components/VerticalMenuContent.vue';
 import VerticalMenuButton from './components/VerticalMenuButton.vue';
+import VerticalMenuBottomBar from './components/VerticalMenuBottomBar.vue';
 
 const components = {
   'vertical-menu-app': VerticalMenuApp,
   'vertical-menu-content': VerticalMenuContent,
   'vertical-menu-button': VerticalMenuButton,
   'vertical-menu-drawer': VerticalMenuDrawer,
+  'vertical-menu-bottom-bar': VerticalMenuBottomBar,
 };
 
 for (const key in components) {

--- a/webapp/src/main/webapp/vue-apps/vertical-menu/main.js
+++ b/webapp/src/main/webapp/vue-apps/vertical-menu/main.js
@@ -32,16 +32,21 @@ if (extensionRegistry) {
 Vue.use(Vuetify);
 const appId = 'verticalMenu';
 
+const lang = eXo?.env?.portal?.language || 'en';
+const i18nUrl = `/social/i18n/locale.portal.HamburgerMenu?lang=${lang}`;
 
 export function init() {
-  Vue.createApp({
-    template: `<vertical-menu-app id="${appId}"/>`,
-    vuetify: Vue.prototype.vuetifyOptions,
-    computed: {
-      isMobile() {
-        return this.$vuetify.breakpoint.smAndDown;
-      },
-    },
-    i18n: exoi18n.i18n},
-  `#${appId}`, 'Vertical menu application');
+  exoi18n.loadLanguageAsync(lang, i18nUrl)
+    .then(i18n => {
+      Vue.createApp({
+        template: `<vertical-menu-app id="${appId}"/>`,
+        vuetify: Vue.prototype.vuetifyOptions,
+        computed: {
+          isMobile() {
+            return this.$vuetify.breakpoint.smAndDown;
+          },
+        },
+        i18n},
+      `#${appId}`, 'Vertical menu application');
+    });
 }


### PR DESCRIPTION
This change adds a bottom bar at the bottom of the Site Vertical Menu portlet, following the burger menu pattern.
It shows the clickable package name and a home icon that opens the main portal (/portal) in a new tab, with a "Go back to main portal" tooltip and title.