### PR TITLE
fix: Group members lists empty in groups management - EXO-89727

### DIFF
--- a/component/core/src/main/java/io/meeds/social/identity/permission/storage/UserPermissionStorage.java
+++ b/component/core/src/main/java/io/meeds/social/identity/permission/storage/UserPermissionStorage.java
@@ -45,7 +45,7 @@ public class UserPermissionStorage {
   }
 
   @Transactional
-  @CacheEvict(cacheNames = "social.userPermissions", key = "#userPermission.userName")
+  @CacheEvict(cacheNames = "social.userPermissions", key = "#p0.userName")
   public UserPermission saveDirectMembership(UserPermission userPermission) {
     UserPermissionEntity entity = userPermissionDAO
                                                    .findByUserNameAndGroupIdAndMembershipType(userPermission.getUserName(),
@@ -62,7 +62,7 @@ public class UserPermissionStorage {
   }
 
   @Transactional
-  @CacheEvict(cacheNames = "social.userPermissions", key = "#userPermission.userName")
+  @CacheEvict(cacheNames = "social.userPermissions", key = "#p0.userName")
   public UserPermission saveInheritedMembership(UserPermission userPermission) {
     UserPermissionEntity entity = userPermissionDAO
                                                    .findByUserNameAndGroupIdAndMembershipType(userPermission.getUserName(),
@@ -82,20 +82,20 @@ public class UserPermissionStorage {
   }
 
   @Transactional
-  @CacheEvict(cacheNames = "social.userPermissions", key = "#userName")
+  @CacheEvict(cacheNames = "social.userPermissions", key = "#p0")
   public void deleteMembership(String userName, String groupId, String membershipType) {
     userPermissionDAO.findByUserNameAndGroupIdAndMembershipType(userName, groupId, membershipType)
                      .ifPresent(userPermissionDAO::delete);
   }
 
   @Transactional
-  @CacheEvict(cacheNames = "social.userPermissions", key = "#userName")
+  @CacheEvict(cacheNames = "social.userPermissions", key = "#p0")
   public void deleteInheritedMemberships(String userName) {
     userPermissionDAO.deleteByUserNameAndInheritedTrue(userName);
   }
 
   @Transactional
-  @CacheEvict(cacheNames = "social.userPermissions", key = "#userName")
+  @CacheEvict(cacheNames = "social.userPermissions", key = "#p0")
   public void deleteByUserName(String userName) {
     userPermissionDAO.deleteByUserName(userName);
   }

--- a/component/core/src/main/java/io/meeds/social/identity/permission/upgrade/UserPermissionBackfillUpgradePlugin.java
+++ b/component/core/src/main/java/io/meeds/social/identity/permission/upgrade/UserPermissionBackfillUpgradePlugin.java
@@ -50,11 +50,11 @@ public class UserPermissionBackfillUpgradePlugin extends UpgradeProductPlugin {
 
   private static final int            USER_BATCH_SIZE             = 250;
 
-  private static final String         LAST_PROCESSED_OFFSET_PARAM = "lastProcessedOffset";
+  private static final String         LAST_PROCESSED_ID_PARAM     = "lastProcessedIdentityId";
 
   private static final String         PLUGIN_NAME                 = "UserPermissionBackfillUpgradePlugin";
 
-  private static final String         PLUGIN_EXECUTED_KEY         = String.format("%sExecuted", PLUGIN_NAME);
+  private static final String         PLUGIN_EXECUTED_KEY         = String.format("%sExecuted_v2", PLUGIN_NAME);
 
   private boolean                     upgradeSucceeded            = false;
 
@@ -109,51 +109,49 @@ public class UserPermissionBackfillUpgradePlugin extends UpgradeProductPlugin {
   @Override
   public void processUpgrade(String oldVersion, String newVersion) {
     long startupTime = System.currentTimeMillis();
-    int startOffset = getLastProcessedOffset();
-    LOG.info("Start Upgrade:: Backfill SOC_USER_PERMISSION from organization service, resuming from offset {}", startOffset);
+    long lastProcessedId = getLastProcessedIdentityId();
+    LOG.info("Start Upgrade:: Backfill SOC_USER_PERMISSION from organization service, resuming after identity id {}",
+             lastProcessedId);
 
     int successCount = 0;
     int errorCount = 0;
     try {
-      int size = identityDAO.getAllIdsCountByProvider(OrganizationIdentityProvider.NAME, null, null, true, null);
-      for (int offset = startOffset; offset < size; offset += USER_BATCH_SIZE) {
-        int limit = Math.min(USER_BATCH_SIZE, size - offset);
-        List<String> userNames = identityDAO.getAllIdsByProviderSorted(OrganizationIdentityProvider.NAME,
-                                                                       null,
-                                                                       null,
-                                                                       true,
-                                                                       null,
-                                                                       null,
-                                                                       null,
-                                                                       null,
-                                                                       null,
-                                                                       null,
-                                                                       true,
-                                                                       offset,
-                                                                       limit);
-        for (String userName : userNames) {
-          if (userName == null) {
-            continue;
-          }
-          if (backfillUserMemberships(userName)) {
+      List<Long> identityIds = identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME,
+                                                                   lastProcessedId,
+                                                                   USER_BATCH_SIZE);
+      while (!identityIds.isEmpty()) {
+        for (Long identityId : identityIds) {
+          if (backfillUserMemberships(identityId)) {
             successCount++;
           } else {
             errorCount++;
           }
         }
-        storeLastProcessedOffset(offset + limit);
-        LOG.info("SOC_USER_PERMISSION backfill progress: {}/{} users processed ({} succeeded, {} failed so far)",
-                 Math.min(offset + limit, size),
-                 size,
+        lastProcessedId = identityIds.get(identityIds.size() - 1);
+        if (errorCount == 0) {
+          storeLastProcessedIdentityId(lastProcessedId);
+        }
+        LOG.info("SOC_USER_PERMISSION backfill progress: {} users processed ({} succeeded, {} failed so far), last processed identity id {}",
+                 successCount + errorCount,
                  successCount,
-                 errorCount);
+                 errorCount,
+                 lastProcessedId);
+        identityIds = identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME,
+                                                          lastProcessedId,
+                                                          USER_BATCH_SIZE);
       }
-      storeLastProcessedOffset(0);
-      upgradeSucceeded = true;
+      if (errorCount == 0) {
+        storeLastProcessedIdentityId(0);
+        upgradeSucceeded = true;
+      } else {
+        LOG.error("SOC_USER_PERMISSION backfill completed with {} failed users out of {}: the plugin stays pending and will replay from the last clean checkpoint on next startup",
+                  errorCount,
+                  successCount + errorCount);
+      }
     } catch (Exception e) {
-      errorCount++;
-      LOG.warn("Error backfilling SOC_USER_PERMISSION from organization service, will resume from last checkpoint on next run",
-               e);
+      LOG.error("Error backfilling SOC_USER_PERMISSION from organization service, will resume after identity id {} on next startup",
+                getLastProcessedIdentityId(),
+                e);
     }
 
     LOG.info("End Upgrade:: SOC_USER_PERMISSION backfill finished. {} users succeeded, {} users failed. It took {} ms",
@@ -162,27 +160,30 @@ public class UserPermissionBackfillUpgradePlugin extends UpgradeProductPlugin {
              (System.currentTimeMillis() - startupTime));
   }
 
-  private int getLastProcessedOffset() {
-    String value = getValue(LAST_PROCESSED_OFFSET_PARAM);
-    return StringUtils.isBlank(value) ? 0 : Integer.parseInt(value);
+  private long getLastProcessedIdentityId() {
+    String value = getValue(LAST_PROCESSED_ID_PARAM);
+    return StringUtils.isBlank(value) ? 0 : Long.parseLong(value);
   }
 
-  private void storeLastProcessedOffset(int offset) {
-    storeValueForPlugin(LAST_PROCESSED_OFFSET_PARAM, String.valueOf(offset));
+  private void storeLastProcessedIdentityId(long identityId) {
+    storeValueForPlugin(LAST_PROCESSED_ID_PARAM, String.valueOf(identityId));
   }
 
-  private boolean backfillUserMemberships(String userName) {
+  private boolean backfillUserMemberships(long identityId) {
+    String userName = null;
     try {
-      Identity identity = identityManager.getOrCreateUserIdentity(userName);
-      if (identity == null) {
+      Identity identity = identityManager.getIdentity(identityId);
+      if (identity == null || StringUtils.isBlank(identity.getRemoteId())) {
+        LOG.warn("Error backfilling SOC_USER_PERMISSION for identity id {}: identity not found", identityId);
         return false;
       }
-      long identityId = Long.parseLong(identity.getId());
+      userName = identity.getRemoteId();
+      String backfilledUserName = userName;
       Collection<Membership> allMemberships = organizationService.getMembershipHandler().findMembershipsByUser(userName, true);
       allMemberships.stream()
                     .filter(membership -> !membership.isInherited())
                     .forEach(membership -> userPermissionService.saveDirectMembership(identityId,
-                                                                                      userName,
+                                                                                      backfilledUserName,
                                                                                       membership.getGroupId(),
                                                                                       membership.getMembershipType()));
       userPermissionService.recomputeInheritedMemberships(identityId, userName, allMemberships);
@@ -190,7 +191,7 @@ public class UserPermissionBackfillUpgradePlugin extends UpgradeProductPlugin {
       indexingService.reindex(ProfileIndexingServiceConnector.TYPE, identity.getId());
       return true;
     } catch (Exception e) {
-      LOG.warn("Error backfilling SOC_USER_PERMISSION for user {}", userName, e);
+      LOG.warn("Error backfilling SOC_USER_PERMISSION for user {} (identity id {})", userName, identityId, e);
       return false;
     }
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAO.java
@@ -41,6 +41,14 @@ public interface IdentityDAO extends GenericDAO<IdentityEntity, Long> {
 
   List<Long> getAllIdsByProvider(String providerId, int offset, int limit);
 
+  /**
+   * @return the non-deleted identity ids of a provider strictly greater than
+   *         lastId, disabled ones included, in ascending id order — keyset
+   *         iteration that never skips a row even when identities are
+   *         soft-deleted while iterating
+   */
+  List<Long> getIdsByProviderAfterId(String providerId, long lastId, int limit);
+
   ListAccess<Map.Entry<IdentityEntity, ConnectionEntity>> findAllIdentitiesWithConnections(long identityId,
                                                                                            String sortField,
                                                                                            String sortDirection);

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/IdentityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/IdentityDAOImpl.java
@@ -133,6 +133,17 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
   }
 
   @Override
+  public List<Long> getIdsByProviderAfterId(String providerId, long lastId, int limit) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("SocIdentity.getIdsByProviderAfterId", Long.class);
+    query.setParameter(PROVIDER_ID_PARAM, providerId);
+    query.setParameter("lastId", lastId);
+    if (limit > 0) {
+      query.setMaxResults(limit);
+    }
+    return query.getResultList();
+  }
+
+  @Override
   public ListAccess<Map.Entry<IdentityEntity, ConnectionEntity>> findAllIdentitiesWithConnections(long identityId, String sortField, String sortDirection) {
     Query listQuery = getIdentitiesQuerySortedByField(OrganizationIdentityProvider.NAME, sortField, sortDirection, true, null, null, null, null, null, null, true);
 

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/IdentityEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/IdentityEntity.java
@@ -79,6 +79,10 @@ import jakarta.persistence.TemporalType;
         @NamedQuery(
                 name = "SocIdentity.getAllIdsByProvider",
                 query = "SELECT i.id FROM SocIdentityEntity i WHERE i.deleted = FALSE AND i.enabled = TRUE AND i.providerId = :providerId"
+        ),
+        @NamedQuery(
+                name = "SocIdentity.getIdsByProviderAfterId",
+                query = "SELECT i.id FROM SocIdentityEntity i WHERE i.deleted = FALSE AND i.providerId = :providerId AND i.id > :lastId ORDER BY i.id ASC"
         )
 })
 public class IdentityEntity {

--- a/component/core/src/test/java/io/meeds/social/identity/permission/storage/UserPermissionCachedStorageTest.java
+++ b/component/core/src/test/java/io/meeds/social/identity/permission/storage/UserPermissionCachedStorageTest.java
@@ -1,0 +1,186 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.identity.permission.storage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.meeds.social.identity.permission.dao.UserPermissionDAO;
+import io.meeds.social.identity.permission.model.UserPermission;
+
+public class UserPermissionCachedStorageTest {
+
+  private static final String                 ALICE           = "alice";
+
+  private static final String                 BOB             = "bob";
+
+  private static final String                 GROUP_ID        = "/platform/test";
+
+  private static final String                 MEMBERSHIP_TYPE = "member";
+
+  private AnnotationConfigApplicationContext context;
+
+  private UserPermissionDAO                   userPermissionDAO;
+
+  private UserPermissionStorage               storage;
+
+  @Configuration
+  @EnableCaching
+  static class CacheTestConfiguration {
+
+    @Bean
+    CacheManager cacheManager() {
+      return new ConcurrentMapCacheManager("social.userPermissions");
+    }
+
+    @Bean
+    UserPermissionDAO userPermissionDAO() {
+      return mock(UserPermissionDAO.class);
+    }
+
+    @Bean
+    UserPermissionStorage userPermissionStorage(UserPermissionDAO userPermissionDAO) {
+      return new UserPermissionStorage(userPermissionDAO);
+    }
+
+  }
+
+  @Before
+  public void setUp() {
+    context = new AnnotationConfigApplicationContext(CacheTestConfiguration.class);
+    userPermissionDAO = context.getBean(UserPermissionDAO.class);
+    storage = context.getBean(UserPermissionStorage.class);
+    when(userPermissionDAO.findByUserName(anyString())).thenReturn(List.of());
+    when(userPermissionDAO.findByUserNameAndGroupIdAndMembershipType(anyString(),
+                                                                     anyString(),
+                                                                     anyString())).thenReturn(Optional.empty());
+    when(userPermissionDAO.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @After
+  public void tearDown() {
+    context.close();
+  }
+
+  @Test
+  public void testGetPermissionsIsCachedPerUser() {
+    storage.getPermissions(ALICE);
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+
+    verify(userPermissionDAO, times(1)).findByUserName(ALICE);
+    verify(userPermissionDAO, times(1)).findByUserName(BOB);
+  }
+
+  @Test
+  public void testSaveDirectMembershipEvictsOnlyTheSavedUser() {
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+
+    storage.saveDirectMembership(new UserPermission(0, 101L, ALICE, GROUP_ID, MEMBERSHIP_TYPE, false));
+
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+    verify(userPermissionDAO, times(2)).findByUserName(ALICE);
+    verify(userPermissionDAO, times(1)).findByUserName(BOB);
+  }
+
+  @Test
+  public void testSaveInheritedMembershipEvictsOnlyTheSavedUser() {
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+
+    storage.saveInheritedMembership(new UserPermission(0, 101L, ALICE, GROUP_ID, MEMBERSHIP_TYPE, true));
+
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+    verify(userPermissionDAO, times(2)).findByUserName(ALICE);
+    verify(userPermissionDAO, times(1)).findByUserName(BOB);
+  }
+
+  @Test
+  public void testDeleteMembershipEvictsOnlyTheDeletedUser() {
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+
+    storage.deleteMembership(ALICE, GROUP_ID, MEMBERSHIP_TYPE);
+
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+    verify(userPermissionDAO, times(2)).findByUserName(ALICE);
+    verify(userPermissionDAO, times(1)).findByUserName(BOB);
+  }
+
+  @Test
+  public void testDeleteInheritedMembershipsEvictsOnlyTheUser() {
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+
+    storage.deleteInheritedMemberships(ALICE);
+
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+    verify(userPermissionDAO, times(2)).findByUserName(ALICE);
+    verify(userPermissionDAO, times(1)).findByUserName(BOB);
+  }
+
+  @Test
+  public void testDeleteByUserNameEvictsOnlyTheUser() {
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+
+    storage.deleteByUserName(ALICE);
+
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+    verify(userPermissionDAO, times(2)).findByUserName(ALICE);
+    verify(userPermissionDAO, times(1)).findByUserName(BOB);
+  }
+
+  @Test
+  public void testDeleteByGroupIdEvictsAllUsers() {
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+
+    storage.deleteByGroupId(GROUP_ID);
+
+    storage.getPermissions(ALICE);
+    storage.getPermissions(BOB);
+    verify(userPermissionDAO, times(2)).findByUserName(ALICE);
+    verify(userPermissionDAO, times(2)).findByUserName(BOB);
+  }
+
+}

--- a/component/core/src/test/java/io/meeds/social/identity/permission/upgrade/UserPermissionBackfillUpgradePluginTest.java
+++ b/component/core/src/test/java/io/meeds/social/identity/permission/upgrade/UserPermissionBackfillUpgradePluginTest.java
@@ -1,15 +1,26 @@
 /**
- * This file is part of the Meeds project (https://meeds.io/). Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io This
- * program is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version. This program
- * is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. You should
- * have received a copy of the GNU Lesser General Public License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package io.meeds.social.identity.permission.upgrade;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -48,7 +59,13 @@ import io.meeds.social.identity.permission.service.UserPermissionService;
 @RunWith(MockitoJUnitRunner.class)
 public class UserPermissionBackfillUpgradePluginTest {
 
-  private static final String                 GROUP_ID = "/platform/test";
+  private static final String                 GROUP_ID            = "/platform/test";
+
+  private static final String                 CHECKPOINT_PARAM    = "lastProcessedIdentityId";
+
+  private static final String                 PLUGIN_EXECUTED_KEY = "UserPermissionBackfillUpgradePluginExecuted_v2";
+
+  private static final int                    BATCH_SIZE          = 250;
 
   @Mock
   private OrganizationService                 organizationService;
@@ -75,7 +92,6 @@ public class UserPermissionBackfillUpgradePluginTest {
 
   @Before
   public void setUp() {
-    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
     plugin = new UserPermissionBackfillUpgradePlugin(new InitParams(),
                                                      organizationService,
                                                      identityManager,
@@ -87,23 +103,11 @@ public class UserPermissionBackfillUpgradePluginTest {
 
   @Test
   public void testProcessUpgradeBackfillsDirectRowThenRecomputesInheritedAndReindexes() throws Exception {
-    when(identityDAO.getAllIdsCountByProvider(OrganizationIdentityProvider.NAME, null, null, true, null)).thenReturn(1);
-    when(identityDAO.getAllIdsByProviderSorted(OrganizationIdentityProvider.NAME,
-                                               null,
-                                               null,
-                                               true,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               true,
-                                               0,
-                                               1)).thenReturn(List.of("alice"));
+    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, BATCH_SIZE)).thenReturn(List.of(101L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 101L, BATCH_SIZE)).thenReturn(List.of());
 
-    Identity aliceIdentity = new Identity("101");
-    when(identityManager.getOrCreateUserIdentity("alice")).thenReturn(aliceIdentity);
+    when(identityManager.getIdentity(101L)).thenReturn(identity("101", "alice"));
 
     Membership directMembership = membership("alice", GROUP_ID, "member", false);
     Membership inheritedMembership = membership("alice", "/platform/admin", "member", true);
@@ -120,23 +124,88 @@ public class UserPermissionBackfillUpgradePluginTest {
   }
 
   @Test
-  public void testProcessUpgradeSkipsUserWhenIdentityCannotBeResolved() throws Exception {
-    when(identityDAO.getAllIdsCountByProvider(OrganizationIdentityProvider.NAME, null, null, true, null)).thenReturn(1);
-    when(identityDAO.getAllIdsByProviderSorted(OrganizationIdentityProvider.NAME,
-                                               null,
-                                               null,
-                                               true,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               true,
-                                               0,
-                                               1)).thenReturn(List.of("ghost"));
+  public void testProcessUpgradeMarksExecutedOnlyOnCleanPass() throws Exception {
+    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, BATCH_SIZE)).thenReturn(List.of(101L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 101L, BATCH_SIZE)).thenReturn(List.of());
+    when(identityManager.getIdentity(101L)).thenReturn(identity("101", "alice"));
+    when(membershipHandler.findMembershipsByUser("alice", true)).thenReturn(List.of());
 
-    when(identityManager.getOrCreateUserIdentity("ghost")).thenReturn(null);
+    plugin.processUpgrade("7.9.0", "8.0.0");
+    plugin.afterUpgrade();
+
+    verify(settingService, times(1)).set(any(Context.class), any(Scope.class), eq(PLUGIN_EXECUTED_KEY), any());
+
+    ArgumentCaptor<SettingValue<?>> storedValues = ArgumentCaptor.forClass(SettingValue.class);
+    verify(settingService, times(2)).set(any(Context.class), any(Scope.class), eq(CHECKPOINT_PARAM), storedValues.capture());
+    List<SettingValue<?>> allStoredValues = storedValues.getAllValues();
+    assertEquals("101", allStoredValues.get(0).getValue());
+    assertEquals("0", allStoredValues.get(1).getValue());
+  }
+
+  @Test
+  public void testProcessUpgradeDoesNotMarkExecutedWhenAUserFails() throws Exception {
+    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, BATCH_SIZE)).thenReturn(List.of(101L, 102L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 102L, BATCH_SIZE)).thenReturn(List.of());
+    when(identityManager.getIdentity(101L)).thenReturn(identity("101", "alice"));
+    when(identityManager.getIdentity(102L)).thenReturn(null);
+    when(membershipHandler.findMembershipsByUser("alice", true)).thenReturn(List.of());
+
+    plugin.processUpgrade("7.9.0", "8.0.0");
+    plugin.afterUpgrade();
+
+    verify(userPermissionService, times(1)).recomputeInheritedMemberships(101L, "alice", List.of());
+    verify(settingService, never()).set(any(Context.class), any(Scope.class), eq(PLUGIN_EXECUTED_KEY), any());
+    verify(settingService, never()).set(any(Context.class), any(Scope.class), eq(CHECKPOINT_PARAM), any());
+  }
+
+  @Test
+  public void testProcessUpgradeFreezesCheckpointOnceAUserFailed() throws Exception {
+    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, BATCH_SIZE)).thenReturn(List.of(101L, 102L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 102L, BATCH_SIZE)).thenReturn(List.of(103L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 103L, BATCH_SIZE)).thenReturn(List.of());
+    when(identityManager.getIdentity(101L)).thenReturn(identity("101", "alice"));
+    when(identityManager.getIdentity(102L)).thenReturn(null);
+    when(identityManager.getIdentity(103L)).thenReturn(identity("103", "carol"));
+    when(membershipHandler.findMembershipsByUser("alice", true)).thenReturn(List.of());
+    when(membershipHandler.findMembershipsByUser("carol", true)).thenReturn(List.of());
+
+    plugin.processUpgrade("7.9.0", "8.0.0");
+    plugin.afterUpgrade();
+
+    verify(userPermissionService, times(1)).recomputeInheritedMemberships(101L, "alice", List.of());
+    verify(userPermissionService, times(1)).recomputeInheritedMemberships(103L, "carol", List.of());
+    verify(settingService, never()).set(any(Context.class), any(Scope.class), eq(PLUGIN_EXECUTED_KEY), any());
+    verify(settingService, never()).set(any(Context.class), any(Scope.class), eq(CHECKPOINT_PARAM), any());
+  }
+
+  @Test
+  public void testProcessUpgradeKeepsCleanCheckpointWhenALaterUserFails() throws Exception {
+    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, BATCH_SIZE)).thenReturn(List.of(101L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 101L, BATCH_SIZE)).thenReturn(List.of(102L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 102L, BATCH_SIZE)).thenReturn(List.of());
+    when(identityManager.getIdentity(101L)).thenReturn(identity("101", "alice"));
+    when(identityManager.getIdentity(102L)).thenReturn(null);
+    when(membershipHandler.findMembershipsByUser("alice", true)).thenReturn(List.of());
+
+    plugin.processUpgrade("7.9.0", "8.0.0");
+    plugin.afterUpgrade();
+
+    verify(settingService, never()).set(any(Context.class), any(Scope.class), eq(PLUGIN_EXECUTED_KEY), any());
+
+    ArgumentCaptor<SettingValue<?>> storedValues = ArgumentCaptor.forClass(SettingValue.class);
+    verify(settingService, times(1)).set(any(Context.class), any(Scope.class), eq(CHECKPOINT_PARAM), storedValues.capture());
+    assertEquals("101", storedValues.getValue().getValue());
+  }
+
+  @Test
+  public void testProcessUpgradeSkipsUserWhenIdentityCannotBeResolved() throws Exception {
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, BATCH_SIZE)).thenReturn(List.of(999L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 999L, BATCH_SIZE)).thenReturn(List.of());
+    when(identityManager.getIdentity(999L)).thenReturn(null);
 
     plugin.processUpgrade("7.9.0", "8.0.0");
 
@@ -146,58 +215,45 @@ public class UserPermissionBackfillUpgradePluginTest {
   }
 
   @Test
-  public void testProcessUpgradeResumesFromLastCheckpointOffset() throws Exception {
-    // A prior, crashed run already completed offset 0 (1 user); the checkpoint says
-    // to resume at 1.
+  public void testProcessUpgradeResumesFromLastCheckpointIdentityId() throws Exception {
+    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
     when(settingService.get(any(Context.class),
                             any(Scope.class),
-                            eq("lastProcessedOffset"))).thenReturn((SettingValue) SettingValue.create("1"));
+                            eq(CHECKPOINT_PARAM))).thenReturn((SettingValue) SettingValue.create("101"));
 
-    when(identityDAO.getAllIdsCountByProvider(OrganizationIdentityProvider.NAME, null, null, true, null)).thenReturn(2);
-    when(identityDAO.getAllIdsByProviderSorted(OrganizationIdentityProvider.NAME,
-                                               null,
-                                               null,
-                                               true,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               null,
-                                               true,
-                                               1,
-                                               1)).thenReturn(List.of("resumed"));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 101L, BATCH_SIZE)).thenReturn(List.of(202L));
+    when(identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 202L, BATCH_SIZE)).thenReturn(List.of());
 
-    Identity resumedIdentity = new Identity("202");
-    when(identityManager.getOrCreateUserIdentity("resumed")).thenReturn(resumedIdentity);
+    when(identityManager.getIdentity(202L)).thenReturn(identity("202", "resumed"));
     when(membershipHandler.findMembershipsByUser("resumed", true)).thenReturn(List.of());
 
     plugin.processUpgrade("7.9.0", "8.0.0");
 
-    // The already-processed offset (0) must never be re-loaded.
-    verify(identityDAO, never()).getAllIdsByProviderSorted(OrganizationIdentityProvider.NAME,
-                                                           null,
-                                                           null,
-                                                           true,
-                                                           null,
-                                                           null,
-                                                           null,
-                                                           null,
-                                                           null,
-                                                           null,
-                                                           true,
-                                                           0,
-                                                           1);
-    verify(identityManager, never()).getOrCreateUserIdentity("skipped");
+    verify(identityDAO, never()).getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, BATCH_SIZE);
     verify(userPermissionService, times(1)).recomputeInheritedMemberships(202L, "resumed", List.of());
 
-    // The checkpoint must be advanced past the resumed batch, then reset to 0 on
-    // full completion.
     ArgumentCaptor<SettingValue<?>> storedValues = ArgumentCaptor.forClass(SettingValue.class);
-    verify(settingService, times(2)).set(any(Context.class), any(Scope.class), eq("lastProcessedOffset"), storedValues.capture());
+    verify(settingService, times(2)).set(any(Context.class), any(Scope.class), eq(CHECKPOINT_PARAM), storedValues.capture());
     List<SettingValue<?>> allStoredValues = storedValues.getAllValues();
-    assertEquals("2", allStoredValues.get(0).getValue());
+    assertEquals("202", allStoredValues.get(0).getValue());
     assertEquals("0", allStoredValues.get(1).getValue());
+  }
+
+  @Test
+  public void testShouldProceedToUpgradeUntilExecutedFlagIsStored() {
+    when(settingService.get(any(Context.class), any(Scope.class), eq(PLUGIN_EXECUTED_KEY))).thenReturn(null);
+    assertTrue(plugin.shouldProceedToUpgrade("8.0.0", "7.9.0", null));
+
+    when(settingService.get(any(Context.class),
+                            any(Scope.class),
+                            eq(PLUGIN_EXECUTED_KEY))).thenReturn((SettingValue) SettingValue.create(true));
+    assertFalse(plugin.shouldProceedToUpgrade("8.0.0", "7.9.0", null));
+  }
+
+  private Identity identity(String id, String remoteId) {
+    Identity identity = new Identity(id);
+    identity.setRemoteId(remoteId);
+    return identity;
   }
 
   private Membership membership(String userName, String groupId, String membershipType, boolean inherited) {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAOTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAOTest.java
@@ -262,6 +262,35 @@ public class IdentityDAOTest extends BaseCoreTest {
     deleteIdentities.add(identitySpace1);
   }
 
+  public void testGetIdsByProviderAfterId() {
+    IdentityEntity identityUser1 = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, "keysetUser1"));
+    IdentityEntity identityUser2 = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, "keysetUser2"));
+    IdentityEntity disabledUser = createIdentity(OrganizationIdentityProvider.NAME, "keysetUser3");
+    disabledUser.setEnabled(false);
+    disabledUser = identityDAO.create(disabledUser);
+    IdentityEntity identitySpace1 = identityDAO.create(createIdentity(SpaceIdentityProvider.NAME, "keysetSpace1"));
+
+    List<Long> ids = identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME, 0, 0);
+    assertTrue(ids.contains(identityUser1.getId()));
+    assertTrue(ids.contains(identityUser2.getId()));
+    assertTrue(ids.contains(disabledUser.getId()));
+    assertFalse(ids.contains(identitySpace1.getId()));
+    List<Long> sortedIds = new ArrayList<>(ids);
+    Collections.sort(sortedIds);
+    assertEquals("List '" + ids + "' is not sorted by id", sortedIds, ids);
+
+    List<Long> idsAfterFirstUser = identityDAO.getIdsByProviderAfterId(OrganizationIdentityProvider.NAME,
+                                                                       identityUser1.getId(),
+                                                                       0);
+    assertFalse(idsAfterFirstUser.contains(identityUser1.getId()));
+    assertTrue(idsAfterFirstUser.contains(identityUser2.getId()));
+
+    deleteIdentities.add(identityUser1);
+    deleteIdentities.add(identityUser2);
+    deleteIdentities.add(disabledUser);
+    deleteIdentities.add(identitySpace1);
+  }
+
   public void testSaveNewIdentity() {
     IdentityEntity entity = createIdentity();
 


### PR DESCRIPTION
## Problem
Group members lists in the groups management page are partially or fully empty (tribe, demo-04). Two chained defects since MIPs#237 replaced live group-member resolution with the denormalized `SOC_USER_PERMISSION` table:

1. **Every write to `SOC_USER_PERMISSION` throws.** The `@CacheEvict` keys on `UserPermissionStorage` referenced parameter names (`#userName`, `#userPermission.userName`); social compiles without `-parameters`, so the SpEL key resolves to null and each save/delete fails with `IllegalArgumentException: Null key returned for cache operation` (visible live in tribe's platform.log, `Error synchronizing user permissions for user …`).
2. **The backfill masked its own total failure.** `UserPermissionBackfillUpgradePlugin` swallowed each user's exception as a WARN, still marked itself executed, and is now ignored on every startup (`Ignore upgrade plugin UserPermissionBackfillUpgradePlugin` in the log) — so the table stays empty for every pre-upgrade membership while the listeners kept failing silently. It also paginated with an ORDER-BY-less OFFSET scan (skippable rows) and excluded disabled users.

## Fix
- Cache keys switched to the position-based form (`#p0`, `#p0.userName`) already used by `SpaceDirectoryStorage` — compiler-flag independent. A repo sweep confirms no other parameter-name SpEL cache key remains in social.
- Backfill rewritten: keyset iteration ordered by identity id (new named query `SocIdentity.getIdsByProviderAfterId`, disabled users included), executed flag stored **only after a zero-failure pass**, checkpoint frozen at the last fully-clean batch and retained across failed/interrupted passes (recovery replays exactly the range covering the failures), reset-to-0 stored before the succeeded flag. The executed flag moves to a `_v2` key so every instance that recorded the defective run (tribe, demo-04, upgraded customers) re-runs the corrected backfill automatically on next startup — the writes are idempotent.

## Tests
- `UserPermissionCachedStorageTest` (new): the storage exercised through a **real Spring cache proxy** (`ConcurrentMapCacheManager`) — with the old keys every eviction test fails with the exact production exception; per-user eviction asserted against the other user's entry staying cached.
- `UserPermissionBackfillUpgradePluginTest` (8 tests): executed-only-on-clean-pass, frozen/retained checkpoint across multi-batch failures, keyset resume, identity-not-found skip.
- `IdentityDAOTest#testGetIdsByProviderAfterId`: the new JPQL executed on the real engine (HSQLDB) — ordering, strict `> lastId`, disabled inclusion, provider filtering.
- **All regression pins mutation-verified**: reverting the cache keys fails the cached-storage tests with the production exception; reverting the executed-flag condition or either checkpoint guard fails the plugin tests.

## Self-review close-out
3 independent review rounds, 8 findings: 6 fixed in this diff (1🟠 crash-resume hole, 1🟡 full-platform replay cost, 4🟢), 2 accepted with reasons — the pre-existing non-atomic `recomputeInheritedMemberships` (delete-then-insert across per-call transactions; durable cure is a single-transaction recompute, follow-up on pre-existing code) and the inert v1 settings rows. Round 3 independently re-executed the mutations and verified identity-id monotonicity rules out checkpoint poisoning.

## Classification
**N1** — ACL-bearing permission store (cache-eviction semantics) + data-migration upgrade plugin. The approver must be an Architect/Senior Developer aware this is N1; author ≠ approver.

Knowledge: pending — eng-standards pitfall PR to be proposed (parameter-name SpEL cache keys are broken without `-parameters`, use `#p0`; an upgrade plugin must never mark itself executed over swallowed per-user failures).
