### PR TITLE
feat: Display an intermediate page when deactivation request confirmed - EXO-89345

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Login_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Login_en.properties
@@ -67,6 +67,12 @@ forgotpassword.resetPassword=Reset your password
 forgotpassword.backToLogin=Back to login
 forgotpassword.go=Go
 
+accountDeactivated.pagetitle=Account Deactivated
+accountDeactivated.title=Your account is now deactivated
+accountDeactivated.support=Need help? Contact our support team.
+accountDeactivated.seeYouSoon=We hope to see you back on the platform soon.
+accountDeactivated.backToLogin=Back to login
+
 internalOnboarding.pagetitle=Create a password
 externalOnboarding.pagetitle=Guest Sign Up
 onboarding.linkExpired=Sorry..., this link has expired.

--- a/webapp/src/main/resources/locale/portlet/Login_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/Login_fr.properties
@@ -67,6 +67,12 @@ forgotpassword.resetPassword=Réinitialiser votre mot de passe
 forgotpassword.backToLogin=Retour
 forgotpassword.go=Ok
 
+accountDeactivated.pagetitle=Compte désactivé
+accountDeactivated.title=Votre compte est maintenant désactivé
+accountDeactivated.support=Besoin d'aide ? Contactez notre équipe de support.
+accountDeactivated.seeYouSoon=Nous espérons vous revoir bientôt sur la plateforme.
+accountDeactivated.backToLogin=Retour à la page de connexion
+
 internalOnboarding.pagetitle=Crée un mot de passe
 externalOnboarding.pagetitle=Inscription
 onboarding.linkExpired=Désolé, ce lien a expiré !

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -435,6 +435,38 @@
   </portlet>
 
   <portlet>
+    <name>AccountDeactivated</name>
+    <module>
+      <script>
+        <minify>false</minify>
+        <path>/js/accountDeactivated.bundle.js</path>
+      </script>
+      <depends>
+        <module>loginCommon</module>
+      </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
+      <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>jquery</module>
+        <as>$</as>
+      </depends>
+      <depends>
+        <module>extensionRegistry</module>
+      </depends>
+    </module>
+  </portlet>
+
+  <portlet>
     <name>InternalOnboarding</name>
     <module>
       <load-group>internal-onboarding-extensions</load-group>

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -437,6 +437,7 @@
   <portlet>
     <name>AccountDeactivated</name>
     <module>
+      <load-group>account-deactivated-extensions</load-group>
       <script>
         <minify>false</minify>
         <path>/js/accountDeactivated.bundle.js</path>

--- a/webapp/src/main/webapp/WEB-INF/jsp/portlet/accountDeactivated.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/portlet/accountDeactivated.jsp
@@ -1,0 +1,14 @@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+<portlet:defineObjects />
+<%
+  String id = "accountDeactivated-" + renderRequest.getWindowID();
+%>
+<div class="VuetifyApp">
+  <div data-app="true"
+    class="v-application white v-application--is-ltr theme--light accountDeactivated"
+    id="<%=id%>">
+    <script type="text/javascript">
+      require(['PORTLET/social/AccountDeactivated'], app => app.init('<%=id%>'));
+    </script>
+  </div>
+</div>

--- a/webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -1326,6 +1326,26 @@
       <keywords>forgot</keywords>
     </portlet-info>
   </portlet>
+
+  <portlet>
+    <portlet-name>AccountDeactivated</portlet-name>
+    <display-name>Account Deactivated</display-name>
+    <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
+    <init-param>
+      <name>portlet-view-dispatched-file-path</name>
+      <value>/WEB-INF/jsp/portlet/accountDeactivated.jsp</value>
+    </init-param>
+    <cache-scope>PUBLIC</cache-scope>
+    <supports>
+      <mime-type>text/html</mime-type>
+    </supports>
+    <supported-locale>en</supported-locale>
+    <resource-bundle>locale.portlet.Login</resource-bundle>
+    <portlet-info>
+      <title>Account Deactivated</title>
+      <keywords>deactivated</keywords>
+    </portlet-info>
+  </portlet>
   <portlet>
     <portlet-name>InternalOnboarding</portlet-name>
     <display-name>Internal Onboarding</display-name>

