### PR TITLE
fix: Pin the groups management placeholder to the top of the pane - EXO-89729

### DIFF
--- a/webapp/src/main/webapp/vue-apps/idm-groups-management/components/GroupManagementPlaceholder.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-groups-management/components/GroupManagementPlaceholder.vue
@@ -20,7 +20,7 @@
 
 -->
 <template>
-  <div class="d-flex flex-column ma-auto">
+  <div class="d-flex flex-column mx-auto mt-15">
     <div class="align-self-center">
       <v-icon size="42" color="tertiary">fa-users</v-icon>
     </div>


### PR DESCRIPTION
The placeholder centered itself vertically (ma-auto) inside the right pane, whose height stretches to match the group tree card, so with many groups it landed far below the viewport. It now keeps only the horizontal centering and sits 60px below the top of the pane