### PR TITLE
fix: load external extensions to document preview - EXO-88985

### DIFF
--- a/webapp/src/main/webapp/vue-apps/attachments-preview/main.js
+++ b/webapp/src/main/webapp/vue-apps/attachments-preview/main.js
@@ -50,4 +50,5 @@ export function init(event) {
   } else {
     document.dispatchEvent(new CustomEvent('open-preview-dialog', event));
   }
+  Vue.prototype.$utils.includeExtensions('Preview');
 }


### PR DESCRIPTION
The fix loads the extensions of the document preview that could add custom preview for documents from the external modules when the application is initialized