### PR TITLE
fix: Display name shown as "undefined" in account deletion confirmation - EXO-89817

### DIFF
--- a/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-users-management/components/UsersManagementList.vue
@@ -297,7 +297,7 @@ export default {
       }
       this.selectedUser = user;
       this.deleteConfirmMessage = `
-        <p>${this.$t('UsersManagement.message.confirmDelete', {0: `<strong>${this.selectedUser.fullName}</strong>`})}</p>
+        <p>${this.$t('UsersManagement.message.confirmDelete', {0: `<strong>${this.selectedUser.fullname}</strong>`})}</p>
         <p class="mb-0">${this.$t('UsersManagement.message.confirmDelete.onceDone')}</p>
         <ul class="mb-2">
           <li>${this.$t('UsersManagement.message.confirmDelete.deactivated')}</li>
@@ -333,7 +333,7 @@ export default {
         .catch(error => {
           error = error.message || String(error);
           const errorI18NKey = `UsersManagement.error.${error}`;
-          const errorI18N = this.$t(errorI18NKey, {0: this.selectedUser.fullName});
+          const errorI18N = this.$t(errorI18NKey, {0: this.selectedUser.fullname});
           if (errorI18N !== errorI18NKey) {
             error = errorI18N;
           }


### PR DESCRIPTION
Prior to this, the account deletion confirmation dialog displayed "undefined" instead of the user's display name.
This is caused by the message reading selectedUser.fullName while the users REST endpoint returns the field as "fullname".
This commit fixes the problem by using the correct "fullname" property, as everywhere else in the users management app.