--- a/webapp/src/main/webapp/vue-apps/login-account-deactivated/components/AccountDeactivated.vue
+++ b/webapp/src/main/webapp/vue-apps/login-account-deactivated/components/AccountDeactivated.vue
@@ -1,0 +1,62 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-app>
+    <v-card
+      width="350px"
+      max-width="100%"
+      class="mx-auto transparent"
+      flat>
+      <div class="text-color font-weight-bold text-center mb-2">
+        {{ $t('accountDeactivated.title') }}
+      </div>
+      <div class="text-color text-center">
+        <div>{{ $t('accountDeactivated.support') }}</div>
+        <div>{{ $t('accountDeactivated.seeYouSoon') }}</div>
+      </div>
+      <v-row class="mx-0 mt-8 pa-0">
+        <v-btn
+          :aria-label="$t('accountDeactivated.backToLogin')"
+          :href="loginUrl"
+          max-width="100%"
+          tabindex="0"
+          class="mx-auto login-button text-none px-4"
+          elevation="0"
+          outlined>
+          <v-icon size="16" class="me-2">fas fa-arrow-left</v-icon>
+          {{ $t('accountDeactivated.backToLogin') }}
+        </v-btn>
+      </v-row>
+    </v-card>
+  </v-app>
+</template>
+<script>
+export default {
+  computed: {
+    loginUrl() {
+      return `${eXo.env.portal.context}/login`;
+    },
+  },
+  mounted() {
+    this.$root.$applicationLoaded();
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/login-account-deactivated/initComponents.js
+++ b/webapp/src/main/webapp/vue-apps/login-account-deactivated/initComponents.js
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import AccountDeactivated from './components/AccountDeactivated.vue';
+
+const components = {
+  'portal-account-deactivated': AccountDeactivated,
+};
+
+for (const key in components) {
+  Vue.component(key, components[key]);
+}

--- a/webapp/src/main/webapp/vue-apps/login-account-deactivated/main.js
+++ b/webapp/src/main/webapp/vue-apps/login-account-deactivated/main.js
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import './initComponents.js';
+
+// get overrided components if exists
+const components = extensionRegistry.loadComponents('AccountDeactivated');
+if (components && components.length > 0) {
+  components.forEach(cmp => {
+    Vue.component(cmp.componentName, cmp.componentOptions);
+  });
+}
+
+//getting language of the PLF
+const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
+
+//should expose the locale ressources as REST API
+const urls = [
+  `/social/i18n/locale.portlet.Login?lang=${lang}`,
+  `/social/i18n/locale.portal.login?lang=${lang}`
+];
+
+export function init(id) {
+  exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
+    // init Vue app when locale ressources are ready
+    Vue.createApp({
+      template: `<portal-account-deactivated id="${id}"/>`,
+      vuetify: Vue.prototype.vuetifyOptions,
+      i18n
+    }, `#${id}`, 'Account Deactivated');
+  });
+}

--- a/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingDeactivateAccountDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/user-setting-security/components/UserSettingDeactivateAccountDrawer.vue
@@ -147,7 +147,10 @@ export default {
       this.saving = true;
       try {
         await this.$accountDeactivationService.requestDeactivation(this.otpMethod, this.otpCode, false);
-        window.location.href = '/portal/logout';
+        // site-less URL, served to anonymous users against the global site,
+        // the same way as the /portal/forgot-password public page
+        const accountDeactivatedPageUri = `${eXo.env.portal.context}/account-deactivated`;
+        window.location.href = `${eXo.env.portal.context}/logout?initialURI=${encodeURIComponent(accountDeactivatedPageUri)}`;
       } catch (e) {
         this.saving = false;
         if (e?.message === '401') {

--- a/webapp/webpack.common.js
+++ b/webapp/webpack.common.js
@@ -27,6 +27,7 @@ let config = {
     fontIcons: './src/main/webapp/vue-apps/common-font-icon/main.js',
     login: './src/main/webapp/vue-apps/login/main.js',
     forgotPassword: './src/main/webapp/vue-apps/login-forgot-password/main.js',
+    accountDeactivated: './src/main/webapp/vue-apps/login-account-deactivated/main.js',
     internalOnboarding: './src/main/webapp/vue-apps/login-internal-onboarding/main.js',
     externalOnboarding: './src/main/webapp/vue-apps/login-external-onboarding/main.js',
     register: './src/main/webapp/vue-apps/user-register/main.js',


### PR DESCRIPTION
A new "account-deactivated" page, following the login page layout and accessible to everyone, is added to the global site along with its navigation node, so administrators can customize it as any other page. An upgrade plugin imports the page and its navigation node on already running platforms.