### PR TITLE
fix: shared widget header background now applies only to the text - EXO-88493

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/Widget.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/Widget.vue
@@ -28,12 +28,12 @@
     <div
       :class="!noMargin && 'pa-5'"
       class="d-flex flex-column flex-grow-1">
-      <div 
+      <div
         v-if="hasHeader"
         :class="headerPadding"
-        class="d-flex align-center widget-text-header">
+        class="d-flex align-center">
         <slot v-if="$slots.title" name="title"></slot>
-        <div v-else-if="title" class="text-truncate">{{ title }}</div> 
+        <div v-else-if="title" class="widget-text-header text-truncate">{{ title }}</div>
         <v-spacer />
         <slot v-if="$slots.action" name="action"></slot>
         <v-btn 


### PR DESCRIPTION
widget-text-header was on the row container instead of the inner title div, stretching the Text Background across the whole row. Affects every widget using this shared wrapper: Space Description, Space Admins/Managers, Space Members, Your Work Experiences.