### PR TITLE
feat: Behaviour when deletion is also requested - EXO-89283

### DIFF
--- a/component/core/src/main/java/io/meeds/social/security/job/AccountDeletionJob.java
+++ b/component/core/src/main/java/io/meeds/social/security/job/AccountDeletionJob.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.job;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import io.meeds.social.security.service.AccountDeletionService;
+
+import lombok.Synchronized;
+
+/**
+ * Job executing the account deletion requests whose grace delay elapsed: no
+ * business logic, it delegates the whole processing to
+ * {@link AccountDeletionService}. Deliberately not transactional: the service
+ * opens one container lifecycle per processed account so a failure never
+ * poisons the rest of the batch. There is no cluster lock either
+ * ({@link Synchronized} only prevents same-node overlaps): the processing is
+ * idempotent by construction — each account's request marker is removed in
+ * its own committed step before the deletion happens.
+ */
+@Configuration
+@EnableScheduling
+public class AccountDeletionJob {
+
+  @Autowired
+  private AccountDeletionService accountDeletionService;
+
+  @Scheduled(cron = "${social.AccountDeletionJob.expression:0 15 5 ? * *}")
+  @Synchronized
+  public void run() {
+    accountDeletionService.processPendingDeletionRequests();
+  }
+
+}

--- a/component/core/src/main/java/io/meeds/social/security/service/AccountDeletionService.java
+++ b/component/core/src/main/java/io/meeds/social/security/service/AccountDeletionService.java
@@ -1,0 +1,220 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.service;
+
+import static io.meeds.social.security.service.AccountDeactivationService.DELETION_REQUEST_SCOPE;
+import static io.meeds.social.security.service.AccountDeactivationService.DELETION_REQUEST_SETTING_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserStatus;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.jpa.search.ProfileIndexingServiceConnector;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.common.ContainerTransactional;
+
+import lombok.Setter;
+
+/**
+ * Executes the account deletion requests recorded by
+ * {@link AccountDeactivationService}, once their grace delay elapsed. The
+ * processing is idempotent without any cluster lock: for each due account the
+ * request marker is removed in its own committed lifecycle first, so a
+ * concurrent or replayed run finds nothing to do, and the deletion itself
+ * (social identity soft-deleted then IDM user removed, mirroring the users
+ * administration deletion) is a no-op once the IDM user is gone.
+ */
+@Service
+public class AccountDeletionService {
+
+  public static final String ACCOUNT_DELETED_EVENT = "social.account.deleted";
+
+  private static final int   PAGE_SIZE             = 20;
+
+  private static final Log   LOG                   = ExoLogger.getLogger(AccountDeletionService.class);
+
+  @Autowired
+  private SettingService     settingService;
+
+  @Autowired
+  private OrganizationService organizationService;
+
+  @Autowired
+  private IdentityManager    identityManager;
+
+  @Autowired
+  private IndexingService    indexingService;
+
+  @Autowired
+  private ListenerService    listenerService;
+
+  /**
+   * Grace delay, in days, between the confirmed deletion request and its
+   * execution.
+   */
+  @Value("${social.AccountDeletionJob.delay.days:30}")
+  @Setter
+  private long               delayDays;
+
+  /**
+   * Processes all the recorded deletion requests: collects the pending
+   * requesters first (the enumeration must not be paged over while its rows
+   * get deleted), then handles each account independently so one failure
+   * never prevents the other deletions.
+   */
+  public void processPendingDeletionRequests() {
+    List<String> usernames = collectPendingRequests();
+    for (String username : usernames) {
+      try {
+        processPendingDeletionRequestOf(username);
+      } catch (Exception e) {
+        LOG.error("Error processing the account deletion request of user {}, the account is left deactivated", username, e);
+      }
+    }
+  }
+
+  public void processPendingDeletionRequestOf(String username) throws Exception { // NOSONAR
+    if (prepareDeletion(username)) {
+      deleteAccount(username);
+    }
+  }
+
+  @ContainerTransactional
+  public List<String> collectPendingRequests() {
+    List<String> usernames = new ArrayList<>();
+    int offset = 0;
+    List<Context> contexts;
+    do {
+      contexts = settingService.getContextsByTypeAndScopeAndSettingName(Context.USER.getName(),
+                                                                        DELETION_REQUEST_SCOPE.getName(),
+                                                                        DELETION_REQUEST_SCOPE.getId(),
+                                                                        DELETION_REQUEST_SETTING_NAME,
+                                                                        offset,
+                                                                        PAGE_SIZE);
+      contexts.stream()
+              .map(Context::getId)
+              .filter(StringUtils::isNotBlank)
+              .forEach(usernames::add);
+      offset += PAGE_SIZE;
+    } while (contexts.size() == PAGE_SIZE);
+    return usernames;
+  }
+
+  /**
+   * Re-checks the eligibility of one recorded request and, when the account
+   * has to be deleted, removes the request marker so the deletion happens at
+   * most once even without any cluster lock. The marker is also cleaned up
+   * for requests that can never execute anymore (revoked by an admin
+   * re-activation, user already gone, externally synchronized account or
+   * unreadable marker). Deliberately not re-checked: the admin deletion
+   * option — the request was confirmed by its user under an enabled policy,
+   * turning the option off only prevents new requests.
+   *
+   * @return true when the account deletion must proceed
+   */
+  @ContainerTransactional
+  public boolean prepareDeletion(String username) throws Exception {
+    SettingValue<?> settingValue = settingService.get(Context.USER.id(username),
+                                                      DELETION_REQUEST_SCOPE,
+                                                      DELETION_REQUEST_SETTING_NAME);
+    if (settingValue == null || settingValue.getValue() == null) {
+      return false;
+    }
+    long requestTime;
+    try {
+      requestTime = Long.parseLong(settingValue.getValue().toString());
+    } catch (NumberFormatException e) {
+      LOG.warn("Unreadable account deletion request time '{}' for user {}, discarding the request",
+               settingValue.getValue(),
+               username);
+      removeDeletionRequest(username);
+      return false;
+    }
+    if (System.currentTimeMillis() - requestTime < delayDays * 86_400_000L) {
+      return false;
+    }
+    User user = organizationService.getUserHandler().findUserByName(username, UserStatus.ANY);
+    if (user == null) {
+      LOG.info("User {} requested the deletion of an account that no longer exists, discarding the request", username);
+      removeDeletionRequest(username);
+      return false;
+    }
+    if (user.isEnabled()) {
+      LOG.info("User {} was re-activated after requesting the deletion of the account, revoking the request", username);
+      removeDeletionRequest(username);
+      return false;
+    }
+    if (!user.isInternalStore()) {
+      LOG.warn("User {} requested the deletion of an externally synchronized account, discarding the request", username);
+      removeDeletionRequest(username);
+      return false;
+    }
+    removeDeletionRequest(username);
+    return true;
+  }
+
+  /**
+   * Deletes the account the way the users administration does: the social
+   * identity is soft-deleted first, then the IDM user is removed without
+   * broadcast — this ordering prevents any concurrent by-username resolution
+   * from resurrecting the deleted identity while the IDM user still exists.
+   * The user content (activities, comments, documents...) is preserved by
+   * design and keeps being displayed.
+   */
+  @ContainerTransactional
+  public void deleteAccount(String username) throws Exception {
+    Identity identity = identityManager.getOrCreateUserIdentity(username);
+    identityManager.hardDeleteIdentity(identity);
+    organizationService.getUserHandler().removeUser(username, false);
+    indexingService.unindex(ProfileIndexingServiceConnector.TYPE, identity.getId());
+    broadcastEvent(username, identity.getId());
+    LOG.info("Account of user {} deleted following the deletion request confirmed more than {} day(s) ago",
+             username,
+             delayDays);
+  }
+
+  private void removeDeletionRequest(String username) {
+    settingService.remove(Context.USER.id(username), DELETION_REQUEST_SCOPE, DELETION_REQUEST_SETTING_NAME);
+  }
+
+  private void broadcastEvent(String username, String identityId) {
+    try {
+      listenerService.broadcast(ACCOUNT_DELETED_EVENT, username, identityId);
+    } catch (Exception e) {
+      LOG.warn("Error broadcasting event {} for user {} with identity id {}", ACCOUNT_DELETED_EVENT, username, identityId, e);
+    }
+  }
+
+}

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
@@ -25,6 +25,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainer;
@@ -40,6 +42,8 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
 import org.exoplatform.social.core.storage.cache.CachedSpaceStorage;
