### PR TITLE
fix: Improve Sidebar Status Menu Accessibility - EXO-89452

### DIFF
--- a/webapp/src/main/resources/locale/portal/HamburgerMenu_en.properties
+++ b/webapp/src/main/resources/locale/portal/HamburgerMenu_en.properties
@@ -15,6 +15,7 @@ menu.confirmation.message.leaveSpace.warning=You are the last space admin. Pleas
 menu.confirmation.ok=OK
 menu.confirmation.cancel=Cancel
 menu.userProfilePageLink=Access your profile
+menu.openStatusMenu=Open your status menu
 menu.profile.external=(Guest)
 menu.role.navigation.first.level=First Level Navigation
 menu.role.navigation.second.level=Second Level Navigation

--- a/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
+++ b/webapp/src/main/webapp/vue-apps/sidebar/components/list/SidebarListFooter.vue
@@ -64,11 +64,13 @@
           bottom
           overlap
           dot>
-          <a
-            :href="profileUri"
-            :aria-label="$t('menu.userProfilePageLink')"
+          <v-btn
+            :aria-label="$t('menu.openStatusMenu')"
             class="userAvatar clickable"
-            @click.stop.prevent="openMenu($event)">
+            width="24"
+            height="24"
+            icon
+            @click.stop="openMenu($event)">
             <v-avatar size="24">
               <img
                 :src="avatarUrl"
@@ -77,7 +79,7 @@
                 width="24"
                 contain>
             </v-avatar>
-          </a>
+          </v-btn>
         </v-badge>
         <v-tooltip v-if="$root.expand" top>
           <template #activator="{ on, attrs }">
@@ -128,7 +130,6 @@ export default {
   data: () => ({
     settingsUrl: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/settings`,
     logoutUrl: `${eXo.env.portal.context}/logout`,
-    profileUri: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile`,
     productName: eXo.env.portal.productName,
     productLink: eXo.env.portal.productLink,
     statusColor: '#707070',

--- a/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarPopupStatusButton.vue
+++ b/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarPopupStatusButton.vue
@@ -26,6 +26,8 @@
     class="pa-0 text-center">
     <v-btn
       :value="value"
+      :aria-label="label"
+      :aria-pressed="isSelected ? 'true' : 'false'"
       active-class="btn-border-active"
       :class="colorClass"
       class="border-radius border-color-primary-grey pa-0 d-flex flex-column align-center mx-auto"

--- a/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarUserPopupContent.vue
+++ b/webapp/src/main/webapp/vue-apps/user-status-popup/components/SidebarUserPopupContent.vue
@@ -26,6 +26,7 @@
       <v-list-item class="py-2">
         <a
           :href="profileUri"
+          :aria-label="$t('menu.userProfilePageLink')"
           rel="noopener noreferrer"
           class="d-inline-flex align-center text-decoration-none">
           <v-badge


### PR DESCRIPTION
Before this change, the sidebar avatar was a link that never navigated, and the profile link and status buttons in the status menu had no accessible names or pressed state. To fix this, the avatar is now a real button labeled Open your status menu, and accessible names (Access your profile, Available, Do not disturb, Invisible) plus aria-pressed were added to the menu elements. After this change, screen reader and keyboard users get accurate names for the avatar, the profile link, and each status option.