### PR TITLE
fix: User directory filter field hasn't a label - EXO-88603

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/PeopleListApplication_en.properties
@@ -33,6 +33,7 @@ peopleList.title.spacesCount=Spaces
 peopleList.title.usersToInvite=Invite users
 peopleList.label.peopleCount=Showing {0} results
 peopleList.label.filterPeople=Filter by name
+peopleList.label.filterPeople.placeholder=Search for a user
 peopleList.label.filter=Filter
 peopleList.label.filter.all=Everyone
 peopleList.label.filter.connections=My Network

--- a/webapp/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/PeopleToolbar.vue
@@ -24,7 +24,8 @@
     id="peopleListApplication"
     :right-text-filter="{
       minCharacters: 3,
-      placeholder: $t('peopleList.label.filterPeople'),
+      placeholder: $t('peopleList.label.filterPeople.placeholder'),
+      ariaLabel: $t('peopleList.label.filterPeople'),
       tooltip: $t('peopleList.label.filterPeople')
     }"
     :right-filter-button="{


### PR DESCRIPTION
## What
Backport to `develop` of EXO-88603 (#5903), originally merged into `feature/maintenance`: adds aria-label/title and updates the placeholder on the user directory filter field.

## Verification
Cherry-picked cleanly with no conflicts; commit references its origin via `-x`. See #5903 for original manual verification.