### PR TITLE
Feat: Disable option to remove a user when this user is synced using LDAP - EXO-89816

### DIFF
--- a/webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -606,6 +606,7 @@ UsersManagement.newPasswordsDoesNotMatch=New Password and Confirm New Password d
 UsersManagement.button.deleteUser=Delete Account
 UsersManagement.button.editUser=Edit user
 UsersManagement.tooltip.editSynchronzedUser=Impossible to edit synchronized users
+UsersManagement.tooltip.deleteSynchronizedUser=User account is synced with external IDM. You cannot delete it.
 UsersManagement.button.membership=Role
 UsersManagement.button.userMemberships=User roles
 

--- a/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementItemMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementItemMenu.vue
@@ -104,18 +104,25 @@
         </v-list-item-icon>
         <v-list-item-title class="ps-0">{{ $t('UsersManagement.selection.enable') }}</v-list-item-title>
       </v-list-item>
-      <v-list-item
-        :disabled="!item.isInternal"
-        class="px-2"
-        dense
-        @click="$emit('delete')">
-        <v-list-item-icon class="mx-1 justify-center">
-          <v-icon size="14" color="error">fa-trash</v-icon>
-        </v-list-item-icon>
-        <v-list-item-title class="ps-0">
-          <div class="error--text">{{ $t('UsersManagement.button.deleteUser') }}</div>
-        </v-list-item-title>
-      </v-list-item>
+      <v-tooltip :disabled="item.isInternal" bottom>
+        <template #activator="{on, attrs}">
+          <div v-on="on" v-bind="attrs">
+            <v-list-item
+              :disabled="!item.isInternal"
+              class="px-2"
+              dense
+              @click="$emit('delete')">
+              <v-list-item-icon class="mx-1 justify-center">
+                <v-icon size="14" :color="item.isInternal ? 'error' : null">fa-trash</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title class="ps-0">
+                <div :class="item.isInternal ? 'error--text' : 'text--disabled'">{{ $t('UsersManagement.button.deleteUser') }}</div>
+              </v-list-item-title>
+            </v-list-item>
+          </div>
+        </template>
+        <span>{{ $t('UsersManagement.tooltip.deleteSynchronizedUser') }}</span>
+      </v-tooltip>
     </v-list>
   </v-menu>
 </template>


### PR DESCRIPTION
Show a tooltip "User account is synced with external IDM. You cannot delete it." on the disabled Delete Account menu entry for externally synchronized users.