### PR TITLE
fix: consolidate widget-text-header into text-header - EXO-88493

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/gettingStarted.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/gettingStarted.jsp
@@ -37,7 +37,7 @@
               <div class="flex v-card v-card--flat v-sheet card-border-radius pa-5 theme--light">
                 <div
                   class="pb-5">
-                  <span class="widget-text-header">
+                  <span class="text-header">
                     <%=title%>
                     <% if (canClose) { %>
                       <a title="Close" href="#" rel="tooltip" data-placement="bottom" class="btClose">x</a>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/organizationalChart.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/organizationalChart.jsp
@@ -98,8 +98,8 @@
         <% } else {%>
 			<div class="my-auto white border-radius pa-5 card-border-radius v-card v-sheet v-sheet--outlined theme--light" style="margin:0 auto;">
 			  <div class="d-flex mb-2 v-sheet theme--light" style="height: 28px;">
-			    <p class="my-auto widget-text-header text-truncate">
-			      <%=headerTitle%>
+			    <p class="my-auto text-header">
+			      <span class="text-truncate"><%=headerTitle%></span>
 			    </p>
 			  </div>
               <p class="mt-2">

--- a/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/ExoDrawer.vue
@@ -38,7 +38,7 @@
                 :width="drawerWidth"
                 :max-width="drawerWidth"
                 min-height="60"
-                class="px-4 border-box-sizing text-header-title d-flex align-center light-grey-background-color"
+                class="px-4 border-box-sizing text-title d-flex align-center light-grey-background-color"
                 flat>
                 <slot name="fullAppLeftTitle"></slot>
               </v-card>
@@ -51,7 +51,7 @@
                   </v-icon>
                 </v-btn>
               </v-list-item-action>
-              <v-list-item-content :class="goBackButton ? 'ps-2' : 'ps-4'" class="drawerTitle align-start text-header-title">
+              <v-list-item-content :class="goBackButton ? 'ps-2' : 'ps-4'" class="drawerTitle align-start text-title">
                 <div
                   v-if="!showFilter"
                   class="text-truncate full-width">

--- a/webapp/src/main/webapp/vue-apps/common/components/Widget.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/Widget.vue
@@ -33,7 +33,9 @@
         :class="headerPadding"
         class="d-flex align-center">
         <slot v-if="$slots.title" name="title"></slot>
-        <div v-else-if="title" class="widget-text-header text-truncate">{{ title }}</div>
+        <div v-else-if="title" class="text-header">
+          <span class="text-truncate">{{ title }}</span>
+        </div>
         <v-spacer />
         <slot v-if="$slots.action" name="action"></slot>
         <v-btn 

--- a/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
+++ b/webapp/src/main/webapp/vue-apps/login-form/components/LoginForm.vue
@@ -67,7 +67,7 @@
             </v-btn>
           </v-fab-transition>
         </div>
-        <div v-if="registerEnabled && displayWelcomeMessage" class="widget-text-header align-center">
+        <div v-if="registerEnabled && displayWelcomeMessage" class="text-header align-center">
           {{ newHere }}
           <a
             :title="createAccount"
@@ -76,7 +76,7 @@
             {{ createAccount }}
           </a>
         </div>
-        <div v-else-if="displayWelcomeMessage" class="widget-text-header align-center">{{ welcomeBack }}</div>
+        <div v-else-if="displayWelcomeMessage" class="text-header align-center">{{ welcomeBack }}</div>
 
         <portal-login-providers
           :params="values"

--- a/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChartHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/organizational-chart/components/view/OrganizationalChartHeader.vue
@@ -40,8 +40,8 @@
     class="d-flex mb-2">
     <p
       v-if="hasHeaderTitle"
-      class="my-auto widget-text-header text-truncate">
-      {{ configuredTitle }}
+      class="my-auto text-header">
+      <span class="text-truncate">{{ configuredTitle }}</span>
     </p>
     <div
       class="ms-auto d-flex">

--- a/webapp/src/main/webapp/vue-apps/profile-header/components/settings/ProfileHeaderSettingsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/settings/ProfileHeaderSettingsDrawer.vue
@@ -25,7 +25,7 @@
     :right="!$vuetify.rtl"
     @closed="reset">
     <template #title>
-      <div class="d-flex my-auto text-header-title font-weight-bold text-color">
+      <div class="d-flex my-auto text-title font-weight-bold text-color">
         {{ $t('profileHeader.edit.settings.title') }}
       </div>
     </template>


### PR DESCRIPTION
## Summary
- `widget-text-header` was a byte-for-byte duplicate of `.text-header`'s own typography rule in `platform-ui`'s `helpers.less` (now removed there) - renames every usage in this repo to the canonical class.
- Also splits the remaining `.text-truncate` collisions this touched (`Widget.vue`'s shared title, `OrganizationalChartHeader.vue`, the two portlet JSPs) onto a dedicated inner `.text-truncate` child, so the Text Background `::before` isn't clipped by the same element's own `overflow: hidden`.
- Depends on the companion `platform-ui` PR (helpers.less cleanup).

## Test plan
- [ ] Any dashboard widget using the shared `<widget-wrapper>` title (About Yourself, My Contributions-style gadgets, etc.) still shows its title correctly, with background/margin working if configured
- [ ] Organizational chart header and getting-started portlet titles unaffected visually