### PR TITLE
feat: bookmark a page from the unified search results - EXO-88572

### DIFF
--- a/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
+++ b/component/core/src/main/java/io/meeds/social/cms/storage/elasticsearch/PageContentIndexingConnector.java
@@ -285,7 +285,13 @@ public class PageContentIndexingConnector extends ElasticIndexingServiceConnecto
     }
   }
 
-  private long parsePageId(String blockId) {
+  /**
+   * @param  blockId a content block document id ({@code buildBlockId}) or a
+   *                  plain page storage id — either way, the leading
+   *                  {@code page_<numeric DB id>} portion is parsed out.
+   * @return the numeric storage id of the page carrying the block.
+   */
+  public static long parsePageId(String blockId) {
     // PageStorageImpl builds page storage ids as "page_" + <numeric DB id>,
     // this connector appends "_" + <block hash> to that
     String withoutPrefix = StringUtils.removeStart(blockId, PAGE_STORAGE_ID_PREFIX);

--- a/component/core/src/main/java/org/exoplatform/social/core/plugin/PageFavoriteACLPlugin.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/plugin/PageFavoriteACLPlugin.java
@@ -18,19 +18,17 @@
  */
 package org.exoplatform.social.core.plugin;
 
-import org.apache.commons.lang3.StringUtils;
-
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.metadata.FavoriteACLPlugin;
 
+import io.meeds.social.cms.storage.elasticsearch.PageContentIndexingConnector;
+
 public class PageFavoriteACLPlugin extends FavoriteACLPlugin {
 
   private static final String PAGE_FAVORITE_TYPE     = "page";
-
-  private static final String PAGE_STORAGE_ID_PREFIX  = "page_";
 
   private final LayoutService layoutService;
 
@@ -48,12 +46,8 @@ public class PageFavoriteACLPlugin extends FavoriteACLPlugin {
 
   @Override
   public boolean canCreateFavorite(Identity userIdentity, String objectId) {
-    Page page = layoutService.getPage(parseStorageId(objectId));
+    Page page = layoutService.getPage(PageContentIndexingConnector.parsePageId(objectId));
     return page != null && userACL.hasAccessPermission(page, userIdentity);
-  }
-
-  private long parseStorageId(String storageId) {
-    return Long.parseLong(StringUtils.removeStart(storageId, PAGE_STORAGE_ID_PREFIX));
   }
 
 }

--- a/component/core/src/test/java/org/exoplatform/social/core/plugin/PageFavoriteACLPluginTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/plugin/PageFavoriteACLPluginTest.java
@@ -87,4 +87,13 @@ public class PageFavoriteACLPluginTest {
     assertFalse(plugin.canCreateFavorite(userIdentity, STORAGE_ID));
   }
 
+  @Test
+  public void shouldResolvePageWhenObjectIdIsAContentBlockId() {
+    Page page = mock(Page.class);
+    when(layoutService.getPage(139L)).thenReturn(page);
+    when(userACL.hasAccessPermission(page, userIdentity)).thenReturn(true);
+
+    assertTrue(plugin.canCreateFavorite(userIdentity, "page_139_79e18345"));
+  }
+
 }


### PR DESCRIPTION
- FavoriteButton wired on the "Pages" search result card and a new PageFavoriteItem in the favorites drawer (compact + expanded view), backed by the generic FavoriteService and a new PageFavoriteACLPlugin.
- New GET /social/rest/pages/{id} endpoint to hydrate a favorited page.