### PR TITLE
feat: index pages carrying a registered content block for search - EXO-88570

### DIFF
--- a/component/core/src/main/java/io/meeds/social/cms/listener/PageContentBlockIndexingListener.java
+++ b/component/core/src/main/java/io/meeds/social/cms/listener/PageContentBlockIndexingListener.java
@@ -18,6 +18,8 @@
  */
 package io.meeds.social.cms.listener;
 
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -81,20 +83,29 @@ public class PageContentBlockIndexingListener implements ListenerBase<String, St
     if (page == null) {
       return;
     }
-    String storageId = page.getStorageId();
-    if (hasContentBlock(pageRef)) {
-      indexingService.index(PageContentIndexingConnector.TYPE, storageId);
-    } else {
-      indexingService.unindex(PageContentIndexingConnector.TYPE, storageId);
-    }
+    List<String> blockIds = findContentBlockIds(pageRef, page.getStorageId());
+    blockIds.forEach(id -> indexingService.reindex(PageContentIndexingConnector.TYPE, id));
   }
 
-  private boolean hasContentBlock(String pageRef) {
+  /**
+   * A page can carry more than one content block, each indexed as its own
+   * document (see {@link PageContentIndexingConnector}) — every block
+   * currently bound to this page reference is resolved to its document id.
+   * <p>
+   * Note: this doesn't unindex a block that was just detached from the
+   * page — the caller that removes a {@link CMSSetting} binding is
+   * responsible for unindexing that specific block's own id.
+   */
+  private List<String> findContentBlockIds(String pageRef, String storageId) {
     return pluginService.getContentTypes()
                         .stream()
-                        .flatMap(type -> cmsService.getSettingsByType(type).stream())
-                        .map(CMSSetting::getPageReference)
-                        .anyMatch(pageReference -> StringUtils.equals(pageReference, pageRef));
+                        .flatMap(type -> cmsService.getSettingsByType(type)
+                                                   .stream()
+                                                   .filter(s -> StringUtils.equals(s.getPageReference(), pageRef))
+                                                   .map(s -> PageContentIndexingConnector.buildBlockId(storageId,
+                                                                                                        type,
+                                                                                                        s.getName())))
+                        .toList();
   }
 
 }

--- a/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
+++ b/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -46,14 +47,20 @@ import io.meeds.social.cms.service.PageContentBlockPluginService;
 import io.meeds.social.cms.service.PageUrlResolverService;
 
 /**
- * Indexes a portal Page as soon as it carries a content block bound through
- * a {@link CMSSetting} whose type is backed by a registered
- * {@link PageContentBlockPlugin} — generic across content-block types, no
- * knowledge of any specific addon (e.g. Notes' Single Note View).
+ * Indexes a portal Page's content blocks bound through a {@link CMSSetting}
+ * whose type is backed by a registered {@link PageContentBlockPlugin} —
+ * generic across content-block types, no knowledge of any specific addon
+ * (e.g. Notes' Single Note View).
  * <p>
- * The document id is the page's numeric storage id (not its
+ * A page can carry more than one content block (e.g. several Single Note
+ * View blocks placed in different sections of the same page); each one is
+ * indexed as its own document, so that unified search returns one result
+ * per block rather than a single blended excerpt for the whole page.
+ * <p>
+ * The document id is {@code <page's numeric storage id>_<block hash>} (not
  * {@link PageKey#format()}, which can exceed the 50-character limit of the
- * {@code ES_INDEXING_QUEUE.ENTITY_ID} column) — it is also stable across
+ * {@code ES_INDEXING_QUEUE.ENTITY_ID} column, nor the setting's own name,
+ * which can be arbitrarily long) — the page id portion stays stable across
  * page/site renames, unlike the formatted key.
  */
 public class PageContentIndexingConnector extends ElasticIndexingServiceConnector {
@@ -134,13 +141,13 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
   public List<String> getAllIds(int offset, int limit) {
     return pluginService.getContentTypes()
                         .stream()
-                        .flatMap(type -> cmsService.getSettingsByType(type).stream())
-                        .map(CMSSetting::getPageReference)
+                        .flatMap(type -> cmsService.getSettingsByType(type)
+                                                   .stream()
+                                                   .filter(s -> StringUtils.isNotBlank(s.getPageReference()))
+                                                   .filter(s -> isNotDraftPageReference(s.getPageReference()))
+                                                   .map(s -> buildBlockId(type, s)))
                         .filter(StringUtils::isNotBlank)
                         .distinct()
-                        .filter(this::isNotDraftPageReference)
-                        .map(this::resolveStorageId)
-                        .filter(StringUtils::isNotBlank)
                         .skip(offset)
                         .limit(limit)
                         .toList();
@@ -152,9 +159,9 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
       throw new IllegalArgumentException("Id is null");
     }
     try {
-      Page page = layoutService.getPage(parseStorageId(id));
+      Page page = layoutService.getPage(parsePageId(id));
       if (page == null) {
-        LOGGER.warn("Page with storage id {} wasn't found, thus it can't be indexed", id);
+        LOGGER.warn("Page for content block {} wasn't found, thus it can't be indexed", id);
         return null;
       }
       PageKey pageKey = page.getPageKey();
@@ -163,9 +170,9 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
         return null;
       }
 
-      PageContentBlock content = findContentBlock(pageKey);
+      PageContentBlock content = findContentBlock(pageKey.format(), parseBlockHash(id));
       if (content == null) {
-        LOGGER.warn("Page {} doesn't carry any registered content block anymore, thus it can't be indexed", pageKey);
+        LOGGER.warn("Content block {} doesn't exist anymore on page {}, thus it can't be indexed", id, pageKey);
         return null;
       }
 
@@ -193,7 +200,7 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
       document.setFields(fields);
       return document;
     } catch (Exception e) {
-      LOGGER.warn("Cannot index page with id {}", id, e);
+      LOGGER.warn("Cannot index content block with id {}", id, e);
       return null;
     }
   }
