### PR TITLE
feat: deactivate account and logout on confirmed deactivation request - EXO-89280

### DIFF
--- a/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
+++ b/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
@@ -1,0 +1,122 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.security.ConversationRegistry;
+import org.exoplatform.services.security.IdentityRegistry;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.portal.security.service.SecuritySettingService;
+import io.meeds.web.security.service.OtpService;
+
+import lombok.SneakyThrows;
+
+@Service
+public class AccountDeactivationService {
+
+  public static final String ACCOUNT_DEACTIVATION_REQUESTED_EVENT = "social.account.deactivation.requested";
+
+  private static final Log   LOG                                  = ExoLogger.getLogger(AccountDeactivationService.class);
+
+  @Autowired
+  private SecuritySettingService securitySettingService;
+
+  @Autowired
+  private OrganizationService    organizationService;
+
+  @Autowired
+  private IdentityManager        identityManager;
+
+  @Autowired
+  private ListenerService        listenerService;
+
+  @Autowired
+  private IdentityRegistry       identityRegistry;
+
+  @Autowired
+  private ConversationRegistry   conversationRegistry;
+
+  @Autowired
+  private OtpService             otpService;
+
+  @SneakyThrows
+  public boolean isDeactivationAllowed(String username) {
+    if (!securitySettingService.getRegistrationSetting().isAccountDeactivationEnabled()) {
+      return false;
+    }
+    User user = organizationService.getUserHandler().findUserByName(username);
+    return user != null && user.isInternalStore();
+  }
+
+  /**
+   * Deactivates the account of the designated user after validating the OTP
+   * code: this is the single authoritative OTP validation of the flow.
+   *
+   * @throws IllegalStateException when the deactivation isn't allowed for the
+   *           user (admin option off or externally synchronized account)
+   * @throws IllegalAccessException when the OTP code is blank, invalid or the
+   *           validation tentatives are exhausted
+   * @throws UnsupportedOperationException when the account deletion is
+   *           requested, until its persistence and processing job are
+   *           delivered
+   */
+  @SneakyThrows
+  public void requestDeactivation(String username,
+                                  String otpMethod,
+                                  String otpCode,
+                                  boolean deleteRequested) throws IllegalAccessException {
+    if (deleteRequested) {
+      // no persistence consumes the deletion request yet: refuse it rather
+      // than silently downgrading it to a plain deactivation
+      throw new UnsupportedOperationException("Account deletion request isn't supported yet");
+    }
+    if (!isDeactivationAllowed(username)) {
+      throw new IllegalStateException(String.format("Account deactivation isn't allowed for user %s", username));
+    }
+    otpService.validateOtp(username, otpMethod, otpCode);
+    String identityId = identityManager.getOrCreateUserIdentity(username).getId();
+    sendUserConfirmationEmail(username);
+    organizationService.getUserHandler().setEnabled(username, false, true);
+    broadcastEvent(ACCOUNT_DEACTIVATION_REQUESTED_EVENT, username, identityId);
+    identityRegistry.unregister(username);
+    conversationRegistry.unregisterByUserId(username);
+  }
+
+  protected void sendUserConfirmationEmail(String username) {
+    // TODO the user confirmation email, sent before disabling the account, is
+    // delivered by a follow-up ticket of the account deactivation feature
+  }
+
+  private void broadcastEvent(String eventName, String username, String identityId) {
+    try {
+      listenerService.broadcast(eventName, username, identityId);
+    } catch (Exception e) {
+      LOG.warn("Error broadcasting event {} for user {} with identity id {}", eventName, username, identityId, e);
+    }
+  }
+
+}

