### PR TITLE
fix: Encode custom emoji reactions to ASCII for storage - EXO-89444 - eXIP7.3.0.16

### DIFF
--- a/component/core/src/main/java/io/meeds/social/reaction/service/ReactionServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/reaction/service/ReactionServiceImpl.java
@@ -115,7 +115,8 @@ public class ReactionServiceImpl implements ReactionService {
     MetadataObject object = activity.getMetadataObject();
 
     MetadataItem existingItem = reactionStorage.getUserReactionItem(object, identityId);
-    String existingReactionId = existingItem == null ? null : existingItem.getMetadata().getName();
+    String existingReactionId = existingItem == null ? null
+                                                    : ReactionStorage.decodeReactionId(existingItem.getMetadata().getName());
     boolean alreadyLiker = ArrayUtils.contains(activity.getLikeIdentityIds(), userIdentity.getId());
     boolean sameReaction = existingItem == null ? LIKE_REACTION_ID.equals(reactionId)
                                                 : StringUtils.equals(existingReactionId, reactionId);
@@ -159,7 +160,8 @@ public class ReactionServiceImpl implements ReactionService {
                                                       objectType,
                                                       objectId));
     }
-    String existingReactionId = existingItem == null ? LIKE_REACTION_ID : existingItem.getMetadata().getName();
+    String existingReactionId = existingItem == null ? LIKE_REACTION_ID
+                                                    : ReactionStorage.decodeReactionId(existingItem.getMetadata().getName());
     if (existingItem != null) {
       reactionStorage.deleteReaction(existingItem.getId(), identityId);
     }
