### PR TITLE
feat: Share the requested scheduling with typed contents addons - EXO-89002

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/toolbar/ActivityComposerDrawer.vue
@@ -605,11 +605,16 @@ export default {
           activityType = 'LINK_ACTIVITY';
         }
         if (this.activityType && this.activityType.length !== 0) {
+          const detail = this.pendingScheduledTime && {
+            message,
+            publicationStartTime: this.pendingScheduledTime,
+          } || message;
           if (this.activityToolbarAction) {
-            document.dispatchEvent(new CustomEvent('post-activity-toolbar-action', {detail: message}));
+            document.dispatchEvent(new CustomEvent('post-activity-toolbar-action', {detail}));
           } else {
-            document.dispatchEvent(new CustomEvent('post-activity', {detail: message}));
+            document.dispatchEvent(new CustomEvent('post-activity', {detail}));
           }
+          this.pendingScheduledTime = null;
         } else {
           if (!this.spaceId && !!eXo.env.portal.spaceId) {
             this.spaceId = eXo.env.portal.spaceId;


### PR DESCRIPTION
The activity of a typed content, like a poll, is created by its own addon through the post activity events, so the composer scheduling was ignored for those contents. 
The requested publication start time is now shared with the addons in the event detail, which stays the message itself when no scheduling is requested, keeping the payload unchanged for addons that don't handle it.
