### PR TITLE
fix: Fix the top-bar menu accessibility - EXO-88911

### DIFF
--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -26,6 +26,7 @@
     :content-class="`topBar-navigation-drop-menu ${isTopBarElement && 'layout-top-bar' || ''}`"
     :left="$vuetify.rtl"
     :open-on-hover="isOpenedOnHover"
+    :open-on-click="false"
     :max-height="menuMaxHeight"
     bottom
     offset-y
@@ -164,7 +165,9 @@ export default {
           window.location.href = this.navigationNodeUri;
         }
       } else if (this.hasChildren && this.childrenHasPage) {
-        this.openDropMenu();
+        // a keyboard activation (event detail = 0) only opens the menu, so that a second
+        // Enter activates the highlighted sub page instead of closing the menu again
+        this.openDropMenu(!e.detail);
       }
     },
     openDropMenu(persist) {

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -32,6 +32,7 @@
       class="py-0 px-0 transparent"
       @click="checkLink">
       <v-menu
+        ref="menu"
         v-model="showMenu"
         rounded
         :content-class="isTopBarElement && 'layout-top-bar' || ''"
@@ -46,6 +47,7 @@
         <template #activator="{ on }">
           <div
             class="d-flex width-full px-4"
+            tabindex="-1"
             v-on="on"
             @mouseleave="showMenu = false">
             <v-list-item-title
@@ -177,7 +179,26 @@ export default {
           window.location.href = this.navigationNodeUri;
         }
       } else if (this.hasChildren && this.childrenHasPage) {
+        if (!e.detail) {
+          // a keyboard activation (event detail = 0) opens the submenu instead of following
+          // the link, and keeps the parent drop menu open under it
+          e.preventDefault();
+          e.stopPropagation();
+        }
         this.showMenu = !this.showMenu;
+        if (this.showMenu && !e.detail) {
+          this.focusSubMenu();
+        }
+      }
+    },
+    focusSubMenu(retries = 10) {
+      // focusing the first entry hands the arrow keys over to the submenu, Vuetify then
+      // navigates it and opens the highlighted page on Enter
+      const firstItem = this.$refs.menu?.$refs?.content?.querySelector('.v-list-item');
+      if (firstItem?.offsetParent) {
+        firstItem.focus();
+      } else if (this.showMenu && retries) {
+        requestAnimationFrame(() => this.focusSubMenu(retries - 1));
       }
     },
     updateNavigationState(value) {


### PR DESCRIPTION
Prior to this change, the top-bar menu opened with Enter but its sub pages could not be reached with the keyboard: Vuetify's own activator click toggle closed the drop menu on Enter, and an opened submenu never received the focus.
This change will keep the drop menu open on a keyboard activation and move the focus into the opened submenu, so the arrow keys navigate the sub pages and Enter opens the highlighted one. Mouse behaviour is unchanged.