@@ -235,7 +237,7 @@ public class ReactionServiceImpl implements ReactionService {
     Map<Long, String> reactionIdsByReactor = reactionStorage.getReactionItemsByCreators(object, pagedLikerIds)
                                                             .stream()
                                                             .collect(Collectors.toMap(MetadataItem::getCreatorId,
-                                                                                      item -> item.getMetadata().getName(),
+                                                                                      item -> ReactionStorage.decodeReactionId(item.getMetadata().getName()),
                                                                                       (first, second) -> first));
     return pagedLikerIds.stream()
                         .map(likerId -> new Reaction(likerId,
@@ -268,7 +270,10 @@ public class ReactionServiceImpl implements ReactionService {
     try {
       reactionStorage.deleteReaction(existingItem.getId(), reactorIdentityId);
       broadcastEvent(REACTION_DELETED_EVENT_NAME,
-                     new Reaction(reactorIdentityId, existingItem.getMetadata().getName(), objectType, objectId),
+                     new Reaction(reactorIdentityId,
+                                  ReactionStorage.decodeReactionId(existingItem.getMetadata().getName()),
+                                  objectType,
+                                  objectId),
                      null);
     } catch (ObjectNotFoundException e) {
       LOG.debug("Reaction item {} already deleted for reactor {} on object {}/{}",

--- a/component/core/src/main/java/io/meeds/social/reaction/storage/ReactionStorage.java
+++ b/component/core/src/main/java/io/meeds/social/reaction/storage/ReactionStorage.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -38,13 +39,39 @@ import org.exoplatform.social.metadata.model.MetadataObject;
 @Component
 public class ReactionStorage {
 
-  private static final int CREATORS_QUERY_CHUNK_SIZE = 500;
+  private static final int    CREATORS_QUERY_CHUNK_SIZE = 500;
+
+  private static final String CUSTOM_REACTION_PREFIX    = "emoji_";
 
   @Autowired
-  private MetadataService  metadataService;
+  private MetadataService     metadataService;
+
+  public static String encodeReactionId(String reactionId) {
+    if (reactionId == null || reactionId.chars().allMatch(character -> character < 128)) {
+      return reactionId;
+    }
+    return CUSTOM_REACTION_PREFIX
+           + reactionId.codePoints()
+                       .mapToObj(Integer::toHexString)
+                       .collect(Collectors.joining("_"));
+  }
+
+  public static String decodeReactionId(String metadataName) {
+    if (metadataName == null || !metadataName.startsWith(CUSTOM_REACTION_PREFIX)) {
+      return metadataName;
+    }
+    StringBuilder reactionId = new StringBuilder();
+    for (String hexCodePoint : metadataName.substring(CUSTOM_REACTION_PREFIX.length()).split("_")) {
+      reactionId.appendCodePoint(Integer.parseInt(hexCodePoint, 16));
+    }
+    return reactionId.toString();
+  }
 
   public Map<String, Long> countReactionsByOption(MetadataObject object) {
-    return metadataService.countMetadataItemsByMetadataTypeAndObjectGroupedByMetadataName(METADATA_TYPE_NAME, object);
+    return metadataService.countMetadataItemsByMetadataTypeAndObjectGroupedByMetadataName(METADATA_TYPE_NAME, object)
+                          .entrySet()
+                          .stream()
+                          .collect(Collectors.toMap(count -> decodeReactionId(count.getKey()), Map.Entry::getValue));
   }
 
   public MetadataItem getUserReactionItem(MetadataObject object, long identityId) {
@@ -82,7 +109,7 @@ public class ReactionStorage {
   }
 
   public List<MetadataItem> getReactionItemsByOption(String reactionId, MetadataObject object, long offset, long limit) {
-    return metadataService.getMetadataItemsByMetadataNameAndTypeAndObject(reactionId,
+    return metadataService.getMetadataItemsByMetadataNameAndTypeAndObject(encodeReactionId(reactionId),
                                                                           METADATA_TYPE_NAME,
                                                                           object.getType(),
                                                                           object.getId(),
@@ -91,7 +118,7 @@ public class ReactionStorage {
   }
 
   public void createReaction(MetadataObject object, String reactionId, long identityId) throws ObjectAlreadyExistsException {
-    metadataService.createMetadataItem(object, new MetadataKey(METADATA_TYPE_NAME, reactionId, 0), identityId);
+    metadataService.createMetadataItem(object, new MetadataKey(METADATA_TYPE_NAME, encodeReactionId(reactionId), 0), identityId);
   }
 
   public void deleteReaction(long itemId, long identityId) throws ObjectNotFoundException {

--- a/component/core/src/test/java/io/meeds/social/reaction/storage/ReactionStorageTest.java
+++ b/component/core/src/test/java/io/meeds/social/reaction/storage/ReactionStorageTest.java
@@ -141,6 +141,36 @@ public class ReactionStorageTest {
   }
 
   @Test
+  public void testCustomEmojiEncodedToAsciiForStorage() throws Exception {
+    reactionStorage.createReaction(OBJECT, "\uD83D\uDD25", 123l);
+
+    ArgumentCaptor<MetadataKey> keyCaptor = ArgumentCaptor.forClass(MetadataKey.class);
+    verify(metadataService).createMetadataItem(eq(OBJECT), keyCaptor.capture(), anyLong());
+    assertEquals("emoji_1f525", keyCaptor.getValue().getName());
+  }
+
+  @Test
+  public void testEncodeDecodeReactionIdRoundTrip() {
+    assertEquals("like", ReactionStorage.encodeReactionId("like"));
+    assertEquals("like", ReactionStorage.decodeReactionId("like"));
+    assertEquals("emoji_1f525", ReactionStorage.encodeReactionId("\uD83D\uDD25"));
+    assertEquals("\uD83D\uDD25", ReactionStorage.decodeReactionId("emoji_1f525"));
+    String heartWithSelector = "\u2764\uFE0F";
+    assertEquals(heartWithSelector,
+                 ReactionStorage.decodeReactionId(ReactionStorage.encodeReactionId(heartWithSelector)));
+    assertNull(ReactionStorage.encodeReactionId(null));
+    assertNull(ReactionStorage.decodeReactionId(null));
+  }
+
+  @Test
+  public void testCountReactionsByOptionDecodesCustomNames() {
+    when(metadataService.countMetadataItemsByMetadataTypeAndObjectGroupedByMetadataName(ReactionService.METADATA_TYPE_NAME,
+                                                                                        OBJECT)).thenReturn(Map.of("emoji_1f525",
+                                                                                                                   3l));
+    assertEquals(Map.of("\uD83D\uDD25", 3l), reactionStorage.countReactionsByOption(OBJECT));
+  }
+
+  @Test
   public void testDeleteReactionDelegates() throws Exception {
     reactionStorage.deleteReaction(77l, 123l);
     verify(metadataService).deleteMetadataItem(77l, 123l);

--- a/webapp/src/main/webapp/vue-apps/activity-reactions/components/ReactionChooser.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-reactions/components/ReactionChooser.vue
@@ -19,7 +19,7 @@
 
 <template>
   <div
-    class="reaction-chooser-wrapper position-relative d-inline-block"
+    class="reaction-chooser-wrapper position-relative d-inline-flex align-center"
     @mouseenter="startHoverTimer"
     @mouseleave="startCloseTimer"
     @touchstart="startLongPressTimer"

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/footer/actions/ActivityCommentLikeAction.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/footer/actions/ActivityCommentLikeAction.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-inline-flex pe-1">
+  <div class="d-inline-flex align-center pe-1">
     <reaction-chooser
       :current-reaction-id="userReactionId"
       object-type="activity"


### PR DESCRIPTION
A custom emoji stored raw as the metadata name fails on databases whose column charset rejects 4-byte UTF-8 (MySQL utf8mb3 NVARCHAR): the storage layer now encodes it as emoji_<codepoints-hex> on write and decodes it on every read (counts, items, events)