### PR TITLE
Fix: URL redirection not ok - EXO-88286

### DIFF
--- a/webapp/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/src/main/webapp/js/ExtendedDomPurify.js
@@ -43,7 +43,7 @@
           case 'url' :
             const url = match.getUrl();
             const tag = match.buildTag();
-            tag.setAttr('href', encodeURI(url));
+            tag.setAttr('href', url);
             if (match.getUrl().indexOf('/') === 0 || match.getUrl().indexOf(window.location.origin) === 0) {
               return true;
             } else {


### PR DESCRIPTION
## What
Backport to `develop` of EXO-88286 (#5908), originally merged into `feature/maintenance`: removes a redundant `encodeURI` call so links in chat/tasks resolve to the correct URL instead of a 404.

Note: the cherry-picked commit's own message is mislabeled ("Space directory filter field doesn't have a label") — its actual diff (`ExtendedDomPurify.js`) matches the PR's real title/description, unrelated to the toolbar accessibility fixes.

## Verification
Cherry-picked cleanly with no conflicts; commit references its origin via `-x`. See #5908 for original manual verification.