--- a/component/core/src/test/java/io/meeds/social/security/service/AccountDeactivationServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/security/service/AccountDeactivationServiceTest.java
@@ -1,0 +1,194 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.service;
+
+import static io.meeds.social.security.service.AccountDeactivationService.ACCOUNT_DEACTIVATION_REQUESTED_EVENT;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.services.security.ConversationRegistry;
+import org.exoplatform.services.security.IdentityRegistry;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.portal.security.model.RegistrationSetting;
+import io.meeds.portal.security.service.SecuritySettingService;
+import io.meeds.web.security.service.OtpService;
+
+import lombok.SneakyThrows;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AccountDeactivationServiceTest {
+
+  private static final String        USERNAME    = "john";
+
+  private static final String        IDENTITY_ID = "123";
+
+  private static final String        OTP_METHOD  = "accountDeactivationEmail";
+
+  private static final String        OTP_CODE    = "12345";
+
+  @Mock
+  private SecuritySettingService     securitySettingService;
+
+  @Mock
+  private OrganizationService        organizationService;
+
+  @Mock
+  private UserHandler                userHandler;
+
+  @Mock
+  private User                       user;
+
+  @Mock
+  private IdentityManager            identityManager;
+
+  @Mock
+  private Identity                   identity;
+
+  @Mock
+  private ListenerService            listenerService;
+
+  @Mock
+  private IdentityRegistry           identityRegistry;
+
+  @Mock
+  private ConversationRegistry       conversationRegistry;
+
+  @Mock
+  private OtpService                 otpService;
+
+  @InjectMocks
+  private AccountDeactivationService accountDeactivationService;
+
+  private RegistrationSetting        registrationSetting;
+
+  @Before
+  @SneakyThrows
+  public void setUp() {
+    registrationSetting = new RegistrationSetting();
+    when(securitySettingService.getRegistrationSetting()).thenReturn(registrationSetting);
+    when(organizationService.getUserHandler()).thenReturn(userHandler);
+    when(userHandler.findUserByName(USERNAME)).thenReturn(user);
+    when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(identity);
+    when(identity.getId()).thenReturn(IDENTITY_ID);
+  }
+
+  @Test
+  public void testDeactivationNotAllowedWhenAdminOptionOff() {
+    registrationSetting.setAccountDeactivationEnabled(false);
+    when(user.isInternalStore()).thenReturn(true);
+    assertFalse(accountDeactivationService.isDeactivationAllowed(USERNAME));
+  }
+
+  @Test
+  public void testDeactivationAllowedForInternalUserWhenAdminOptionOn() {
+    registrationSetting.setAccountDeactivationEnabled(true);
+    when(user.isInternalStore()).thenReturn(true);
+    assertTrue(accountDeactivationService.isDeactivationAllowed(USERNAME));
+  }
+
+  @Test
+  public void testDeactivationNotAllowedForExternalStoreUser() {
+    registrationSetting.setAccountDeactivationEnabled(true);
+    when(user.isInternalStore()).thenReturn(false);
+    assertFalse(accountDeactivationService.isDeactivationAllowed(USERNAME));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testDeactivationNotAllowedForUnknownUser() {
+    registrationSetting.setAccountDeactivationEnabled(true);
+    when(userHandler.findUserByName(USERNAME)).thenReturn(null);
+    assertFalse(accountDeactivationService.isDeactivationAllowed(USERNAME));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationDisablesUserAndInvalidatesSessions() {
+    allowDeactivation();
+    accountDeactivationService.requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, false);
+
+    verify(otpService).validateOtp(USERNAME, OTP_METHOD, OTP_CODE);
+    verify(userHandler).setEnabled(USERNAME, false, true);
+    verify(listenerService).broadcast(ACCOUNT_DEACTIVATION_REQUESTED_EVENT, USERNAME, IDENTITY_ID);
+    verify(identityRegistry).unregister(USERNAME);
+    verify(conversationRegistry).unregisterByUserId(USERNAME);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationWithDeletionRefusedUntilImplemented() {
+    allowDeactivation();
+    assertThrows(UnsupportedOperationException.class,
+                 () -> accountDeactivationService.requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, true));
+
+    verify(otpService, never()).validateOtp(anyString(), anyString(), anyString());
+    verify(userHandler, never()).setEnabled(anyString(), anyBoolean(), anyBoolean());
+    verify(listenerService, never()).broadcast(anyString(), anyString(), anyString());
+    verify(identityRegistry, never()).unregister(anyString());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationRejectedWhenNotAllowed() {
+    registrationSetting.setAccountDeactivationEnabled(false);
+    assertThrows(IllegalStateException.class,
+                 () -> accountDeactivationService.requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, false));
+
+    verify(otpService, never()).validateOtp(anyString(), anyString(), anyString());
+    verify(userHandler, never()).setEnabled(anyString(), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationRejectedWhenOtpCodeInvalid() {
+    allowDeactivation();
+    doThrow(new IllegalAccessException()).when(otpService).validateOtp(USERNAME, OTP_METHOD, OTP_CODE);
+    assertThrows(IllegalAccessException.class,
+                 () -> accountDeactivationService.requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, false));
+
+    verify(userHandler, never()).setEnabled(anyString(), anyBoolean(), anyBoolean());
+    verify(identityRegistry, never()).unregister(anyString());
+  }
+
+  private void allowDeactivation() {
+    registrationSetting.setAccountDeactivationEnabled(true);
+    when(user.isInternalStore()).thenReturn(true);
+  }
+
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/test/NoContainerTestSuite.java
@@ -56,6 +56,7 @@ import io.meeds.social.authorization.AuthorizationManagerTest;
 import io.meeds.social.category.service.CategoryServiceUnitTest;
 import io.meeds.social.coediting.service.CoeditingServiceTest;
 import io.meeds.social.publication.service.ContentPublicationServiceTest;
+import io.meeds.social.security.service.AccountDeactivationServiceTest;
 import io.meeds.social.core.identity.service.UserExportServiceTest;
 import io.meeds.social.core.identity.service.UserImportServiceTest;
 import io.meeds.social.core.plugin.SiteAttachmentPluginTest;
@@ -143,7 +144,8 @@ import io.meeds.social.organizationalunit.storage.OrganizationalUnitStorageTest;
     PageRemovedIndexingListenerTest.class,
     PageContentIndexingConnectorTest.class,
     PageContentSearchConnectorTest.class,
-    PageFavoriteACLPluginTest.class
+    PageFavoriteACLPluginTest.class,
+    AccountDeactivationServiceTest.class
 })
 public class NoContainerTestSuite {
 

--- a/component/service/src/main/java/io/meeds/social/security/model/AccountDeactivationRequest.java
+++ b/component/service/src/main/java/io/meeds/social/security/model/AccountDeactivationRequest.java
@@ -1,34 +1,36 @@
-/*
+/**
  * This file is part of the Meeds project (https://meeds.io/).
- * 
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
- * 
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+package io.meeds.social.security.model;
 
-import * as otpService from './js/OtpService.js';
-import * as accountDeactivationService from './js/AccountDeactivationService.js';
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-if (!Vue.prototype.$otpService) {
-  window.Object.defineProperty(Vue.prototype, '$otpService', {
-    value: otpService,
-  });
-}
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountDeactivationRequest {
 
-if (!Vue.prototype.$accountDeactivationService) {
-  window.Object.defineProperty(Vue.prototype, '$accountDeactivationService', {
-    value: accountDeactivationService,
-  });
+  private String  otpMethod;
+
+  private String  otpCode;
+
+  private boolean deleteAccount;
+
 }

--- a/component/service/src/main/java/io/meeds/social/security/rest/AccountDeactivationRest.java
+++ b/component/service/src/main/java/io/meeds/social/security/rest/AccountDeactivationRest.java
@@ -1,0 +1,78 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import io.meeds.social.security.model.AccountDeactivationRequest;
+import io.meeds.social.security.service.AccountDeactivationService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/account/deactivation")
+@Tag(name = "/account/deactivation", description = "Manage current user account deactivation request")
+public class AccountDeactivationRest {
+
+  @Autowired
+  private AccountDeactivationService accountDeactivationService;
+
+  @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+  @Secured("users")
+  @ResponseStatus(code = HttpStatus.NO_CONTENT)
+  @Operation(summary = "Deactivates the current user account after validating the OTP code", method = "POST")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "204", description = "Account deactivated and sessions invalidated"),
+    @ApiResponse(responseCode = "401", description = "OTP code is blank, invalid or tentatives are exhausted"),
+    @ApiResponse(responseCode = "403", description = "Account deactivation is not allowed for the current user"),
+    @ApiResponse(responseCode = "501", description = "Account deletion request isn't supported yet"),
+  })
+  public void requestDeactivation(HttpServletRequest request,
+                                  @Parameter(description = "OTP method, code and deletion option")
+                                  @RequestBody
+                                  AccountDeactivationRequest deactivationRequest) {
+    try {
+      accountDeactivationService.requestDeactivation(request.getRemoteUser(),
+                                                     deactivationRequest.getOtpMethod(),
+                                                     deactivationRequest.getOtpCode(),
+                                                     deactivationRequest.isDeleteAccount());
+    } catch (IllegalStateException e) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+    } catch (IllegalAccessException e) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "OTP_CODE_INVALID");
+    } catch (UnsupportedOperationException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED);
+    }
+  }
+
+}

--- a/component/service/src/test/java/io/meeds/social/security/rest/AccountDeactivationRestTest.java
+++ b/component/service/src/test/java/io/meeds/social/security/rest/AccountDeactivationRestTest.java
@@ -1,0 +1,146 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.rest;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import io.meeds.social.security.service.AccountDeactivationService;
+import io.meeds.spring.web.security.PortalAuthenticationManager;
+import io.meeds.spring.web.security.WebSecurityConfiguration;
+
+import jakarta.servlet.Filter;
+import lombok.SneakyThrows;
+
+@SpringBootTest(classes = { AccountDeactivationRest.class, PortalAuthenticationManager.class, })
+@ContextConfiguration(classes = { WebSecurityConfiguration.class })
+@AutoConfigureWebMvc
+@AutoConfigureMockMvc(addFilters = false)
+@RunWith(SpringRunner.class)
+public class AccountDeactivationRestTest {
+
+  private static final String        USERNAME     = "john";
+
+  private static final String        OTP_METHOD   = "accountDeactivationEmail";
+
+  private static final String        OTP_CODE     = "12345";
+
+  private static final String        REQUEST_BODY = """
+      {"otpMethod": "accountDeactivationEmail", "otpCode": "12345", "deleteAccount": true}""";
+
+  private MockMvc                    mockMvc;
+
+  @Autowired
+  private SecurityFilterChain        filterChain;
+
+  @Autowired
+  private WebApplicationContext      context;
+
+  @MockitoBean
+  private AccountDeactivationService accountDeactivationService;
+
+  @Before
+  public void setup() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                             .addFilters(filterChain.getFilters().toArray(new Filter[0]))
+                             .build();
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationAnonymously() {
+    mockMvc.perform(post("/account/deactivation").content(REQUEST_BODY)
+                                                 .contentType(MediaType.APPLICATION_JSON))
+           .andExpect(status().isForbidden());
+    verify(accountDeactivationService, never()).requestDeactivation(anyString(), anyString(), anyString(), anyBoolean());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationWhenNotAllowed() {
+    doThrow(new IllegalStateException()).when(accountDeactivationService)
+                                        .requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, true);
+    mockMvc.perform(post("/account/deactivation").content(REQUEST_BODY)
+                                                 .contentType(MediaType.APPLICATION_JSON)
+                                                 .with(testUser()))
+           .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationWithWrongOtpCode() {
+    doThrow(new IllegalAccessException()).when(accountDeactivationService)
+                                         .requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, true);
+    mockMvc.perform(post("/account/deactivation").content(REQUEST_BODY)
+                                                 .contentType(MediaType.APPLICATION_JSON)
+                                                 .with(testUser()))
+           .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationWithDeletionNotImplemented() {
+    doThrow(new UnsupportedOperationException()).when(accountDeactivationService)
+                                                .requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, true);
+    mockMvc.perform(post("/account/deactivation").content(REQUEST_BODY)
+                                                 .contentType(MediaType.APPLICATION_JSON)
+                                                 .with(testUser()))
+           .andExpect(status().isNotImplemented());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationWithoutDeletion() {
+    mockMvc.perform(post("/account/deactivation").content("""
+        {"otpMethod": "accountDeactivationEmail", "otpCode": "12345", "deleteAccount": false}""")
+                                                 .contentType(MediaType.APPLICATION_JSON)
+                                                 .with(testUser()))
+           .andExpect(status().isNoContent());
+    verify(accountDeactivationService).requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, false);
+  }
+
+  private RequestPostProcessor testUser() {
+    return user(USERNAME).authorities(new SimpleGrantedAuthority("users"));
+  }
+
+}

--- a/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.service.test;
 
+import io.meeds.social.security.rest.AccountDeactivationRestTest;
 import io.meeds.social.security.rest.LoginRestTest;
 import io.meeds.social.security.rest.OtpRestTest;
 import org.junit.AfterClass;
@@ -74,6 +75,7 @@ import io.meeds.social.translation.rest.TranslationRestResourcesTest;
   ContentLinkRestTest.class,
   LoginRestTest.class,
   OtpRestTest.class,
+  AccountDeactivationRestTest.class,
 })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/web/pom.xml
+++ b/component/web/pom.xml
@@ -29,6 +29,9 @@
   <packaging>jar</packaging>
   <name>Meeds:: PLF:: Social Web Component</name>
   <description>Meeds Social Web Component</description>
+  <properties>
+    <exo.test.coverage.ratio>0.02</exo.test.coverage.ratio>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>io.meeds.social</groupId>
@@ -41,6 +44,15 @@
     <dependency>
       <groupId>io.meeds.social</groupId>
       <artifactId>social-component-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.meeds.social</groupId>
+      <artifactId>social-component-service</artifactId>
+      <type>test-jar</type>
+      <!--
+        Disable test scope to make a transitive dependency to all
+        dependant test-jar modules
+      -->
     </dependency>
   </dependencies>
   <build>

--- a/component/web/src/main/java/io/meeds/social/handler/ProfileAccessHandler.java
+++ b/component/web/src/main/java/io/meeds/social/handler/ProfileAccessHandler.java
@@ -1,0 +1,88 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.handler;
+
+import static org.exoplatform.portal.application.PortalRequestHandler.REQUEST_PATH;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.web.ControllerContext;
+import org.exoplatform.web.WebAppController;
+import org.exoplatform.web.WebRequestHandler;
+
+import jakarta.servlet.ServletConfig;
+
+/**
+ * Checks the profile page owner before letting the portal render it: the
+ * profile of a not existing, disabled or deleted user isn't accessible and
+ * ends up on the page not found, following the space access check pattern.
+ */
+public class ProfileAccessHandler extends WebRequestHandler {
+
+  public static final String      HANDLER_NAME = "profile-access";
+
+  private IdentityManager         identityManager;
+
+  private UserPortalConfigService portalConfigService;
+
+  @Override
+  public void onInit(WebAppController controller, ServletConfig sConfig) throws Exception {
+    super.onInit(controller, sConfig);
+
+    PortalContainer container = PortalContainer.getInstance();
+    this.identityManager = container.getComponentInstanceOfType(IdentityManager.class);
+    this.portalConfigService = container.getComponentInstanceOfType(UserPortalConfigService.class);
+  }
+
+  @Override
+  public String getHandlerName() {
+    return HANDLER_NAME;
+  }
+
+  @Override
+  protected boolean getRequiresLifeCycle() {
+    return true;
+  }
+
+  @Override
+  public boolean execute(ControllerContext controllerContext) throws Exception {
+    String path = controllerContext.getParameter(REQUEST_PATH);
+    String profileOwner = StringUtils.isBlank(path) ? null : path.split("/")[0];
+    String username = controllerContext.getRequest().getRemoteUser();
+    if (StringUtils.isBlank(profileOwner) || StringUtils.equals(profileOwner, username)) {
+      return false;
+    }
+    Identity identity = identityManager.getOrCreateUserIdentity(profileOwner);
+    if (identity == null || !identity.isEnable() || identity.isDeleted()) {
+      String pageNotFoundUrl = "/portal/" + getPageNotFoundSite(username) + "/page-not-found";
+      controllerContext.getResponse().sendRedirect(pageNotFoundUrl);
+      return true;
+    }
+    return false;
+  }
+
+  private String getPageNotFoundSite(String username) {
+    return StringUtils.isBlank(username) ? "public" : portalConfigService.getMetaPortal();
+  }
+
+}

--- a/component/web/src/test/java/io/meeds/social/handler/ProfileAccessHandlerTest.java
+++ b/component/web/src/test/java/io/meeds/social/handler/ProfileAccessHandlerTest.java
@@ -1,0 +1,156 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.handler;
+
+import static org.exoplatform.portal.application.PortalRequestHandler.REQUEST_PATH;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.web.ControllerContext;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.SneakyThrows;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class ProfileAccessHandlerTest {
+
+  private static final String     USERNAME      = "john";
+
+  private static final String     PROFILE_OWNER = "mary";
+
+  @Mock
+  private IdentityManager         identityManager;
+
+  @Mock
+  private UserPortalConfigService portalConfigService;
+
+  @Mock
+  private ControllerContext       controllerContext;
+
+  @Mock
+  private HttpServletRequest      request;
+
+  @Mock
+  private HttpServletResponse     response;
+
+  @Mock
+  private Identity                identity;
+
+  @InjectMocks
+  private ProfileAccessHandler    profileAccessHandler;
+
+  @Before
+  public void setUp() {
+    when(controllerContext.getRequest()).thenReturn(request);
+    when(controllerContext.getResponse()).thenReturn(response);
+    when(request.getRemoteUser()).thenReturn(USERNAME);
+    when(portalConfigService.getMetaPortal()).thenReturn("dw");
+  }
+
+  @Test
+  public void testGetHandlerName() {
+    assertEquals("profile-access", profileAccessHandler.getHandlerName());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testLetsBlankPathThrough() {
+    when(controllerContext.getParameter(REQUEST_PATH)).thenReturn("");
+    assertFalse(profileAccessHandler.execute(controllerContext));
+    verify(response, never()).sendRedirect(anyString());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testLetsOwnProfileThrough() {
+    when(controllerContext.getParameter(REQUEST_PATH)).thenReturn(USERNAME);
+    assertFalse(profileAccessHandler.execute(controllerContext));
+    verify(response, never()).sendRedirect(anyString());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testLetsEnabledUserProfileThrough() {
+    when(controllerContext.getParameter(REQUEST_PATH)).thenReturn(PROFILE_OWNER + "/some/sub/path");
+    when(identityManager.getOrCreateUserIdentity(PROFILE_OWNER)).thenReturn(identity);
+    when(identity.isEnable()).thenReturn(true);
+    when(identity.isDeleted()).thenReturn(false);
+    assertFalse(profileAccessHandler.execute(controllerContext));
+    verify(response, never()).sendRedirect(anyString());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRedirectsDisabledUserProfileToPageNotFound() {
+    when(controllerContext.getParameter(REQUEST_PATH)).thenReturn(PROFILE_OWNER);
+    when(identityManager.getOrCreateUserIdentity(PROFILE_OWNER)).thenReturn(identity);
+    when(identity.isEnable()).thenReturn(false);
+    assertTrue(profileAccessHandler.execute(controllerContext));
+    verify(response).sendRedirect("/portal/dw/page-not-found");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRedirectsDeletedUserProfileToPageNotFound() {
+    when(controllerContext.getParameter(REQUEST_PATH)).thenReturn(PROFILE_OWNER);
+    when(identityManager.getOrCreateUserIdentity(PROFILE_OWNER)).thenReturn(identity);
+    when(identity.isEnable()).thenReturn(true);
+    when(identity.isDeleted()).thenReturn(true);
+    assertTrue(profileAccessHandler.execute(controllerContext));
+    verify(response).sendRedirect("/portal/dw/page-not-found");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRedirectsUnknownUserProfileToPageNotFound() {
+    when(controllerContext.getParameter(REQUEST_PATH)).thenReturn(PROFILE_OWNER);
+    when(identityManager.getOrCreateUserIdentity(PROFILE_OWNER)).thenReturn(null);
+    assertTrue(profileAccessHandler.execute(controllerContext));
+    verify(response).sendRedirect("/portal/dw/page-not-found");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRedirectsAnonymousViewerToPublicPageNotFound() {
+    when(request.getRemoteUser()).thenReturn(null);
+    when(controllerContext.getParameter(REQUEST_PATH)).thenReturn(PROFILE_OWNER);
+    when(identityManager.getOrCreateUserIdentity(PROFILE_OWNER)).thenReturn(identity);
+    when(identity.isEnable()).thenReturn(false);
+    assertTrue(profileAccessHandler.execute(controllerContext));
+    verify(response).sendRedirect("/portal/public/page-not-found");
+    verify(portalConfigService, never()).getMetaPortal();
+  }
+
+}

--- a/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
@@ -46,9 +46,10 @@ UserSettings.security.deleteAccount.confirmAccess.sendingEmail=Email with OTP co
 UserSettings.security.deleteAccount.confirmAccess.inputTitle=OTP Code input
 UserSettings.security.deleteAccount.confirmAccess.inputPlaceholder=Enter the code received
 UserSettings.security.deleteAccount.resend=Re-send
-UserSettings.security.deleteAccount.codeVerified=Code verified
 UserSettings.security.deleteAccount.wrongOtpCode=Invalid OTP Code
 UserSettings.security.deleteAccount.otpSendError=Error while sending the code by email, please retry using the Re-send button
+UserSettings.security.deleteAccount.notAllowed=Account deactivation is not available anymore, please contact your administrator
+UserSettings.security.deleteAccount.deactivationError=Error while deactivating your account, please retry later
 
 UserSettings.socialNetworks=Social Networks
 UserSettings.button.cancel=Cancel

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -847,6 +847,11 @@
         <type>io.meeds.social.handler.SpacePermanentLinkHandler</type>
       </component-plugin>
       <component-plugin>
+        <name>ProfileAccessHandler</name>
+        <set-method>register</set-method>
+        <type>io.meeds.social.handler.ProfileAccessHandler</type>
+      </component-plugin>
+      <component-plugin>
         <name>spaceCreationInstantiationHandler</name>
         <set-method>register</set-method>
         <type>io.meeds.social.handler.SpaceCreationInstantiationHandler</type>

--- a/webapp/src/main/webapp/vue-apps/popover/components/UserPopoverContent.vue
+++ b/webapp/src/main/webapp/vue-apps/popover/components/UserPopoverContent.vue
@@ -46,7 +46,7 @@
         </v-list-item-title>
       </v-list-item-content>
     </v-list-item>
-    <div v-if="!isCurrentUser" class="d-flex justify-end">
+    <div v-if="displayActions" class="d-flex justify-end">
       <div class="me-auto">
         <v-btn
           v-for="extension in filteredUserNavigationExtensions"
@@ -94,6 +94,7 @@ export default {
     return {
       externalExtensions: [],
       userExtensions: [],
+      ownerEnabled: false,
     };
   },
   computed: {
@@ -125,6 +126,10 @@ export default {
     isCurrentUser() {
       return eXo.env.portal.userName === this.username;
     },
+    displayActions() {
+      // no action is suggested on disabled or deleted users (only the name)
+      return !this.isCurrentUser && this.ownerEnabled;
+    },
   },
   watch: {
     username: {
@@ -132,6 +137,7 @@ export default {
       handler(newVal, oldVal) {
         if (newVal !== oldVal) {
           this.refreshExtensions();
+          this.checkOwnerEnabled();
         }
       },
     },
@@ -141,6 +147,27 @@ export default {
     document.addEventListener('user-extension-updated', this.refreshUserExtensions);
   },
   methods: {
+    async checkOwnerEnabled() {
+      // no action is suggested on a disabled or deleted user: hide on any
+      // negative signal of the hover payload, otherwise display and double
+      // check against the server state which is the only reliable source
+      // (the hover payload is often stale or partial)
+      this.ownerEnabled = !!this.username && !this.isCurrentUser
+          && this.identity?.enabled !== false && !this.identity?.deleted;
+      if (!this.ownerEnabled) {
+        return;
+      }
+      try {
+        const user = await this.$userService.getUser(this.username);
+        if (!user || user.enabled === false || user.enabled === 'false'
+            || user.deleted === true || user.deleted === 'true') {
+          this.ownerEnabled = false;
+        }
+      } catch {
+        // keep the actions displayed: the profile access check and the
+        // backend enforce the real restrictions on disabled users
+      }
+    },
     refreshUserExtensions() {
       this.userExtensions = extensionRegistry.loadExtensions('user-extension', 'navigation') || [];
       this.userExtensions.sort((elementOne, elementTwo) => (elementOne.order || 100) - (elementTwo.order || 100));

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingDeactivateAccountDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingDeactivateAccountDrawer.vue
@@ -58,7 +58,7 @@
               v-model="otpCode"
               :title="$t('UserSettings.security.deleteAccount.confirmAccess.inputTitle')"
               :placeholder="$t('UserSettings.security.deleteAccount.confirmAccess.inputPlaceholder')"
-              :readonly="verifying || codeVerified"
+              :readonly="saving"
               prepend-inner-icon="fas fa-lock icon-default-color ms-n2"
               class="border-box-sizing flex-grow-1 px-0 pt-1 pb-0 me-2"
               name="otpCode"
@@ -72,19 +72,13 @@
               @keyup.enter="confirmRequest" />
             <v-btn
               :aria-label="$t('UserSettings.security.deleteAccount.resend')"
-              :disabled="sendingCode || verifying || codeVerified"
+              :disabled="sendingCode || saving"
               :loading="sendingCode"
               height="40"
               class="btn"
               @click="sendOtpCode">
               {{ $t('UserSettings.security.deleteAccount.resend') }}
             </v-btn>
-          </div>
-          <div
-            v-if="codeVerified"
-            class="d-flex align-center success--text mt-2">
-            <v-icon size="16" class="success--text me-1">fa-check</v-icon>
-            {{ $t('UserSettings.security.deleteAccount.codeVerified') }}
           </div>
         </template>
         <div v-else class="mt-4">
@@ -103,8 +97,8 @@
         </v-btn>
         <v-btn
           :aria-label="$t('UserSettings.button.confirm')"
-          :disabled="!otpCode || verifying || sendingCode"
-          :loading="verifying"
+          :disabled="!otpCode || saving || sendingCode"
+          :loading="saving"
           class="btn btn-danger"
           @click="confirmRequest">
           {{ $t('UserSettings.button.confirm') }}
@@ -122,14 +116,12 @@ export default {
     otpCode: null,
     emailSent: false,
     sendingCode: false,
-    verifying: false,
-    codeVerified: false,
+    saving: false,
   }),
   methods: {
     open() {
       this.otpCode = null;
       this.emailSent = false;
-      this.codeVerified = false;
       this.sendOtpCode();
       this.$refs.drawer.open();
     },
@@ -140,7 +132,6 @@ export default {
       this.sendingCode = true;
       try {
         this.otpCode = null;
-        this.codeVerified = false;
         await this.$otpService.sendOtpCode(this.otpMethod);
       } catch {
         this.$root.$emit('alert-message', this.$t('UserSettings.security.deleteAccount.otpSendError'), 'error');
@@ -149,28 +140,23 @@ export default {
         this.emailSent = true;
       }
     },
-    async verify() {
-      if (!this.otpCode || this.codeVerified || this.verifying) {
+    async confirmRequest() {
+      if (!this.otpCode || this.saving) {
         return;
       }
-      this.verifying = true;
+      this.saving = true;
       try {
-        await this.$otpService.validateOtpCode(this.otpMethod, this.otpCode);
-        this.codeVerified = true;
-      } catch {
-        this.$root.$emit('alert-message', this.$t('UserSettings.security.deleteAccount.wrongOtpCode'), 'error');
-      } finally {
-        this.verifying = false;
-      }
-    },
-    confirmRequest() {
-      if (!this.codeVerified) {
-        // first confirmation verifies the entered code (UX gate), then the
-        // drawer switches to the identity-confirmed state
-        this.verify();
-      } else {
-        // the state-changing call carrying the OTP code, validated server-side
-        // at that single authoritative point, is delivered by EXO-89280
+        await this.$accountDeactivationService.requestDeactivation(this.otpMethod, this.otpCode, false);
+        window.location.href = '/portal/logout';
+      } catch (e) {
+        this.saving = false;
+        if (e?.message === '401') {
+          this.$root.$emit('alert-message', this.$t('UserSettings.security.deleteAccount.wrongOtpCode'), 'error');
+        } else if (e?.message === '403') {
+          this.$root.$emit('alert-message', this.$t('UserSettings.security.deleteAccount.notAllowed'), 'error');
+        } else {
+          this.$root.$emit('alert-message', this.$t('UserSettings.security.deleteAccount.deactivationError'), 'error');
+        }
       }
     },
   },

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/js/AccountDeactivationService.js
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/js/AccountDeactivationService.js
@@ -1,8 +1,8 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * 
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
- * 
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -12,23 +12,26 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import * as otpService from './js/OtpService.js';
-import * as accountDeactivationService from './js/AccountDeactivationService.js';
-
-if (!Vue.prototype.$otpService) {
-  window.Object.defineProperty(Vue.prototype, '$otpService', {
-    value: otpService,
+export async function requestDeactivation(otpMethod, otpCode, deleteAccount) {
+  const resp = await fetch('/social/rest/account/deactivation', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      otpMethod,
+      otpCode,
+      deleteAccount,
+    }),
   });
-}
-
-if (!Vue.prototype.$accountDeactivationService) {
-  window.Object.defineProperty(Vue.prototype, '$accountDeactivationService', {
-    value: accountDeactivationService,
-  });
+  if (!resp?.ok) {
+    throw new Error(String(resp?.status || 'error'));
+  }
 }


### PR DESCRIPTION
Confirming the deactivation request now performs the operation:  he new AccountDeactivationService validates the OTP code (single authoritative validation), disables the user account, broadcasts a deactivation or deletion requested event and invalidates the server side authentication state so every active session stops being served; 
the drawer then redirects to the logout page. The REST endpoint answers 403 when the admin option is off or the account is externally synchronized, and 401 on an invalid code.

Once deactivated, the user profile page leads to the not found page (new ProfileAccessHandler following the space access check pattern) and the profile popover no more suggests any action on the user.