### PR TITLE
fix: Remove unecessary button from categories and topbar menu - EXO-88911

### DIFF
--- a/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryChip.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryChip.vue
@@ -59,15 +59,18 @@
           flat>
           {{ category.name }}
         </v-card>
-        <v-icon
+        <span
           v-if="category.categories?.length"
-          :color="selected && 'white' || 'primary'"
-          class="ms-2"
-          size="16"
-          right
-          @click.stop.prevent="menu = true">
-          fa-chevron-down
-        </v-icon>
+          class="d-flex align-center"
+          aria-hidden="true">
+          <v-icon
+            :color="selected && 'white' || 'primary'"
+            class="ms-3 mr-0"
+            size="16"
+            right>
+            fa-chevron-down
+          </v-icon>
+        </span>
       </v-chip>
     </template>
     <v-list class="pa-0" dense>

--- a/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryTab.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryTab.vue
@@ -47,13 +47,14 @@
           flat>
           {{ category.name }}
         </v-card>
-        <v-icon
-          class="ms-2"
-          size="16"
-          right
-          @click.stop.prevent="menu = true">
-          fa-chevron-down
-        </v-icon>
+        <span class="d-flex align-center" aria-hidden="true">
+          <v-icon
+            class="ms-3 mr-0"
+            size="16"
+            right>
+            fa-chevron-down
+          </v-icon>
+        </span>
       </v-tab>
     </template>
     <v-list class="pa-0" dense>

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -55,15 +55,14 @@
           class="mx-1">
           fa-external-link-alt
         </v-icon>
-        <v-btn
+        <span
           v-if="hasChildren && childrenHasPage"
-          icon
-          @click.stop.prevent="openDropMenu"
-          @mouseover="showMenu = true">
-          <v-icon size="20">
+          class="d-flex align-center"
+          aria-hidden="true">
+          <v-icon class="ms-3" size="20">
             fa-angle-down
           </v-icon>
-        </v-btn>
+        </span>
       </v-tab>
     </template>
     <navigation-menu-sub-item

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -43,9 +43,8 @@
         absolute
         eager
         offset-x>
-        <template #activator="{ attrs, on }">
+        <template #activator="{ on }">
           <div
-            v-bind="attrs"
             class="d-flex width-full px-4"
             v-on="on"
             @mouseleave="showMenu = false">
@@ -62,15 +61,12 @@
             </v-list-item-title>
             <v-list-item-icon
               v-if="hasChildren && childrenHasPage"
-              class="ms-0 me-n2 ma-auto full-height">
-              <v-btn
-                icon
-                @click.stop.prevent="showMenu = !showMenu">
-                <v-icon
-                  size="18">
+              class="ms-0 ma-auto full-height">
+              <span class="d-flex align-center" aria-hidden="true">
+                <v-icon size="18">
                   {{ $vuetify.rtl && 'fa-angle-left' || 'fa-angle-right' }}
                 </v-icon>
-              </v-btn>
+              </span>
             </v-list-item-icon>
           </div>
         </template>
@@ -180,6 +176,8 @@ export default {
         } else {
           window.location.href = this.navigationNodeUri;
         }
+      } else if (this.hasChildren && this.childrenHasPage) {
+        this.showMenu = !this.showMenu;
       }
     },
     updateNavigationState(value) {

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/mobile/NavigationMobileMenuItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/mobile/NavigationMobileMenuItem.vue
@@ -24,7 +24,7 @@
     v-model="showMenu"
     rounded
     offset-y>
-    <template #activator="{ attrs, on }">
+    <template #activator="{ attrs }">
       <v-tab
         class="mx-auto pa-1 text-break navigation-mobile-menu-tab"
         v-bind="attrs"
@@ -41,22 +41,14 @@
           class="text-truncate-2 pt-2">
           {{ navigation.label }}
         </span>
-        <v-btn
-          v-if="hasPage && hasChildren"
-          v-on="hasChildren && on"
-          class="mt-2"
-          icon
-          @click.stop.prevent="openDropMenu">
-          <v-icon size="20">
+        <span
+          v-if="hasChildren"
+          class="d-flex align-center"
+          aria-hidden="true">
+          <v-icon class="pa-3 mt-2" size="20">
             fa-angle-up
           </v-icon>
-        </v-btn>
-        <v-icon
-          class="pa-3 mt-2"
-          v-else-if="hasChildren"
-          size="20">
-          fa-angle-up
-        </v-icon>
+        </span>
       </v-tab>
     </template>
     <navigation-mobile-menu-sub-item


### PR DESCRIPTION
Prior to this change, the chevron in the top-bar menu items and in the category tabs/chips was a clickable `v-btn`/`v-icon`, which Vuetify renders as a `<button>` nested inside the parent tab/chip — invalid HTML and an accessibility issue (duplicate tab stop, unnamed control).
This change will render the chevron as a non-interactive `<span aria-hidden="true">` wrapping the icon, the submenu being opened by the single remaining interactive element (hover or click on the item itself).