### PR TITLE
fix: Switch a digest frequency off when its last category is unchecked - EXO-89484 - eXIP7.3.0.22

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
@@ -130,6 +130,18 @@ export default {
         this.weeklyCategories = this.allCategoryIds.slice();
       }
     },
+    // Unchecking every category of a frequency switches the frequency itself
+    // off (spec §1: unchecking all switches off the option)
+    dailyCategories() {
+      if (this.daily && this.categories.length && !this.dailyCategories.length) {
+        this.daily = false;
+      }
+    },
+    weeklyCategories() {
+      if (this.weekly && this.categories.length && !this.weeklyCategories.length) {
+        this.weekly = false;
+      }
+    },
   },
   methods: {
     open() {


### PR DESCRIPTION
Functional gap found by testing the merged US03 against spec §1: **'Unchecking all switches off the option.'**

Unchecking the last category of a frequency now unchecks the frequency itself, instead of leaving an invalid choice that only disabled Apply. Checking the frequency again proposes every category anew, per the design. The Apply dirty-state logic (merged with #6046) then does the right thing in both directions: back-to-initial keeps Apply asleep, a real switch-off wakes it.

## AI contribution
Classified **N1** — human-driven, no auto-merge, author ≠ approver.