### PR TITLE
feat: Suggest users to delete their account - EXO-89274

### DIFF
--- a/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
@@ -36,6 +36,10 @@ UserSettings.security.passwordChange.condition.passwordOneLowercase=1 Lowercase
 UserSettings.security.passwordChange.condition.passwordOneNumber=1 Numerous character
 UserSettings.security.passwordChange.condition.passwordOneSpecialCharacter=1 Special character
 
+UserSettings.security.deleteAccount.title=Delete Account
+UserSettings.security.deleteAccount.tooltip=Deactivate or delete your account
+UserSettings.security.deleteAccount.drawerTitle=Deactivate or delete your account
+
 UserSettings.socialNetworks=Social Networks
 UserSettings.button.cancel=Cancel
 UserSettings.button.apply=Apply

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingSecurity.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingSecurity.jsp
@@ -1,3 +1,4 @@
+<%@page import="io.meeds.portal.security.service.SecuritySettingService"%>
 <%@page import="org.exoplatform.container.ExoContainerContext"%>
 <%@page import="org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting"%>
 <%@page import="org.exoplatform.social.core.profileproperty.ProfilePropertyService"%>
@@ -7,6 +8,9 @@
   ProfilePropertyService profilePropertyService = ExoContainerContext.getService(ProfilePropertyService.class);
   ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("email");
   boolean emailEditable = profilePropertySetting == null || profilePropertySetting.isEditable();
+  boolean deactivationAllowed = ExoContainerContext.getService(SecuritySettingService.class)
+                                                   .getRegistrationSetting()
+                                                   .isAccountDeactivationEnabled();
 %>
 <div class="VuetifyApp">
   <div data-app="true"
@@ -14,7 +18,7 @@
     id="UserSettingSecurity">
     <v-cacheable-dom-app cache-id="UserSettingSecurity"></v-cacheable-dom-app>
     <script type="text/javascript">
-      require(['PORTLET/social/UserSettingSecurity'], app => app.init(<%=ssoEnabled%>, <%=emailEditable%>));
+      require(['PORTLET/social/UserSettingSecurity'], app => app.init(<%=ssoEnabled%>, <%=emailEditable%>, <%=deactivationAllowed%>));
     </script>
   </div>
 </div>

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingDeactivateAccountDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingDeactivateAccountDrawer.vue
@@ -1,0 +1,46 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <exo-drawer
+    id="UserSettingDeactivateAccountDrawer"
+    ref="drawer"
+    v-model="drawer"
+    no-x-scroll
+    right>
+    <template #title>
+      {{ $t('UserSettings.security.deleteAccount.drawerTitle') }}
+    </template>
+  </exo-drawer>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    drawer: false,
+  }),
+  methods: {
+    open() {
+      this.$refs.drawer.open();
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingSecurity.vue
@@ -85,12 +85,40 @@
           parent-element="div"
           element="div"
           class=" d-flex flex-column" />
+        <v-list-item v-if="$root.deactivationAllowed" dense>
+          <v-list-item-content>
+            <v-list-item-title class="error--text">
+              {{ $t('UserSettings.security.deleteAccount.title') }}
+            </v-list-item-title>
+          </v-list-item-content>
+          <v-list-item-action>
+            <v-tooltip bottom>
+              <template #activator="{on, attrs}">
+                <div
+                  v-on="on"
+                  v-bind="attrs">
+                  <v-btn
+                    :aria-label="deleteAccountTooltip"
+                    small
+                    icon
+                    @click="$refs.deactivateAccountDrawer.open()">
+                    <v-icon size="18" class="error--text">fa-trash</v-icon>
+                  </v-btn>
+                </div>
+              </template>
+              <span>{{ deleteAccountTooltip }}</span>
+            </v-tooltip>
+          </v-list-item-action>
+        </v-list-item>
       </v-list>
     </v-card>
     <user-setting-security-email-drawer
       ref="emailDrawer" />
     <user-setting-security-password-drawer
       ref="passwordDrawer" />
+    <user-setting-deactivate-account-drawer
+      v-if="$root.deactivationAllowed"
+      ref="deactivateAccountDrawer" />
   </v-app>
 </template>
 
@@ -110,6 +138,9 @@ export default {
     },
     emailChangeTooltip() {
       return this.$t('UserSettings.security.emailChange.tooltip');
+    },
+    deleteAccountTooltip() {
+      return this.$t('UserSettings.security.deleteAccount.tooltip');
     },
   },
   watch: {

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/initComponents.js
@@ -21,11 +21,13 @@
 import UserSettingSecurity from './components/UserSettingSecurity.vue';
 import UserSettingSecurityEmailDrawer from './components/UserSettingSecurityEmailDrawer.vue';
 import UserSettingSecurityPasswordDrawer from './components/UserSettingSecurityPasswordDrawer.vue';
+import UserSettingDeactivateAccountDrawer from './components/UserSettingDeactivateAccountDrawer.vue';
 
 const components = {
   'user-setting-security': UserSettingSecurity,
   'user-setting-security-email-drawer': UserSettingSecurityEmailDrawer,
   'user-setting-security-password-drawer': UserSettingSecurityPasswordDrawer,
+  'user-setting-deactivate-account-drawer': UserSettingDeactivateAccountDrawer,
 };
 
 for (const key in components) {

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/main.js
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/main.js
@@ -41,7 +41,7 @@ const appId = 'UserSettingSecurity';
 
 document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
 
-export function init(ssoEnabled, isEmailEditable) {
+export function init(ssoEnabled, isEmailEditable, deactivationAllowed) {
   exoi18n.loadLanguageAsync(lang, url)
     .then(i18n => {
       const appElement = document.createElement('div');
@@ -51,6 +51,7 @@ export function init(ssoEnabled, isEmailEditable) {
         data: {
           ssoEnabled,
           isEmailEditable,
+          deactivationAllowed,
         },
         mounted() {
           document.dispatchEvent(new CustomEvent('hideTopBarLoading'));


### PR DESCRIPTION
Add a "Delete Account" entry at the end of the Security section of the personal settings, displayed with the error color and a trash icon action titled "Deactivate or delete your account".
The entry is rendered only when account deactivation is allowed