### PR TITLE
feat: Add Global JS Variable for Topbar Apps - EXO-89261

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/search.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/search.jsp
@@ -77,6 +77,10 @@
             document.dispatchEvent(new CustomEvent('search-open'));
           });
         }));
+        eXo.env.portal.topbarDisplayedApps = eXo.env.portal.topbarDisplayedApps || [];
+        if (!eXo.env.portal.topbarDisplayedApps.includes('search')) {
+          eXo.env.portal.topbarDisplayedApps.push('search');
+        }
       </script>
     </div>
   </div>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/topbarNotification.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/topbarNotification.jsp
@@ -23,6 +23,10 @@
           </button>
           <script type="text/javascript">
             require(['PORTLET/social/TopBarNotification'], app => app.init(<%=badge%>));
+            eXo.env.portal.topbarDisplayedApps = eXo.env.portal.topbarDisplayedApps || [];
+            if (!eXo.env.portal.topbarDisplayedApps.includes('notifications')) {
+              eXo.env.portal.topbarDisplayedApps.push('notifications');
+            }
           </script>
         </div>
       </div>


### PR DESCRIPTION
This change announces that the `search` and `webNotification` Applications are displayed in the topbar by the administrator, so the Application Center disables pinning it: pinned, the same icon would appear twice. Only this entry point registers — the hidden instance the Application Center quick action mounts does not go through `init()`.