### PR TITLE
feat: ask for many objects' category links in one query EXO-89589

### DIFF
--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
@@ -49,7 +49,14 @@ public interface CategoryLinkService {
    * rows by lookup instead of by a query each.
    *
    * @param objectType {@link CategoryObject} type, example: Space, Activity ...
-   * @param objectIds the objects' identifiers
+   * @param objectIds the objects' identifiers, <strong>in stored form</strong>. Unlike
+   *          {@link #getLinkedIds(CategoryObject)}, this read does not put its ids
+   *          through {@link io.meeds.social.category.service.CategoryPluginService#getObject}
+   *          first, so a plugin that rewrites the object - the space one resolves any id
+   *          form to the space's technical id, the activity one redirects to the
+   *          activity's metadata object and changes the type with it - is not applied
+   *          here. Passing a form the plugin would have normalised returns no categories
+   *          for that id. The keys of the returned map are the ids as given.
    * @return {@link Map} of linked {@link Category} identifiers keyed by object id; an
    *         object with no category is absent from the map rather than present with an
    *         empty list

--- a/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
+++ b/component/api/src/main/java/io/meeds/social/category/service/CategoryLinkService.java
@@ -19,6 +19,7 @@
 package io.meeds.social.category.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -38,6 +39,22 @@ public interface CategoryLinkService {
    * @return {@link List} of linked {@link Category} identifiers
    */
   List<Long> getLinkedIds(CategoryObject object);
+
+  /**
+   * The categories each of several objects is filed under, in one query.
+   * <p>
+   * {@link #getLinkedIds(CategoryObject)} is the right call for a reader looking at one
+   * thing, and the wrong one for a list: a page of rows showing what each is filed under
+   * would ask it once per row. This answers the whole page, so the caller decorates its
+   * rows by lookup instead of by a query each.
+   *
+   * @param objectType {@link CategoryObject} type, example: Space, Activity ...
+   * @param objectIds the objects' identifiers
+   * @return {@link Map} of linked {@link Category} identifiers keyed by object id; an
+   *         object with no category is absent from the map rather than present with an
+   *         empty list
+   */
+  Map<String, List<Long>> getLinkedIds(String objectType, List<String> objectIds);
 
   /**
    * @param objectType {@link CategoryObject} type, example: Space, Activity ...

--- a/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
+++ b/component/api/src/main/java/org/exoplatform/social/metadata/MetadataService.java
@@ -380,6 +380,20 @@ public interface MetadataService {
   List<MetadataItem> getMetadataItemsByMetadataTypeAndObject(String metadataType, MetadataObject object);
 
   /**
+   * Retrieves the {@link MetadataItem} of several objects of one type at once, so a
+   * caller listing rows can ask a single question instead of one per row.
+   *
+   * @param metadataType {@link Metadata} type
+   * @param objectType the objects' type identifier, like ACTIVITY, COMMENT, NOTE, FILE
+   * @param objectIds the objects' technical identifiers
+   * @return {@link List} of linked {@link MetadataItem} across all the given objects,
+   *         each carrying the objectId it belongs to
+   */
+  List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectIds(String metadataType,
+                                                                String objectType,
+                                                                List<String> objectIds);
+
+  /**
    * Retrieves the list of Metadata items attached to a given {@link Metadata}
    * type and an object identified by its name and identifier
    *

--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryLinkServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryLinkServiceImpl.java
@@ -19,6 +19,7 @@
 package io.meeds.social.category.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +61,11 @@ public class CategoryLinkServiceImpl implements CategoryLinkService {
   @Override
   public List<Long> getLinkedIds(CategoryObject object) {
     return categoryStorage.getLinkedIds(getObject(object));
+  }
+
+  @Override
+  public Map<String, List<Long>> getLinkedIds(String objectType, List<String> objectIds) {
+    return categoryStorage.getLinkedIds(objectType, objectIds);
   }
 
   @Override

--- a/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
@@ -171,6 +171,10 @@ public class CategoryStorage {
    * what each is filed under would ask it once per row, which is a query per message on
    * a mail folder and per document on a drive. This answers the page, so the caller
    * decorates its rows by lookup.
+   * <p>
+   * It is not a drop-in replacement in one respect: the ids are used as given, where the
+   * single-object call puts its object through the category plugin first. See the caveat
+   * on {@link io.meeds.social.category.service.CategoryLinkService#getLinkedIds(String, java.util.List)}.
    *
    * @param objectType the objects' type, as registered by a category plugin
    * @param objectIds the objects' identifiers

--- a/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
+++ b/component/core/src/main/java/io/meeds/social/category/storage/CategoryStorage.java
@@ -163,6 +163,34 @@ public class CategoryStorage {
                               .toList();
   }
 
+  /**
+   * The categories each of several objects is filed under, in one query.
+   * <p>
+   * The single-object {@link #getLinkedIds(CategoryObject)} is the right call for a
+   * reader looking at one thing, and the wrong one for a list: a page of rows showing
+   * what each is filed under would ask it once per row, which is a query per message on
+   * a mail folder and per document on a drive. This answers the page, so the caller
+   * decorates its rows by lookup.
+   *
+   * @param objectType the objects' type, as registered by a category plugin
+   * @param objectIds the objects' identifiers
+   * @return the category identifiers of each object, keyed by object id; an object with
+   *         no category is absent from the map rather than present with an empty list
+   */
+  public Map<String, List<Long>> getLinkedIds(String objectType, List<String> objectIds) {
+    if (CollectionUtils.isEmpty(objectIds)) {
+      return Collections.emptyMap();
+    }
+    List<MetadataItem> items = metadataService.getMetadataItemsByMetadataTypeAndObjectIds(METADATA_TYPE.getName(),
+                                                                                          objectType,
+                                                                                          objectIds);
+    return items == null ? Collections.emptyMap() :
+                         items.stream()
+                              .collect(Collectors.groupingBy(MetadataItem::getObjectId,
+                                                             Collectors.mapping(item -> item.getMetadata().getId(),
+                                                                                Collectors.toList())));
+  }
+
   public List<Long> getLinkedIds(String objectType) {
     List<MetadataItem> items = metadataService.getMetadataItemsByMetadataTypeAndObjectType(METADATA_TYPE.getName(), objectType);
     return items == null ? Collections.emptyList() :

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -72,9 +72,12 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
 
   private static final String OBJECT_IDS           = "objectIds";
 
-  // Oracle's hard limit on IN literals (ORA-01795), as IdentityDAOImpl uses in this
-  // package. ReactionStorage chunks the same table at 500; that is a throughput
-  // choice for a hot path, this one is the dialect bound itself.
+  // A self-imposed bound, not a dialect limit: the platform supports MySQL and
+  // PostgreSQL, and neither refuses an IN list at any particular count. It is here
+  // because an unbounded list still has to be serialised into one statement and
+  // digested by the planner, and a page of rows can be arbitrarily long. 1000 matches
+  // IdentityDAOImpl in this package - which declares the same constant with no stated
+  // reason - so the two agree; ReactionStorage chunks the same table at 500.
   private static final int    MAX_ITEMS_PER_IN_CLAUSE = 1000;
 
   private static final String SPACE_ID             = "spaceId";
@@ -179,10 +182,12 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
    * The same read for a page of objects at once, so a caller listing rows can ask once
    * instead of once per row.
    * <p>
-   * Issued in chunks: Oracle refuses an IN list past 1000 literals (ORA-01795), which a
-   * page of rows can exceed — a mailbox caches a thousand messages by default and may be
-   * configured for five thousand. The chunk size follows {@code IdentityDAOImpl}, which
-   * meets the same limit in this package.
+   * Issued in chunks, because a page of rows can be arbitrarily long — a mailbox caches a
+   * thousand messages by default and may be configured for five thousand — and the whole
+   * list would otherwise go into a single statement. The bound is self-imposed rather than
+   * a dialect limit: on MySQL and PostgreSQL, the databases the platform supports, an IN
+   * list has no fixed maximum count. The size follows {@code IdentityDAOImpl} in this
+   * package.
    *
    * @param metadataType the metadata type id
    * @param objectType the object type, e.g. the one a category plugin registers

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -72,8 +72,6 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
 
   private static final String OBJECT_IDS           = "objectIds";
 
-  // Oracle refuses an IN list past 1000 literals (ORA-01795); same bound, and same
-  // reason, as IdentityDAOImpl in this package.
   // Oracle's hard limit on IN literals (ORA-01795), as IdentityDAOImpl uses in this
   // package. ReactionStorage chunks the same table at 500; that is a throughput
   // choice for a hot path, this one is the dialect bound itself.
@@ -203,17 +201,23 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
                                                                              MetadataItemEntity.class);
     query.setParameter(METADATA_TYPE, metadataType);
     query.setParameter(OBJECT_TYPE, objectType);
+    // SQL IN collapses duplicate literals, so a repeated id costs nothing inside one
+    // chunk - but the chunks partition this list positionally, and a duplicate that
+    // straddles a boundary is asked for twice and its rows added twice, which hands the
+    // caller that object's categories doubled. Distinct once, up front; it also makes
+    // the sort guard below exact rather than approximate.
+    List<String> distinctIds = objectIds.stream().distinct().toList();
     List<MetadataItemEntity> items = new ArrayList<>();
-    for (int start = 0; start < objectIds.size(); start += MAX_ITEMS_PER_IN_CLAUSE) {
-      int end = Math.min(start + MAX_ITEMS_PER_IN_CLAUSE, objectIds.size());
-      query.setParameter(OBJECT_IDS, objectIds.subList(start, end));
+    for (int start = 0; start < distinctIds.size(); start += MAX_ITEMS_PER_IN_CLAUSE) {
+      int end = Math.min(start + MAX_ITEMS_PER_IN_CLAUSE, distinctIds.size());
+      query.setParameter(OBJECT_IDS, distinctIds.subList(start, end));
       items.addAll(query.getResultList());
     }
     // Each chunk is ordered, their concatenation is not: object ids ascend within a chunk
     // and restart at the next one. All the rows of one object sit in a single chunk, so a
     // stable sort on the object id restores the documented grouping while leaving the
     // within-object ordering the query established untouched.
-    if (objectIds.size() > MAX_ITEMS_PER_IN_CLAUSE) {
+    if (distinctIds.size() > MAX_ITEMS_PER_IN_CLAUSE) {
       items.sort(Comparator.comparing(MetadataItemEntity::getObjectId));
     }
     return items;

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.social.core.jpa.storage.dao.jpa;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -67,6 +68,12 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
   private static final String PARENT_OBJECT_ID     = "parentObjectId";
 
   private static final String OBJECT_ID            = "objectId";
+
+  private static final String OBJECT_IDS           = "objectIds";
+
+  // Oracle refuses an IN list past 1000 literals (ORA-01795); same bound, and same
+  // reason, as IdentityDAOImpl in this package.
+  private static final int    MAX_ITEMS_PER_IN_CLAUSE = 1000;
 
   private static final String SPACE_ID             = "spaceId";
 
@@ -164,6 +171,40 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
                 .stream()
                 .collect(Collectors.toMap(tuple -> tuple.get("name", String.class),
                                           tuple -> tuple.get("itemsCount", Long.class)));
+  }
+
+  /**
+   * The same read for a page of objects at once, so a caller listing rows can ask once
+   * instead of once per row.
+   * <p>
+   * Issued in chunks: Oracle refuses an IN list past 1000 literals (ORA-01795), which a
+   * page of rows can exceed — a mailbox caches a thousand messages by default and may be
+   * configured for five thousand. The chunk size follows {@code IdentityDAOImpl}, which
+   * meets the same limit in this package.
+   *
+   * @param metadataType the metadata type id
+   * @param objectType the object type, e.g. the one a category plugin registers
+   * @param objectIds the object ids to read, in any order
+   * @return the items of those objects, empty when no id is given
+   */
+  public List<MetadataItemEntity> getMetadataItemsByMetadataTypeAndObjectIds(long metadataType,
+                                                                             String objectType,
+                                                                             List<String> objectIds) {
+    if (CollectionUtils.isEmpty(objectIds)) {
+      return Collections.emptyList();
+    }
+    TypedQuery<MetadataItemEntity> query =
+                                         getEntityManager().createNamedQuery("SocMetadataItemEntity.getMetadataItemsByMetadataTypeAndObjectIds",
+                                                                             MetadataItemEntity.class);
+    query.setParameter(METADATA_TYPE, metadataType);
+    query.setParameter(OBJECT_TYPE, objectType);
+    List<MetadataItemEntity> items = new ArrayList<>();
+    for (int start = 0; start < objectIds.size(); start += MAX_ITEMS_PER_IN_CLAUSE) {
+      int end = Math.min(start + MAX_ITEMS_PER_IN_CLAUSE, objectIds.size());
+      query.setParameter(OBJECT_IDS, objectIds.subList(start, end));
+      items.addAll(query.getResultList());
+    }
+    return items;
   }
 
   public List<MetadataItemEntity> getMetadataItemsByMetadataTypeAndObject(long metadataType,

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/MetadataItemDAO.java
@@ -21,6 +21,7 @@ package org.exoplatform.social.core.jpa.storage.dao.jpa;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -73,6 +74,9 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
 
   // Oracle refuses an IN list past 1000 literals (ORA-01795); same bound, and same
   // reason, as IdentityDAOImpl in this package.
+  // Oracle's hard limit on IN literals (ORA-01795), as IdentityDAOImpl uses in this
+  // package. ReactionStorage chunks the same table at 500; that is a throughput
+  // choice for a hot path, this one is the dialect bound itself.
   private static final int    MAX_ITEMS_PER_IN_CLAUSE = 1000;
 
   private static final String SPACE_ID             = "spaceId";
@@ -184,7 +188,8 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
    *
    * @param metadataType the metadata type id
    * @param objectType the object type, e.g. the one a category plugin registers
-   * @param objectIds the object ids to read, in any order
+   * @param objectIds the object ids to read; the order they are given in does not
+   *          matter, the result is ordered by object either way
    * @return the items of those objects, empty when no id is given
    */
   public List<MetadataItemEntity> getMetadataItemsByMetadataTypeAndObjectIds(long metadataType,
@@ -203,6 +208,13 @@ public class MetadataItemDAO extends GenericDAOJPAImpl<MetadataItemEntity, Long>
       int end = Math.min(start + MAX_ITEMS_PER_IN_CLAUSE, objectIds.size());
       query.setParameter(OBJECT_IDS, objectIds.subList(start, end));
       items.addAll(query.getResultList());
+    }
+    // Each chunk is ordered, their concatenation is not: object ids ascend within a chunk
+    // and restart at the next one. All the rows of one object sit in a single chunk, so a
+    // stable sort on the object id restores the documented grouping while leaving the
+    // within-object ordering the query established untouched.
+    if (objectIds.size() > MAX_ITEMS_PER_IN_CLAUSE) {
+      items.sort(Comparator.comparing(MetadataItemEntity::getObjectId));
     }
     return items;
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -70,16 +70,20 @@ import jakarta.persistence.Table;
         + " ORDER BY mi.id ASC"
 )
 // The same read for a page of objects at once. A caller listing rows and showing what
-// each is filed under would otherwise ask the query above once per row, which is a query
-// per message on a mail folder and per document on a drive. Ordered by object first so a
-// caller can group the answer as it walks it.
+// each is filed under would otherwise ask getSortedMetadataItemsByMetadataTypeAndObject
+// once per row, which is a query per message on a mail folder and per document on a drive.
+// Grouped by object first, then ordered within an object exactly as that per-object query
+// orders it - most recently touched first - so one object's slice of this result is the
+// same list, in the same order, that asking for it alone would return.
 @NamedQuery(
     name = "SocMetadataItemEntity.getMetadataItemsByMetadataTypeAndObjectIds",
     query = "SELECT mi FROM SocMetadataItemEntity mi WHERE "
         + " mi.metadata.type = :metadataType AND"
         + " mi.objectType = :objectType AND"
-        + " mi.objectId IN :objectIds"
-        + " ORDER BY mi.objectId ASC, mi.id ASC"
+        + " mi.objectId IN (:objectIds)"
+        + " ORDER BY mi.objectId ASC,"
+        + " COALESCE(mi.updatedDate, mi.createdDate) DESC,"
+        + " mi.createdDate DESC, mi.id DESC"
 )
 @NamedQuery(
     name = "SocMetadataItemEntity.getSortedMetadataItemsByMetadataTypeAndObject",

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/MetadataItemEntity.java
@@ -69,6 +69,18 @@ import jakarta.persistence.Table;
         + " mi.objectId = :objectId"
         + " ORDER BY mi.id ASC"
 )
+// The same read for a page of objects at once. A caller listing rows and showing what
+// each is filed under would otherwise ask the query above once per row, which is a query
+// per message on a mail folder and per document on a drive. Ordered by object first so a
+// caller can group the answer as it walks it.
+@NamedQuery(
+    name = "SocMetadataItemEntity.getMetadataItemsByMetadataTypeAndObjectIds",
+    query = "SELECT mi FROM SocMetadataItemEntity mi WHERE "
+        + " mi.metadata.type = :metadataType AND"
+        + " mi.objectType = :objectType AND"
+        + " mi.objectId IN :objectIds"
+        + " ORDER BY mi.objectId ASC, mi.id ASC"
+)
 @NamedQuery(
     name = "SocMetadataItemEntity.getSortedMetadataItemsByMetadataTypeAndObject",
     query = "SELECT mi FROM SocMetadataItemEntity mi WHERE "

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/MetadataServiceImpl.java
@@ -349,6 +349,13 @@ public class MetadataServiceImpl implements MetadataService, Startable {
   }
 
   @Override
+  public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectIds(String metadataType,
+                                                                       String objectType,
+                                                                       List<String> objectIds) {
+    return this.metadataStorage.getMetadataItemsByMetadataTypeAndObjectIds(metadataType, objectType, objectIds);
+  }
+
+  @Override
   public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectType(String metadataType, String objectType) {
     return this.metadataStorage.getMetadataItemsByMetadataTypeAndObjectType(metadataType, objectType);
   }

--- a/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/metadata/storage/MetadataStorage.java
@@ -410,6 +410,32 @@ public class MetadataStorage {
     return metadataItemEntities.stream().map(this::fromEntity).toList();
   }
 
+  /**
+   * The same read for a page of objects of one type, so a caller listing rows asks once
+   * instead of once per row.
+   *
+   * @param metadataTypeName the metadata type name
+   * @param objectType the objects' type
+   * @param objectIds the object ids to read
+   * @return the items of those objects, empty when no id is given
+   */
+  public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectIds(String metadataTypeName,
+                                                                       String objectType,
+                                                                       List<String> objectIds) {
+    if (CollectionUtils.isEmpty(objectIds)) {
+      return Collections.emptyList();
+    }
+    MetadataType metadataType = getMetadataTypeWithCheck(metadataTypeName);
+    List<MetadataItemEntity> metadataItemEntities =
+                                                  metadataItemDAO.getMetadataItemsByMetadataTypeAndObjectIds(metadataType.getId(),
+                                                                                                             objectType,
+                                                                                                             objectIds);
+    if (CollectionUtils.isEmpty(metadataItemEntities)) {
+      return Collections.emptyList();
+    }
+    return metadataItemEntities.stream().map(this::fromEntity).toList();
+  }
+
   public List<MetadataItem> getMetadataItemsByMetadataTypeAndObjectType(String metadataTypeName, String objectType) {
     MetadataType metadataType = getMetadataTypeWithCheck(metadataTypeName);
     List<MetadataItemEntity> metadataItemEntities =

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
@@ -56,8 +56,9 @@ public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
    * listing rows can stop asking once per row, and it is worth nothing if the two can
    * drift apart. It holds for ids in stored form - the bulk call does not put its ids
    * through the category plugin, as the caveat on CategoryLinkService#getLinkedIds
-   * spells out - which is the form this test uses. An object with no category is absent from the map rather than present
-   * with an empty list, so a caller can tell "none" from "not asked for".
+   * spells out - which is the form this test uses. An object with no category is
+   * absent from the map rather than present with an empty list, so a caller can tell
+   * "none" from "not asked for".
    */
   @Test
   @SneakyThrows

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
@@ -71,6 +71,16 @@ public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
                                                      linkedSpace.getSpaceId());
     categoryLinkService.link(rootCategory.getId(), linkedObject);
 
+    // A second category on the same object is what makes the equivalence assertion below
+    // bite: with a single link the two calls return one-element lists and any ordering
+    // difference between them is invisible.
+    Category secondCategory = new Category();
+    secondCategory.setOwnerId(getAdminGroupIdentityId());
+    secondCategory.setParentId(rootCategory.getId());
+    secondCategory.setIcon("test-icon");
+    secondCategory = categoryService.createCategory(secondCategory, ROOT_USER);
+    categoryLinkService.link(secondCategory.getId(), linkedObject);
+
     Space unlinkedSpace = new Space();
     unlinkedSpace.setRegistration(Space.OPEN);
     unlinkedSpace.setVisibility(Space.PUBLIC);
@@ -82,9 +92,12 @@ public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
     Map<String, List<Long>> linkedIds = categoryLinkService.getLinkedIds(SpaceCategoryPlugin.OBJECT_TYPE,
                                                                          List.of(linkedObject.getId(), unlinkedObject.getId()));
 
-    // what the per-object call says, said for the whole page in one query
+    // what the per-object call says, said for the whole page in one query - same
+    // categories, same order, which only means something now the list has two entries
+    assertEquals(2, linkedIds.get(linkedObject.getId()).size());
     assertEquals(categoryLinkService.getLinkedIds(linkedObject), linkedIds.get(linkedObject.getId()));
     assertTrue(linkedIds.get(linkedObject.getId()).contains(rootCategory.getId()));
+    assertTrue(linkedIds.get(linkedObject.getId()).contains(secondCategory.getId()));
     // an object with no category is absent, not empty
     assertTrue(CollectionUtils.isEmpty(categoryLinkService.getLinkedIds(unlinkedObject)));
     assertNull(linkedIds.get(unlinkedObject.getId()));

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
@@ -54,7 +54,9 @@ public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
    * <p>
    * That equivalence is the whole contract: the bulk call exists only so a caller
    * listing rows can stop asking once per row, and it is worth nothing if the two can
-   * drift apart. An object with no category is absent from the map rather than present
+   * drift apart. It holds for ids in stored form - the bulk call does not put its ids
+   * through the category plugin, as the caveat on CategoryLinkService#getLinkedIds
+   * spells out - which is the form this test uses. An object with no category is absent from the map rather than present
    * with an empty list, so a caller can tell "none" from "not asked for".
    */
   @Test

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryLinkServiceTest.java
@@ -19,6 +19,7 @@
 package io.meeds.social.category.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Test;
@@ -44,6 +46,49 @@ import io.meeds.social.space.plugin.SpaceCategoryPlugin;
 import lombok.SneakyThrows;
 
 public class CategoryLinkServiceTest extends AbstractCategoryConfigurationTest {
+
+
+  /**
+   * The bulk read answers a page of objects at once, and answers it exactly as the
+   * single-object read would have, object by object.
+   * <p>
+   * That equivalence is the whole contract: the bulk call exists only so a caller
+   * listing rows can stop asking once per row, and it is worth nothing if the two can
+   * drift apart. An object with no category is absent from the map rather than present
+   * with an empty list, so a caller can tell "none" from "not asked for".
+   */
+  @Test
+  @SneakyThrows
+  public void testGetLinkedIdsInBulkAgreesWithThePerObjectRead() {
+    Category rootCategory = categoryService.getRootCategory(getAdminGroupIdentityId());
+
+    Space linkedSpace = new Space();
+    linkedSpace.setRegistration(Space.OPEN);
+    linkedSpace.setVisibility(Space.PUBLIC);
+    linkedSpace = spaceService.createSpace(linkedSpace, ROOT_USER);
+    CategoryObject linkedObject = new CategoryObject(SpaceCategoryPlugin.OBJECT_TYPE,
+                                                     linkedSpace.getId(),
+                                                     linkedSpace.getSpaceId());
+    categoryLinkService.link(rootCategory.getId(), linkedObject);
+
+    Space unlinkedSpace = new Space();
+    unlinkedSpace.setRegistration(Space.OPEN);
+    unlinkedSpace.setVisibility(Space.PUBLIC);
+    unlinkedSpace = spaceService.createSpace(unlinkedSpace, ROOT_USER);
+    CategoryObject unlinkedObject = new CategoryObject(SpaceCategoryPlugin.OBJECT_TYPE,
+                                                       unlinkedSpace.getId(),
+                                                       unlinkedSpace.getSpaceId());
+
+    Map<String, List<Long>> linkedIds = categoryLinkService.getLinkedIds(SpaceCategoryPlugin.OBJECT_TYPE,
+                                                                         List.of(linkedObject.getId(), unlinkedObject.getId()));
+
+    // what the per-object call says, said for the whole page in one query
+    assertEquals(categoryLinkService.getLinkedIds(linkedObject), linkedIds.get(linkedObject.getId()));
+    assertTrue(linkedIds.get(linkedObject.getId()).contains(rootCategory.getId()));
+    // an object with no category is absent, not empty
+    assertTrue(CollectionUtils.isEmpty(categoryLinkService.getLinkedIds(unlinkedObject)));
+    assertNull(linkedIds.get(unlinkedObject.getId()));
+  }
 
   @Test
   @SneakyThrows


### PR DESCRIPTION
Backport of `feature/ai-contribution` to `develop` for EXO-89589 (source PR #6008), tested and validated.

### Included tasks
| Ticket | Source PR | What it brings |
|---|---|---|
| EXO-89589 | #6008 | a page of objects asks for its category links once, not once per row |

### Scope
Only EXO-89589. The three commits before it on the branch (EXO-88511, EXO-88493) belong to
another board and are deliberately left behind.

### Conflict resolution — needs a real look
`MetadataItemDAO.java` conflicted: develop has since gained
`getMetadataItemsByMetadataTypeAndObjectAndCreators` and
`countMetadataItemsByMetadataTypeAndObjectGroupedByMetadataName` in the same region. Resolved
**keep-both** — the two develop methods and the new bulk read are independent additions, none
was dropped or reordered. That hunk re-enters classification and wants a full review.

### Verification
`mvn install`: **BUILD SUCCESS** across the reactor.

### Downstream
exoplatform/email-connector EXO-89588 calls `getLinkedIds(String, List<String>)` from this PR
and does not compile without it. EXO-89588 is on Wait behind this one; once this merges, it can go.

### Classification
**N1** by the deterministic trigger — `MetadataItemEntity.java` is a JPA entity file. In
substance the change is a `@NamedQuery` addition plus a chunked DAO read: no column, no table,
no migration. Flagged up rather than argued down; the level is a human's to lower, not mine.

Knowledge: none — mechanical backport, no new mechanism.