### PR TITLE
Fix: URL redirection not ok - EXO-88286

### DIFF
--- a/webapp/src/main/webapp/js/ExtendedDomPurify.js
+++ b/webapp/src/main/webapp/js/ExtendedDomPurify.js
@@ -53,7 +53,7 @@
           case 'url' :
             const url = match.getUrl();
             const tag = match.buildTag();
-            tag.setAttr('href', encodeURI(url));
+            tag.setAttr('href', url);
             if (match.getUrl().indexOf('/') === 0 || match.getUrl().indexOf(window.location.origin) === 0) {
               return true;
             } else {


### PR DESCRIPTION
Backport of #5924 to stable/7.2.x-exo.

Before this change, sending a URL in chat or tasks displayed the link correctly, but clicking it opened a URL that doesn't exist, showing a 404 page. The redundant `encodeURI` call is removed; the raw URL, already correctly encoded as returned by `match.getUrl()`, is used — consistent with `Utils.js:toLinkUrl`, which already works without this additional encoding.