### PR TITLE
fix: Fix the navigation menu accessibility - EXO-88911

### DIFF
--- a/webapp/src/main/webapp/skin/less/portlet/TopBarMenu/Style.less
+++ b/webapp/src/main/webapp/skin/less/portlet/TopBarMenu/Style.less
@@ -67,3 +67,24 @@
   top: -10%;
   position: absolute;
 }
+
+/* EXO-88911 - walking the menu with the arrow keys must look exactly like hovering it:
+   Vuetify applies its overlay on real pointer hover only, so the focused entry is given the
+   same overlay opacity here rather than a focus border. */
+.navigation-menu-sub-item {
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
+
+  &.theme--light:focus::before,
+  &.theme--light:focus-visible::before {
+    opacity: 0.04;
+  }
+
+  &.theme--dark:focus::before,
+  &.theme--dark:focus-visible::before {
+    opacity: 0.08;
+  }
+}

--- a/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryTab.vue
+++ b/webapp/src/main/webapp/vue-apps/category-components/components/filter/CategoryTab.vue
@@ -39,6 +39,9 @@
           click: () => $listeners.click(category),
         } || on"
         :value="category.id"
+        :aria-label="category.name"
+        aria-haspopup="true"
+        :aria-expanded="String(menu)"
         @focus="menu = true">
         <v-card
           :title="category.name"
@@ -69,6 +72,7 @@
         }"
         :key="subItem.id"
         :color="selectedId === subItem.id && 'var(--allPagesTertiaryColor) !important'"
+        :aria-label="subItem.name"
         dense>
         <v-card
           :title="subItem.name"

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -175,6 +175,13 @@ export default {
     document.addEventListener('click', this.handleCloseMenu);
     this.$root.$on('close-sibling-drop-menus', this.handleCloseSiblingMenus);
   },