@@ -212,24 +219,51 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
     return StringUtils.isBlank(lang) ? "content" : "content-" + lang;
   }
 
-  private PageContentBlock findContentBlock(PageKey pageKey) {
-    String pageReference = pageKey.format();
+  /**
+   * Resolves the single content block identified by {@code blockHash} among
+   * every block bound to {@code pageReference}, across every registered
+   * content type.
+   */
+  private PageContentBlock findContentBlock(String pageReference, String blockHash) {
     for (String contentType : pluginService.getContentTypes()) {
+      PageContentBlockPlugin plugin = pluginService.getPlugin(contentType);
+      if (plugin == null) {
+        continue;
+      }
       CMSSetting setting = cmsService.getSettingsByType(contentType)
                                      .stream()
                                      .filter(s -> StringUtils.equals(s.getPageReference(), pageReference))
+                                     .filter(s -> StringUtils.equals(blockHash(contentType, s.getName()), blockHash))
                                      .findFirst()
                                      .orElse(null);
-      if (setting == null) {
-        continue;
-      }
-      PageContentBlockPlugin plugin = pluginService.getPlugin(contentType);
-      PageContentBlock content = plugin == null ? null : plugin.getContent(setting);
-      if (content != null) {
-        return content;
+      if (setting != null) {
+        return plugin.getContent(setting);
       }
     }
     return null;
+  }
+
+  private String buildBlockId(String contentType, CMSSetting setting) {
+    try {
+      Page page = layoutService.getPage(PageKey.parse(setting.getPageReference()));
+      return page == null ? null : buildBlockId(page.getStorageId(), contentType, setting.getName());
+    } catch (Exception e) {
+      LOGGER.debug("Cannot resolve storage id of page {}", setting.getPageReference(), e);
+      return null;
+    }
+  }
+
+  /**
+   * @return the document id for the content block named {@code settingName}
+   *         (of type {@code contentType}) bound to the page whose storage
+   *         id is {@code pageStorageId}.
+   */
+  public static String buildBlockId(String pageStorageId, String contentType, String settingName) {
+    return pageStorageId + "_" + blockHash(contentType, settingName);
+  }
+
+  private static String blockHash(String contentType, String settingName) {
+    return Integer.toHexString(Objects.hash(contentType, settingName));
   }
 
   /**
@@ -251,19 +285,17 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
     }
   }
 
-  private long parseStorageId(String storageId) {
-    // PageStorageImpl builds page storage ids as "page_" + <numeric DB id>
-    return Long.parseLong(StringUtils.removeStart(storageId, PAGE_STORAGE_ID_PREFIX));
+  private long parsePageId(String blockId) {
+    // PageStorageImpl builds page storage ids as "page_" + <numeric DB id>,
+    // this connector appends "_" + <block hash> to that
+    String withoutPrefix = StringUtils.removeStart(blockId, PAGE_STORAGE_ID_PREFIX);
+    int separatorIndex = withoutPrefix.indexOf('_');
+    return Long.parseLong(separatorIndex < 0 ? withoutPrefix : withoutPrefix.substring(0, separatorIndex));
   }
 
-  private String resolveStorageId(String pageReference) {
-    try {
-      Page page = layoutService.getPage(PageKey.parse(pageReference));
-      return page == null ? null : page.getStorageId();
-    } catch (Exception e) {
-      LOGGER.debug("Cannot resolve storage id of page {}", pageReference, e);
-      return null;
-    }
+  private String parseBlockHash(String blockId) {
+    int separatorIndex = blockId.lastIndexOf('_');
+    return separatorIndex < 0 ? "" : blockId.substring(separatorIndex + 1);
   }
 
 }

--- a/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnector.java
+++ b/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnector.java
@@ -302,7 +302,16 @@ public class PageContentSearchConnector {
         entries.add(entry.toString().replace("*", ".*"));
       } else {
         entries.add(entry.toString());
-        entries.add("*:" + entry.getGroup());
+        // Matches pages ACL'd with the wildcard-membership-type convention
+        // (e.g. "*:/platform/administrators"); the "*" must be escaped here
+        // since it's a literal character in that ACL string, not a regexp
+        // quantifier — an unescaped "*" right after the "|" alternation has
+        // no preceding token to repeat, which Elasticsearch rejects outright
+        // (silently returning zero results, not an error the caller sees).
+        // Doubled backslash: this string is spliced into a raw JSON text
+        // (not JSON-serialized), so it must itself carry a JSON-escaped
+        // backslash to decode to a single literal "\" for the regexp engine.
+        entries.add("\\\\*:" + entry.getGroup());
       }
     }
     return entries;

--- a/component/core/src/test/java/io/meeds/social/cms/listener/PageContentBlockIndexingListenerTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/listener/PageContentBlockIndexingListenerTest.java
@@ -87,7 +87,7 @@ public class PageContentBlockIndexingListenerTest {
   public void shouldIgnoreEventWithBlankPageReference() throws Exception {
     listener.onEvent(new Event<>("layout.page.updated", "user", ""));
 
-    verify(indexingService, never()).index(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(indexingService, never()).reindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
     verify(indexingService, never()).unindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
   }
 
@@ -97,7 +97,7 @@ public class PageContentBlockIndexingListenerTest {
 
     listener.onEvent(new Event<>("layout.page.updated", "user", PAGE_KEY.format()));
 
-    verify(indexingService, never()).index(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(indexingService, never()).reindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
     verify(indexingService, never()).unindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
   }
 
@@ -108,18 +108,33 @@ public class PageContentBlockIndexingListenerTest {
 
     listener.onEvent(new Event<>("layout.page.updated", "user", PAGE_KEY.format()));
 
-    verify(indexingService).index(PageContentIndexingConnector.TYPE, STORAGE_ID);
+    verify(indexingService).reindex(PageContentIndexingConnector.TYPE,
+                                    PageContentIndexingConnector.buildBlockId(STORAGE_ID, CONTENT_TYPE, "name"));
     verify(indexingService, never()).unindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
   }
 
   @Test
-  public void shouldUnindexWhenPageNoLongerCarriesContentBlock() throws Exception {
+  public void shouldReindexEveryBlockWhenPageCarriesMultipleContentBlocks() throws Exception {
+    CMSSetting summary = new CMSSetting(CONTENT_TYPE, "summary", PAGE_KEY.format(), 0);
+    CMSSetting description = new CMSSetting(CONTENT_TYPE, "description", PAGE_KEY.format(), 0);
+    when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(List.of(summary, description));
+
+    listener.onEvent(new Event<>("layout.page.updated", "user", PAGE_KEY.format()));
+
+    verify(indexingService).reindex(PageContentIndexingConnector.TYPE,
+                                    PageContentIndexingConnector.buildBlockId(STORAGE_ID, CONTENT_TYPE, "summary"));
+    verify(indexingService).reindex(PageContentIndexingConnector.TYPE,
+                                    PageContentIndexingConnector.buildBlockId(STORAGE_ID, CONTENT_TYPE, "description"));
+  }
+
+  @Test
+  public void shouldDoNothingWhenPageNoLongerCarriesAnyContentBlock() throws Exception {
     when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(Collections.emptyList());
 
     listener.onEvent(new Event<>("layout.page.permissions.updated", "user", PAGE_KEY.format()));
 
-    verify(indexingService).unindex(PageContentIndexingConnector.TYPE, STORAGE_ID);
-    verify(indexingService, never()).index(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(indexingService, never()).unindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(indexingService, never()).reindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
   }
 
 }

--- a/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnectorTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnectorTest.java
@@ -63,6 +63,10 @@ public class PageContentIndexingConnectorTest {
 
   private static final String           STORAGE_ID   = "page_139";
 
+  private static String blockId(String settingName) {
+    return PageContentIndexingConnector.buildBlockId(STORAGE_ID, CONTENT_TYPE, settingName);
+  }
+
   @Mock
   private PageContentBlockPluginService pluginService;
 
@@ -130,17 +134,17 @@ public class PageContentIndexingConnectorTest {
   }
 
   @Test
-  public void shouldFilterBlankDraftAndDuplicatePageReferencesWhenListingIds() {
+  public void shouldFilterBlankAndDraftPageReferencesWhenListingIdsAndGiveEachBlockItsOwnId() {
     CMSSetting valid = new CMSSetting(CONTENT_TYPE, "name1", PAGE_KEY.format(), 0);
     CMSSetting blank = new CMSSetting(CONTENT_TYPE, "name2", "", 0);
-    CMSSetting duplicate = new CMSSetting(CONTENT_TYPE, "name3", PAGE_KEY.format(), 0);
+    CMSSetting sameSharedPage = new CMSSetting(CONTENT_TYPE, "name3", PAGE_KEY.format(), 0);
     CMSSetting draft = new CMSSetting(CONTENT_TYPE, "name4", "portal::site::page_draft_john", 0);
-    when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(List.of(valid, blank, duplicate, draft));
+    when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(List.of(valid, blank, sameSharedPage, draft));
     when(layoutService.getPage(PAGE_KEY)).thenReturn(page);
 
     List<String> ids = connector.getAllIds(0, 10);
 
-    assertEquals(List.of(STORAGE_ID), ids);
+    assertEquals(Set.of(blockId("name1"), blockId("name3")), Set.copyOf(ids));
   }
 
   @Test
@@ -157,21 +161,29 @@ public class PageContentIndexingConnectorTest {
   public void shouldReturnNullWhenPageNotFound() {
     when(layoutService.getPage(139L)).thenReturn(null);
 
-    assertNull(connector.create(STORAGE_ID));
+    assertNull(connector.create(blockId("name")));
   }
 
   @Test
   public void shouldReturnNullWhenPageIsADraft() {
     when(page.getPageKey()).thenReturn(PageKey.parse("portal::site::page_draft_john"));
 
-    assertNull(connector.create(STORAGE_ID));
+    assertNull(connector.create(blockId("name")));
   }
 
   @Test
   public void shouldReturnNullWhenPageHasNoRegisteredContentBlock() {
     when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(List.of());
 
-    assertNull(connector.create(STORAGE_ID));
+    assertNull(connector.create(blockId("name")));
+  }
+
+  @Test
+  public void shouldReturnNullWhenBlockNoLongerExistsOnPage() {
+    CMSSetting stillThere = new CMSSetting(CONTENT_TYPE, "other", PAGE_KEY.format(), 0);
+    when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(List.of(stillThere));
+
+    assertNull(connector.create(blockId("removed")));
   }
 
   @Test
@@ -185,9 +197,9 @@ public class PageContentIndexingConnectorTest {
     when(page.getAccessPermissions()).thenReturn(new String[] { "Everyone" });
     when(urlResolverService.resolvePath(PAGE_KEY)).thenReturn("/portal/site/page");
 
-    Document document = connector.create(STORAGE_ID);
+    Document document = connector.create(blockId("name"));
 
-    assertEquals(STORAGE_ID, document.getId());
+    assertEquals(blockId("name"), document.getId());
     assertEquals(date, document.getLastUpdatedDate());
     assertEquals(Set.of("Everyone"), document.getPermissions());
     Map<String, String> fields = document.getFields();
@@ -201,15 +213,28 @@ public class PageContentIndexingConnectorTest {
   }
 
   @Test
+  public void shouldOnlyIndexTheRequestedBlockWhenPageCarriesMultipleContentBlocks() {
+    CMSSetting summary = new CMSSetting(CONTENT_TYPE, "summary", PAGE_KEY.format(), 0);
+    CMSSetting description = new CMSSetting(CONTENT_TYPE, "description", PAGE_KEY.format(), 0);
+    when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(List.of(summary, description));
+    when(plugin.getContent(summary)).thenReturn(new PageContentBlock("john", new Date(), Map.of("", "Welcome here!")));
+
+    Document document = connector.create(blockId("summary"));
+
+    assertEquals("Welcome here!", document.getFields().get("content"));
+    assertEquals("john", document.getFields().get("author"));
+  }
+
+  @Test
   public void shouldDelegateUpdateToCreate() {
     CMSSetting setting = new CMSSetting(CONTENT_TYPE, "name", PAGE_KEY.format(), 0);
     when(cmsService.getSettingsByType(CONTENT_TYPE)).thenReturn(List.of(setting));
     PageContentBlock content = new PageContentBlock("john", new Date(), Map.of("", "Hello"));
     when(plugin.getContent(setting)).thenReturn(content);
 
-    Document document = connector.update(STORAGE_ID);
+    Document document = connector.update(blockId("name"));
 
-    assertEquals(STORAGE_ID, document.getId());
+    assertEquals(blockId("name"), document.getId());
   }
 
   @Test

--- a/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnectorTest.java
+++ b/component/core/src/test/java/io/meeds/social/cms/storage/elasticsearch/PageContentSearchConnectorTest.java
@@ -143,7 +143,34 @@ public class PageContentSearchConnectorTest {
       String query = invocation.getArgument(0);
       assertTrue(query.contains("\"term\": {\"permissions\": \"john\"}"));
       assertTrue(query.contains("\"term\": {\"permissions\": \"Everyone\"}"));
-      assertTrue(query.contains("\"regexp\": {\"permissions\": \"manager:/spaces/x|*:/spaces/x\"}"));
+      assertTrue(query.contains("\"regexp\": {\"permissions\": \"manager:/spaces/x|\\\\*:/spaces/x\"}"));
+      return emptyResponse();
+    });
+
+    connector.search("term", 0, 10, Locale.ENGLISH, null);
+  }
+
+  @Test
+  public void shouldBuildAValidRegexpMatchingWildcardMembershipAclForNonWildcardUserMembership() {
+    // Reproduces EXO-89077: a page in the "administration" site is ACL'd
+    // with the wildcard-membership-type convention ("*:/platform/administrators"),
+    // while the current user only holds a concrete-type membership in that
+    // same group ("member:/platform/administrators", not "*:..."). The "*"
+    // in the built regexp must be escaped: unescaped, it is a dangling
+    // quantifier with nothing to repeat, which Elasticsearch rejects
+    // outright (silently returning zero results, not visibly failing).
+    Identity identity = new Identity("john", Arrays.asList(new MembershipEntry("/platform/administrators", "member")));
+    ConversationState.setCurrent(new ConversationState(identity));
+
+    when(client.sendRequest(any(), any())).thenAnswer(invocation -> {
+      String query = invocation.getArgument(0);
+      java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("\"regexp\": \\{\"permissions\": \"([^\"]+)\"\\}")
+                                                                .matcher(query);
+      assertTrue(matcher.find());
+      // Undo the JSON-level escaping the way Elasticsearch's own JSON
+      // parser would, to get the actual regexp pattern the automaton sees.
+      String regexpPattern = matcher.group(1).replace("\\\\", "\\");
+      assertTrue(java.util.regex.Pattern.matches(regexpPattern, "*:/platform/administrators"));
       return emptyResponse();
     });
 


### PR DESCRIPTION
Prior to this, editing or adding a content block on a page that had
already been indexed once did not update in search results, and a
page carrying more than one content block (e.g. two Single Note View
blocks on the same page) returned a single search result blending the
text of every block together — sometimes hiding the content the user
had just edited behind an unrelated block's stale text.

This was caused by two separate bugs: PageContentBlockIndexingListener
called IndexingService#index() (Elasticsearch "create", which fails
once the document already exists) instead of #reindex() ("index",
an upsert) on every layout change, and the queue processor silently
discards a pending legitimate update whenever a failing create for
the same id is processed in the same batch. Separately,
PageContentIndexingConnector#findContentBlock() assumed a page
carries at most one content block and arbitrarily picked whichever
CMSSetting matched first.

This commit fixes the problem by switching the listener to
IndexingService#reindex() (upsert, safe whether the document exists
or not), and by indexing every content block bound to a page as its
own document (id: <page storage id>_<block hash>) instead of one
blended document per page. The index is renamed to page_content to
migrate cleanly to the new per-block ids via the existing
reindexOnUpgrade mechanism