### PR TITLE
feat: Notification for deactivation request to platform admins only - EXO-89279

### DIFF
--- a/component/notification/src/main/java/io/meeds/social/notification/rest/NotificationSettingsRestService.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/rest/NotificationSettingsRestService.java
@@ -63,6 +63,8 @@ public class NotificationSettingsRestService implements ResourceContainer {
 
   private static final String NOTIFICATION_LABEL_CHANNEL_DEFAULT = "UINotification.label.channel.default";
 
+  private static final String ACCOUNT_NOTIFICATIONS_GROUP        = "account";
+
   private static final String   MAIN_RESOURCE_BUNDLE_NAME = "locale.portlet.UserNotificationPortlet";
 
   private static final Log      LOG                       = ExoLogger.getLogger(NotificationSettingsRestService.class);
@@ -485,6 +487,11 @@ public class NotificationSettingsRestService implements ResourceContainer {
     }
   }
 
+  private boolean isAdministrator(String username) {
+    Identity identity = userACL.getUserIdentity(username);
+    return identity != null && userACL.isAdministrator(identity);
+  }
+
   private UserNotificationSettings mapToRestModel(UserSetting setting, boolean activeChannelsOnly) {
     Locale userLocale = LocalizationFilter.getCurrentLocale();
     if (userLocale == null) {
@@ -499,6 +506,13 @@ public class NotificationSettingsRestService implements ResourceContainer {
     List<String> channels = getChannels(activeChannelsOnly);
     Map<String, Boolean> channelStatus = computeChannelStatuses(setting, channels);
     List<GroupProvider> groups = pluginSettingService.getGroupPlugins();
+    if (StringUtils.isNotBlank(setting.getUserId()) && !isAdministrator(setting.getUserId())) {
+      // the account notifications target platform administrators only: other
+      // users don't see the group in their notification settings
+      groups = groups.stream()
+                     .filter(group -> !ACCOUNT_NOTIFICATIONS_GROUP.equals(group.getGroupId()))
+                     .toList();
+    }
     Map<String, String> groupsLabels = groups.stream()
                                              .collect(Collectors.toMap(GroupProvider::getGroupId,
                                                                        group -> context.pluginRes(group.getResourceBundleKey(),

--- a/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/channel/template/MailTemplateProvider.java
@@ -78,6 +78,7 @@ import org.jsoup.Jsoup;
     @TemplateConfig(pluginId = LikePlugin.ID, template = "war:/notification/templates/LikePlugin.gtmpl"),
     @TemplateConfig(pluginId = LikeCommentPlugin.ID, template = "war:/notification/templates/LikeCommentPlugin.gtmpl"),
     @TemplateConfig(pluginId = NewUserPlugin.ID, template = "war:/notification/templates/NewUserPlugin.gtmpl"),
+    @TemplateConfig(pluginId = AccountDeactivationRequestPlugin.ID, template = "war:/notification/templates/AccountDeactivationRequestPlugin.gtmpl"),
     @TemplateConfig(pluginId = PostActivityPlugin.ID, template = "war:/notification/templates/PostActivityPlugin.gtmpl"),
     @TemplateConfig(pluginId = PostActivitySpaceStreamPlugin.ID, template = "war:/notification/templates/PostActivitySpaceStreamPlugin.gtmpl"),
     @TemplateConfig(pluginId = RelationshipReceivedRequestPlugin.ID, template = "war:/notification/templates/RelationshipReceivedRequestPlugin.gtmpl"),
@@ -766,6 +767,77 @@ public class MailTemplateProvider extends TemplateProvider {
     
   };
 
+  /** Defines the template builder for AccountDeactivationRequestPlugin */
+  private AbstractTemplateBuilder accountDeactivationRequest = new AbstractTemplateBuilder() {
+    @Override
+    protected MessageInfo makeMessage(NotificationContext ctx) {
+      NotificationInfo notification = ctx.getNotificationInfo();
+      String language = getLanguage(notification);
+      TemplateContext templateContext = new TemplateContext(notification.getKey().getId(), language);
+      SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
+
+      String remoteId = notification.getValueOwnerParameter(SocialNotificationUtils.REMOTE_ID.getKey());
+      Identity identity = Utils.getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, remoteId, true);
+      if (identity == null) {
+        return null;
+      }
+
+      templateContext.put("USER", identity.getProfile().getFullName());
+      String subject = TemplateUtils.processSubject(templateContext);
+
+      templateContext.put("USERS_MANAGEMENT_URL",
+                          CommonsUtils.getCurrentDomain() + "/portal/administration/home/organisation/users?status=DISABLED");
+      String body = TemplateUtils.processGroovy(templateContext);
+      ctx.setException(templateContext.getException());
+
+      return new MessageInfo().subject(subject).body(body).end();
+    }
+
+    @Override
+    protected boolean makeDigest(NotificationContext ctx, Writer writer) {
+      List<NotificationInfo> notifications = ctx.getNotificationInfos();
+      NotificationInfo first = notifications.get(0);
+
+      String language = getLanguage(first);
+      TemplateContext templateContext = new TemplateContext(first.getKey().getId(), language);
+
+      // deduplicated by username: the same account can be deactivated,
+      // reactivated and deactivated again within one digest period
+      Map<String, String> requesterNames = new LinkedHashMap<>();
+      for (NotificationInfo message : notifications) {
+        String remoteId = message.getValueOwnerParameter(SocialNotificationUtils.REMOTE_ID.getKey());
+        Identity identity = Utils.getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, remoteId, true);
+        if (identity == null || identity.isDeleted()) {
+          continue;
+        }
+        requesterNames.putIfAbsent(remoteId, identity.getProfile().getFullName());
+      }
+      if (requesterNames.isEmpty()) {
+        return false;
+      }
+
+      List<String> names = List.copyOf(requesterNames.values());
+      int count = names.size();
+      if (count == 1) {
+        templateContext.put("USER", names.get(0));
+      } else if (count <= 3) {
+        templateContext.put("USER_LIST", String.join(", ", names));
+      } else {
+        templateContext.put("LAST3_USERS", String.join(", ", names.subList(0, 3)));
+        templateContext.put("COUNT", String.valueOf(count - 3));
+      }
+      try {
+        writer.append("<li style=\"margin: 0 0 13px 14px; font-size: 13px; line-height: 18px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif;\">")
+              .append(TemplateUtils.processDigest(templateContext.digestType(count)))
+              .append("</li>");
+      } catch (IOException e) {
+        ctx.setException(e);
+        return false;
+      }
+      return true;
+    }
+  };
+
   /** Defines the template builder for NewUserPlugin*/
   private AbstractTemplateBuilder newUser = new AbstractTemplateBuilder() {
     @Override
@@ -1332,6 +1404,7 @@ public class MailTemplateProvider extends TemplateProvider {
     this.templateBuilders.put(PluginKey.key(LikePlugin.ID), like);
     this.templateBuilders.put(PluginKey.key(LikeCommentPlugin.ID), likeComment);
     this.templateBuilders.put(PluginKey.key(NewUserPlugin.ID), newUser);
+    this.templateBuilders.put(PluginKey.key(AccountDeactivationRequestPlugin.ID), accountDeactivationRequest);
     this.templateBuilders.put(PluginKey.key(PostActivityPlugin.ID), postActivity);
     this.templateBuilders.put(PluginKey.key(PostActivitySpaceStreamPlugin.ID), postActivitySpace);
     this.templateBuilders.put(PluginKey.key(SharedActivitySpaceStreamPlugin.ID), shareActivitySpace);

--- a/component/notification/src/main/java/org/exoplatform/social/notification/listener/AccountDeactivationNotificationListener.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/listener/AccountDeactivationNotificationListener.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.notification.listener;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.notification.plugin.AccountDeactivationRequestPlugin;
+
+/**
+ * Notifies the platform administrators when the account deactivation
+ * requested event is broadcast (source = username, data = identity id).
+ * Asynchronous: the admin fan-out must not delay the user's deactivation
+ * request.
+ */
+@Asynchronous
+public class AccountDeactivationNotificationListener extends Listener<String, String> {
+
+  @Override
+  public void onEvent(Event<String, String> event) throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance()
+                                                     .append(AccountDeactivationRequestPlugin.REQUESTER, event.getSource());
+    ctx.getNotificationExecutor()
+       .with(ctx.makeCommand(PluginKey.key(AccountDeactivationRequestPlugin.ID)))
+       .execute(ctx);
+  }
+
+}

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/AccountDeactivationRequestPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/AccountDeactivationRequestPlugin.java
@@ -1,0 +1,91 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.notification.plugin;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+
+/**
+ * Notifies the platform administrators, and only them, that a user has
+ * requested to deactivate their account.
+ */
+public class AccountDeactivationRequestPlugin extends BaseNotificationPlugin {
+
+  public static final String                  ID                    = "AccountDeactivationRequestPlugin";
+
+  public static final String                  ADMINISTRATORS_GROUP  = "/platform/administrators";
+
+  public static final ArgumentLiteral<String> REQUESTER             = new ArgumentLiteral<>(String.class, "requester");
+
+  public AccountDeactivationRequestPlugin(InitParams initParams) {
+    super(initParams);
+  }
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public NotificationInfo makeNotification(NotificationContext ctx) {
+    String requester = ctx.value(REQUESTER);
+    try {
+      List<String> administrators = getPlatformAdministrators(requester);
+      if (administrators.isEmpty()) {
+        return null;
+      }
+      return NotificationInfo.instance()
+                             .key(getId())
+                             .to(administrators)
+                             .with(SocialNotificationUtils.REMOTE_ID.getKey(), requester)
+                             .setFrom(requester)
+                             .end();
+    } catch (Exception e) {
+      ctx.setException(e);
+      return null;
+    }
+  }
+
+  @Override
+  public boolean isValid(NotificationContext ctx) {
+    return StringUtils.isNotBlank(ctx.value(REQUESTER));
+  }
+
+  private List<String> getPlatformAdministrators(String requester) throws Exception {
+    OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+    ListAccess<User> administrators = organizationService.getUserHandler().findUsersByGroupId(ADMINISTRATORS_GROUP);
+    return Arrays.stream(administrators.load(0, administrators.getSize()))
+                 .map(User::getUserName)
+                 .filter(username -> !StringUtils.equals(username, requester))
+                 .toList();
+  }
+
+}

--- a/component/notification/src/test/java/io/meeds/social/notification/rest/NotificationSettingsRestServiceTest.java
+++ b/component/notification/src/test/java/io/meeds/social/notification/rest/NotificationSettingsRestServiceTest.java
@@ -72,6 +72,8 @@ public class NotificationSettingsRestServiceTest extends BaseRestServicesTestCas
 
   private static final String       GROUP_PROVIDER_ID = "groupId";
 
+  private static final String       ACCOUNT_GROUP_ID  = "account";
+
   private static final String       PLUGIN_ID         = "pluginId";
 
   private static final PluginInfo   PLUGIN_PROVIDER   = new PluginInfo();
@@ -254,6 +256,80 @@ public class NotificationSettingsRestServiceTest extends BaseRestServicesTestCas
 
     // Ensure no error is raised
     testGetSettingsSameUser();
+  }
+
+  public void testGetSettingsFiltersAccountGroupForNonAdministratorOwner() throws Exception {
+    // Given
+    when(pluginSettingService.getGroupPlugins()).thenReturn(Arrays.asList(GROUP_PROVIDER, newAccountGroupProvider()));
+    Identity user1Identity = new Identity(USER_1);
+    when(userACL.getUserIdentity(USER_1)).thenReturn(user1Identity);
+    when(userACL.isAdministrator(user1Identity)).thenReturn(false);
+
+    String path = getPath(USER_1, "");
+    MockHttpServletRequest httpRequest = new MockHttpServletRequest(path,
+                                                                    null,
+                                                                    0,
+                                                                    "GET",
+                                                                    null);
+    EnvironmentContext envctx = new EnvironmentContext();
+    envctx.put(HttpServletRequest.class, httpRequest);
+    startSessionAs(USER_1);
+
+    // When
+    ContainerResponse resp = launcher.service("GET",
+                                              path,
+                                              "",
+                                              null,
+                                              null,
+                                              envctx);
+
+    // Then
+    assertEquals(String.valueOf(resp.getEntity()), 200, resp.getStatus());
+    UserNotificationSettings notificationSettings = (UserNotificationSettings) resp.getEntity();
+    assertNotNull(notificationSettings);
+    assertEquals(1, notificationSettings.getGroups().size());
+    assertEquals(GROUP_PROVIDER_ID, notificationSettings.getGroups().get(0).getGroupId());
+  }
+
+  public void testGetSettingsKeepsAccountGroupForAdministratorOwner() throws Exception {
+    // Given
+    when(pluginSettingService.getGroupPlugins()).thenReturn(Arrays.asList(GROUP_PROVIDER, newAccountGroupProvider()));
+    Identity user1Identity = new Identity(USER_1);
+    when(userACL.getUserIdentity(USER_1)).thenReturn(user1Identity);
+    when(userACL.isAdministrator(user1Identity)).thenReturn(true);
+
+    String path = getPath(USER_1, "");
+    MockHttpServletRequest httpRequest = new MockHttpServletRequest(path,
+                                                                    null,
+                                                                    0,
+                                                                    "GET",
+                                                                    null);
+    EnvironmentContext envctx = new EnvironmentContext();
+    envctx.put(HttpServletRequest.class, httpRequest);
+    startSessionAs(USER_1);
+
+    // When
+    ContainerResponse resp = launcher.service("GET",
+                                              path,
+                                              "",
+                                              null,
+                                              null,
+                                              envctx);
+
+    // Then
+    assertEquals(String.valueOf(resp.getEntity()), 200, resp.getStatus());
+    UserNotificationSettings notificationSettings = (UserNotificationSettings) resp.getEntity();
+    assertNotNull(notificationSettings);
+    assertEquals(2, notificationSettings.getGroups().size());
+    assertTrue(notificationSettings.getGroups().stream().anyMatch(group -> ACCOUNT_GROUP_ID.equals(group.getGroupId())));
+  }
+
+  private static GroupProvider newAccountGroupProvider() {
+    PluginInfo accountPlugin = new PluginInfo();
+    accountPlugin.setType("AccountDeactivationRequestPlugin");
+    GroupProvider accountGroup = new GroupProvider(ACCOUNT_GROUP_ID);
+    accountGroup.setPluginInfos(Collections.singletonList(accountPlugin));
+    return accountGroup;
   }
 
   public void testSaveDisableChannel() throws Exception {

--- a/component/notification/src/test/java/org/exoplatform/social/notification/InitContainerTestSuite.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/InitContainerTestSuite.java
@@ -29,6 +29,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.exoplatform.commons.testing.BaseExoContainerTestSuite;
 import org.exoplatform.commons.testing.ConfigTestCase;
 import org.exoplatform.social.notification.channel.MailTemplateProviderTest;
+import org.exoplatform.social.notification.channel.template.AccountDeactivationRequestMailBuilderTest;
 import org.exoplatform.social.notification.channel.template.ActivityCommentMailBuilderTest;
 import org.exoplatform.social.notification.channel.template.ActivityCommentReplyMailBuilderTest;
 import org.exoplatform.social.notification.channel.template.ActivityMentionMailBuilderTest;
@@ -42,6 +43,8 @@ import org.exoplatform.social.notification.channel.template.ReceiveRequestMailBu
 import org.exoplatform.social.notification.channel.template.RequestJoinSpaceMailBuilderTest;
 import org.exoplatform.social.notification.channel.template.SpaceInvitationMailBuilderTest;
 import org.exoplatform.social.notification.impl.SpaceWebNotificationServiceTest;
+import org.exoplatform.social.notification.listener.AccountDeactivationNotificationListenerTest;
+import org.exoplatform.social.notification.plugin.AccountDeactivationRequestPluginTest;
 import org.exoplatform.social.notification.plugin.SocialNotificationUtilsTest;
 
 import io.meeds.social.security.plugin.AccountDeactivationEmailOtpPluginTest;
@@ -69,7 +72,10 @@ import io.meeds.social.security.plugin.EmailOtpPluginTest;
   EmailOtpPluginTest.class,
   AccountDeactivationEmailOtpPluginTest.class,
   SpaceMembershipNotificationListenerTest.class,
-  JoinedSpaceByInvitationLinkPluginTest.class
+  JoinedSpaceByInvitationLinkPluginTest.class,
+  AccountDeactivationRequestPluginTest.class,
+  AccountDeactivationNotificationListenerTest.class,
+  AccountDeactivationRequestMailBuilderTest.class
 })
 @ConfigTestCase(AbstractCoreTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/MailTemplateProviderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/MailTemplateProviderTest.java
@@ -115,7 +115,11 @@ public class MailTemplateProviderTest extends AbstractCoreTest {
     actual = channel.getTemplateFilePath(PluginKey.key(NewUserPlugin.ID));
     expected = "war:/notification/templates/NewUserPlugin.gtmpl";
     assertEquals(expected, actual);
-    
+
+    actual = channel.getTemplateFilePath(PluginKey.key(AccountDeactivationRequestPlugin.ID));
+    expected = "war:/notification/templates/AccountDeactivationRequestPlugin.gtmpl";
+    assertEquals(expected, actual);
+
     actual = channel.getTemplateFilePath(PluginKey.key(PostActivityPlugin.ID));
     expected = "war:/notification/templates/PostActivityPlugin.gtmpl";
     assertEquals(expected, actual);
@@ -148,6 +152,7 @@ public class MailTemplateProviderTest extends AbstractCoreTest {
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(EditCommentPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(EditActivityPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(NewUserPlugin.ID)));
+    assertTrue(channel.hasTemplateBuilder(PluginKey.key(AccountDeactivationRequestPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(PostActivityPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(PostActivitySpaceStreamPlugin.ID)));
     assertTrue(channel.hasTemplateBuilder(PluginKey.key(RelationshipReceivedRequestPlugin.ID)));

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/AccountDeactivationRequestMailBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/AccountDeactivationRequestMailBuilderTest.java
@@ -1,0 +1,125 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package org.exoplatform.social.notification.channel.template;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.channel.AbstractChannel;
+import org.exoplatform.commons.api.notification.channel.ChannelManager;
+import org.exoplatform.commons.api.notification.channel.template.AbstractTemplateBuilder;
+import org.exoplatform.commons.api.notification.model.ChannelKey;
+import org.exoplatform.commons.api.notification.model.MessageInfo;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.notification.channel.MailChannel;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.notification.AbstractCoreTest;
+import org.exoplatform.social.notification.plugin.AccountDeactivationRequestPlugin;
+import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
+
+public class AccountDeactivationRequestMailBuilderTest extends AbstractCoreTest {
+
+  private AbstractTemplateBuilder builder;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    ChannelManager manager = getService(ChannelManager.class);
+    AbstractChannel channel = manager.getChannel(ChannelKey.key(MailChannel.ID));
+    assertNotNull(channel);
+    assertTrue(channel.hasTemplateBuilder(PluginKey.key(AccountDeactivationRequestPlugin.ID)));
+    builder = channel.getTemplateBuilder(PluginKey.key(AccountDeactivationRequestPlugin.ID));
+  }
+
+  public void testMakeMessage() {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.setNotificationInfo(makeNotification(maryIdentity).setTo(rootIdentity.getRemoteId()));
+
+    MessageInfo message = builder.buildMessage(ctx);
+
+    assertNotNull(message);
+    String requesterFullName = maryIdentity.getProfile().getFullName();
+    assertEquals("Account Deactivation Request by " + requesterFullName, message.getSubject());
+    assertTrue(message.getBody().contains(requesterFullName));
+    assertTrue(message.getBody().contains("/portal/administration/home/organisation/users?status=DISABLED"));
+  }
+
+  public void testMakeDigestWithOneRequester() throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.setNotificationInfos(List.of(makeNotification(maryIdentity)));
+    StringWriter writer = new StringWriter();
+
+    assertTrue(builder.buildDigest(ctx, writer));
+
+    String digest = writer.toString();
+    assertTrue(digest, digest.contains(maryIdentity.getProfile().getFullName()));
+    assertTrue(digest, digest.contains("has requested to deactivate their account"));
+  }
+
+  public void testMakeDigestDeduplicatesSameRequester() throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    // the same account deactivated, reactivated and deactivated again within
+    // one digest period counts once
+    ctx.setNotificationInfos(Arrays.asList(makeNotification(maryIdentity), makeNotification(maryIdentity)));
+    StringWriter writer = new StringWriter();
+
+    assertTrue(builder.buildDigest(ctx, writer));
+
+    String digest = writer.toString();
+    assertTrue(digest, digest.contains("has requested to deactivate their account"));
+  }
+
+  public void testMakeDigestWithFewRequesters() throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.setNotificationInfos(Arrays.asList(makeNotification(maryIdentity), makeNotification(johnIdentity)));
+    StringWriter writer = new StringWriter();
+
+    assertTrue(builder.buildDigest(ctx, writer));
+
+    String digest = writer.toString();
+    assertTrue(digest, digest.contains(maryIdentity.getProfile().getFullName()));
+    assertTrue(digest, digest.contains(johnIdentity.getProfile().getFullName()));
+    assertTrue(digest, digest.contains("have requested to deactivate their accounts"));
+  }
+
+  public void testMakeDigestWithManyRequesters() throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.setNotificationInfos(Arrays.asList(makeNotification(maryIdentity),
+                                           makeNotification(johnIdentity),
+                                           makeNotification(demoIdentity),
+                                           makeNotification(rootIdentity)));
+    StringWriter writer = new StringWriter();
+
+    assertTrue(builder.buildDigest(ctx, writer));
+
+    String digest = writer.toString();
+    assertTrue(digest, digest.contains(maryIdentity.getProfile().getFullName()));
+    assertTrue(digest, digest.contains(johnIdentity.getProfile().getFullName()));
+    assertTrue(digest, digest.contains(demoIdentity.getProfile().getFullName()));
+    assertFalse(digest, digest.contains(rootIdentity.getProfile().getFullName()));
+    assertTrue(digest, digest.contains("more have requested to deactivate their accounts"));
+  }
+
+  private NotificationInfo makeNotification(Identity requesterIdentity) {
+    return NotificationInfo.instance()
+                           .key(AccountDeactivationRequestPlugin.ID)
+                           .with(SocialNotificationUtils.REMOTE_ID.getKey(), requesterIdentity.getRemoteId())
+                           .setFrom(requesterIdentity.getRemoteId())
+                           .setTo(rootIdentity.getRemoteId());
+  }
+}

--- a/component/notification/src/test/java/org/exoplatform/social/notification/listener/AccountDeactivationNotificationListenerTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/listener/AccountDeactivationNotificationListenerTest.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package org.exoplatform.social.notification.listener;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.command.NotificationCommand;
+import org.exoplatform.commons.api.notification.command.NotificationExecutor;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.social.notification.plugin.AccountDeactivationRequestPlugin;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AccountDeactivationNotificationListenerTest {
+
+  private static final String                     REQUESTER_ID = "jdoe";
+
+  private AccountDeactivationNotificationListener listener     = new AccountDeactivationNotificationListener();
+
+  @Test
+  public void testOnEventExecutesNotificationCommandWithRequester() throws Exception {
+    NotificationContext ctx = mock(NotificationContext.class);
+    NotificationExecutor executor = mock(NotificationExecutor.class);
+    NotificationCommand command = mock(NotificationCommand.class);
+
+    when(ctx.append(AccountDeactivationRequestPlugin.REQUESTER, REQUESTER_ID)).thenReturn(ctx);
+    when(ctx.getNotificationExecutor()).thenReturn(executor);
+    when(ctx.makeCommand(PluginKey.key(AccountDeactivationRequestPlugin.ID))).thenReturn(command);
+    when(executor.with(command)).thenReturn(executor);
+
+    try (MockedStatic<NotificationContextImpl> mockedStatic = mockStatic(NotificationContextImpl.class)) {
+      mockedStatic.when(NotificationContextImpl::cloneInstance).thenReturn(ctx);
+
+      listener.onEvent(new Event<>("social.account.deactivation.requested", REQUESTER_ID, "5"));
+
+      verify(ctx).append(AccountDeactivationRequestPlugin.REQUESTER, REQUESTER_ID);
+      verify(executor).with(command);
+      verify(executor).execute(ctx);
+    }
+  }
+}

--- a/component/notification/src/test/java/org/exoplatform/social/notification/mock/MockMailTemplateProvider.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/mock/MockMailTemplateProvider.java
@@ -34,6 +34,7 @@ import org.exoplatform.social.notification.plugin.*;
     @TemplateConfig(pluginId = EditCommentPlugin.ID, template = "classpath:/notification/templates/EditCommentPlugin.gtmpl"),
     @TemplateConfig(pluginId = LikeCommentPlugin.ID, template = "classpath:/notification/templates/LikeCommentPlugin.gtmpl"),
     @TemplateConfig(pluginId = NewUserPlugin.ID, template = "classpath:/notification/templates/NewUserPlugin.gtmpl"),
+    @TemplateConfig(pluginId = AccountDeactivationRequestPlugin.ID, template = "classpath:/notification/templates/AccountDeactivationRequestPlugin.gtmpl"),
     @TemplateConfig(pluginId = PostActivityPlugin.ID, template = "classpath:/notification/templates/PostActivityPlugin.gtmpl"),
     @TemplateConfig(pluginId = PostActivitySpaceStreamPlugin.ID, template = "classpath:/notification/templates/PostActivitySpaceStreamPlugin.gtmpl"),
     @TemplateConfig(pluginId = RelationshipReceivedRequestPlugin.ID, template = "classpath:/notification/templates/RelationshipReceivedRequestPlugin.gtmpl"),

--- a/component/notification/src/test/java/org/exoplatform/social/notification/plugin/AccountDeactivationRequestPluginTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/plugin/AccountDeactivationRequestPluginTest.java
@@ -1,0 +1,146 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package org.exoplatform.social.notification.plugin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserHandler;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AccountDeactivationRequestPluginTest {
+
+  private static final String              REQUESTER_ID = "jdoe";
+
+  @Mock
+  private InitParams                       initParams;
+
+  @Mock
+  private OrganizationService              organizationService;
+
+  @Mock
+  private UserHandler                      userHandler;
+
+  @Mock
+  private ListAccess<User>                 administrators;
+
+  private AccountDeactivationRequestPlugin plugin;
+
+  @Before
+  public void setUp() {
+    plugin = new AccountDeactivationRequestPlugin(initParams);
+  }
+
+  @Test
+  public void testGetId() {
+    assertEquals(AccountDeactivationRequestPlugin.ID, plugin.getId());
+  }
+
+  @Test
+  public void testIsValidOnlyWithRequester() {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    assertFalse(plugin.isValid(ctx));
+
+    ctx.append(AccountDeactivationRequestPlugin.REQUESTER, REQUESTER_ID);
+    assertTrue(plugin.isValid(ctx));
+  }
+
+  @Test
+  public void testMakeNotificationTargetsAdministratorsWithoutRequester() throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance()
+                                                     .append(AccountDeactivationRequestPlugin.REQUESTER, REQUESTER_ID);
+    // the requester is still member of the administrators group: they must not
+    // be notified of their own deactivation request
+    User[] users = { mockUser("admin1"), mockUser(REQUESTER_ID), mockUser("admin2") };
+    when(administrators.getSize()).thenReturn(3);
+    when(administrators.load(0, 3)).thenReturn(users);
+
+    try (MockedStatic<CommonsUtils> commonsUtils = mockStatic(CommonsUtils.class)) {
+      commonsUtils.when(() -> CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+      when(organizationService.getUserHandler()).thenReturn(userHandler);
+      when(userHandler.findUsersByGroupId(AccountDeactivationRequestPlugin.ADMINISTRATORS_GROUP)).thenReturn(administrators);
+
+      NotificationInfo notification = plugin.makeNotification(ctx);
+
+      assertNotNull(notification);
+      assertEquals(plugin.getKey(), notification.getKey());
+      assertEquals(Arrays.asList("admin1", "admin2"), notification.getSendToUserIds());
+      assertEquals(REQUESTER_ID, notification.getFrom());
+      assertEquals(REQUESTER_ID, notification.getValueOwnerParameter(SocialNotificationUtils.REMOTE_ID.getKey()));
+    }
+  }
+
+  @Test
+  public void testMakeNotificationWhenRequesterIsTheOnlyAdministrator() throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance()
+                                                     .append(AccountDeactivationRequestPlugin.REQUESTER, REQUESTER_ID);
+    User[] users = { mockUser(REQUESTER_ID) };
+    when(administrators.getSize()).thenReturn(1);
+    when(administrators.load(0, 1)).thenReturn(users);
+
+    try (MockedStatic<CommonsUtils> commonsUtils = mockStatic(CommonsUtils.class)) {
+      commonsUtils.when(() -> CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+      when(organizationService.getUserHandler()).thenReturn(userHandler);
+      when(userHandler.findUsersByGroupId(AccountDeactivationRequestPlugin.ADMINISTRATORS_GROUP)).thenReturn(administrators);
+
+      assertNull(plugin.makeNotification(ctx));
+    }
+  }
+
+  @Test
+  public void testMakeNotificationWhenAdministratorsResolutionFails() throws Exception {
+    NotificationContext ctx = NotificationContextImpl.cloneInstance()
+                                                     .append(AccountDeactivationRequestPlugin.REQUESTER, REQUESTER_ID);
+
+    try (MockedStatic<CommonsUtils> commonsUtils = mockStatic(CommonsUtils.class)) {
+      commonsUtils.when(() -> CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+      when(organizationService.getUserHandler()).thenReturn(userHandler);
+      when(userHandler.findUsersByGroupId(AccountDeactivationRequestPlugin.ADMINISTRATORS_GROUP))
+                                                                                                 .thenThrow(new IllegalStateException("fake failure"));
+
+      // the failure must be swallowed into the context, not propagated to the
+      // deactivation flow
+      assertNull(plugin.makeNotification(ctx));
+    }
+  }
+
+  private User mockUser(String username) {
+    User user = mock(User.class);
+    when(user.getUserName()).thenReturn(username);
+    return user;
+  }
+}

--- a/component/notification/src/test/resources/conf/exo.social.component.notification-configuration.xml
+++ b/component/notification/src/test/resources/conf/exo.social.component.notification-configuration.xml
@@ -527,6 +527,46 @@
     <component-plugin>
       <name>notification.plugins</name>
       <set-method>addPlugin</set-method>
+      <type>org.exoplatform.social.notification.plugin.AccountDeactivationRequestPlugin</type>
+      <description>Initial information for plugin.</description>
+      <init-params>
+        <object-param>
+          <name>template.AccountDeactivationRequestPlugin</name>
+          <description>The template of AccountDeactivationRequestPlugin</description>
+          <object type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+            <field name="pluginId">
+              <string>AccountDeactivationRequestPlugin</string>
+            </field>
+            <field name="resourceBundleKey">
+              <string>UINotification.label.AccountDeactivationRequestPlugin</string>
+            </field>
+            <field name="order">
+              <string>1</string>
+            </field>
+            <field name="defaultConfig">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>instantly</string>
+                </value>
+              </collection>
+            </field>
+            <field name="groupId">
+              <string>account</string>
+            </field>
+            <field name="bundlePath">
+              <string>locale.notification.template.Notification</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
+    <component-plugin>
+      <name>notification.plugins</name>
+      <set-method>addPlugin</set-method>
       <type>org.exoplatform.social.notification.plugin.RelationshipReceivedRequestPlugin</type>
       <description>Initial information for plugin.</description>
       <init-params>

--- a/component/notification/src/test/resources/locale/notification/template/Notification_en.properties
+++ b/component/notification/src/test/resources/locale/notification/template/Notification_en.properties
@@ -12,6 +12,23 @@ Notification.label.Reply=Reply
 Notification.label.CompanyName=eXoPlatform
 Notification.label.ViewFullDiscussion=View the full discussion
 Notification.label.footer=If you do not want to receive such notifications, <a target="_blank" style="color: #2f5e92; text-decoration: none;font-family:'HelveticaNeue bold',verdana,arial,tahoma" href="{0}">click here</a> to change your notification settings
+#####################################################################################
+#                     AccountDeactivationRequestPlugin                              #
+#####################################################################################
+UINotification.label.group.Account=Account
+UINotification.label.AccountDeactivationRequestPlugin=Someone requested to deactivate their account
+UINotification.title.AccountDeactivationRequestPlugin=Someone requested to deactivate their account
+Notification.subject.AccountDeactivationRequestPlugin=Account Deactivation Request by $USER
+Notification.title.AccountDeactivationRequestPlugin=Account Deactivation Request by {0}
+Notification.label.AccountDeactivationRequestPlugin.sayHello=Hello
+Notification.message.AccountDeactivationRequestPlugin={0} has requested to deactivate the platform account they are relating to.
+Notification.label.AccountDeactivationRequestPlugin.loggedOut=The user is now logged out and no longer receives notifications from the platform.
+Notification.label.AccountDeactivationRequestPlugin.reactivate=If needed, you can activate it again from the platform users management.
+Notification.label.AccountDeactivationRequestPlugin.seeMore=See More
+Notification.label.AccountDeactivationRequestPlugin.thanks=Thanks
+Notification.digest.one.AccountDeactivationRequestPlugin=$USER <span style="color:#333333">has requested to deactivate their account.</span>
+Notification.digest.three.AccountDeactivationRequestPlugin=$USER_LIST <span style="color:#333333">have requested to deactivate their accounts.</span>
+Notification.digest.more.AccountDeactivationRequestPlugin=$LAST3_USERS <span style="color:#333333">and</span> $COUNT <span style="color:#333333">more have requested to deactivate their accounts.</span>
 #############################################################################
 #                         NewUserPlugin                                     #
 #############################################################################

--- a/component/notification/src/test/resources/notification/templates/AccountDeactivationRequestPlugin.gtmpl
+++ b/component/notification/src/test/resources/notification/templates/AccountDeactivationRequestPlugin.gtmpl
@@ -1,0 +1,23 @@
+<div style="margin: 20px; background: #EDF5FF;font-family:HelveticaNeue,arial,tahoma,serif;">
+	<div style="line-height:45px;min-height:45px; border: solid 1px #d8d8d8; border-bottom:none;;font-weight:bold;vertical-align:middle;background-color:#efefef;color:#2f5e92;font-size:18px;text-align:center">
+		<span><%=_ctx.appRes("Notification.title.AccountDeactivationRequestPlugin", USER)%></span>
+	</div>
+	<div style="border:solid 1px #d8d8d8; padding:20px;border-bottom:none;">
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.sayHello")%> $FIRSTNAME,<br/>
+		<br/>
+		<%=_ctx.appRes("Notification.message.AccountDeactivationRequestPlugin", "<b>" + USER + "</b>")%><br/>
+		<br/>
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.loggedOut")%><br/>
+		<br/>
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.reactivate")%><br/>
+		<br/>
+		<a target="_blank" href="$USERS_MANAGEMENT_URL"><%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.seeMore")%></a>
+		<br/><br/>
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.thanks")%>
+		<br/><br/>
+		<div style="line-height:20px;color:#b7b7b7"><%=_ctx.appRes("Notification.label.footer", FOOTER_LINK)%></div>
+	</div>
+	<div style="border:1px solid #456693;font-size:14px;line-height:40px;min-height:40px; color:#fff;vertical-align:middle;background:#456693;text-align:center;font-weight:bold;">
+		<%=_ctx.appRes("Notification.label.CompanyName")%>
+	</div>
+</div>

--- a/webapp/src/main/resources/locale/notification/template/Notification_en.properties
+++ b/webapp/src/main/resources/locale/notification/template/Notification_en.properties
@@ -2,6 +2,25 @@
 #                         Commons label                                     #
 #############################################################################
 Notification.label.SayHello=Hi
+
+#####################################################################################
+#                     AccountDeactivationRequestPlugin                              #
+#####################################################################################
+UINotification.label.group.Account=Account
+UINotification.label.AccountDeactivationRequestPlugin=Someone requested to deactivate their account
+UINotification.title.AccountDeactivationRequestPlugin=Someone requested to deactivate their account
+Notification.subject.AccountDeactivationRequestPlugin=Account Deactivation Request by $USER
+Notification.title.AccountDeactivationRequestPlugin=Account Deactivation Request by {0}
+Notification.label.AccountDeactivationRequestPlugin.sayHello=Hello
+Notification.message.AccountDeactivationRequestPlugin={0} has requested to deactivate the platform account they are relating to.
+Notification.label.AccountDeactivationRequestPlugin.loggedOut=The user is now logged out and no longer receives notifications from the platform.
+Notification.label.AccountDeactivationRequestPlugin.reactivate=If needed, you can activate it again from the platform users management.
+Notification.label.AccountDeactivationRequestPlugin.seeMore=See More
+Notification.label.AccountDeactivationRequestPlugin.thanks=Thanks
+Notification.intranet.message.AccountDeactivationRequestPlugin=Account Deactivation Request by {0}
+Notification.digest.one.AccountDeactivationRequestPlugin=$USER <span style="color:#333333">has requested to deactivate their account.</span>
+Notification.digest.three.AccountDeactivationRequestPlugin=$USER_LIST <span style="color:#333333">have requested to deactivate their accounts.</span>
+Notification.digest.more.AccountDeactivationRequestPlugin=$LAST3_USERS <span style="color:#333333">and</span> $COUNT <span style="color:#333333">more have requested to deactivate their accounts.</span>
 Notification.label.ConnectNow=Connect now
 Notification.label.Confirm=Confirm
 Notification.label.Accept=Accept

--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -229,6 +229,7 @@ Notification.label.types=Types
 Notification.label.types.all=All
 Notification.label.types.usersAndSpaces=Spaces & Users
 Notification.label.types.stream=Discussions
+Notification.label.types.account=Account
 Notification.label.types.unread={0} unread notifications
 
 #####################################################################################

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/notification-plugins-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/notification-plugins-configuration.xml
@@ -806,4 +806,82 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.notification.service.setting.PluginSettingService</target-component>
+    <component-plugin>
+      <name>notification.groups</name>
+      <set-method>registerGroupConfig</set-method>
+      <type>org.exoplatform.commons.api.notification.plugin.GroupProviderPlugin</type>
+      <description>Account notifications group</description>
+      <init-params>
+        <object-param>
+          <name>group.account</name>
+          <description>The information of group account</description>
+          <object type="org.exoplatform.commons.api.notification.plugin.config.GroupConfig">
+            <field name="id">
+              <string>account</string>
+            </field>
+            <field name="resourceBundleKey">
+              <string>UINotification.label.group.Account</string>
+            </field>
+            <field name="order">
+              <string>100</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
+    <component-plugin>
+      <name>notification.plugins</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.social.notification.plugin.AccountDeactivationRequestPlugin</type>
+      <description>Initial information for plugin.</description>
+      <init-params>
+        <object-param>
+          <name>template.AccountDeactivationRequestPlugin</name>
+          <description>The template of AccountDeactivationRequestPlugin</description>
+          <object
+                  type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+            <field name="pluginId">
+              <string>AccountDeactivationRequestPlugin</string>
+            </field>
+            <field name="resourceBundleKey">
+              <string>UINotification.label.AccountDeactivationRequestPlugin</string>
+            </field>
+            <field name="order">
+              <string>1</string>
+            </field>
+            <field name="defaultConfig">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>instantly</string>
+                </value>
+              </collection>
+            </field>
+            <field name="groupId">
+              <string>account</string>
+            </field>
+            <field name="bundlePath">
+              <string>locale.notification.template.Notification</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>social.account.deactivation.requested</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.social.notification.listener.AccountDeactivationNotificationListener</type>
+      <description>Notifies platform administrators on account deactivation request</description>
+    </component-plugin>
+  </external-component-plugins>
 </configuration>

--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/upgrade-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/upgrade-configuration.xml
@@ -49,6 +49,34 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>AccountDeactivationRequestPlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.notification.upgrade.NotificationUpgradePlugin</type>
+      <description>An upgrade plugin to set a notification plugin </description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>5</value>
+        </value-param>
+        <value-param>
+          <name>notificationPluginId</name>
+          <description>Notification Plugin Id</description>
+          <value>AccountDeactivationRequestPlugin</value>
+        </value-param>
+        <value-param>
+          <name>notificationChannelId</name>
+          <description>Notification Channel Id, applied to all when empty</description>
+          <value></value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/webapp/src/main/webapp/WEB-INF/notification/templates/AccountDeactivationRequestPlugin.gtmpl
+++ b/webapp/src/main/webapp/WEB-INF/notification/templates/AccountDeactivationRequestPlugin.gtmpl
@@ -1,0 +1,23 @@
+<div style="margin: 20px; background: #EDF5FF;font-family:HelveticaNeue,arial,tahoma,serif;">
+	<div style="line-height:45px;min-height:45px; border: solid 1px #d8d8d8; border-bottom:none;;font-weight:bold;vertical-align:middle;background-color:#efefef;color:#2f5e92;font-size:18px;text-align:center">
+		<span><%=_ctx.appRes("Notification.title.AccountDeactivationRequestPlugin", USER)%></span>
+	</div>
+	<div style="border:solid 1px #d8d8d8; padding:20px;border-bottom:none;">
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.sayHello")%> $FIRSTNAME,<br/>
+		<br/>
+		<%=_ctx.appRes("Notification.message.AccountDeactivationRequestPlugin", "<b>" + USER + "</b>")%><br/>
+		<br/>
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.loggedOut")%><br/>
+		<br/>
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.reactivate")%><br/>
+		<br/>
+		<a target="_blank" href="$USERS_MANAGEMENT_URL"><%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.seeMore")%></a>
+		<br/><br/>
+		<%=_ctx.appRes("Notification.label.AccountDeactivationRequestPlugin.thanks")%>
+		<br/><br/>
+		<div style="line-height:20px;color:#b7b7b7"><%=_ctx.appRes("Notification.label.footer", FOOTER_LINK)%></div>
+	</div>
+	<div style="border:1px solid #456693;font-size:14px;line-height:40px;min-height:40px; color:#fff;vertical-align:middle;background:#456693;text-align:center;font-weight:bold;">
+		<%=_ctx.appRes("Notification.label.CompanyName")%>
+	</div>
+</div>

--- a/webapp/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/application-toolbar/components/ApplicationToolbar.vue
@@ -330,6 +330,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    expanded: { // Initially expand the right filter inputs instead of collapsing them behind the cone button
+      type: Boolean,
+      default: false,
+    },
     noTextTruncate: { // Avoid using overflow-hidden/text-truncate on parent elements to allow overflow
       type: Boolean,
       default: false,
@@ -343,8 +347,8 @@ export default {
       default: false,
     },
   },
-  data: () => ({
-    expandFilter: false,
+  data: (vm) => ({
+    expandFilter: vm.expanded,
     toggle: null,
     select: null,
     term: null,

--- a/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagement.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagement.vue
@@ -17,10 +17,10 @@
 </template>
 <script>
 export default {
-  data: () => ({
+  data: (vm) => ({
     exportUsersUrl: null,
     totalSize: null,
-    filter: 'ENABLED',
+    filter: vm.$root.presetStatus,
   }),
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementFilterDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementFilterDrawer.vue
@@ -117,9 +117,9 @@
 </template>
 <script>
 export default {
-  data: () => ({
+  data: (vm) => ({
     drawer: false,
-    status: 'ENABLED',
+    status: vm.$root.presetStatus,
     type: 'ALL',
     connectionStatus: 'ALL',
     enrollmentStatus: 'ALL',

--- a/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
@@ -86,7 +86,7 @@
 </template>
 <script>
 export default {
-  data: () => ({
+  data: (vm) => ({
     itemsPerPageOptions: [20, 50, 100],
     users: [],
     user: null,
@@ -96,7 +96,7 @@ export default {
     deleteConfirmMessage: null,
     tableMenus: {},
     keyword: null,
-    filter: null,
+    filter: vm.$root.presetStatus === 'DISABLED' ? { status: 'DISABLED' } : null,
     lang: eXo.env.portal.language,
     options: {
       page: 1,

--- a/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementToolbar.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementToolbar.vue
@@ -11,6 +11,7 @@
       text: $t('UsersManagement.filterBy')
     }"
     :filters-count="filtersCount"
+    :expanded="$root.presetStatus === 'DISABLED'"
     compact
     @filter-button-click="$root.$emit('open-advanced-filter-drawer')"
     @filter-text-input-end-typing="keyword = $event">
@@ -109,11 +110,11 @@ export default {
       default: () => 0,
     },
   },
-  data: () => ({
+  data: (vm) => ({
     initialized: false,
     keyword: null,
     usersSelected: false,
-    filter: null,
+    filter: vm.$root.presetStatus === 'DISABLED' ? { status: 'DISABLED' } : null,
     menu: false,
     exportId: null,
     exporting: false,

--- a/webapp/src/main/webapp/vue-apps/idm-users-management/main.js
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/main.js
@@ -29,6 +29,9 @@ export function init() {
     Vue.createApp({
       data: {
         isSuperUser: false,
+        // the status filter can be preset through the page URL, allowing deep
+        // links such as the account deactivation request notification one
+        presetStatus: new URLSearchParams(window.location.search).get('status') === 'DISABLED' ? 'DISABLED' : 'ENABLED',
       },
       computed: {
         isMobile() {

--- a/webapp/src/main/webapp/vue-apps/notification-extensions/components/plugins/AccountDeactivationRequest.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/components/plugins/AccountDeactivationRequest.vue
@@ -1,0 +1,33 @@
+<template>
+  <user-notification-template
+    :notification="notification"
+    :avatar-url="profileAvatarUrl"
+    :message="message"
+    :url="usersManagementUrl" />
+</template>
+<script>
+export default {
+  props: {
+    notification: {
+      type: Object,
+      default: null,
+    },
+  },
+  data: () => ({
+    usersManagementUrl: `${eXo.env.portal.context}/administration/home/organisation/users?status=DISABLED`,
+  }),
+  computed: {
+    profile() {
+      return this.notification?.from;
+    },
+    profileAvatarUrl() {
+      return this.profile?.avatar;
+    },
+    message() {
+      return this.profile && this.$t('Notification.intranet.message.AccountDeactivationRequestPlugin', {
+        0: `<span class="user-name font-weight-bold">${this.profile.fullname}</span>`,
+      }) || '';
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/notification-extensions/extensions.js
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/extensions.js
@@ -47,6 +47,19 @@ extensionRegistry.registerExtension('WebNotification', 'notification-group-exten
   ],
   icon: 'fa-stream',
 });
+extensionRegistry.registerExtension('WebNotification', 'notification-group-extension', {
+  rank: 40,
+  name: 'account',
+  plugins: [
+    'AccountDeactivationRequestPlugin'
+  ],
+  icon: 'fa-user-lock',
+});
+extensionRegistry.registerExtension('WebNotification', 'notification-content-extension', {
+  type: 'AccountDeactivationRequestPlugin',
+  rank: 10,
+  vueComponent: Vue.options.components['user-notification-account-deactivation-request'],
+});
 extensionRegistry.registerExtension('WebNotification', 'notification-content-extension', {
   type: 'NewUserPlugin',
   rank: 10,

--- a/webapp/src/main/webapp/vue-apps/notification-extensions/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/notification-extensions/initComponents.js
@@ -28,6 +28,7 @@ import UserNotificationType from './components/UserNotificationType.vue';
 import UserEmptyNotifications from './components/UserEmptyNotifications.vue';
 
 import NewUser from './components/plugins/NewUser.vue';
+import AccountDeactivationRequest from './components/plugins/AccountDeactivationRequest.vue';
 import RelationshipReceivedRequestPlugin from './components/plugins/RelationshipReceivedRequestPlugin.vue';
 import SpaceInvitationPlugin from './components/plugins/SpaceInvitationPlugin.vue';
 import RequestJoinSpacePlugin from './components/plugins/RequestJoinSpacePlugin.vue';
@@ -58,6 +59,7 @@ const components = {
   'user-notification-template': UserNotificationTemplate,
   'user-notification-menu': UserNotificationMenu,
   'user-notification-new-user': NewUser,
+  'user-notification-account-deactivation-request': AccountDeactivationRequest,
   'user-notification-relationship-received-request': RelationshipReceivedRequestPlugin,
   'user-notification-space-invitation': SpaceInvitationPlugin,
   'user-notification-space-join-request': RequestJoinSpacePlugin,


### PR DESCRIPTION
Platform administrators, and only them, are now notified when a user requests to deactivate their account, through a new notification plugin listening to the deactivation requested event, under a new "Account" notifications category visible to administrators only in the settings. The email carries the functional wording with a See More link, and the onsite notification opens the users management focused on the disabled users, through a new status deep link support of the page URL. The notification is active by default on both channels, including on already running platforms through an upgrade plugin covering the already stored user settings.