### PR TITLE
fix: cap notification badge display at 99+ - EXO-88997

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotification.vue
@@ -29,7 +29,7 @@
           @click="openDrawer">
           <v-badge
             :value="badge > 0"
-            :content="badge"
+            :content="badgeContent"
             flat
             color="var(--allPagesBadgePrimaryColor, #d32a2a)"
             overlap>
@@ -55,6 +55,9 @@ export default {
   computed: {
     tooltip() {
       return `${this.$t('UIIntranetNotificationsPortlet.title.notifications')} ${this.$t('UIIntranetNotificationsPortlet.title.notifications.shortcut')}`;
+    },
+    badgeContent() {
+      return this.badge > 99 && '99+' || this.badge;
     },
   },
   watch: {


### PR DESCRIPTION
Mirrors the existing 99+ cap already used for per-type unread counts so the topbar bell badge renders consistently with large counts, instead of showing the raw number.