### PR TITLE
fix: Wake the digest drawer Apply up only on a real change - EXO-89484 - eXIP7.3.0.22

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
@@ -94,12 +94,15 @@ export default {
     allCategoryIds() {
       return this.categories.map(category => category.id);
     },
+    // The comparison is on the effective state: the categories of a frequency
+    // that is off don't count, unchecking a frequency after having played with
+    // its categories is going back to the initial state
     changed() {
       return this.loadedSettings
         && (this.daily !== this.loadedSettings.daily
           || this.weekly !== this.loadedSettings.weekly
-          || !this.sameCategories(this.dailyCategories, this.loadedSettings.dailyCategories)
-          || !this.sameCategories(this.weeklyCategories, this.loadedSettings.weeklyCategories));
+          || this.daily && !this.sameCategories(this.dailyCategories, this.loadedSettings.dailyCategories)
+          || this.weekly && !this.sameCategories(this.weeklyCategories, this.loadedSettings.weeklyCategories));
     },
     // Apply stays disabled until the user changes something, then follows the
     // server rule: an enabled frequency with no category would send an empty

--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
@@ -88,15 +88,27 @@ export default {
     dailyCategories: [],
     weekly: false,
     weeklyCategories: [],
+    loadedSettings: null,
   }),
   computed: {
     allCategoryIds() {
       return this.categories.map(category => category.id);
     },
-    // An enabled frequency with no category would send an empty digest, the
-    // server refuses it as well
+    changed() {
+      return this.loadedSettings
+        && (this.daily !== this.loadedSettings.daily
+          || this.weekly !== this.loadedSettings.weekly
+          || !this.sameCategories(this.dailyCategories, this.loadedSettings.dailyCategories)
+          || !this.sameCategories(this.weeklyCategories, this.loadedSettings.weeklyCategories));
+    },
+    // Apply stays disabled until the user changes something, then follows the
+    // server rule: an enabled frequency with no category would send an empty
+    // digest, the server refuses it as well. Unchecking everything stays a
+    // change to apply: it is how the user switches his digest off
     disabled() {
       return this.saving
+        || this.loading
+        || !this.changed
         || this.daily && !this.dailyCategories.length
         || this.weekly && !this.weeklyCategories.length;
     },
@@ -130,6 +142,14 @@ export default {
           // categories already loaded to leave the choices of the user alone
           this.daily = settings?.daily || false;
           this.weekly = settings?.weekly || false;
+          // What the server holds right now: Apply wakes up when the choices
+          // differ from it
+          this.loadedSettings = {
+            daily: this.daily,
+            dailyCategories: this.dailyCategories.slice(),
+            weekly: this.weekly,
+            weeklyCategories: this.weeklyCategories.slice(),
+          };
         })
         .catch(() => {
           this.$root.$emit('alert-message', this.$t('UserSettings.digest.error.load'), 'error');
@@ -146,7 +166,12 @@ export default {
       this.dailyCategories = [];
       this.weekly = false;
       this.weeklyCategories = [];
+      this.loadedSettings = null;
       this.saving = false;
+    },
+    sameCategories(categories, loadedCategories) {
+      return categories.length === loadedCategories.length
+        && categories.every(id => loadedCategories.includes(id));
     },
     save() {
       this.saving = true;


### PR DESCRIPTION
Follow-up fix of Meeds-io/social#6027, found by functional testing of the merged US03 (together with Meeds-io/commons#773, which fixes the empty category list).

**Reported:** Apply was enabled on a freshly opened drawer, and went disabled as soon as a frequency was checked — the reverse of the expected behavior.

**Why both symptoms had one root:** the category list arrived empty (the commons#773 bug), so checking a frequency selected zero categories, which the validity rule rightly refuses. And Apply had no dirty check, so a pristine drawer was 'valid' and enabled.

**Fix:** the drawer snapshots what the server holds at open time; Apply wakes up only when the choices differ from it, then still follows the server rule (an enabled frequency with no category stays refused). Unchecking everything remains a change to apply — it is how the user switches his digest off, per §1 'Unchecking all switches off the option'.

With commons#773 deployed, checking a frequency proposes all categories checked (per the design) and Apply enables; reverting to the loaded state disables it again.

## AI contribution
Classified **N1** — human-driven, no auto-merge, author ≠ approver.