### PR TITLE
fix: Feed actions align to left instead of aligned to right - EXO-88876

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/ActivityActions.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/footer/ActivityActions.vue
@@ -1,13 +1,15 @@
 <template>
-  <extension-registry-components
-    :params="params"
-    :class="actionBarBorderClass"
-    class="d-flex flex-no-wrap py-2 activity-footer-actions"
-    name="ActivityFooter"
-    type="activity-footer-action"
-    parent-element="div"
-    element="div"
-    :element-class="elementClass" />
+  <div :class="actionsAlignmentClass">
+    <extension-registry-components
+      :params="params"
+      :class="actionBarBorderClass"
+      class="d-flex flex-no-wrap py-2 activity-footer-actions"
+      name="ActivityFooter"
+      type="activity-footer-action"
+      parent-element="div"
+      element="div"
+      :element-class="elementClass" />
+  </div>
 </template>
 <script>
 export default {
@@ -35,7 +37,10 @@ export default {
       };
     },
     actionBarBorderClass() {
-      return (!this.isDesktop || this.$root.reducedWidth) && 'border-top-color border-light-color' || ' ms-auto';
+      return (!this.isDesktop || this.$root.reducedWidth) && 'border-top-color border-light-color' || '';
+    },
+    actionsAlignmentClass() {
+      return (this.isDesktop && !this.$root.reducedWidth) && 'ms-auto' || '';
     },
     isDesktop() {
       return this.$vuetify.breakpoint.width >= this.$vuetify.breakpoint.thresholds.lg;


### PR DESCRIPTION
Backport of #5925 to stable/7.2.x-exo.

Fix feed actions align to left instead of aligned to right.

Note: the original diff's template touches a `v-tooltip`/`isScheduled` wrapper that doesn't exist yet on stable/7.2.x-exo (a later, unrelated develop feature). Adapted the fix to this branch's simpler template — moving the `ms-auto` alignment out of `actionBarBorderClass` into a new `actionsAlignmentClass` applied to a wrapping `div` around the existing `extension-registry-components`, same as the original fix's intent. The `<script>` computed changes applied identically to upstream.