### PR TITLE
fix: display the drawers mask above an active dialog EXO-89861

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
@@ -16,10 +16,28 @@ export default {
     openedDrawers: 0,
     uiPortalApplicationElement: null,
     drawerZIndex: 1035,
+    // Mirrors @zindexModal, the plane the skin clamps an active Vuetify dialog
+    // to inside #vuetify-apps, exactly as drawerZIndex mirrors @zindexDrawer
+    modalZIndex: 1050,
+    aboveDialog: false,
   }),
   computed: {
+    /**
+     * Computes the z-index of the shared drawers mask, which has to paint above
+     * everything it dims and below the topmost opened drawer.
+     * Its base plane is the drawer plane, unless the drawers were opened while
+     * a Vuetify dialog was active: such a dialog is clamped by the skin to
+     * @zindexModal, above the drawer plane, so basing the mask on the drawer
+     * plane would bury it under the dialog instead of dimming it. In that case
+     * the modal plane is used as base, which keeps the mask above the dialog
+     * and still below a drawer climbing to @zindexSnackBar.
+     * When no dialog is active, this returns the very same value as it did
+     * before the computation was made dialog aware.
+     * @returns {Number} z-index to apply on the mask
+     */
     zIndex() {
-      return this.overlay ? (this.drawerZIndex - 1 + (this.openedDrawers || 0)) : this.drawerZIndex - 1;
+      const baseZIndex = this.aboveDialog ? this.modalZIndex : this.drawerZIndex - 1;
+      return this.overlay ? (baseZIndex + (this.openedDrawers || 0)) : baseZIndex;
     },
     overlay() {
       return this.openedDrawers && !this.openedModals;
@@ -50,10 +68,22 @@ export default {
     closeDisplayedDrawerEffectively() {
       document.dispatchEvent(new CustomEvent('closeDisplayedDrawer'));
     },
+    /**
+     * Displays the shared mask when a drawer delegating its overlay to this
+     * component is opened.
+     * Probes the DOM for an active Vuetify dialog at that very moment, with the
+     * same selector and in the same tick as ExoDrawer does when it decides to
+     * climb above such a dialog, so that a drawer and its mask can never
+     * disagree on which plane they are being displayed on.
+     * @param {CustomEvent} event 'drawerOpened' event, its detail being true
+     *          when the drawer displays an overlay of its own
+     * @returns {void}
+     */
     showOverlay(event) {
       this.uiPortalApplicationElement.classList.add('decrease-z-index');
       const showOverlay = !event?.detail;
       if (showOverlay) {
+        this.aboveDialog = !!document.querySelector('.v-dialog--active');
         window.setTimeout(() => {
           this.openedDrawers += 1;
         }, 10);
@@ -70,12 +100,21 @@ export default {
       this.openedDrawers = 1;
       this.hideOverlay();
     },
+    /**
+     * Hides the shared mask when a drawer delegating its overlay to this
+     * component is closed, and gives the mask its drawer plane back once the
+     * last drawer is closed.
+     * @param {CustomEvent} event 'drawerClosed' event, its detail being true
+     *          when the drawer displays an overlay of its own
+     * @returns {void}
+     */
     hideOverlay(event) {
       const showOverlay = !event?.detail;
       if (showOverlay && this.openedDrawers > 0) {
         window.setTimeout(() => {
           this.openedDrawers -= 1;
           if (this.openedDrawers === 0) {
+            this.aboveDialog = false;
             this.uiPortalApplicationElement.classList.remove('decrease-z-index');
           }
         }, 10);


### PR DESCRIPTION
Task: [EXO-89861](https://community.exoplatform.com/portal/dw/tasks/taskDetail/89861) · [Plan](https://claude.ai/code/artifact/65497303-9aa8-46a8-9b61-4b75c49fb36a)

> **Classification: N2** — a shared component with a platform-wide blast radius, but purely presentational: no REST, DAO, schema or ACL surface in the diff.

## The defect

With a full-page form open (agenda's event form), opening a drawer shows **no mask**. The page stays lit and the drawer does not read as modal.

The mask *is* rendered — it paints **behind** the form. Measured live on the rig:

| Case | mask | dialog | drawer |
|---|---|---|---|
| 1 drawer, **no** dialog | **1035** | — | 1036 |
| 1 drawer, **over** the fullscreen form | **1035** | **1050** | **1060** |

`ExoDrawer` learned to climb above an active dialog. **`DrawersOverlay` never did** — its arithmetic starts at 1035 and climbs by ones, so a dialog at 1050 is outside its number line. Watched happening in one DOM: `ExoDrawer`'s probe returned true and it went to 1060; the mask stayed at 1035.

## Why it belongs here and not in agenda

`platform-ui`'s `globalLayout.less:193-200` clamps, **inside `#vuetify-apps`**, every active overlay to 1040 and every active dialog to 1050 — both `!important`. Any overlay agenda creates is in that scope (the form even sets `attach="#vuetify-apps"`), so it is pinned below the dialog and cannot win.

`DrawersOverlay` is mounted on a **sibling** of `#vuetify-apps` — confirmed at `portal .../UIPortalApplication.gtmpl:267`, body child 5 vs child 4, and measured live (`vuetifyApps.contains(mask) === false`). It is the only overlay on the page that can legally sit above a dialog.

## The change — four behavioural lines

Probe `.v-dialog--active` when a drawer opens; when one is present, base the mask at 1050 + count (→ 1051), above the form and below the drawer.

**This is not a second mechanism running alongside `ExoDrawer`'s.** `ExoDrawer.vue:379` dispatches `drawerOpened` **synchronously**, from inside the very watcher that probes at `:405`, 26 lines later — so `DrawersOverlay.showOverlay` runs in the *same tick against the same DOM*. With the same selector the two halves read one fact at one instant and **cannot disagree**.

**Open-only, not reactive — and this matters.** A reactive probe would break that identity: `ExoDrawer:404` probes only at open, so a dialog appearing *after* a drawer opened would move the mask to 1051 while its drawer stayed at inline 1036 — **the mask would paint over its own drawer**, turning a cosmetic bug into an unclickable one. Open-only keeps the pair in lockstep by construction. The base is assigned on every counted open rather than accumulated, so a later drawer opened with no dialog drops it back down — mask below both drawers, the safe direction.

## The no-dialog path is unchanged, and that was executed rather than asserted

With `aboveDialog === false`, `baseZIndex` is literally `this.drawerZIndex - 1` and the expression reduces to the old one character for character.

Checked exhaustively over all **52 reachable** `(openedDrawers 0..12, openedModals 0..3)` states: **0 mismatches** — with a mutation control (base off by one) failing **52/52**, so the check is not vacuous. Over a dialog the mask lands at 1051–1054, strictly between the dialog's 1050 and the drawer's 1060; it would only reach the drawer plane at **10 simultaneous drawers**.

Modal suppression (`openedModals`) is untouched.

## What is and is not verified

- **`webpack --mode production`: exit 0**, zero warnings on the changed file. `eslint` clean (it caught two missing `@returns`, fixed).
- **`social/webapp` has no JS test harness** — no jest/karma/mocha/vitest dependency, no `test` script, no spec files. Verified, not assumed. No harness was invented for a four-line fix.
- **The arithmetic is tested**; the paint geometry is not. Nothing computes stacking in jsdom.
- **The defect and the arithmetic were verified live; the cure was not** — the branch was not deployed by the author. It has since been deployed to the rig for eyes-on checking.

## Screens to check

Should **change**: the full-page event form → participants / reminders / recurrence drawers — mask visible, dimming the form, drawer lit above it; clicking the mask closes the drawer and leaves the form.

Must be **pixel-identical**, compared side by side rather than from memory: quick-add drawer → participants (two stacked drawers, no dialog); a plain drawer from a page (space members, notifications); a drawer in another add-on (task, notes, app-center); and **modal suppression — the mask must still not appear** over a `ConfirmDialog`.

## Known limitation, unchanged and out of scope

Two drawers stacked *above* a dialog are both pinned at 1060 by `z-index-snackbar`, so the mask at 1051 cannot slot between them and the lower one stays lit.

## Context

Not a regression. `f3310f53b3` (2021-07-13, TASK-46364) centralised the per-drawer overlays into `DrawersOverlay` at a time when nothing opened a drawer over a fullscreen dialog; the agenda full-page form came later and walked into the gap. The component has served **40 consumers across 11 add-ons for five years** — small diff, wide surface, which is why the no-dialog equivalence above is the review criterion.

Knowledge: none - a stacking fix in a shared component; the norms it follows are already written.