### PR TITLE
fix: the home page isn't displayed - EXO-88361

### DIFF
--- a/webapp/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
+++ b/webapp/src/main/webapp/vue-apps/page-not-found/components/PageNotFound.vue
@@ -50,7 +50,7 @@
 export default {
   computed: {
     defaultLink() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}`;
+      return eXo.env.portal.homeLink || `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}`;
     },
   },
   mounted() {


### PR DESCRIPTION
Backport of #5911 to stable/7.2.x-exo.

Before this change, when a user set spaceX's notes page as their own home page and visited a URL that generates a page-not-found, clicking the Back Home button led to /dw instead of their configured home page. Fixed by changing the default link in PageNotFound to the home link.