### PR TITLE
fix: article content not displayed on details page - EXO-89489

### DIFF
--- a/webapp/src/main/webapp/js/sanitize-html-directive.js
+++ b/webapp/src/main/webapp/js/sanitize-html-directive.js
@@ -18,10 +18,11 @@
  */
 (function() {
   function setSanitizedHtml(el, html) {
-    el.innerHTML = html && EmojiAccessibility.addAccessibleNameToEmojis(html) || '';
-    if (html && !EmojiAccessibility.isReady()) {
-      EmojiAccessibility.onReady(el, () => {
-        el.innerHTML = EmojiAccessibility.addAccessibleNameToEmojis(html);
+    const emojiAccessibility = window.EmojiAccessibility;
+    el.innerHTML = html && (emojiAccessibility ? emojiAccessibility.addAccessibleNameToEmojis(html) : html) || '';
+    if (html && emojiAccessibility && !emojiAccessibility.isReady()) {
+      emojiAccessibility.onReady(el, () => {
+        el.innerHTML = emojiAccessibility.addAccessibleNameToEmojis(html);
       });
     }
   }

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityEmbeddedHTML.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/content/ActivityEmbeddedHTML.vue
@@ -24,7 +24,7 @@
 
 <script>
 export default {
-  mixins: [EmojiAccessibility.readyMixin],
+  mixins: window.EmojiAccessibility ? [window.EmojiAccessibility.readyMixin] : [],
   props: {
     activity: {
       type: Object,
@@ -98,7 +98,7 @@ export default {
       }
       const tempdiv = document.createElement('div');
       const purifiedHtml = this.purifiedHtmlCache.html;
-      tempdiv.innerHTML = this.emojiBankReady && EmojiAccessibility.addAccessibleNameToEmojis(purifiedHtml) || purifiedHtml;
+      tempdiv.innerHTML = this.emojiBankReady && window.EmojiAccessibility && window.EmojiAccessibility.addAccessibleNameToEmojis(purifiedHtml) || purifiedHtml;
       if (tempdiv.firstElementChild.style.maxWidth) {
         tempdiv.firstElementChild.style.maxWidth = `${this.maxWidth}px`;
       }

--- a/webapp/src/main/webapp/vue-apps/common/components/DynamicHTMLElement.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/DynamicHTMLElement.vue
@@ -1,10 +1,10 @@
 <script>
 export default {
-  mixins: [EmojiAccessibility.readyMixin],
+  mixins: window.EmojiAccessibility ? [window.EmojiAccessibility.readyMixin] : [],
   render: function (createElement) {
     if (this.html) {
       const purifiedHtml = ExtendedDomPurify.purify(`<div>${this.html}</div>`);
-      const formattedHtml = this.emojiBankReady && EmojiAccessibility.addAccessibleNameToEmojis(purifiedHtml) || purifiedHtml;
+      const formattedHtml = this.emojiBankReady && window.EmojiAccessibility && window.EmojiAccessibility.addAccessibleNameToEmojis(purifiedHtml) || purifiedHtml;
       return createElement(this.element || 'div', {
         domProps: {
           innerHTML: formattedHtml


### PR DESCRIPTION
Before this change, when the emoji accessibility feature was added, setSanitizedHtml and related components referenced the bare EmojiAccessibility identifier instead of window.EmojiAccessibility, which resolved to undefined inside the purifyGRP bundle and threw an uncaught error while rendering sanitized HTML, leaving article content blank. To fix this, the code now reads window.EmojiAccessibility explicitly and falls back to the plain purified HTML when it is unavailable. After this change, article content is displayed reliably, with accessible emoji names still applied whenever EmojiAccessibility is ready.