+
+import io.meeds.social.security.service.AccountDeactivationService;
 
 /**
  * Listens to user updating events. Created by hanh.vi@exoplatform.com Jan 17,
@@ -151,6 +155,13 @@ public class SocialUserEventListenerImpl extends UserEventListener {
   @Override
   @ExoTransactional
   public void postSetEnabled(User user) throws Exception {
+    if (user.isEnabled()) {
+      // a re-activation revokes any pending account deletion request
+      CommonsUtils.getService(SettingService.class)
+                  .remove(Context.USER.id(user.getUserName()),
+                          AccountDeactivationService.DELETION_REQUEST_SCOPE,
+                          AccountDeactivationService.DELETION_REQUEST_SETTING_NAME);
+    }
     // Makes sure the user has been synchronized in LDAP, then to enable/disable
     // it.
     IdentityStorage storage = container.getComponentInstanceOfType(IdentityStorage.class);

--- a/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/service/LinkProvider.java
@@ -56,6 +56,7 @@ import org.exoplatform.web.url.navigation.NodeURL;
 
 import io.meeds.portal.permlink.model.PermanentLinkObject;
 import io.meeds.portal.permlink.service.PermanentLinkService;
+import io.meeds.portal.security.service.SecuritySettingService;
 import io.meeds.social.space.plugin.SpacePermanentLinkPlugin;
 
 import lombok.SneakyThrows;
@@ -175,6 +176,17 @@ public class LinkProvider {
     Identity identity = getIdentityManager().getOrCreateIdentity(OrganizationIdentityProvider.NAME, username);
     Validate.notNull(identity, "Identity must not be null.");
     String lang = getCurrentUserLanguage(username);
+    String fullName = identity.getProfile().getFullName();
+    String avatarUrl = identity.getProfile().getAvatarUrl();
+    if (identity.isDeleted()) {
+      // a deleted user renders with the neutral default avatar and, when the
+      // platform anonymizes deleted accounts, with the admin-configured label
+      avatarUrl = PROFILE_DEFAULT_AVATAR_URL;
+      SecuritySettingService securitySettingService = CommonsUtils.getService(SecuritySettingService.class);
+      if (securitySettingService.isAccountDeletionAnonymizationEnabled()) {
+        fullName = securitySettingService.getDeletedUserLabel(Locale.forLanguageTag(lang));
+      }
+    }
     //
     String configuredDomainUrl;
     try {
@@ -198,10 +210,10 @@ public class LinkProvider {
                .append(identity.getRemoteId())
                .append("',")
                .append("fullName: '")
-               .append(identity.getProfile().getFullName().replace("'", "\\\\'").replace("\"", "&quot;"))
+               .append(fullName.replace("'", "\\\\'").replace("\"", "&quot;"))
                .append("',")
                .append("avatar: '")
-               .append(identity.getProfile().getAvatarUrl())
+               .append(avatarUrl)
                .append("',")
                .append("position: '")
                .append(identity.getProfile().getPosition() == null ? "" : identity.getProfile().getPosition().replace("'", "\\\\'").replace("\"", "&quot;"))
@@ -212,6 +224,9 @@ public class LinkProvider {
                .append("enabled: '")
                .append(identity.isEnable() && !identity.isDeleted())
                .append("',")
+               .append("deleted: '")
+               .append(identity.isDeleted())
+               .append("',")
                .append("displayedEmail: '")
                .append(identity.getProfile().getProperty(Profile.DISPLAYED_EMAIL))
                .append("',")
@@ -220,7 +235,7 @@ public class LinkProvider {
                .append("',")
                .append("}\"")
                .append(">")
-               .append(StringEscapeUtils.escapeHtml4(identity.getProfile().getFullName()));
+               .append(StringEscapeUtils.escapeHtml4(fullName));
     if(identity.getProfile().getProperty("external") != null && identity.getProfile().getProperty("external").equals("true")){
       profileLink = profileLink.append("<span class=\"externalFlagClass\">").append(" (").append(getResourceBundleLabel(Locale.forLanguageTag(lang), "external.label.tag")).append(")").append("</span>");
     }

--- a/component/core/src/test/java/io/meeds/social/security/service/AccountDeletionServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/security/service/AccountDeletionServiceTest.java
@@ -1,0 +1,265 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.security.service;
+
+import static io.meeds.social.security.service.AccountDeactivationService.DELETION_REQUEST_SCOPE;
+import static io.meeds.social.security.service.AccountDeactivationService.DELETION_REQUEST_SETTING_NAME;
+import static io.meeds.social.security.service.AccountDeletionService.ACCOUNT_DELETED_EVENT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.services.organization.UserStatus;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.jpa.search.ProfileIndexingServiceConnector;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import lombok.SneakyThrows;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class AccountDeletionServiceTest {
+
+  private static final String    USERNAME    = "john";
+
+  private static final String    IDENTITY_ID = "123";
+
+  private static final long      DAY_IN_MS   = 86_400_000L;
+
+  @Mock
+  private SettingService         settingService;
+
+  @Mock
+  private OrganizationService    organizationService;
+
+  @Mock
+  private UserHandler            userHandler;
+
+  @Mock
+  private User                   user;
+
+  @Mock
+  private IdentityManager        identityManager;
+
+  @Mock
+  private Identity               identity;
+
+  @Mock
+  private IndexingService        indexingService;
+
+  @Mock
+  private ListenerService        listenerService;
+
+  @InjectMocks
+  private AccountDeletionService accountDeletionService;
+
+  @Before
+  @SneakyThrows
+  public void setUp() {
+    accountDeletionService.setDelayDays(30L);
+    when(organizationService.getUserHandler()).thenReturn(userHandler);
+    when(userHandler.findUserByName(USERNAME, UserStatus.ANY)).thenReturn(user);
+    when(user.isInternalStore()).thenReturn(true);
+    when(user.isEnabled()).thenReturn(false);
+    when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(identity);
+    when(identity.getId()).thenReturn(IDENTITY_ID);
+  }
+
+  @Test
+  public void testCollectPendingRequestsPagesUntilShortPage() {
+    List<Context> firstPage = IntStream.range(0, 20)
+                                       .mapToObj(i -> Context.USER.id("user" + i))
+                                       .toList();
+    List<Context> secondPage = List.of(Context.USER.id("user20"), Context.USER.id("user21"));
+    when(settingService.getContextsByTypeAndScopeAndSettingName(eq(Context.USER.getName()),
+                                                                eq(DELETION_REQUEST_SCOPE.getName()),
+                                                                eq(DELETION_REQUEST_SCOPE.getId()),
+                                                                eq(DELETION_REQUEST_SETTING_NAME),
+                                                                eq(0),
+                                                                anyInt())).thenReturn(firstPage);
+    when(settingService.getContextsByTypeAndScopeAndSettingName(eq(Context.USER.getName()),
+                                                                eq(DELETION_REQUEST_SCOPE.getName()),
+                                                                eq(DELETION_REQUEST_SCOPE.getId()),
+                                                                eq(DELETION_REQUEST_SETTING_NAME),
+                                                                eq(20),
+                                                                anyInt())).thenReturn(secondPage);
+    List<String> usernames = accountDeletionService.collectPendingRequests();
+    assertEquals(22, usernames.size());
+    assertEquals("user0", usernames.get(0));
+    assertEquals("user21", usernames.get(21));
+    verify(settingService, times(2)).getContextsByTypeAndScopeAndSettingName(anyString(),
+                                                                             anyString(),
+                                                                             anyString(),
+                                                                             anyString(),
+                                                                             anyInt(),
+                                                                             anyInt());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestNotYetDueIsLeftUntouched() {
+    stubRequestTime(System.currentTimeMillis() - 5 * DAY_IN_MS);
+    assertFalse(accountDeletionService.prepareDeletion(USERNAME));
+    verify(settingService, never()).remove(any(Context.class), any(), anyString());
+    verify(identityManager, never()).hardDeleteIdentity(any());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testDueRequestDeletesAccountInOrder() {
+    stubRequestTime(System.currentTimeMillis() - 31 * DAY_IN_MS);
+    accountDeletionService.processPendingDeletionRequestOf(USERNAME);
+
+    InOrder order = inOrder(settingService, identityManager, userHandler, indexingService, listenerService);
+    order.verify(settingService).remove(Context.USER.id(USERNAME), DELETION_REQUEST_SCOPE, DELETION_REQUEST_SETTING_NAME);
+    order.verify(identityManager).hardDeleteIdentity(identity);
+    order.verify(userHandler).removeUser(USERNAME, false);
+    order.verify(indexingService).unindex(ProfileIndexingServiceConnector.TYPE, IDENTITY_ID);
+    order.verify(listenerService).broadcast(ACCOUNT_DELETED_EVENT, USERNAME, IDENTITY_ID);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testReEnabledUserIsNeverDeletedAndRequestRevoked() {
+    stubRequestTime(System.currentTimeMillis() - 31 * DAY_IN_MS);
+    when(user.isEnabled()).thenReturn(true);
+    assertFalse(accountDeletionService.prepareDeletion(USERNAME));
+    verify(settingService).remove(Context.USER.id(USERNAME), DELETION_REQUEST_SCOPE, DELETION_REQUEST_SETTING_NAME);
+    verify(identityManager, never()).hardDeleteIdentity(any());
+    verify(userHandler, never()).removeUser(anyString(), anyBoolean());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testExternalStoreUserIsSkippedAndRequestDiscarded() {
+    stubRequestTime(System.currentTimeMillis() - 31 * DAY_IN_MS);
+    when(user.isInternalStore()).thenReturn(false);
+    assertFalse(accountDeletionService.prepareDeletion(USERNAME));
+    verify(settingService).remove(Context.USER.id(USERNAME), DELETION_REQUEST_SCOPE, DELETION_REQUEST_SETTING_NAME);
+    verify(identityManager, never()).hardDeleteIdentity(any());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testMissingUserIsSkippedAndRequestDiscarded() {
+    stubRequestTime(System.currentTimeMillis() - 31 * DAY_IN_MS);
+    when(userHandler.findUserByName(USERNAME, UserStatus.ANY)).thenReturn(null);
+    assertFalse(accountDeletionService.prepareDeletion(USERNAME));
+    verify(settingService).remove(Context.USER.id(USERNAME), DELETION_REQUEST_SCOPE, DELETION_REQUEST_SETTING_NAME);
+    verify(identityManager, never()).hardDeleteIdentity(any());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testMalformedRequestTimeIsDiscarded() {
+    when(settingService.get(Context.USER.id(USERNAME),
+                            DELETION_REQUEST_SCOPE,
+                            DELETION_REQUEST_SETTING_NAME)).thenReturn((SettingValue) SettingValue.create("not-a-number"));
+    assertFalse(accountDeletionService.prepareDeletion(USERNAME));
+    verify(settingService).remove(Context.USER.id(USERNAME), DELETION_REQUEST_SCOPE, DELETION_REQUEST_SETTING_NAME);
+    verify(identityManager, never()).hardDeleteIdentity(any());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testMissingMarkerIsSkippedSilently() {
+    when(settingService.get(Context.USER.id(USERNAME),
+                            DELETION_REQUEST_SCOPE,
+                            DELETION_REQUEST_SETTING_NAME)).thenReturn(null);
+    assertFalse(accountDeletionService.prepareDeletion(USERNAME));
+    verify(settingService, never()).remove(any(Context.class), any(), anyString());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testDeletionFailureDoesNotStopTheBatch() {
+    List<Context> page = List.of(Context.USER.id("failing"), Context.USER.id(USERNAME));
+    when(settingService.getContextsByTypeAndScopeAndSettingName(anyString(),
+                                                                anyString(),
+                                                                anyString(),
+                                                                anyString(),
+                                                                eq(0),
+                                                                anyInt())).thenReturn(page);
+    when(settingService.get(any(Context.class),
+                            eq(DELETION_REQUEST_SCOPE),
+                            eq(DELETION_REQUEST_SETTING_NAME))).thenReturn((SettingValue) SettingValue.create(String.valueOf(System.currentTimeMillis()
+        - 31 * DAY_IN_MS)));
+    when(userHandler.findUserByName("failing", UserStatus.ANY)).thenReturn(user);
+    when(identityManager.getOrCreateUserIdentity("failing")).thenReturn(identity);
+    doThrow(new RuntimeException("IDM down")).when(userHandler).removeUser("failing", false);
+
+    accountDeletionService.processPendingDeletionRequests();
+
+    verify(userHandler).removeUser("failing", false);
+    verify(userHandler).removeUser(USERNAME, false);
+    verify(listenerService).broadcast(ACCOUNT_DELETED_EVENT, USERNAME, IDENTITY_ID);
+    verify(listenerService, never()).broadcast(ACCOUNT_DELETED_EVENT, "failing", IDENTITY_ID);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testNoPendingRequestDoesNothing() {
+    when(settingService.getContextsByTypeAndScopeAndSettingName(anyString(),
+                                                                anyString(),
+                                                                anyString(),
+                                                                anyString(),
+                                                                anyInt(),
+                                                                anyInt())).thenReturn(Collections.emptyList());
+    accountDeletionService.processPendingDeletionRequests();
+    verify(identityManager, never()).hardDeleteIdentity(any());
+    verify(userHandler, never()).removeUser(anyString(), anyBoolean());
+  }
+
+  private void stubRequestTime(long requestTime) {
+    when(settingService.get(Context.USER.id(USERNAME),
+                            DELETION_REQUEST_SCOPE,
+                            DELETION_REQUEST_SETTING_NAME)).thenReturn((SettingValue) SettingValue.create(String.valueOf(requestTime)));
+  }
+
+}

--- a/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/EntityBuilder.java
@@ -52,6 +52,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import io.meeds.portal.security.service.SecuritySettingService;
 import io.meeds.social.html.model.HtmlTransformerContext;
 import io.meeds.social.html.utils.HtmlUtils;
 import io.meeds.social.reaction.service.ReactionService;
@@ -421,6 +422,10 @@ public class EntityBuilder {
       userEntity.setIsManager(userACL.isMemberOf(aclIdentity, MANAGER, groupId));
       userEntity.getDataEntity().put("isRedactor", userACL.isMemberOf(aclIdentity, REDACTOR_MEMBERSHIP, groupId));
       userEntity.getDataEntity().put("isPublisher", userACL.isMemberOf(aclIdentity, PUBLISHER_MEMBERSHIP, groupId));
+    }
+
+    if (profile.getIdentity().isDeleted()) {
+      anonymizeDeletedUser(userEntity);
     }
 
     String[] expandArray = StringUtils.split(expand, ",");
@@ -2534,6 +2539,41 @@ public class EntityBuilder {
 
   private static Locale getLocale() {
     return LocalizationFilter.getCurrentLocale();
+  }
+
+  /**
+   * A deleted user always renders with the neutral default avatar, and, when
+   * the platform anonymizes deleted accounts, with the admin-configured label
+   * (resolved against the request locale) in place of any name. The
+   * substitution deliberately happens here, per request, and never in the
+   * storage/cache layers which are locale-unaware and must stay truthful.
+   */
+  private static void anonymizeDeletedUser(ProfileEntity userEntity) {
+    userEntity.setAvatar(LinkProvider.PROFILE_DEFAULT_AVATAR_URL);
+    userEntity.setDefaultAvatar(true);
+    if (getSecuritySettingService().isAccountDeletionAnonymizationEnabled()) {
+      userEntity.setFullname(getSecuritySettingService().getDeletedUserLabel(getLocale()));
+      userEntity.setFirstname(null);
+      userEntity.setLastname(null);
+      userEntity.setEmail(null);
+    }
+  }
+
+  /**
+   * @return a value changing whenever the deleted-users anonymization display
+   *         policy changes, to fold into the ETag of any cached payload
+   *         embedding user profiles
+   */
+  public static int getAnonymizationEtagValue() {
+    SecuritySettingService securitySettingService = getSecuritySettingService();
+    return securitySettingService.isAccountDeletionAnonymizationEnabled() ? 1
+                                                                            + securitySettingService.getDeletedUserLabels()
+                                                                                                    .hashCode() :
+                                                                          0;
+  }
+
+  private static SecuritySettingService getSecuritySettingService() {
+    return ExoContainerContext.getService(SecuritySettingService.class);
   }
 
   private static org.exoplatform.services.security.Identity getCurrentUserIdentity() {

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRest.java
@@ -357,7 +357,11 @@ public class ActivityRest implements ResourceContainer {
     }
 
     long cacheTime = computeCacheTime(activity);
-    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand, LocalizationFilter.getCurrentLocale()));
+    String eTagValue = String.valueOf(Objects.hash(cacheTime,
+                                                   authenticatedUser,
+                                                   expand,
+                                                   LocalizationFilter.getCurrentLocale(),
+                                                   EntityBuilder.getAnonymizationEtagValue()));
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
     if (builder == null) {

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/identity/IdentityRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/identity/IdentityRest.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.portal.application.localization.LocalizationFilter;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -157,7 +158,11 @@ public class IdentityRest implements ResourceContainer {
                                                                                              Long.parseLong(identity.getId()))));
     }
     long cacheTime = identity.getCacheTime();
