### PR TITLE
fix: Space directory filter field hasn't a label - EXO-88604

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/SpacesListApplication_en.properties
@@ -10,6 +10,7 @@ spacesList.label.members={0} Members
 spacesList.label.oneMember=1 Member
 spacesList.label.SpaceMembers=Members
 spacesList.label.filterSpaces=Filter by name or description
+spacesList.label.filterSpaces.placeholder=Search for a space
 spacesList.label.filterSpacesByName=Filter by name
 spacesList.label.spacesSize={0} spaces listed
 spacesList.label.ok=OK

--- a/webapp/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
@@ -135,6 +135,8 @@
                   ref="applicationToolbarFilterInput"
                   v-model="term"
                   :placeholder="rightTextFilter.placeholder"
+                  :aria-label="rightTextFilter.ariaLabel || rightTextFilter.placeholder"
+                  :title="rightTextFilter.ariaLabel || rightTextFilter.placeholder"
                   :disabled="rightTextFilter.disabled"
                   :autofocus="autofocusTextFilter"
                   :height="isCompact && 24 || 36"
@@ -268,6 +270,7 @@ export default {
         maxWidth: 'unset',
         minCharacters: 3,
         placeholder: 'example',
+        ariaLabel: 'Item',
         tooltip: 'Item',
       }),
     },

--- a/webapp/src/main/webapp/vue-apps/spaces-list-components/components/toolbar/SpacesToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-list-components/components/toolbar/SpacesToolbar.vue
@@ -23,7 +23,8 @@
     id="spacesListToolbar"
     :right-text-filter="{
       minCharacters: 3,
-      placeholder: $t('spacesList.label.filterSpaces'),
+      placeholder: $t('spacesList.label.filterSpaces.placeholder'),
+      ariaLabel: $t('spacesList.label.filterSpaces'),
       tooltip: $t('spacesList.label.filterSpaces')
     }"
     :right-filter-button="displayRightFilter && {


### PR DESCRIPTION
Backport of #5921 to stable/7.2.x-exo.

Before this change, accessing the space directory and clicking the filter button showed a filter field with no aria-label/title, making it inaccessible to screen readers. Adds aria-label/title=`Filter by name or description` and updates the placeholder to `Search for a space`.

Note: the follow-up PR #5910 (also EXO-88604, removing a redundant custom tooltip on the shared toolbar) is deliberately not included here — same as on develop, that follow-up isn't needed as a separate backport since #5922 (EXO-88603, PR #5939 here) already brings the compatible `ApplicationToolbar.vue`/`PeopleToolbar.vue` state to this branch.