### PR TITLE
fix: Display the rich editor floating formatting toolbar on text selection - EXO-89596

### DIFF
--- a/webapp/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
+++ b/webapp/src/main/webapp/js/ckeditorPlugins/linkBalloon/plugin.js
@@ -230,10 +230,13 @@
       await new Promise(resolve => window.require(['SHARED/extensionRegistry'], extensionRegistry => {
         const extensions = extensionRegistry.loadExtensions('RichEditor', 'BalloonToolbarButtons');
         if (extensions?.length) {
-          Promise.all(extensions.map(ext => ext.init(editor, items, hideBalloonToolbar)))
-            .then(resolve);
+          Promise.all(extensions.map(ext => Promise.resolve().then(() => ext.init(editor, items, hideBalloonToolbar))))
+            .catch(e => console.warn('Error initializing balloon toolbar extensions', e)) // eslint-disable-line no-console
+            .finally(resolve);
+        } else {
+          resolve();
         }
-      }));
+      }, resolve));
       balloonToolbar.addItems(items);
     }
     if (!noShow) {


### PR DESCRIPTION
The balloon toolbar init awaited a promise that only resolved when a BalloonToolbarButtons extension was registered and its init fulfilled. Without the ai addon (the only registrar), or when its bindings call failed, the promise never settled: the toolbar items were never added and the selection listeners never attached, so selecting text in the composer displayed no bold/italic/link toolbar.

Make the promise settle on every path: resolve explicitly when no extension is registered, guard extension init against rejection and synchronous throw, and add the module-load errback. The nominal ai-enabled path is unchanged.