-    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expandedSettings));
+    String eTagValue = String.valueOf(Objects.hash(cacheTime,
+                                                   authenticatedUser,
+                                                   expandedSettings,
+                                                   LocalizationFilter.getCurrentLocale(),
+                                                   EntityBuilder.getAnonymizationEtagValue()));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
@@ -247,7 +252,11 @@ public class IdentityRest implements ResourceContainer {
     String authenticatedUser = authenticatedUserIdentity.getUserId();
 
     long cacheTime = identity.getCacheTime();
-    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expand));
+    String eTagValue = String.valueOf(Objects.hash(cacheTime,
+                                                   authenticatedUser,
+                                                   expand,
+                                                   LocalizationFilter.getCurrentLocale(),
+                                                   EntityBuilder.getAnonymizationEtagValue()));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -84,6 +84,7 @@ import org.exoplatform.commons.utils.IOUtil;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.application.localization.LocalizationFilter;
 import org.exoplatform.portal.rest.UserFieldValidator;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -821,7 +822,12 @@ public class UserRest implements ResourceContainer, Startable {
     }
 
     long cacheTime = identity.getCacheTime();
-    String eTagValue = String.valueOf(Objects.hash(cacheTime, authenticatedUser, expandedSettings, configuredCardProperties));
+    String eTagValue = String.valueOf(Objects.hash(cacheTime,
+                                                   authenticatedUser,
+                                                   expandedSettings,
+                                                   configuredCardProperties,
+                                                   LocalizationFilter.getCurrentLocale(),
+                                                   EntityBuilder.getAnonymizationEtagValue()));
 
     EntityTag eTag = new EntityTag(eTagValue, true);
     Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
