### PR TITLE
fix: Can't access profile link through tabulating - EXO-81463 

### DIFF
--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
@@ -49,6 +49,7 @@
       <v-spacer v-if="$root.expand" />
       <div v-else class="me-3"></div>
       <v-list-item-action
+        ref="avatarFooter"
         :class="$root.expand && 'mx-0' || 'ms-2'"
         class="my-auto d-flex flex-row user-avatar-footer">
         <v-badge
@@ -63,18 +64,20 @@
           bottom
           overlap
           dot>
-          <v-avatar
+          <a
             :href="profileUri"
+            :aria-label="$t('menu.userProfilePageLink')"
             class="userAvatar clickable"
-            size="24"
-            @click.stop="openMenu($event)">
-            <img
-              :src="avatarUrl"
-              alt=""
-              height="24"
-              width="24"
-              contain>
-          </v-avatar>
+            @click.stop.prevent="openMenu($event)">
+            <v-avatar size="24">
+              <img
+                :src="avatarUrl"
+                alt=""
+                height="24"
+                width="24"
+                contain>
+            </v-avatar>
+          </a>
         </v-badge>
         <v-tooltip v-if="$root.expand" top>
           <template #activator="{ on, attrs }">
@@ -112,8 +115,8 @@
     </v-list-item>
     <sidebar-user-popup
       ref="menu"
-      v-if="$root.expand"
-      attach-to=".user-avatar-footer"
+      v-if="$root.expand && avatarFooterReady"
+      :attach-to="$refs.avatarFooter?.$el"
       position-top="0"
       position-right="20"
       @user-status-updated="statusColor = $event" />
@@ -128,10 +131,14 @@ export default {
     profileUri: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile`,
     productName: eXo.env.portal.productName,
     productLink: eXo.env.portal.productLink,
-    statusColor: '#707070'
+    statusColor: '#707070',
+    avatarFooterReady: false
   }),
   created() {
     document.addEventListener('user-status-updated', this.changeStatusColor);
+  },
+  mounted() {
+    this.avatarFooterReady = true;
   },
   beforeDestroy() {
     document.removeEventListener('user-status-updated', this.changeStatusColor);

--- a/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarUserPopup.vue
+++ b/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarUserPopup.vue
@@ -55,7 +55,7 @@
 export default {
   props: {
     attachTo: {
-      type: String,
+      type: [String, HTMLElement],
       default: ''
     },
     positionTop: {
@@ -73,6 +73,7 @@ export default {
       profileUri: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile`,
       user: null,
       menu: false,
+      triggerElement: null,
       position: {x: 0, y: 0},
       statusMap: {
         available: '#2eb58c',
@@ -89,15 +90,25 @@ export default {
   },
   mounted() {
     document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.handleKeydown, true);
     document.addEventListener('user-status-updated', this.handleStatusChangeEvent);
   },
   beforeDestroy() {
     document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.handleKeydown, true);
     document.removeEventListener('user-status-updated', this.handleStatusChangeEvent);
   },
   watch: {
     status() {
       this.$emit('user-status-updated', this.statusColor);
+    },
+    menu(opened) {
+      if (opened) {
+        this.focusContent();
+      } else if (this.triggerElement) {
+        this.triggerElement.focus();
+        this.triggerElement = null;
+      }
     }
   },
   computed: {
@@ -109,9 +120,52 @@ export default {
     open(x, y) {
       this.position.x = x;
       this.position.y = y;
+      this.triggerElement = document.activeElement;
       this.$nextTick(() => {
         this.menu = !this.menu;
       });
+    },
+    focusContent() {
+      const [firstEl] = this.getFocusableElements();
+      if (firstEl) {
+        firstEl.focus();
+      } else if (this.menu) {
+        requestAnimationFrame(() => this.focusContent());
+      }
+    },
+    getFocusableElements() {
+      const contentEl = this.$refs.menuContent?.$el;
+      if (!contentEl) {
+        return [];
+      }
+      return Array.from(contentEl.querySelectorAll('a[href], button:not([disabled])'))
+        .filter(el => el.offsetParent !== null);
+    },
+    handleKeydown(event) {
+      if (!this.menu) {
+        return;
+      }
+      if (event.key === 'Escape') {
+        this.menu = false;
+        return;
+      }
+      if (event.key !== 'Tab') {
+        return;
+      }
+      event.stopPropagation();
+      const focusable = this.getFocusableElements();
+      if (!focusable.length) {
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     },
     handleClickOutside(event) {
       if (!this.menu) {

--- a/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarUserPopupContent.vue
+++ b/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarUserPopupContent.vue
@@ -26,7 +26,8 @@
       <v-list-item class="py-2">
         <a
           :href="profileUri"
-          rel="noopener noreferrer">
+          rel="noopener noreferrer"
+          class="d-inline-flex align-center text-decoration-none">
           <v-badge
             :color="statusColor"
             :value="true"
@@ -50,25 +51,15 @@
                 :alt="fullName" />
             </v-list-item-avatar>
           </v-badge>
+          <v-list-item-content class="pa-0 width-fit-content text-left">
+            <v-list-item-title class="mb-0">
+              <span class="text-color font-weight-bold">{{ fullName }}</span>
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              <span class="text-subtitle">{{ $t('menu.userProfilePageLink') }}</span>
+            </v-list-item-subtitle>
+          </v-list-item-content>
         </a>
-        <v-list-item-content class="pa-0 width-fit-content">
-          <v-list-item-title class="mb-0">
-            <a
-              :href="profileUri"
-              rel="noopener noreferrer"
-              class="text-decoration-none text-color font-weight-bold">
-              {{ fullName }}
-            </a>
-          </v-list-item-title>
-          <v-list-item-subtitle>
-            <a
-              class="text-subtitle"
-              :href="profileUri"
-              rel="noopener noreferrer">
-              {{ $t('menu.userProfilePageLink') }}
-            </a>
-          </v-list-item-subtitle>
-        </v-list-item-content>
       </v-list-item>
     </v-list>
     <div class="mb-4">


### PR DESCRIPTION
Before this change, the profile avatar in the left sidebar could not be reached with the Tab key, and its popup card exposed three separate links (avatar, name, subtitle) all pointing to the same profile page, with Tab either escaping the popup or closing it unexpectedly. To fix this, the avatar is now a real focusable link, the popup traps Tab/Shift+Tab between its own items until Escape is pressed, and its three redundant profile links are merged into a single focusable item. After this change, the profile icon and its popup are fully keyboard-operable, Enter opens the popup, Tab cycles only through its items without leaving, and Escape closes it and returns focus to the profile icon.