### PR TITLE
fix: add no data label to the nested group list - EXO-89341

### DIFF
--- a/webapp/src/main/webapp/vue-apps/idm-groups-management/components/NestedGroups/NestedGroupsList.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-groups-management/components/NestedGroups/NestedGroupsList.vue
@@ -46,7 +46,7 @@
     </template>
     <template #no-data>
       <div class="d-flex flex-column align-center justify-center py-8">
-        {{ $t('groupsManagement.nestedGroups.emptyTitle') }}
+        {{ $t('groupsManagement.nestedGroup.emptyTitle') }}
       </div>
     </template>
   </v-data-table>


### PR DESCRIPTION
Prior to this change, the “No data” label in the nested group list was displaying the translation key instead of the translated label. This change sets the correct translation key, resolving the issue