### PR TITLE
feat: Send confirmation email to users once the deletion request is confirmed - EXO-89632

### DIFF
--- a/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
+++ b/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
@@ -111,6 +111,10 @@ public class AccountDeactivationService {
   @Setter
   private String                 emailBodyPath;
 
+  @Value("${social.accountDeletion.confirmation.email.templatePath:assets/account-deletion-confirmation-email-content.html}")
+  @Setter
+  private String                 deletionEmailBodyPath;
+
   /**
    * The deactivation is offered only for accounts whose lifecycle belongs to
    * the platform: externally synchronized accounts (LDAP) are excluded, and
@@ -179,7 +183,7 @@ public class AccountDeactivationService {
     } else {
       settingService.remove(Context.USER.id(username), DELETION_REQUEST_SCOPE, DELETION_REQUEST_SETTING_NAME);
     }
-    sendUserConfirmationEmail(username);
+    sendUserConfirmationEmail(username, deleteRequested);
     organizationService.getUserHandler().setEnabled(username, false, true);
     broadcastEvent(ACCOUNT_DEACTIVATION_REQUESTED_EVENT, username, identityId);
     if (deleteRequested) {
@@ -191,16 +195,18 @@ public class AccountDeactivationService {
 
   /**
    * Sends the confirmation email to the user, before the account gets
-   * disabled. The sending is best effort: a mail server failure doesn't
-   * prevent the deactivation deliberately requested by the user.
+   * disabled. When the deletion was also requested, the email additionally
+   * reminds that the account will be deleted in 30 days. The sending is best
+   * effort: a mail server failure doesn't prevent the deactivation
+   * deliberately requested by the user.
    */
-  protected void sendUserConfirmationEmail(String username) {
+  protected void sendUserConfirmationEmail(String username, boolean deleteRequested) {
     try {
       String lang = brandedEmailSender.getUserLang(username);
       String emailSubject = resourceBundleService.getSharedString("social.accountDeactivation.confirmation.email.subject",
                                                                   LocaleUtils.toLocale(lang))
                                                  .replace("{0}", brandingService.getCompanyName());
-      brandedEmailSender.sendEmail(username, emailSubject, emailBodyPath, Map.of());
+      brandedEmailSender.sendEmail(username, emailSubject, deleteRequested ? deletionEmailBodyPath : emailBodyPath, Map.of());
     } catch (Exception e) {
       LOG.warn("Error sending the account deactivation confirmation email to user {}", username, e);
     }

--- a/component/core/src/main/resources/assets/account-deletion-confirmation-email-content.html
+++ b/component/core/src/main/resources/assets/account-deletion-confirmation-email-content.html
@@ -1,0 +1,15 @@
+<p style="margin: 10px 0;">
+  ${social.accountDeactivation.confirmation.email.label.reminder}
+</p>
+<p style="margin: 10px 0;">
+  ${social.accountDeactivation.confirmation.email.label.loggedOut}
+</p>
+<p style="margin: 10px 0;">
+  ${social.accountDeactivation.confirmation.email.label.deletion}
+</p>
+<p style="margin: 10px 0;">
+  ${social.accountDeactivation.confirmation.email.label.support}
+</p>
+<p style="margin: 10px 0;">
+  ${social.accountDeactivation.confirmation.email.label.thanks}
+</p>

--- a/component/core/src/test/java/io/meeds/social/security/service/AccountDeactivationServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/security/service/AccountDeactivationServiceTest.java
@@ -137,6 +137,7 @@ public class AccountDeactivationServiceTest {
     when(brandingService.getCompanyName()).thenReturn("MyCompany");
     when(resourceBundleService.getSharedString(anyString(), any())).thenReturn("TranslatedText");
     accountDeactivationService.setEmailBodyPath("assets/account-deactivation-confirmation-email-content.html");
+    accountDeactivationService.setDeletionEmailBodyPath("assets/account-deletion-confirmation-email-content.html");
   }
 
   @Test
@@ -349,6 +350,18 @@ public class AccountDeactivationServiceTest {
 
     assertTrue("Email subject should carry the platform name",
                subjectCaptor.getValue().contains("MyCompany"));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDeactivationWithDeletionSendsDeletionConfirmationEmail() {
+    allowDeletion();
+    accountDeactivationService.requestDeactivation(USERNAME, OTP_METHOD, OTP_CODE, true);
+
+    verify(brandedEmailSender).sendEmail(eq(USERNAME),
+                                         anyString(),
+                                         eq("assets/account-deletion-confirmation-email-content.html"),
+                                         anyMap());
   }
 
   @Test

--- a/component/service/src/main/resources/locale/social/Webui_en.properties
+++ b/component/service/src/main/resources/locale/social/Webui_en.properties
@@ -1025,5 +1025,6 @@ social.accountDeactivation.otp.email.label.thanks=Thanks.
 social.accountDeactivation.confirmation.email.subject=Your access to {0}
 social.accountDeactivation.confirmation.email.label.reminder=You have requested to stop accessing $SITE_NAME.
 social.accountDeactivation.confirmation.email.label.loggedOut=You have been logged-out as expected and you will no longer receive notifications from it.
+social.accountDeactivation.confirmation.email.label.deletion=In addition, your account will be deleted as requested in 30 days.
 social.accountDeactivation.confirmation.email.label.support=If needed, contact your support services for any further information.
 social.accountDeactivation.confirmation.email.label.thanks=Thanks.


### PR DESCRIPTION

When the confirmed deactivation request also carries the account deletion, the confirmation email sent to the user additionally reminds that the account will be deleted as requested in 30 days, through a dedicated branded template sharing the deactivation email paragraphs. The subject and the plain deactivation email remain unchanged.