### PR TITLE
fix: Add bottom  bar to site vertical menu portlet - EXO-88532 - eXIP7.3.0.9

### DIFF
--- a/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuBottomBar.vue
+++ b/webapp/src/main/webapp/vue-apps/vertical-menu/components/VerticalMenuBottomBar.vue
@@ -46,7 +46,6 @@
               v-bind="attrs"
               v-on="on"
               :href="mainPortalLink"
-              :title="$t('menu.goBackToMainPortal')"
               :aria-label="$t('menu.goBackToMainPortal')"
               class="goBackToMainPortalLink me-n2 my-auto"
               target="_blank"


### PR DESCRIPTION
This change will remove the title attribute from the home icon of the vertical bottom bar.