### PR TITLE
fix: UI/UX issues on notifications multi-selection - EXO-88842

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationMenu.vue
@@ -50,7 +50,7 @@
           dense
           @click="$emit('select')">
           <v-list-item-icon class="mx-1 justify-center">
-            <v-icon size="14" class="icon-default-color">fa-check-double</v-icon>
+            <v-icon size="14" class="icon-default-color">fa-mouse-pointer</v-icon>
           </v-list-item-icon>
           <v-list-item-title class="pl-0">{{ $t('Notification.select') }}</v-list-item-title>
         </v-list-item>

--- a/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
@@ -45,6 +45,7 @@
         </v-card>
       </div>
       <div
+        v-if="!selectMode"
         :class="$vuetify.rtl && 'l-0' || 'r-0'"
         class="position-absolute t-0 pt-2px me-2 d-none z-index-two d-sm-block"
         @click.stop="0">
@@ -87,7 +88,7 @@
           @contextmenu="showContextMenu">
           <v-checkbox
             v-if="selectMode"
-            class="flex-grow-0 flex-shrink-0 ms-0 me-2 mt-0 pt-0 align-self-center"
+            class="flex-grow-0 flex-shrink-0 ms-2 me-2 mt-0 pt-0 align-self-center"
             color="primary"
             background-color="transparent"
             hide-details
@@ -114,7 +115,9 @@
                 alt="">
             </v-avatar>
           </v-list-item-avatar>
-          <v-list-item-content class="py-0 pe-5 text-color">
+          <v-list-item-content
+            :class="!selectMode && 'pe-5'"
+            class="py-0 text-color">
             <v-list-item-title
               v-sanitized-html="message"
               class="text-wrap text-truncate-2" />
@@ -297,6 +300,9 @@ export default {
     },
     showContextMenu(event) {
       event.preventDefault();
+      if (this.selectMode) {
+        return;
+      }
       this.$refs.menu.showMenu(event.clientX, event.clientY);
     },
     markAsReadMouseDown(event) {

--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -26,7 +26,7 @@
     body-classes="hide-scroll"
     allow-expand
     right
-    @closed="$emit('closed')"
+    @closed="onClosed"
     @expand-updated="expanded = $event">
     <template slot="title">
       <div v-if="selectMode" class="d-flex align-center">
@@ -247,7 +247,15 @@ export default {
       this.cancelSelect();
       this.$refs.drawer.close();
     },
+    onClosed() {
+      this.cancelSelect();
+      this.$emit('closed');
+    },
     cancelSelect() {
+      // Reset the root state directly: the drawer is destroyed on close, so the
+      // listener of 'notification-cancel-select' may not be mounted yet on reopen
+      this.$root.selectMode = false;
+      this.$root.selectedNotificationIds = [];
       this.$root.$emit('notification-cancel-select');
     },
     markSelectedAsRead() {


### PR DESCRIPTION
Prior to this change, the multi-selection introduced in the notifications
drawer had four UI/UX issues:

- The checkbox of each notification was not aligned with the "Select all"
  one.
- The "Select" action did not use the same icon as the Mail application.
- Closing the drawer kept the selection mode active, so reopening it
  restored the previously selected notifications.
- The three dots menu stayed available on every notification while
  selecting, suggesting that bulk actions could be triggered from it.

This change:

- Adds `ms-2` to the notification checkbox. It started 8px from the left
  edge, which is the padding of the `v-list-item`, while the "Select all"
  checkbox starts at 16px (`ps-4`).
- Replaces `fa-check-double` by `fa-mouse-pointer` on the "Select" menu
  entry, consistent with the Mail application.
- Resets the selection when the drawer is closed. The drawer is destroyed
  on close but `selectMode` and `selectedNotificationIds` are held by the
  application root, so the state survived it. `close()` already reset the
  selection but is only reached through `openSettings()`: closing with the
  cross, the overlay or Escape goes through the `closed` event of
  `exo-drawer`, which only bubbled up. The reset is now done directly on
  the root rather than through the `notification-cancel-select` event,
  whose only listener lives in `UserNotifications` and is not mounted yet
  when the drawer reopens.
- Hides the three dots menu while selecting and drops the `pe-5` padding
  that only existed to reserve room for it, so the notification content
  takes the whole available width. `showContextMenu()` is guarded as well,
  as it would have dereferenced a missing `$refs.menu` on right click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
