### PR TITLE
feat: ask for many objects' category links in one query EXO-89589

### DIFF
--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
@@ -19,6 +19,7 @@
 package io.meeds.social.category.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -38,6 +39,22 @@ public interface CategoryLinkService {
    * @return {@link List} of linked {@link Category} identifiers
    */
   List<Long> getLinkedIds(CategoryObject object);
+
+  /**
+   * The categories each of several objects is filed under, in one query.
+   * <p>
+   * {@link #getLinkedIds(CategoryObject)} is the right call for a reader looking at one
+   * thing, and the wrong one for a list: a page of rows showing what each is filed under
+   * would ask it once per row. This answers the whole page, so the caller decorates its
+   * rows by lookup instead of by a query each.
+   *
+   * @param objectType {@link CategoryObject} type, example: Space, Activity ...
+   * @param objectIds the objects' identifiers
+   * @return {@link Map} of linked {@link Category} identifiers keyed by object id; an
+   *         object with no category is absent from the map rather than present with an
+   *         empty list
+   */
+  Map<String, List<Long>> getLinkedIds(String objectType, List<String> objectIds);
 
   /**
    * @param objectType {@link CategoryObject} type, example: Space, Activity ...

--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -380,6 +380,20 @@ public interface MetadataService {
   List<MetadataItem> getMetadataItemsByMetadataTypeAndObject(String metadataType, MetadataObject object);
 
   /**
+   * Retrieves the {@link MetadataItem} of several objects of one type at once, so a
+   * caller listing rows can ask a single question instead of one per row.
+   *
+   * @param metadataType {@link Metadata} type
+   * @param objectType the objects' type identifier, like ACTIVITY, COMMENT, NOTE, FILE
+   * @param objectIds the objects' technical identifiers
+   * @return {@link List} of linked {@link MetadataItem} across all the given objects,
+   *         each carrying the objectId it belongs to
+   */
+  List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectIds(String metadataType,
+                                                                String objectType,
+                                                                List<String> objectIds);
+
+  /**
    * Retrieves the list of Metadata items attached to a given {@link Metadata}
    * type and an object identified by its name and identifier
    *

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryLinkServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryLinkServiceImpl.java
@@ -19,6 +19,7 @@
 package io.meeds.social.category.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +61,11 @@ public class CategoryLinkServiceImpl implements CategoryLinkService {
   @Override
   public List<Long> getLinkedIds(CategoryObject object) {
     return categoryStorage.getLinkedIds(getObject(object));
+  }
+
+  @Override
+  public Map<String, List<Long>> getLinkedIds(String objectType, List<String> objectIds) {
+    return categoryStorage.getLinkedIds(objectType, objectIds);
   }
 
   @Override

--- a/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
@@ -163,6 +163,34 @@ public class CategoryStorage {
                               .toList();
   }
 
+  /**
+   * The categories each of several objects is filed under, in one query.
+   * <p>
+   * The single-object {@link #getLinkedIds(CategoryObject)} is the right call for a
+   * reader looking at one thing, and the wrong one for a list: a page of rows showing
+   * what each is filed under would ask it once per row, which is a query per message on
+   * a mail folder and per document on a drive. This answers the page, so the caller
+   * decorates its rows by lookup.
+   *
+   * @param objectType the objects' type, as registered by a category plugin
+   * @param objectIds the objects' identifiers
+   * @return the category identifiers of each object, keyed by object id; an object with
+   *         no category is absent from the map rather than present with an empty list
+   */
+  public Map<String, List<Long>> getLinkedIds(String objectType, List<String> objectIds) {
+    if (CollectionUtils.isEmpty(objectIds)) {
+      return Collections.emptyMap();
+    }
+    List<MetadataItem> items = metadataService.getMetadataItemsByMetadataTypeAndObjectIds(METADATA_TYPE.getName(),
+                                                                                          objectType,
+                                                                                          objectIds);
+    return items == null ? Collections.emptyMap() :
+                         items.stream()
+                              .collect(Collectors.groupingBy(MetadataItem::getObjectId,
+                                                             Collectors.mapping(item -> item.getMetadata().getId(),
+                                                                                Collectors.toList())));
+  }
+
   public List<Long> getLinkedIds(String objectType) {
     List<MetadataItem> items = metadataService.getMetadataItemsByMetadataTypeAndObjectType(METADATA_TYPE.getName(), objectType);
     return items == null ? Collections.emptyList() :

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.core.jpa.storage.dao.jpa;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -67,6 +68,12 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
   private static final String PARENT_OBJECT_ID     = "parentObjectId";
 
   private static final String OBJECT_ID            = "objectId";
+
+  private static final String OBJECT_IDS           = "objectIds";
+
+  // Oracle refuses an IN list past 1000 literals (ORA-01795); same bound, and same
+  // reason, as IdentityDAOImpl in this package.
+  private static final int    MAX_ITEMS_PER_IN_CLAUSE = 1000;
 
   private static final String SPACE_ID             = "spaceId";
 
@@ -129,6 +136,40 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
     query.setParameter(OBJECT_TYPE, objectType);
     query.setParameter(OBJECT_ID, objectId);
     return query.getResultList();
+  }
+
+  /**
+   * The same read for a page of objects at once, so a caller listing rows can ask once
+   * instead of once per row.
+   * <p>
+   * Issued in chunks: Oracle refuses an IN list past 1000 literals (ORA-01795), which a
+   * page of rows can exceed — a mailbox caches a thousand messages by default and may be
+   * configured for five thousand. The chunk size follows {@code IdentityDAOImpl}, which
+   * meets the same limit in this package.
+   *
+   * @param metadataType the metadata type id
+   * @param objectType the object type, e.g. the one a category plugin registers
+   * @param objectIds the object ids to read, in any order
+   * @return the items of those objects, empty when no id is given
+   */
+  public List<MetadataItemEntity> getMetadataItemsByMetadataTypeAndObjectIds(long metadataType,
+                                                                             String objectType,
+                                                                             List<String> objectIds) {
+    if (CollectionUtils.isEmpty(objectIds)) {
+      return Collections.emptyList();
+    }
+    TypedQuery<MetadataItemEntity> query =
+                                         getEntityManager().createNamedQuery("SocMetadataItemEntity.getMetadataItemsByMetadataTypeAndObjectIds",
+                                                                             MetadataItemEntity.class);
+    query.setParameter(METADATA_TYPE, metadataType);
+    query.setParameter(OBJECT_TYPE, objectType);
+    List<MetadataItemEntity> items = new ArrayList<>();
+    for (int start = 0; start < objectIds.size(); start += MAX_ITEMS_PER_IN_CLAUSE) {
+      int end = Math.min(start + MAX_ITEMS_PER_IN_CLAUSE, objectIds.size());
+      query.setParameter(OBJECT_IDS, objectIds.subList(start, end));
+      items.addAll(query.getResultList());
+    }
+    return items;
   }
 
   public List<MetadataItemEntity> getMetadataItemsByMetadataTypeAndObject(long metadataType,

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -69,6 +69,18 @@ import jakarta.persistence.Table;
         + " mi.objectId = :objectId"
         + " ORDER BY mi.id ASC"
 )
+// The same read for a page of objects at once. A caller listing rows and showing what
+// each is filed under would otherwise ask the query above once per row, which is a query
+// per message on a mail folder and per document on a drive. Ordered by object first so a
+// caller can group the answer as it walks it.
+@NamedQuery(
+    name = "SocMetadataItemEntity.getMetadataItemsByMetadataTypeAndObjectIds",
+    query = "SELECT mi FROM SocMetadataItemEntity mi WHERE "
+        + " mi.metadata.type = :metadataType AND"
+        + " mi.objectType = :objectType AND"
+        + " mi.objectId IN :objectIds"
+        + " ORDER BY mi.objectId ASC, mi.id ASC"
+)
 @NamedQuery(
     name = "SocMetadataItemEntity.getSortedMetadataItemsByMetadataTypeAndObject",
     query = "SELECT mi FROM SocMetadataItemEntity mi WHERE "

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -349,6 +349,13 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   }
 
   @Override
+  public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectIds(String metadataType,
+                                                                       String objectType,
+                                                                       List<String> objectIds) {
+    return this.metadataStorage.getMetadataItemsByMetadataTypeAndObjectIds(metadataType, objectType, objectIds);
+  }
+
+  @Override
   public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectType(String metadataType, String objectType) {
     return this.metadataStorage.getMetadataItemsByMetadataTypeAndObjectType(metadataType, objectType);
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
@@ -387,6 +387,32 @@ public class MetadataStorage {
     return metadataItemEntities.stream().map(this::fromEntity).toList();
   }
 
+  /**
+   * The same read for a page of objects of one type, so a caller listing rows asks once
+   * instead of once per row.
+   *
+   * @param metadataTypeName the metadata type name
+   * @param objectType the objects' type
+   * @param objectIds the object ids to read
+   * @return the items of those objects, empty when no id is given
+   */
+  public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectIds(String metadataTypeName,
+                                                                       String objectType,
+                                                                       List<String> objectIds) {
+    if (CollectionUtils.isEmpty(objectIds)) {
+      return Collections.emptyList();
+    }
+    MetadataType metadataType = getMetadataTypeWithCheck(metadataTypeName);
+    List<MetadataItemEntity> metadataItemEntities =
+                                                  metadataItemDAO.getMetadataItemsByMetadataTypeAndObjectIds(metadataType.getId(),
+                                                                                                             objectType,
+                                                                                                             objectIds);
+    if (CollectionUtils.isEmpty(metadataItemEntities)) {
+      return Collections.emptyList();
+    }
+    return metadataItemEntities.stream().map(this::fromEntity).toList();
+  }
+
   public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectType(String metadataTypeName, String objectType) {
     MetadataType metadataType = getMetadataTypeWithCheck(metadataTypeName);
     List<MetadataItemEntity> metadataItemEntities =

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
@@ -19,6 +19,7 @@
 package io.meeds.social.category.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Test;
@@ -44,6 +46,49 @@ import io.meeds.social.space.plugin.SpaceCategoryPlugin;
 import lombok.SneakyThrows;
 
 public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
+
+
+  /**
+   * The bulk read answers a page of objects at once, and answers it exactly as the
+   * single-object read would have, object by object.
+   * <p>
+   * That equivalence is the whole contract: the bulk call exists only so a caller
+   * listing rows can stop asking once per row, and it is worth nothing if the two can
+   * drift apart. An object with no category is absent from the map rather than present
+   * with an empty list, so a caller can tell "none" from "not asked for".
+   */
+  @Test
+  @SneakyThrows
+  public void testGetLinkedIdsInBulkAgreesWithThePerObjectRead() {
+    Category rootCategory = categoryService.getRootCategory(getAdminGroupIdentityId());
+
+    Space linkedSpace = new Space();
+    linkedSpace.setRegistration(Space.OPEN);
+    linkedSpace.setVisibility(Space.PUBLIC);
+    linkedSpace = spaceService.createSpace(linkedSpace, ROOT_USER);
+    CategoryObject linkedObject = new CategoryObject(SpaceCategoryPlugin.OBJECT_TYPE,
+                                                     linkedSpace.getId(),
+                                                     linkedSpace.getSpaceId());
+    categoryLinkService.link(rootCategory.getId(), linkedObject);
+
+    Space unlinkedSpace = new Space();
+    unlinkedSpace.setRegistration(Space.OPEN);
+    unlinkedSpace.setVisibility(Space.PUBLIC);
+    unlinkedSpace = spaceService.createSpace(unlinkedSpace, ROOT_USER);
+    CategoryObject unlinkedObject = new CategoryObject(SpaceCategoryPlugin.OBJECT_TYPE,
+                                                       unlinkedSpace.getId(),
+                                                       unlinkedSpace.getSpaceId());
+
+    Map<String, List<Long>> linkedIds = categoryLinkService.getLinkedIds(SpaceCategoryPlugin.OBJECT_TYPE,
+                                                                         List.of(linkedObject.getId(), unlinkedObject.getId()));
+
+    // what the per-object call says, said for the whole page in one query
+    assertEquals(categoryLinkService.getLinkedIds(linkedObject), linkedIds.get(linkedObject.getId()));
+    assertTrue(linkedIds.get(linkedObject.getId()).contains(rootCategory.getId()));
+    // an object with no category is absent, not empty
+    assertTrue(CollectionUtils.isEmpty(categoryLinkService.getLinkedIds(unlinkedObject)));
+    assertNull(linkedIds.get(unlinkedObject.getId()));
+  }
 
   @Test
   @SneakyThrows


### PR DESCRIPTION
`CategoryLinkService` could only be asked about one object at a time, so anything listing rows and showing what each is filed under ran **one query per row** — and there was no way to avoid it from outside social.

## Where it bites

The mail drawer. `EmailBoxStorage.fromEntity` calls `getLinkedIds` per message, so a mailbox with 500 cached messages runs ~500 serial SELECTs to draw a list; 5000 at the cache ceiling an administrator may configure. It isn't specific to mail — any domain listing categorised rows meets the same wall.

## Why nothing existing would do

| Existing method | Why not |
|---|---|
| `getLinkedIds(CategoryObject)` | the per-object call — this *is* the N+1 |
| `getLinkedIds(String objectType)` | which **categories** a type uses, not which categories each object is in |
| `getLinkedObjects(categoryId, types, offset, limit)` | goes by category, and isn't user-scoped |
| `CategoryService.getCategoryEntries(...)` | user-scoped, but a UI card builder: over-fetches 3× and filters per item — heavier than the N+1 it would replace |

## What this adds

`getLinkedIds(objectType, objectIds)` → `Map<String, List<Long>>`, down through a new named query beside the existing one.

A map rather than a flat list, so the grouping isn't pushed onto every caller. An object with no category is **absent** from the map rather than present with an empty list, so a caller can tell "none" from "not asked for".

## Purely additive

**196 lines, no deletions.** Every current caller keeps its method, its SQL and its results — the new named query sits beside the old one, the DAO method beside the old one, and each layer above gets an overload.

No schema change and no migration: the same `objectType` + `objectId` columns the existing query already uses, with `IN` instead of `=`.

The `IN` list is chunked at 1000 — Oracle's limit (ORA-01795) — following `IdentityDAOImpl`, which meets the same bound in that package.

## Considered and rejected

Adding `@Cacheable` to `CategoryStorage.getLinkedIds`, which its three sibling methods already carry. It's one annotation, but it changes the behaviour of **every existing caller** rather than adding a new path, needs eviction to be right on every link and unlink, and helps least where it's needed most: auto-categorization links constantly, so entries would be evicted often, and a cold mailbox still pays every query.

## Verification

`component/api` and `component/core` compile. `CategoryLinkServiceTest` 6/6, metadata suites 38/38 green.

The new test asserts the bulk answer **equals the per-object one, object by object**. That equivalence is the whole contract: the call exists so a caller can stop asking per row, and is worth nothing if the two can drift apart.

Not measured against a large dataset — the win is structural (N queries become one), and the caller that will demonstrate it is the follow-up below.

## Follow-up, not part of this

email-connector's listing switches to the bulk call once this is released: one query for the page instead of one per row, taking the drawer's open from ~505 statements to about 6. Context in [EXO-89588](https://community.exoplatform.com/portal/dw/tasks/taskDetail/89588) and PRs [#360](https://github.com/exoplatform/email-connector/pull/360) / [#361](https://github.com/exoplatform/email-connector/pull/361).

**N2** — shared component, additive API, no schema/ACL/trust-boundary surface. Worth a reviewer who knows the metadata layer, since that is where the new query lives.