@@ -931,7 +937,10 @@ public class UserRest implements ResourceContainer, Startable {
 
     builder = eTag == null ? null : request.evaluatePreconditions(eTag);
     if (builder == null) {
-      if (isDefault || lastUpdated == null) {
+      // a disabled or deleted user always renders with the neutral default
+      // avatar: the stored file (or the generated one carrying the user
+      // initials) must not leak anymore
+      if (isDefault || lastUpdated == null || !identity.isEnable() || identity.isDeleted()) {
         builder = getDefaultAvatarBuilder();
       } else {
         if (RestUtils.isAnonymous() && !LinkProvider.isAttachmentTokenValid(token,
@@ -943,32 +952,30 @@ public class UserRest implements ResourceContainer, Startable {
           return Response.status(Status.NOT_FOUND).build();
         }
 
-        if (identity.isEnable() && !identity.isDeleted()) {
-          int[] dimension = Utils.parseDimension(size);
-          byte[] avatarContent = null;
-          try {
-            FileItem avatarFile = identityManager.getAvatarFile(identity);
-            if (identityManager.getAvatarFile(identity) != null) {
-              if (dimension[0] == 0 || dimension[1] == 0) {
-                avatarContent = avatarFile.getAsByte();
-              } else {
-                FileInfo fileInfo = avatarFile.getFileInfo();
-                FileItem file = imageThumbnailService.getOrCreateThumbnail(FileThumbnailPlugin.FILE_TYPE,
-                                                                           Long.toString(fileInfo.getId()),
-                                                                           fileInfo.getUpdater(),
-                                                                           dimension[0],
-                                                                           dimension[1]);
-                avatarContent = file != null ? file.getAsByte() : avatarFile.getAsByte();
-              }
+        int[] dimension = Utils.parseDimension(size);
+        byte[] avatarContent = null;
+        try {
+          FileItem avatarFile = identityManager.getAvatarFile(identity);
+          if (identityManager.getAvatarFile(identity) != null) {
+            if (dimension[0] == 0 || dimension[1] == 0) {
+              avatarContent = avatarFile.getAsByte();
+            } else {
+              FileInfo fileInfo = avatarFile.getFileInfo();
+              FileItem file = imageThumbnailService.getOrCreateThumbnail(FileThumbnailPlugin.FILE_TYPE,
+                                                                         Long.toString(fileInfo.getId()),
+                                                                         fileInfo.getUpdater(),
+                                                                         dimension[0],
+                                                                         dimension[1]);
+              avatarContent = file != null ? file.getAsByte() : avatarFile.getAsByte();
             }
-          } catch (Exception e) {
-            LOG.error("Error while resizing avatar of user identity with Id {}, original Image will be returned",
-                      identity.getId(),
-                      e);
           }
-          if (avatarContent != null) {
-            builder = Response.ok(avatarContent, IMAGE_PNG_MEDIA_TYPE);
-          }
+        } catch (Exception e) {
+          LOG.error("Error while resizing avatar of user identity with Id {}, original Image will be returned",
+                    identity.getId(),
+                    e);
+        }
+        if (avatarContent != null) {
+          builder = Response.ok(avatarContent, IMAGE_PNG_MEDIA_TYPE);
         }
       }
     }

--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -206,6 +206,7 @@ label.expand=Expand
 label.collapse=Collapse
 label.remove=Remove
 label.disabled=Disabled
+label.deleted=Deleted user
 label.filter=Filter
 
 Widget.label.seeAll=See all

--- a/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/UserAvatar.vue
@@ -42,13 +42,13 @@
         class="text-truncate my-auto">
         {{ userFullname }}
         <span
-          v-if="!enabled"
-          :title="$t('label.disabled')"
+          v-if="showStatusIcon"
+          :title="statusIconTitle"
           class="muted font-weight-regular">
           <v-icon
             class="primary--text mb-1"
             small>
-            fas fa-user-slash
+            {{ statusIcon }}
           </v-icon>
         </span>
         <span v-if="isExternal" class="muted font-weight-regular">{{ externalTag }} </span>
@@ -88,13 +88,13 @@
           class="text-truncate text-left mb-0">
           {{ userFullname }}
           <span
-            v-if="!enabled"
-            :title="$t('label.disabled')"
+            v-if="showStatusIcon"
+            :title="statusIconTitle"
             class="muted font-weight-regular">
             <v-icon
               class="primary--text mb-1"
               small>
-              fas fa-user-slash
+              {{ statusIcon }}
             </v-icon>
           </span>
           <span v-if="isExternal" class="muted font-weight-regular">{{ externalTag }} </span>
@@ -153,13 +153,13 @@
         class="text-truncate my-auto">
         {{ userFullname }}
         <span
-          v-if="!enabled"
-          :title="$t('label.disabled')"
+          v-if="showStatusIcon"
+          :title="statusIconTitle"
           class="muted font-weight-regular">
           <v-icon
             class="primary--text mb-1"
             small>
-            fas fa-user-slash
+            {{ statusIcon }}
           </v-icon>
         </span>
         <span v-if="isExternal" class="muted font-weight-regular">{{ externalTag }} </span>
@@ -214,13 +214,13 @@
           class="text-truncate text-left mb-0">
           {{ userFullname }}
           <span
-            v-if="!enabled"
-            :title="$t('label.disabled')"
+            v-if="showStatusIcon"
+            :title="statusIconTitle"
             class="muted font-weight-regular">
             <v-icon
               class="primary--text mb-1"
               small>
-              fas fa-user-slash
+              {{ statusIcon }}
             </v-icon>
           </span>
           <span v-if="isExternal" class="muted font-weight-regular">{{ externalTag }} </span>
@@ -388,9 +388,18 @@ export default {
     },
     enabled() {
       return this.userIdentity?.enabled || this.identity?.dataEntity?.enabled;
-    },  
+    },
     deleted() {
-      return this.userIdentity?.deleted;
+      return this.userIdentity?.deleted === true || this.userIdentity?.deleted === 'true';
+    },
+    showStatusIcon() {
+      return this.deleted || !this.enabled;
+    },
+    statusIcon() {
+      return this.deleted && 'fas fa-users-slash' || 'fas fa-user-slash';
+    },
+    statusIconTitle() {
+      return this.deleted && this.$t('label.deleted') || this.$t('label.disabled');
     },
     userFullname() {
       return this.userIdentity?.fullname || this.name;
@@ -405,6 +414,9 @@ export default {
       return this.userIdentity?.displayedPhone;
     },
     userAvatarUrl() {
+      if (this.deleted) {
+        return `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/default-image/avatar`;
+      }
       return this.enabled ? (this.userIdentity.avatar || this.avatarUrl || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/${this.username || this.profileId}/avatar`) : (this.avatarUrl  || `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/users/default-image/avatar`);
     },
     profileUrl() {

--- a/webapp/src/main/webapp/vue-apps/top-bar-favorites/components/FavoriteUserAvatar.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-favorites/components/FavoriteUserAvatar.vue
@@ -37,6 +37,13 @@
     <div class="ms-1 text-truncate">
       {{ fullname }}
     </div>
+    <v-icon
+      v-if="deleted"
+      :title="$t('label.deleted')"
+      class="primary--text ms-1"
+      size="12">
+      fas fa-users-slash
+    </v-icon>
   </div>
 </template>
 <script>
@@ -65,6 +72,9 @@ export default {
     },
     avatarUrl() {
       return this.userIdentity?.avatar;
+    },
+    deleted() {
+      return this.userIdentity?.deleted === true || this.userIdentity?.deleted === 'true';
     },
   },
   created() {


### PR DESCRIPTION
A daily job deletes the accounts whose deletion request was confirmed more than 30 days ago (delay configurable via
social.AccountDeletionJob.delay.days). A request is revoked when an admin re-activates the account, and externally synchronized accounts are never deleted.

The deleted user's content remains displayed: grey default avatar, a users-slash icon titled "Deleted user" next to the name, the admin-configured label in place of the name when anonymization is enabled, and the profile link leads to the not-found page