### PR TITLE
fix: UI/UX issues on notifications multi-selection - EXO-88842 (#5953)

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationMenu.vue
@@ -50,7 +50,7 @@
           dense
           @click="$emit('select')">
           <v-list-item-icon class="mx-1 justify-center">
-            <v-icon size="14" class="icon-default-color">fa-check-double</v-icon>
+            <v-icon size="14" class="icon-default-color">fa-mouse-pointer</v-icon>
           </v-list-item-icon>
           <v-list-item-title class="pl-0">{{ $t('Notification.select') }}</v-list-item-title>
         </v-list-item>

--- a/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/components/UserNotificationTemplate.vue
@@ -45,6 +45,7 @@
         </v-card>
       </div>
       <div
+        v-if="!selectMode"
         :class="$vuetify.rtl && 'l-0' || 'r-0'"
         class="position-absolute t-0 pt-2px me-2 d-none z-index-two d-sm-block"
         @click.stop="0">
@@ -87,7 +88,7 @@
           @contextmenu="showContextMenu">
           <v-checkbox
             v-if="selectMode"
-            class="flex-grow-0 flex-shrink-0 ms-0 me-2 mt-0 pt-0 align-self-center"
+            class="flex-grow-0 flex-shrink-0 ms-2 me-2 mt-0 pt-0 align-self-center"
             color="primary"
             background-color="transparent"
             hide-details
@@ -114,7 +115,9 @@
                 alt="">
             </v-avatar>
           </v-list-item-avatar>
-          <v-list-item-content class="py-0 pe-5 text-color">
+          <v-list-item-content
+            :class="!selectMode && 'pe-5'"
+            class="py-0 text-color">
             <v-list-item-title
               v-sanitized-html="message"
               class="text-wrap text-truncate-2" />
@@ -297,6 +300,9 @@ export default {
     },
     showContextMenu(event) {
       event.preventDefault();
+      if (this.selectMode) {
+        return;
+      }
       this.$refs.menu.showMenu(event.clientX, event.clientY);
     },
     markAsReadMouseDown(event) {

--- a/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-top-bar/components/TopBarNotificationDrawer.vue
@@ -26,7 +26,7 @@
     body-classes="hide-scroll"
     allow-expand
     right
-    @closed="$emit('closed')"
+    @closed="onClosed"
     @expand-updated="expanded = $event">
     <template slot="title">
       <div v-if="selectMode" class="d-flex align-center">
@@ -247,7 +247,15 @@ export default {
       this.cancelSelect();
       this.$refs.drawer.close();
     },
+    onClosed() {
+      this.cancelSelect();
+      this.$emit('closed');
+    },
     cancelSelect() {
+      // Reset the root state directly: the drawer is destroyed on close, so the
+      // listener of 'notification-cancel-select' may not be mounted yet on reopen
+      this.$root.selectMode = false;
+      this.$root.selectedNotificationIds = [];
       this.$root.$emit('notification-cancel-select');
     },
     markSelectedAsRead() {


### PR DESCRIPTION
Backport of Meeds-io/social#5953 from `feature/ai-contribution` to `develop`.

Clean cherry-pick of 6d3b8c84d — no conflict. The three resulting files are
byte-identical to their `feature/ai-contribution` versions, and the patch-id of
the backported commit matches the original one.

## What it fixes

Four UI/UX issues on the notification center multi-selection:

- **Checkbox alignment.** The checkbox of each notification started 8px from the
  left edge (the `v-list-item` padding) while the "Select all" one starts at
  16px (`ps-4`). `ms-2` aligns both.
- **Icon.** The `fa-check-double` icon of the "Select" menu entry becomes
  `fa-mouse-pointer`, consistent with the Mail application.
- **Selection persisted across reopen.** The drawer is destroyed on close, but
  `selectMode` and `selectedNotificationIds` are held by the application root,
  so the selection came back on reopen. `close()` already reset it but is only
  used by `openSettings()`: closing with the cross, the overlay or Escape goes
  through the `closed` event of `exo-drawer`, which only bubbled up. That event
  is now handled, and the root state is reset directly rather than relying on
  the `notification-cancel-select` event, whose only listener lives in
  `UserNotifications` and is not mounted yet when the drawer reopens.
- **Three dots menu while selecting.** It suggested bulk actions could be
  triggered from it, so it is hidden during selection, and the `pe-5` padding
  that only reserved room for it is dropped so the content takes the whole
  width. `showContextMenu()` is also guarded — it would have dereferenced a
  missing `$refs.menu` on right click.

## Interaction with `develop`

The two other commits sitting on `feature/ai-contribution` (EXO-88511 #5873 and
EXO-88493 #5956) touch disjoint files, so this backport carries nothing else.

## Validation

Functionally tested and validated on the `feature/ai-contribution` acceptance
server — eXo Tribe task EXO-88842, validated by @Samuel.Renault and
@jihed_chabbeh on 2026-08-04.
