### PR TITLE
fix: Update post categories dynamically after edition - EXO-89001

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/list/ActivityStreamList.vue
@@ -323,11 +323,18 @@ export default {
     refreshActivitiesByCategories(event) {
       const objectType = event?.detail?.objectType;
       const objectId = event?.detail?.objectId;
-      if (objectType === 'activity'
-          && this.activitiesToDisplay.find(a => a.id === objectId)
-          && this.$root.allowFilteringPerCategory
+      if (objectType !== 'activity'
+          || !this.activitiesToDisplay.find(activity => Number(activity.id) === Number(objectId))) {
+        return;
+      }
+      if (this.$root.allowFilteringPerCategory
           && (this.selectedCategoryIds?.length || this.$root.settingsSubcategoryIds?.length)) {
+        // The activity may not match the applied categories filtering anymore
         this.loadActivityIds();
+      } else {
+        // Refresh the categories displayed in the activity, since the stream
+        // isn't filtered per categories and thus isn't reloaded
+        this.updateActivityDisplayById(objectId);
       }
     },
     refreshActivities() {


### PR DESCRIPTION
Editing the categories of a post displayed in a stream that isn't filtered per categories, like the scheduled posts filter, didn't update the displayed categories until the page was refreshed, since the stream was only reloaded when a categories filtering was applied. 
The categories of the edited post are now refreshed in place in that case, reusing the existing activity refresh.