+  beforeDestroy() {
+    // the navigation tree is rebuilt on `space-settings-updated`, so these components are
+    // destroyed and recreated: without this, every rebuild leaves a document listener and a
+    // $root handler behind, holding the dead instance alive (EXO-88911 review)
+    document.removeEventListener('click', this.handleCloseMenu);
+    this.$root.$off('close-sibling-drop-menus', this.handleCloseSiblingMenus);
+  },
   methods: {
     updateNavigationState() {
       this.$emit('update-navigation-state', this.navigationNodeUri);

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuItem.vue
@@ -31,10 +31,11 @@
     :max-height="menuMaxHeight"
     bottom
     offset-y
+    disable-keys
     eager>
     <template #activator="{ on, attrs }">
       <v-tab
-        v-if="hasPage || hasChildren && childrenHasPage"
+        v-if="hasPage || hasSubMenu"
         ref="tab"
         :href="navigationNodeUri"
         :target="navigationNodeTarget"
@@ -46,10 +47,16 @@
         v-on="on"
         v-bind="attrs"
         role="tab"
+        :aria-haspopup="hasSubMenu && 'true' || null"
+        :aria-expanded="hasSubMenu && String(showMenu) || null"
         @focus="openDropMenuOnFocus"
         @keydown.tab="showMenu = false"
-        @keydown.right="focusHighlightedItem"
-        @keydown.left="focusHighlightedItem"
+        @keydown.down.prevent="walkDeeper"
+        @keydown.up.prevent="walkDeeperFromEnd"
+        @keydown.right.prevent="onForwardKey"
+        @keydown.left.prevent="onBackKey"
+        @keydown.esc="showMenu = false"
+        @keydown.enter="onEnterKey"
         @click="checkLink"
         @change="updateNavigationState">
         <span
@@ -63,7 +70,7 @@
           fa-external-link-alt
         </v-icon>
         <span
-          v-if="hasChildren && childrenHasPage"
+          v-if="hasSubMenu"
           class="d-flex align-center"
           aria-hidden="true">
           <v-icon class="ms-3" size="20">
@@ -74,21 +81,26 @@
     </template>
     <navigation-menu-sub-item
       v-for="children in navigation.children"
+      ref="entries"
       class="transparent"
       :key="children.id"
       :navigation="children"
       :base-site-uri="baseSiteUri"
       :parent-navigation-uri="navigation.uri"
       :selected-path="selectedPath"
-      :highlighted="renderedChildren[highlightedIndex] === children"
       @update-navigation-state="updateNavigationState"
       @exit-menu="exitMenu"
+      @walk="walkFromEntry"
+      @leave-level="focusSelf"
       @select="updateNavigationState" />
   </v-menu>
 </template>
 
 <script>
+import menuKeyboardNavigation from '../menuKeyboardNavigation.js';
+
 export default {
+  mixins: [menuKeyboardNavigation],
   props: {
     navigation: {
       type: Object,
@@ -107,7 +119,6 @@ export default {
     return {
       showMenu: false,
       exitingMenu: false,
-      highlightedIndex: -1,
       isOpenedOnHover: true,
       menuMaxHeight: '100vh'
     };
@@ -137,13 +148,13 @@ export default {
     childrenHasPage() {
       return this.checkChildrenHasPage(this.navigation);
     },
+    hasSubMenu() {
+      // a node opens a submenu only when it has children that actually lead somewhere;
+      // this is what aria-haspopup/aria-expanded must reflect, so it is computed once
+      return !!(this.hasChildren && this.childrenHasPage);
+    },
     isTopBarElement() {
       return this.$root.isTopBarElement;
-    },
-    renderedChildren() {
-      // the entries the menu actually shows, in the same order as the menu own tiles
-      return this.navigation?.children?.filter(child => !!child.pageKey
-        || child.children?.length && this.checkChildrenHasPage(child)) || [];
     },
   },
   watch: {
@@ -159,11 +170,6 @@ export default {
         }
       }
     },
-  },
-  mounted() {
-    // the arrow keys only add a css class on the highlighted entry, so watch the menu own index
-    // to tell that entry to open its submenu right away, without waiting for a horizontal arrow
-    this.$watch(() => this.$refs.menu?.listIndex, index => this.highlightedIndex = index);
   },
   created() {
     document.addEventListener('click', this.handleCloseMenu);
@@ -191,7 +197,7 @@ export default {
         // the focus is only passing by on its way out of the menu, don't open it again
         return;
       }
-      this.showMenu = this.hasChildren && this.childrenHasPage || false;
+      this.showMenu = this.hasSubMenu;
     },
     exitMenu() {
       // Tab from a sub item must leave the menu instead of walking through the drop menu
@@ -201,11 +207,6 @@ export default {
       this.showMenu = false;
       this.$refs.tab?.$el?.focus();
       this.$nextTick(() => this.exitingMenu = false);
-    },
-    focusHighlightedItem() {
-      // hand the keyboard over to the sub item the arrow keys highlighted, so that its own
-      // submenu opens on focus and takes the next keys (either arrow, the direction flips in RTL)
-      this.$refs.menu?.$refs?.content?.querySelector('.v-list-item--highlighted')?.focus();
     },
     handleCloseSiblingMenus(emitter) {
       if (this !== emitter && this.showMenu) {
@@ -218,22 +219,6 @@ export default {
           this.showMenu = false;
         }, 100);
       }
-    },
-    checkChildrenHasPage(navigation) {
-      let childrenHasPage = false;
-      navigation.children.forEach(child => {
-        if (childrenHasPage === true) {
-          return;
-        }
-        if (child.pageKey) {
-          childrenHasPage = true;
-        } else if (child.children.length > 0) {
-          childrenHasPage = this.checkChildrenHasPage(child);
-        } else {
-          childrenHasPage = false;
-        }
-      });
-      return childrenHasPage;
     },
   }
 };

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -189,9 +189,6 @@ export default {
       this.positionY = this.$el.getBoundingClientRect().top;
       this.$root.$emit('close-sibling-drop-menus-children', this);
     },
-    hasPage() {
-      return !!this.navigation?.pageKey;
-    },
   },
   mounted() {
     this.rowElement = this.$refs.row?.$el;
@@ -199,6 +196,11 @@ export default {
   created() {
     window.addEventListener('resize', this.updateSize);
     this.$root.$on('close-sibling-drop-menus-children', this.handleCloseSiblingMenus);
+  },
+  beforeDestroy() {
+    // same as the parent: the tree is rebuilt on `space-settings-updated` (EXO-88911 review)
+    window.removeEventListener('resize', this.updateSize);
+    this.$root.$off('close-sibling-drop-menus-children', this.handleCloseSiblingMenus);
   },
   methods: {
     checkLink(e) {

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/components/NavigationMenuSubItem.vue
@@ -20,23 +20,62 @@
 
 -->
 <template>
+  <!-- role="none": one v-list wraps each entry, so without it a generic container sits between
+       the menu (role="menu", set by Vuetify on its content) and its menuitems, and the menu no
+       longer owns its own items - which is what a screen reader counts and announces -->
   <v-list
     class="pa-0"
+    role="none"
     dense>
+    <!-- the keyboard counterpart of @mouseleave is not @blur here: the arrow keys hand focus
+         over to the submenu on purpose, so closing on blur would shut it as it opens. Focus
+         leaving the menu for real is handled by @keydown.tab -> exit-menu. -->
+    <!-- eslint-disable-next-line vuejs-accessibility/mouse-events-have-key-events -->
     <v-list-item
-      v-if="hasPage || hasChildren && childrenHasPage"
+      v-if="hasPage || hasSubMenu"
       ref="row"
       :href="navigationNodeUri"
       :target="navigationNodeTarget"
       :rel="navigationNodeRel"
       :link="!!hasPage"
-      class="py-0 px-0 transparent"
+      :aria-label="navigation.label"
+      :aria-haspopup="hasSubMenu && 'true' || null"
+      :aria-expanded="hasSubMenu && String(showMenu) || null"
+      class="py-0 px-0 transparent navigation-menu-sub-item"
       @click="checkLink"
       @keydown.stop
-      @focus="showMenu = hasChildren && childrenHasPage || false"
+      @focus="showMenu = hasSubMenu"
+      @mouseleave="showMenu = false"
       @keydown.tab="$emit('exit-menu')"
-      @keydown.right="focusHighlightedItem"
-      @keydown.left="focusHighlightedItem">
+      @keydown.down.prevent="walkNext"
+      @keydown.up.prevent="walkPrevious"
+      @keydown.right.prevent="onForwardKey"
+      @keydown.left.prevent="onBackKey"
+      @keydown.esc.prevent="walkBack"
+      @keydown.enter="onEnterKey">
+      <div
+        class="d-flex width-full px-4">
+        <v-list-item-title
+          class="pt-5 pb-5 d-flex"
+          :class="hasPage && ' ' || ' not-clickable '">
+          <span class="text-body">{{ navigation.label }}</span>
+          <v-icon
+            v-if="navigation.target === 'NEW_TAB'"
+            size="12"
+            class="mx-1">
+            fa-external-link-alt
+          </v-icon>
+        </v-list-item-title>
+        <v-list-item-icon
+          v-if="hasSubMenu"
+          class="ms-0 me-n2 ma-auto full-height">
+          <span class="d-flex align-center" aria-hidden="true">
+            <v-icon class="pa-3" size="18">
+              {{ $vuetify.rtl && 'fa-angle-left' || 'fa-angle-right' }}
+            </v-icon>
+          </span>
+        </v-list-item-icon>
+      </div>
       <v-menu
         ref="menu"
         v-model="showMenu"
@@ -50,45 +89,22 @@
         :left="$vuetify.rtl"
         :open-on-hover="isOpenedOnHover"
         absolute
+        disable-keys
         eager
         offset-x>
-        <template #activator>
-          <div
-            class="d-flex width-full px-4"
-            @mouseleave="showMenu = false">
-            <v-list-item-title
-              class="pt-5 pb-5 d-flex"
-              :class="hasPage && ' ' || ' not-clickable '">
-              <span class="text-body">{{ navigation.label }}</span>
-              <v-icon
-                v-if="navigation.target === 'NEW_TAB'"
-                size="12"
-                class="mx-1">
-                fa-external-link-alt
-              </v-icon>
-            </v-list-item-title>
-            <v-list-item-icon
-              v-if="hasChildren && childrenHasPage"
-              class="ms-0 me-n2 ma-auto full-height">
-              <span class="d-flex align-center" aria-hidden="true">
-                <v-icon class="pa-3" size="18">
-                  {{ $vuetify.rtl && 'fa-angle-left' || 'fa-angle-right' }}
-                </v-icon>
-              </span>
-            </v-list-item-icon>
-          </div>
-        </template>
         <navigation-menu-sub-item
           v-for="children in navigation.children"
+          ref="entries"
           class="transparent"
           :key="children.id"
           :navigation="children"
           :parent-navigation-uri="parentNavigationUri"
           :base-site-uri="baseSiteUri"
           :selected-path="selectedPath"
-          :highlighted="renderedChildren[highlightedIndex] === children"
           @update-navigation-state="updateNavigationState"
           @exit-menu="$emit('exit-menu')"
+          @walk="walkFromEntry"
+          @leave-level="leaveLevel"
           @select="$emit('select')" />
       </v-menu>
     </v-list-item>
@@ -96,7 +112,10 @@
 </template>
 
 <script>
+import menuKeyboardNavigation from '../menuKeyboardNavigation.js';
+
 export default {
+  mixins: [menuKeyboardNavigation],
   props: {
     navigation: {
       type: Object,
@@ -114,17 +133,12 @@ export default {
       type: String,
       default: null
     },
-    highlighted: {
-      type: Boolean,
-      default: false
-    },
   },
   data() {
     return {
       isOpenedOnHover: true,
       showMenu: false,
       rowElement: null,
-      highlightedIndex: -1,
       positionX: 0,
       positionY: 0,
     };
@@ -138,6 +152,11 @@ export default {
     },
     childrenHasPage() {
       return this.checkChildrenHasPage(this.navigation);
+    },
+    hasSubMenu() {
+      // a node opens a submenu only when it has children that actually lead somewhere;
+      // this is what aria-haspopup/aria-expanded must reflect, so it is computed once
+      return !!(this.hasChildren && this.childrenHasPage);
     },
     navigationNodeUri() {
       return this.$navigationUtils.getNavigationNodeUri(this.baseSiteUri, this.navigation);
@@ -154,10 +173,6 @@ export default {
     isTopBarElement() {
       return this.$root.isTopBarElement;
     },
-    renderedChildren() {
-      return this.navigation?.children?.filter(child => !!child.pageKey
-        || child.children?.length && this.checkChildrenHasPage(child)) || [];
-    },
   },
   watch: {
     isSelected: {
@@ -167,9 +182,6 @@ export default {
           this.$emit('select');
         }
       }
-    },
-    highlighted() {
-      this.showMenu = this.highlighted && (this.hasChildren && this.childrenHasPage || false);
     },
     showMenu() {
       this.isOpenedOnHover = !this.showMenu;
@@ -182,9 +194,6 @@ export default {
     },
   },
   mounted() {
-    // the arrow keys only add a css class on the highlighted entry, so watch the menu own index
-    // to tell that entry to open its submenu right away, without waiting for a horizontal arrow
-    this.$watch(() => this.$refs.menu?.listIndex, index => this.highlightedIndex = index);
     this.rowElement = this.$refs.row?.$el;
   },
   created() {
@@ -205,32 +214,20 @@ export default {
         } else {
           window.location.href = this.navigationNodeUri;
         }
-      } else if (!this.hasPage && this.hasChildren && this.childrenHasPage) {
+      } else if (!this.hasPage && this.hasSubMenu) {
         this.showMenu = !this.showMenu;
       }
     },
-    focusHighlightedItem() {
-      // same hand-off as the parent level, which makes it work at any depth
-      this.$refs.menu?.$refs?.content?.querySelector('.v-list-item--highlighted')?.focus();
+    leaveLevel() {
+      // an entry of the submenu asked to come back to this level: take the focus first, then
+      // collapse the level the focus just left (the row's own @focus reopens it otherwise)
+      if (!this.focusSelf()) {
+        return;
+      }
+      this.showMenu = false;
     },
     updateNavigationState(value) {
       this.$emit('update-navigation-state', value);
-    },
-    checkChildrenHasPage(navigation) {
-      let childrenHasPage = false;
-      navigation.children.forEach(child => {
-        if (childrenHasPage === true) {
-          return;
-        }
-        if (child.pageKey) {
-          childrenHasPage = true;
-        } else if (child.children.length > 0) {
-          childrenHasPage = this.checkChildrenHasPage(child);
-        } else {
-          childrenHasPage = false;
-        }
-      });
-      return childrenHasPage;
     },
     handleCloseSiblingMenus(emitter) {
       if (!this.showMenu || !emitter) {

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/menuKeyboardNavigation.js
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/menuKeyboardNavigation.js
@@ -1,0 +1,155 @@
+/*
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2022 Meeds Association contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+/**
+ * The keyboard walk of the top bar menu, shared by every level of it (EXO-88911).
+ *
+ * ONE cursor, and one only: the DOM focus. Vuetify's own menu cursor - its `listIndex` and the
+ * `.v-list-item--highlighted` class it moves - is switched off by passing `disable-keys` to every
+ * `v-menu` of the tree, which drops the `keydown` listener Vuetify binds on the activator.
+ * Two cursors is what made the walk depth-dependent: the arrows moved Vuetify's highlight inside
+ * the menu the *activator* belonged to while the focus stayed behind on that activator, so a
+ * vertical arrow pressed after stepping into a submenu walked the level above instead of the one
+ * on screen.
+ *
+ * Levels are read from the component tree, never from the DOM: menu contents are detached to
+ * `[data-app]` (Vuetify's Detachable mixin, at mount here since the menus are `eager`), so DOM
+ * nesting says nothing about menu depth - while `$refs.entries`, ordered against
+ * `navigation.children`, is exactly the entries of the level a component opens, at any depth.
+ *
+ * A component using this mixin must provide:
+ *  - `showMenu` (data)          : the model of the `v-menu` it opens,
+ *  - `hasSubMenu` (computed)    : whether it opens one at all,
+ *  - `$refs.entries`            : the `navigation-menu-sub-item` v-for of that menu,
+ *  - `$refs.row` or `$refs.tab` : its own focusable element,
+ * and must handle `walk` / `leave-level` emitted by its entries.
+ */
+export default {
+  mounted() {
+    // Vuetify already gives the detached content role="menu" (VMenu.genContent), but nothing
+    // names it: entering a submenu is announced as a nameless "menu", so a screen reader user
+    // is told nothing about which node it belongs to (EXO-88911, QA feedback). Name it after
+    // the node that opens it. Set on the DOM rather than passed as a prop because the content
+    // is Vuetify's own element, detached to [data-app] at mount.
+    const content = this.$refs.menu?.$refs?.content;
+    if (content && this.navigation?.label) {
+      content.setAttribute('aria-label', this.navigation.label);
+    }
+  },
+  methods: {
+    menuEntries() {
+      // The walk must follow the order the menu displays, and a v-for `$refs` array is not
+      // guaranteed to be in the source order (Vue 2), so the order comes from the data and the
+      // components are matched to it. An entry with neither a page nor a submenu of its own
+      // renders nothing (v-if), so it is not part of the walk even though its instance exists.
+      const entries = this.$refs.entries || [];
+      return (this.navigation?.children || [])
+        .map(child => entries.find(entry => entry.navigation === child))
+        .filter(entry => entry && (entry.hasPage || entry.hasSubMenu));
+    },
+    focusSelf() {
+      // the focus goes on the row/tab itself, never on a nested child: it is the element carrying
+      // the accessible name and aria-expanded, and the one the focus style is written for
+      const element = this.$refs.row?.$el || this.$refs.tab?.$el;
+      if (!element?.offsetParent) {
+        return false;
+      }
+      element.focus();
+      return true;
+    },
+    focusMenuEntry(index, attempt) {
+      const entries = this.menuEntries();
+      if (!entries.length) {
+        return;
+      }
+      const entry = entries[(index % entries.length + entries.length) % entries.length];
+      // only one branch stays open: entries the focus leaves behind close their own submenu,
+      // whatever opened it - a previous key, or the pointer that hovered them
+      entries.filter(other => other !== entry && other.showMenu)
+        .forEach(other => other.showMenu = false);
+      if (!entry.focusSelf() && (attempt || 0) < 10) {
+        // the menu is rendered eagerly but is only focusable once displayed, and it is displayed
+        // one transition after showMenu flipped: retry briefly instead of guessing a delay
+        window.setTimeout(() => this.focusMenuEntry(index, (attempt || 0) + 1), 30);
+      }
+    },
+    walkFromEntry(entry, step) {
+      // vertical walk inside the level THIS component opens: the entry asks its own level to move,
+      // so the step is always applied to the list the focused entry belongs to, whatever its depth
+      const entries = this.menuEntries();
+      const current = entries.indexOf(entry);
+      if (current < 0) {
+        return;
+      }
+      this.focusMenuEntry(current + step);
+    },
+    walkNext() {
+      this.$emit('walk', this, 1);
+    },
+    walkPrevious() {
+      this.$emit('walk', this, -1);
+    },
+    // the horizontal arrows step in and out of a submenu, flipped in RTL
+    onForwardKey() {
+      return this.$vuetify.rtl ? this.walkBack() : this.walkDeeper();
+    },
+    onBackKey() {
+      return this.$vuetify.rtl ? this.walkDeeper() : this.walkBack();
+    },
+    walkDeeper() {
+      this.openMenuOn(0);
+    },
+    walkDeeperFromEnd() {
+      this.openMenuOn(-1);
+    },
+    openMenuOn(index) {
+      if (!this.hasSubMenu) {
+        return;
+      }
+      this.showMenu = true;
+      this.focusMenuEntry(index);
+    },
+    walkBack() {
+      // close the submenu this entry may have opened, then let the level above take the focus back
+      this.showMenu = false;
+      this.$emit('leave-level');
+    },
+    onEnterKey(event) {
+      if (this.hasPage) {
+        return; // the row is a link: let the browser follow it
+      }
+      // a node with no page of its own has nothing to open but its submenu
+      event.preventDefault();
+      this.walkDeeper();
+    },
+    checkChildrenHasPage(navigation) {
+      let childrenHasPage = false;
+      navigation.children.forEach(child => {
+        if (childrenHasPage === true) {
+          return;
+        }
+        if (child.pageKey) {
+          childrenHasPage = true;
+        } else if (child.children.length > 0) {
+          childrenHasPage = this.checkChildrenHasPage(child);
+        } else {
+          childrenHasPage = false;
+        }
+      });
+      return childrenHasPage;
+    },
+  },
+};

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/menuKeyboardNavigation.js
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/menuKeyboardNavigation.js
@@ -1,6 +1,6 @@
 /*
   This file is part of the Meeds project (https://meeds.io/).
-  Copyright (C) 2022 Meeds Association contact@meeds.io
+  Copyright (C) 2026 Meeds Association contact@meeds.io
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either

--- a/webapp/src/main/webapp/vue-apps/top-bar-menu/menuKeyboardNavigation.js
+++ b/webapp/src/main/webapp/vue-apps/top-bar-menu/menuKeyboardNavigation.js
@@ -44,10 +44,10 @@ export default {
     // is told nothing about which node it belongs to (EXO-88911, QA feedback). Name it after
     // the node that opens it. Set on the DOM rather than passed as a prop because the content
     // is Vuetify's own element, detached to [data-app] at mount.
-    const content = this.$refs.menu?.$refs?.content;
-    if (content && this.navigation?.label) {
-      content.setAttribute('aria-label', this.navigation.label);
-    }
+    // Watched, not set once: the navigation tree is refetched on `space-settings-updated` and the
+    // v-for is keyed on the node id, so a component is REUSED when a page is renamed or the
+    // language changes - a name written only at mount would keep announcing the old label.
+    this.$watch(() => this.navigation?.label, label => this.nameOpenedMenu(label), { immediate: true });
   },
   methods: {
     menuEntries() {
@@ -79,11 +79,20 @@ export default {
       // only one branch stays open: entries the focus leaves behind close their own submenu,
       // whatever opened it - a previous key, or the pointer that hovered them
       entries.filter(other => other !== entry && other.showMenu)
-        .forEach(other => other.showMenu = false);
+        .forEach(other => other.closeSubMenu());
       if (!entry.focusSelf() && (attempt || 0) < 10) {
         // the menu is rendered eagerly but is only focusable once displayed, and it is displayed
         // one transition after showMenu flipped: retry briefly instead of guessing a delay
         window.setTimeout(() => this.focusMenuEntry(index, (attempt || 0) + 1), 30);
+      }
+    },
+    closeSubMenu() {
+      this.showMenu = false;
+    },
+    nameOpenedMenu(label) {
+      const content = this.$refs.menu?.$refs?.content;
+      if (content && label) {
+        content.setAttribute('aria-label', label);
       }
     },
     walkFromEntry(entry, step) {


### PR DESCRIPTION
Prior to this change, the top bar menu could not be walked with the keyboard beyond the level the focus happened to sit on — Vuetify's own highlight and the code's focus were two competing cursors, so an arrow pressed inside a submenu moved the level above it — and a screen reader announced neither the parent node nor the submenu being entered.

This change leaves a single cursor, the focus, and reads the levels from the component tree instead of the DOM, so the arrows always walk the list on screen at any depth (Escape/ArrowLeft step back, RTL flipped), and every menu is announced with the name of the node that opens it.