### PR TITLE
fix: Ensure a deletion of the user account deactivates it - EXO-89700

### DIFF
--- a/component/core/src/main/java/io/meeds/social/security/job/AccountDeletionJob.java
+++ b/component/core/src/main/java/io/meeds/social/security/job/AccountDeletionJob.java
@@ -44,7 +44,7 @@ public class AccountDeletionJob {
   @Autowired
   private AccountDeletionService accountDeletionService;
 
-  @Scheduled(cron = "${social.AccountDeletionJob.expression:0 15 5 ? * *}")
+  @Scheduled(cron = "${exo.accountDeletion.job.expression:0 15 5 ? * *}")
   @Synchronized
   public void run() {
     accountDeletionService.processPendingDeletionRequests();

--- a/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
+++ b/component/core/src/main/java/io/meeds/social/security/service/AccountDeactivationService.java
@@ -107,11 +107,11 @@ public class AccountDeactivationService {
   @Autowired
   private ResourceBundleService  resourceBundleService;
 
-  @Value("${social.accountDeactivation.confirmation.email.templatePath:assets/account-deactivation-confirmation-email-content.html}")
+  @Value("${exo.accountDeactivation.confirmation.email.templatePath:assets/account-deactivation-confirmation-email-content.html}")
   @Setter
   private String                 emailBodyPath;
 
-  @Value("${social.accountDeletion.confirmation.email.templatePath:assets/account-deletion-confirmation-email-content.html}")
+  @Value("${exo.accountDeletion.confirmation.email.templatePath:assets/account-deletion-confirmation-email-content.html}")
   @Setter
   private String                 deletionEmailBodyPath;
 

--- a/component/core/src/main/java/io/meeds/social/security/service/AccountDeletionService.java
+++ b/component/core/src/main/java/io/meeds/social/security/service/AccountDeletionService.java
@@ -84,7 +84,7 @@ public class AccountDeletionService {
    * Grace delay, in days, between the confirmed deletion request and its
    * execution.
    */
-  @Value("${social.AccountDeletionJob.delay.days:30}")
+  @Value("${exo.accountDeletion.delay.days:30}")
   @Setter
   private long               delayDays;
 

--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
@@ -145,6 +145,9 @@ public class SocialUserEventListenerImpl extends UserEventListener {
     Identity identity = storage.findIdentity(OrganizationIdentityProvider.NAME, user.getUserName());
     try {
       if (identity != null) {
+        // a deleted account is firstly deactivated: an account deleted by an
+        // admin while still active must never keep surfacing as enabled
+        storage.processEnabledIdentity(identity, false);
         storage.hardDeleteIdentity(identity);
       }
     } catch (Exception e) {

--- a/component/notification/src/main/java/io/meeds/social/security/plugin/AccountDeactivationEmailOtpPlugin.java
+++ b/component/notification/src/main/java/io/meeds/social/security/plugin/AccountDeactivationEmailOtpPlugin.java
@@ -35,7 +35,7 @@ public class AccountDeactivationEmailOtpPlugin extends EmailOtpPlugin {
 
   public static final String NAME = "accountDeactivationEmail";
 
-  @Value("${social.accountDeactivation.otp.email.templatePath:assets/account-deactivation-otp-email-content.html}")
+  @Value("${exo.accountDeactivation.otp.email.templatePath:assets/account-deactivation-otp-email-content.html}")
   @Setter
   private String             accountDeactivationEmailBodyPath;
 

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -1396,8 +1396,12 @@ public class UserRest implements ResourceContainer, Startable {
     if (identity == null) {
       throw new WebApplicationException(Response.Status.BAD_REQUEST);
     }
+    // a deleted account is firstly deactivated: an account deleted by an
+    // admin while still active must never keep surfacing as enabled
+    identityManager.processEnabledIdentity(id, false);
     identityManager.hardDeleteIdentity(identity);
     identity.setDeleted(true);
+    identity.setEnable(false);
     // Deletes the user on Portal side
     UserHandler userHandler = organizationService.getUserHandler();
     userHandler.removeUser(id, false);


### PR DESCRIPTION
Prior to this, an account deleted by an admin while still active kept surfacing as enabled in the feed and in the REST payloads.

This is caused by the deletion flow soft-deleting the social identity without ever touching its enabled flag, which only the deactivation flow used to set.

This commit fixes the problem by deactivating the identity on the two admin deletion paths right before the identity soft-deletion; the 30-days job path already guarantees the account is deactivated before executing the deletion.