### PR TITLE
Revert "Fix: Duplicate link declarations on avatar and text for requests to review in the spaces directory - EXO-87925"

### DIFF
--- a/webapp/src/main/webapp/vue-apps/spaces-list-components/components/space-card/menu/SpaceRoleListItem.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list-components/components/space-card/menu/SpaceRoleListItem.vue
@@ -29,7 +29,6 @@
     <exo-user-avatar
       :identity="user"
       :size="30"
-      :url="false"
       extra-class="text-truncate ms-n6 mt-6"
       avatar />
     <v-list-item-content class="py-0 accountTitleLabel text-truncate">


### PR DESCRIPTION
## What
Reverts #5885 (EXO-87925), which removed the avatar's own link (`:url="false"` on `exo-user-avatar` in `SpaceRoleListItem.vue`), leaving only the name as the clickable link to the profile.

Requested by Malek Ben Salem to be reverted.

This reverts commit 0ae7aeb6e370d013c390dbc98aba3a30b4219b7c.