### PR TITLE
feat: No deactivation option for LDAP profiles related - EXO-89286

### DIFF
--- a/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
+++ b/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
@@ -117,7 +117,8 @@ public class AccountDeactivationService {
    * code: this is the single authoritative OTP validation of the flow.
    *
    * @throws IllegalStateException when the deactivation isn't allowed for the
-   *           user (admin option off or externally synchronized account)
+   *           user (admin option off, externally synchronized account or
+   *           account whose creation source isn't managed by the platform)
    * @throws IllegalAccessException when the OTP code is blank, invalid or the
    *           validation tentatives are exhausted
    * @throws UnsupportedOperationException when the account deletion is

--- a/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
+++ b/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
@@ -21,6 +21,7 @@ package io.meeds.social.security.service;
 import java.util.Map;
 
 import org.apache.commons.lang3.LocaleUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,13 @@ import lombok.SneakyThrows;
 public class AccountDeactivationService {
 
   public static final String   ACCOUNT_DEACTIVATION_REQUESTED_EVENT = "social.account.deactivation.requested";
+
+  /**
+   * The only creation source qualifying an account as managed by the platform
+   * itself, as stamped by the users management UI
+   * (org.exoplatform.portal.rest.UserRestResourcesV1#CREATION_SOURCE_UI).
+   */
+  public static final String   UI_CREATION_SOURCE                   = "ui";
 
   private static final Log     LOG                                  = ExoLogger.getLogger(AccountDeactivationService.class);
 
@@ -84,13 +92,24 @@ public class AccountDeactivationService {
   @Setter
   private String                 emailBodyPath;
 
+  /**
+   * The deactivation is offered only for accounts whose lifecycle belongs to
+   * the platform: externally synchronized accounts (LDAP) are excluded, and
+   * among the others only those created through the platform UI qualify. An
+   * account with no creation source predates the stamping of that attribute:
+   * it keeps the option rather than losing it on an unknown provenance.
+   */
   @SneakyThrows
   public boolean isDeactivationAllowed(String username) {
     if (!securitySettingService.getRegistrationSetting().isAccountDeactivationEnabled()) {
       return false;
     }
     User user = organizationService.getUserHandler().findUserByName(username);
-    return user != null && user.isInternalStore();
+    if (user == null || !user.isInternalStore()) {
+      return false;
+    }
+    String creationSource = user.getCreationSource();
+    return StringUtils.isBlank(creationSource) || StringUtils.equals(creationSource, UI_CREATION_SOURCE);
   }
 
   /**

--- a/component/core/src/test/java/io/meeds/social/security/service/AccountDeactivationServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/security/service/AccountDeactivationServiceTest.java
@@ -152,6 +152,32 @@ public class AccountDeactivationServiceTest {
   }
 
   @Test
+  public void testDeactivationAllowedForUiCreatedUser() {
+    registrationSetting.setAccountDeactivationEnabled(true);
+    when(user.isInternalStore()).thenReturn(true);
+    when(user.getCreationSource()).thenReturn(AccountDeactivationService.UI_CREATION_SOURCE);
+    assertTrue(accountDeactivationService.isDeactivationAllowed(USERNAME));
+  }
+
+  @Test
+  public void testDeactivationAllowedWhenCreationSourceIsUnknown() {
+    // accounts created before the creationSource stamping keep the option
+    registrationSetting.setAccountDeactivationEnabled(true);
+    when(user.isInternalStore()).thenReturn(true);
+    when(user.getCreationSource()).thenReturn(null);
+    assertTrue(accountDeactivationService.isDeactivationAllowed(USERNAME));
+  }
+
+  @Test
+  public void testDeactivationNotAllowedForUserCreatedByAnotherSource() {
+    // any known source other than the UI one, e.g. the CSV file importation
+    registrationSetting.setAccountDeactivationEnabled(true);
+    when(user.isInternalStore()).thenReturn(true);
+    when(user.getCreationSource()).thenReturn("fileImportation");
+    assertFalse(accountDeactivationService.isDeactivationAllowed(USERNAME));
+  }
+
+  @Test
   @SneakyThrows
   public void testDeactivationNotAllowedForUnknownUser() {
     registrationSetting.setAccountDeactivationEnabled(true);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -175,6 +175,15 @@ public class UserRest implements ResourceContainer, Startable {
 
   private static final String             IMAGE_PNG_MEDIA_TYPE        = "image/png";
 
+  /**
+   * Creation source stamped on accounts provisioned through this API, as
+   * opposed to the "ui" source stamped by the users management screens
+   * (org.exoplatform.portal.rest.UserRestResourcesV1#CREATION_SOURCE_UI). It
+   * marks accounts whose lifecycle is driven by the integrating system, which
+   * excludes them from the self service account deactivation.
+   */
+  public static final String              CREATION_SOURCE_API         = "api";
+
   private static final String             THIRD_USER_FIELD            = "thirdField";
 
   private static final String             USER_DISPLAYED_PHONE        = "displayedPhone";
@@ -725,6 +734,7 @@ public class UserRest implements ResourceContainer, Startable {
     user.setLastName(model.getLastname());
     user.setEmail(model.getEmail());
     user.setPassword(model.getPassword());
+    user.setCreationSource(CREATION_SOURCE_API);
     userHandler.createUser(user, true);
     //
     return EntityBuilder.getResponse(EntityBuilder.buildEntityProfile(model.getUsername(), uriInfo.getPath(), expand),

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -60,6 +60,7 @@ import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.cache.CacheService;
 import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.rest.impl.ContainerResponse;
@@ -947,6 +948,30 @@ public class UserRestResourcesTest extends AbstractResourceTest {
                                                         (ArrayList<Map<String, String>>) importedUserProfile.getProperty("custom-multi-property");
     assertNull(customMultiValuedProperty);
 
+  }
+
+  public void testAddUserStampsApiCreationSource() throws Exception {
+    startSessionAs("root");
+
+    byte[] jsonData = ("{\"username\":\"api.created\",\"password\":\"Passw0rd!\",\"email\":\"api.created@exoplatform.com\","
+        + "\"firstname\":\"Api\",\"lastname\":\"Created\"}").getBytes(StandardCharsets.UTF_8);
+    MultivaluedMap<String, String> headers = new MultivaluedMapImpl();
+    headers.putSingle("content-type", "application/json");
+    headers.putSingle("content-length", "" + jsonData.length);
+
+    ContainerResponse response = service("POST", getURLResource("users"), "", headers, jsonData);
+
+    assertNotNull(response);
+    assertEquals(String.valueOf(response.getEntity()), 200, response.getStatus());
+    try {
+      User createdUser = organizationService.getUserHandler().findUserByName("api.created");
+      assertNotNull(createdUser);
+      // accounts provisioned through the API are excluded from the self
+      // service account deactivation, which keys on this source
+      assertEquals(UserRest.CREATION_SOURCE_API, createdUser.getCreationSource());
+    } finally {
+      organizationService.getUserHandler().removeUser("api.created", false);
+    }
   }
 
   public void testImportUsers() throws Exception {

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingSecurity.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/userSettingSecurity.jsp
@@ -1,4 +1,4 @@
-<%@page import="io.meeds.portal.security.service.SecuritySettingService"%>
+<%@page import="io.meeds.social.security.service.AccountDeactivationService"%>
 <%@page import="org.exoplatform.container.ExoContainerContext"%>
 <%@page import="org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting"%>
 <%@page import="org.exoplatform.social.core.profileproperty.ProfilePropertyService"%>
@@ -8,9 +8,11 @@
   ProfilePropertyService profilePropertyService = ExoContainerContext.getService(ProfilePropertyService.class);
   ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("email");
   boolean emailEditable = profilePropertySetting == null || profilePropertySetting.isEditable();
-  boolean deactivationAllowed = ExoContainerContext.getService(SecuritySettingService.class)
-                                                   .getRegistrationSetting()
-                                                   .isAccountDeactivationEnabled();
+  // single source of truth: the admin option AND the account being managed by
+  // the platform itself, so externally synchronized users (LDAP) get no
+  // deactivation option at all
+  boolean deactivationAllowed = ExoContainerContext.getService(AccountDeactivationService.class)
+                                                   .isDeactivationAllowed(request.getRemoteUser());
 %>
 <div class="VuetifyApp">
   <div data-app="true"


### PR DESCRIPTION
This PR hides the deactivation request button for LDAP users, and more generally reserves the self service account deactivation to accounts managed by the platform itself.

The security settings UI (`userSettingSecurity.jsp`) now delegates to `AccountDeactivationService#isDeactivationAllowed` instead of only consulting the admin option, so the button no longer shows for users whose deactivation request would anyway be rejected server side.

**Deliberate behavior change, beyond the ticket title (recorded here on purpose):** the eligibility now requires all of:
- the admin option enabled (as before),
- an internal store account â€” LDAP / externally synchronized accounts are excluded,
- a creation source that is either blank (accounts created before the stamping of that attribute keep the option) or `ui` (users management UI).

As a consequence, CSV imported accounts (`fileImportation`) and accounts provisioned through `POST /v1/social/users` â€” now stamped `api` by this PR â€” no longer get the self deactivation option: their lifecycle is driven by the importing/integrating system, not by the platform. Accounts created by those channels before this PR carry no creation source and keep the option: this asymmetry is accepted, preferring to keep the option on unknown provenance rather than removing it.
