### PR TITLE
feat: index pages carrying a registered content block for search - EXO-88570

### DIFF
--- a/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
+++ b/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
@@ -79,7 +79,7 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
           "siteName" : {"type" : "keyword"},
           "siteType" : {"type" : "keyword"},
           "pageName" : {"type" : "keyword"},
-          "pageTitle" : {"type" : "keyword"},
+          "pageTitle" : {"type" : "text"},
           "pagePath" : {"type" : "keyword"},
           "author" : {"type" : "keyword"},
           "permissions" : {"type" : "keyword"},


### PR DESCRIPTION
Adds a generic extension-point architecture in Social so that indexing a page's bound content block doesn't depend on any specific addon (e.g. Notes' Single Note View):

- PageContentBlockPlugin/PageContentBlockPluginService: pluggable content extraction per CMSSetting content type.
- PageUrlResolver/PageUrlResolverService: pluggable page-path resolution, since Social can't depend on Layout's routing/webui primitives (dependency-inversion, mirrors ContentLinkPlugin).
- PageContentIndexingConnector: generic ElasticSearch connector indexing siteName/siteType/pageName/pageTitle/pagePath/author/date and per-language content, excluding draft pages/sites.
- PageContentBlockIndexingListener: keeps the index in sync with Layout's page update/permission events.

Both registries use push-based self-registration (addPlugin), not an eager bean scan, so registration doesn't depend on webapp deployment order across addons.