### PR TITLE
fix: Favorite activity of a posted news isn't displayed in favorite activities filter - EXO-87180

### DIFF
--- a/component/api/src/main/java/org/exoplatform/social/core/ActivityTypePlugin.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/ActivityTypePlugin.java
@@ -18,6 +18,9 @@
  */
 package org.exoplatform.social.core;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.exoplatform.container.component.BaseComponentPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.security.Identity;
@@ -94,12 +97,37 @@ public class ActivityTypePlugin extends BaseComponentPlugin {
 
   /**
    * Return specific activity title
-   * 
+   *
    * @param  activity {@link ExoSocialActivity}
    * @return          activity title to use in notification by example
    */
   public String getActivityTitle(ExoSocialActivity activity) {
     return activity.getTitle();
+  }
+
+  /**
+   * Return the specific Metadata Object Type that the activities of this type
+   * redirect their Metadata facts to (see ExoSocialActivity#hasSpecificMetadataObject)
+   * activities. Used to resolve Metadata items (favorites by example) attached
+   * to the specific object back to their displaying activities.
+   *
+   * @return the specific Metadata Object Type, or null when activities of this
+   *         type hold their Metadata facts themselves (the default)
+   */
+  public String getMetadataObjectType() {
+    return null;
+  }
+
+  /**
+   * Resolve the ids of the activities displaying the given specific Metadata
+   * objects (of type {@link ActivityTypePlugin#getMetadataObjectType()})
+   *
+   * @param  metadataObjectIds {@link List} of Metadata object ids
+   * @return                   {@link List} of corresponding activity ids,
+   *                           omitting objects with no resolvable activity
+   */
+  public List<String> getActivityIds(List<String> metadataObjectIds) {
+    return Collections.emptyList();
   }
 
   private String getParamValue(InitParams params, String paramName, String defaultValue) {

--- a/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.core.manager;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -416,11 +417,25 @@ public interface ActivityManager {
 
   /**
    * Adds an Activity Type options such as activity notification enabling
-   * 
+   *
    * @param plugin {@link ActivityTypePlugin}
    */
   default void addActivityTypePlugin(ActivityTypePlugin plugin) {
     // No operation
+  }
+
+  /**
+   * Retrieves the ids of the activities displaying the given specific Metadata
+   * objects (news, notes...), resolved by the registered
+   * {@link ActivityTypePlugin} declaring this Metadata Object Type
+   * @param  metadataObjectType specific Metadata Object Type
+   * @param  metadataObjectIds  {@link List} of Metadata object ids
+   * @return                    {@link List} of corresponding activity ids,
+   *                            empty when no registered plugin declares the
+   *                            given Metadata Object Type
+   */
+  default List<String> getActivityIdsByMetadataObjects(String metadataObjectType, List<String> metadataObjectIds) {
+    return Collections.emptyList();
   }
 
   void addActivityEventListener(ActivityListenerPlugin activityListenerPlugin);

--- a/component/api/src/main/java/org/exoplatform/social/metadata/favorite/FavoriteService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/favorite/FavoriteService.java
@@ -86,6 +86,24 @@ public interface FavoriteService {
   }
 
   /**
+   * Retrieves the favorite items attached to a given {@link MetadataItem}
+   * creatorId and {@link MetadataObject} spaceId, whatever the
+   * {@link MetadataObject} type
+   *
+   * @param creatorId {@link MetadataItem} creatorId
+   * @param spaceId {@link MetadataItem} spaceId
+   * @param offset offset of ids to retrieve
+   * @param limit limit of ids to retrieve
+   * @return {@link List} of linked {@link MetadataItem}
+   */
+  default List<MetadataItem> getFavoriteItemsByCreatorAndSpaceId(long creatorId,
+                                                                 long spaceId,
+                                                                 long offset,
+                                                                 long limit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Count the favorite items attached to a given {@link MetadataItem} creatorId
    *
    * @param creatorId {@link MetadataItem} creatorId

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -67,6 +67,7 @@ import org.exoplatform.social.core.jpa.storage.entity.ActivityEntity;
 import org.exoplatform.social.core.jpa.storage.entity.ActivityShareActionEntity;
 import org.exoplatform.social.core.jpa.storage.entity.StreamItemEntity;
 import org.exoplatform.social.core.jpa.storage.entity.StreamType;
+import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.SpaceFilter;
 import org.exoplatform.social.core.space.model.Space;
@@ -812,26 +813,36 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       Identity spaceIdentity = identityStorage.findIdentityById(String.valueOf(spaceIdentityId));
       if (spaceIdentity != null) {
         Space space = spaceStorage.getSpaceByPrettyName(spaceIdentity.getRemoteId());
-        metadataItems =
-                      favoriteService.getFavoriteItemsByCreatorAndTypeAndSpaceId(ExoSocialActivityImpl.DEFAULT_ACTIVITY_METADATA_OBJECT_TYPE,
-                                                                                 userIdentityId,
-                                                                                 Long.parseLong(space.getId()),
-                                                                                 0,
-                                                                                 -1);
+        metadataItems = favoriteService.getFavoriteItemsByCreatorAndSpaceId(userIdentityId,
+                                                                            Long.parseLong(space.getId()),
+                                                                            0,
+                                                                            -1);
       }
 
     } else {
-      metadataItems =
-                    favoriteService.getFavoriteItemsByCreatorAndType(ExoSocialActivityImpl.DEFAULT_ACTIVITY_METADATA_OBJECT_TYPE,
-                                                                     userIdentityId,
-                                                                     0,
-                                                                     -1);
+      metadataItems = favoriteService.getFavoriteItemsByCreator(userIdentityId, 0, -1);
     }
 
-    return metadataItems.stream()
-                        .map(metadataItem -> getActivityStorage().getActivity(String.valueOf(metadataItem.getObjectId())))
-                        .sorted(Comparator.comparing(ExoSocialActivity::getUpdated).reversed())
-                        .collect(Collectors.toList());
+    Map<String, List<String>> objectIdsByType =
+        metadataItems.stream()
+                     .collect(Collectors.groupingBy(MetadataItem::getObjectType,
+                                                    Collectors.mapping(MetadataItem::getObjectId,
+                                                                       Collectors.toList())));
+    ActivityManager activityManager = ExoContainerContext.getService(ActivityManager.class);
+    return objectIdsByType.entrySet()
+                          .stream()
+                          .flatMap(objectIds -> StringUtils.equals(objectIds.getKey(),
+                                                                   ExoSocialActivityImpl.DEFAULT_ACTIVITY_METADATA_OBJECT_TYPE) ?
+                              objectIds.getValue()
+                                       .stream() :
+                              activityManager.getActivityIdsByMetadataObjects(objectIds.getKey(),
+                                                                              objectIds.getValue())
+                                             .stream())
+                          .distinct()
+                          .map(activityId -> getActivityStorage().getActivity(activityId))
+                          .filter(Objects::nonNull)
+                          .sorted(Comparator.comparing(ExoSocialActivity::getUpdated).reversed())
+                          .collect(Collectors.toList());
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -20,6 +20,7 @@ package org.exoplatform.social.core.manager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -127,6 +128,8 @@ public class ActivityManagerImpl implements ActivityManager {
   private Set<String>                     systemActivityTypes            = new HashSet<>();
 
   private Map<String, ActivityTypePlugin> activityTypePlugins            = new HashMap<>();
+
+  private Map<String, ActivityTypePlugin> activityTypePluginsByMetadataObjectType = new HashMap<>();
 
   private Set<String>                     systemActivityTitleIds         = new HashSet<>(Arrays.asList("has_joined",
                                                                                                        "space_avatar_edited",
@@ -819,6 +822,24 @@ public class ActivityManagerImpl implements ActivityManager {
   @Override
   public void addActivityTypePlugin(ActivityTypePlugin plugin) {
     activityTypePlugins.put(plugin.getActivityType(), plugin);
+    if (StringUtils.isNotBlank(plugin.getMetadataObjectType())) {
+      ActivityTypePlugin replacedPlugin = activityTypePluginsByMetadataObjectType.put(plugin.getMetadataObjectType(), plugin);
+      if (replacedPlugin != null) {
+        LOG.warn("ActivityTypePlugin of activity type {} replaces {} on Metadata Object Type {}",
+                 plugin.getActivityType(),
+                 replacedPlugin.getActivityType(),
+                 plugin.getMetadataObjectType());
+      }
+    }
+  }
+
+  @Override
+  public List<String> getActivityIdsByMetadataObjects(String metadataObjectType, List<String> metadataObjectIds) {
+    ActivityTypePlugin activityTypePlugin = activityTypePluginsByMetadataObjectType.get(metadataObjectType);
+    if (activityTypePlugin == null || CollectionUtils.isEmpty(metadataObjectIds)) {
+      return Collections.emptyList();
+    }
+    return activityTypePlugin.getActivityIds(metadataObjectIds);
   }
 
   /**

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/favorite/FavoriteServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/favorite/FavoriteServiceImpl.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.core.metadata.favorite;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +85,15 @@ public class FavoriteServiceImpl implements FavoriteService {
   @Override
   public List<MetadataItem> getFavoriteItemsByCreatorAndTypeAndSpaceId(String objectType, long creatorId, long spaceId, long offset, long limit) {
     return metadataService.getMetadataItemsByMetadataNameAndTypeAndObjectAndSpaceId(String.valueOf(creatorId), METADATA_TYPE.getName(), objectType, spaceId, offset, limit);
+  }
+
+  @Override
+  public List<MetadataItem> getFavoriteItemsByCreatorAndSpaceId(long creatorId, long spaceId, long offset, long limit) {
+    return metadataService.getMetadataItemsByMetadataNameAndTypeAndSpaceIds(String.valueOf(creatorId),
+                                                                            METADATA_TYPE.getName(),
+                                                                            Collections.singletonList(spaceId),
+                                                                            offset,
+                                                                            limit);
   }
 
   @Override

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -3105,8 +3105,9 @@ public class ActivityManagerTest extends AbstractCoreTest {
                                           null,
                                           Long.parseLong(demoIdentity.getId()));
     favoriteService.createFavorite(favoriteSpace);
+    String demoActivityId = activityManager.getActivitiesWithListAccess(demoIdentity).load(0, 1)[0].getId();
     Favorite favoriteActivity = new Favorite(ExoSocialActivityImpl.DEFAULT_ACTIVITY_METADATA_OBJECT_TYPE,
-                                             "1",
+                                             demoActivityId,
                                              null,
                                              Long.parseLong(demoIdentity.getId()));
     favoriteService.createFavorite(favoriteActivity);
@@ -3135,6 +3136,93 @@ public class ActivityManagerTest extends AbstractCoreTest {
     activityFilter.setStreamType(ActivityStreamType.FAVORITE_SPACES_STREAM);
     streamTypeActivities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
     assertEquals(4, streamTypeActivities.load(0, 10).length);
+  }
+
+  @SneakyThrows
+  public void testGetFavoriteActivityOfSpecificMetadataObject() {
+    // Activity redirecting its Metadata facts to a specific object
+    String metadataObjectType = "testContent";
+    String metadataObjectId = "5";
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    activity.setTitle("content activity");
+    activity.setUserId(demoIdentity.getId());
+    activity.setMetadataObjectType(metadataObjectType);
+    activity.setMetadataObjectId(metadataObjectId);
+    activityManager.saveActivityNoReturn(demoIdentity, activity);
+    restartTransaction();
+
+    // Favorite stored against the specific object, as the favorite button of
+    // such an activity does
+    FavoriteService favoriteService = ExoContainerContext.getService(FavoriteService.class);
+    favoriteService.createFavorite(new Favorite(metadataObjectType,
+                                                metadataObjectId,
+                                                null,
+                                                Long.parseLong(demoIdentity.getId())));
+
+    ActivityFilter activityFilter = new ActivityFilter();
+    activityFilter.setStreamType(ActivityStreamType.USER_FAVORITE_STREAM);
+
+    // No ActivityTypePlugin declaring the Metadata Object Type: the favorite
+    // resolves to no activity and doesn't break the listing
+    RealtimeListAccess<ExoSocialActivity> favoriteActivities =
+                                                             activityManager.getActivitiesByFilterWithListAccess(demoIdentity,
+                                                                                                                 activityFilter);
+    String activityId = activity.getId();
+    assertFalse(Arrays.stream(favoriteActivities.load(0, 10)).anyMatch(favorite -> activityId.equals(favorite.getId())));
+
+    // Register the ActivityTypePlugin resolving the specific objects to their
+    // displaying activities. The plugin registry has
+    // no removal API, thus the plugin (with its test-specific activity &
+    // Metadata Object types) stays registered in the shared container for the
+    // whole suite.
+    Map<String, String> activityIdsByObjectId = new HashMap<>();
+    activityIdsByObjectId.put(metadataObjectId, activityId);
+    InitParams initParams = new InitParams();
+    ValueParam typeParam = new ValueParam();
+    typeParam.setName(ActivityTypePlugin.ACTIVITY_TYPE_PARAM);
+    typeParam.setValue("testContentActivityType");
+    initParams.addParameter(typeParam);
+    activityManager.addActivityTypePlugin(new ActivityTypePlugin(initParams) {
+      @Override
+      public String getMetadataObjectType() {
+        return metadataObjectType;
+      }
+
+      @Override
+      public List<String> getActivityIds(List<String> metadataObjectIds) {
+        return metadataObjectIds.stream().map(activityIdsByObjectId::get).filter(StringUtils::isNotBlank).toList();
+      }
+    });
+
+    favoriteActivities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    assertTrue(Arrays.stream(favoriteActivities.load(0, 10)).anyMatch(favorite -> activityId.equals(favorite.getId())));
+
+    // Space-filtered favorite activities: only the favorites carrying the
+    // space id are returned
+    Space space = getSpaceInstance(18);
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    String spaceMetadataObjectId = "6";
+    ExoSocialActivity spaceActivity = new ExoSocialActivityImpl();
+    spaceActivity.setTitle("space content activity");
+    spaceActivity.setUserId(demoIdentity.getId());
+    spaceActivity.setMetadataObjectType(metadataObjectType);
+    spaceActivity.setMetadataObjectId(spaceMetadataObjectId);
+    activityManager.saveActivityNoReturn(spaceIdentity, spaceActivity);
+    restartTransaction();
+
+    String spaceActivityId = spaceActivity.getId();
+    activityIdsByObjectId.put(spaceMetadataObjectId, spaceActivityId);
+    favoriteService.createFavorite(new Favorite(metadataObjectType,
+                                                spaceMetadataObjectId,
+                                                null,
+                                                Long.parseLong(demoIdentity.getId()),
+                                                Long.parseLong(space.getId())));
+
+    activityFilter.setSpaceIdentityId(Long.parseLong(spaceIdentity.getId()));
+    favoriteActivities = activityManager.getActivitiesByFilterWithListAccess(demoIdentity, activityFilter);
+    ExoSocialActivity[] spaceFavoriteActivities = favoriteActivities.load(0, 10);
+    assertTrue(Arrays.stream(spaceFavoriteActivities).anyMatch(favorite -> spaceActivityId.equals(favorite.getId())));
+    assertFalse(Arrays.stream(spaceFavoriteActivities).anyMatch(favorite -> activityId.equals(favorite.getId())));
   }
 
   public void testLoadMoreActivities() throws Exception {


### PR DESCRIPTION
Resolve favorites stored on an activity's specific Metadata object (news, notes...) back to their displaying activities in the favorite activities stream filter, through a new resolution SPI on ActivityTypePlugin.

Knowledge: Meeds-io/eng-standards#44