### PR TITLE
feat: bookmark a page from the unified search results - EXO-88572

### DIFF
--- a/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
+++ b/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
@@ -37,7 +37,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
               v-sanitized-html="excerptHtml">
             </v-list-item-subtitle>
           </v-list-item-content>
-          <v-list-item-action v-if="result && result.id">
+          <v-list-item-action v-if="result && result.id" v-show="hover || isMobile">
             <favorite-button
               :id="result.id"
               :favorite="result.favorite"
@@ -63,6 +63,9 @@ export default {
     },
   },
   computed: {
+    isMobile() {
+      return this.$vuetify.breakpoint.mobile;
+    },
     title() {
       const name = this.result?.pageTitle || this.result?.pageName || '';
       const site = this.result?.siteName || '';


### PR DESCRIPTION
- FavoriteButton wired on the "Pages" search result card and a new PageFavoriteItem in the favorites drawer (compact + expanded view), backed by the generic FavoriteService and a new PageFavoriteACLPlugin.
- New GET /social/rest/pages/{id} endpoint to hydrate a favorited page.