### PR TITLE
feat: break ties in the space list order by name EXO-89908

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
@@ -84,6 +84,8 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
 
   private static final String                      PARAM_HIDDEN_VISIBILITY     = "hiddenVisibility";
 
+  private static final String                      DISPLAY_NAME_SORT_FIELD     = "s.displayName";
+
   private static final String                      QUERY_FILTER_FIND_PREFIX    = "Space.findSpaces";
 
   private static final String                      QUERY_FILTER_COUNT_PREFIX   = "Space.countSpaces";
@@ -309,7 +311,7 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
                                        List<String> parameterNames,
                                        boolean count) {
     String querySelect = count ? "SELECT COUNT(DISTINCT s.id) FROM SocSpaceEntity s " :
-                               "SELECT DISTINCT(s.id), " + getSortField(spaceFilter) + " FROM SocSpaceEntity s ";
+                               "SELECT DISTINCT(s.id), " + getSelectedSortFields(spaceFilter) + " FROM SocSpaceEntity s ";
     boolean lastAccess = isLastAccess(spaceFilter);
     if (parameterNames.contains(PARAM_USER_ID) || lastAccess) {
       if (StringUtils.isNotBlank(spaceFilter.getRemoteId()) && lastAccess) {
@@ -336,8 +338,7 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
       queryContent = querySelect + " WHERE " + StringUtils.join(predicates, " AND ");
     }
     if (!count) {
-      queryContent += " ORDER BY " + getSortField(spaceFilter) +
-          (isSortDescending(spaceFilter) ? " DESC " : " ASC ");
+      queryContent += " ORDER BY " + getOrderByClause(spaceFilter);
     }
     return queryContent;
   }
@@ -491,8 +492,46 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
     } else if (sorting.sortBy.equals(SortBy.DATE)) {
       return "s.createdDate";
     } else {
-      return "s.displayName";
+      return DISPLAY_NAME_SORT_FIELD;
     }
+  }
+
+  /**
+   * Gives the fields the query has to select for its own ordering: the sort
+   * field, and the display name it is broken ties with. Both are needed in the
+   * select list because the query is a SELECT DISTINCT, which may only be
+   * ordered by what it selects.
+   *
+   * @param spaceFilter filter the query is built from
+   * @return the sort fields, comma separated, without the ordering direction
+   */
+  private String getSelectedSortFields(XSpaceFilter spaceFilter) {
+    String sortField = getSortField(spaceFilter);
+    return DISPLAY_NAME_SORT_FIELD.equals(sortField) ? sortField : sortField + ", " + DISPLAY_NAME_SORT_FIELD;
+  }
+
+  /**
+   * Builds the ordering of a space list: the requested sort field, then the
+   * display name as a tie-break.
+   * <p>
+   * <strong>The tie-break is what makes a paginated list stable.</strong>
+   * Neither of the other two sort fields is unique across spaces, and the last
+   * visit is the extreme case: every space a user has never opened carries the
+   * same default date, so on the ordering alone the database is free to return
+   * them in any order it likes, and in a different one from one page — or one
+   * refetch — to the next. A caller paging through such a list sees rows move
+   * under it for no reason it can observe. Ordering by the name after the sort
+   * field costs nothing where the field is already unique, and turns the rest
+   * of the list from arbitrary into alphabetical.
+   *
+   * @param spaceFilter filter the query is built from
+   * @return the ORDER BY clause content, directions included
+   */
+  private String getOrderByClause(XSpaceFilter spaceFilter) {
+    String sortField = getSortField(spaceFilter);
+    String direction = isSortDescending(spaceFilter) ? " DESC " : " ASC ";
+    return DISPLAY_NAME_SORT_FIELD.equals(sortField) ? sortField + direction
+                                                     : sortField + direction + ", " + DISPLAY_NAME_SORT_FIELD + " ASC ";
   }
 
   private boolean isSortDescending(XSpaceFilter spaceFilter) {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
@@ -1569,6 +1569,66 @@ public class SpaceStorageTest extends AbstractCoreTest {
     assertEquals(space3.getId(), result.get(0).getId());
   }
 
+  /**
+   * The last-visit order alone does not order anything below the spaces the
+   * user has actually opened: every other space carries the same default date,
+   * so on that field alone the database may return them in any order, and in a
+   * different one from one page or one refetch to the next. Rows then move
+   * under a user paging through a long list for no reason they can observe.
+   * <p>
+   * The spaces below are saved in an order that is neither alphabetical nor
+   * the reverse, so a list that came back sorted by name cannot be the
+   * insertion order having survived by chance.
+   *
+   * @throws Exception when the space cannot be saved
+   */
+  public void testLastAccessedSpacesAreOrderedByNameWithinTheSameLastVisit() throws Exception {
+    Space middle = saveSpaceNamed(21, "my space test middle");
+    Space last = saveSpaceNamed(22, "my space test zulu");
+    Space first = saveSpaceNamed(23, "my space test alpha");
+
+    SpaceFilter filter = new SpaceFilter();
+    filter.setRemoteId("ghost");
+
+    restartTransaction();
+    cacheService.getSpacesCache().clearCache();
+
+    List<Space> neverVisited = spaceStorage.getLastAccessedSpace(filter, 0, -1);
+    assertEquals(3, neverVisited.size());
+    assertEquals(first.getId(), neverVisited.get(0).getId());
+    assertEquals(middle.getId(), neverVisited.get(1).getId());
+    assertEquals(last.getId(), neverVisited.get(2).getId());
+
+    // a visited space still comes first: the name only breaks ties
+    spaceStorage.updateSpaceAccessed("ghost", last);
+    restartTransaction();
+    cacheService.getSpacesCache().clearCache();
+
+    List<Space> afterVisit = spaceStorage.getLastAccessedSpace(filter, 0, -1);
+    assertEquals(3, afterVisit.size());
+    assertEquals(last.getId(), afterVisit.get(0).getId());
+    assertEquals(first.getId(), afterVisit.get(1).getId());
+    assertEquals(middle.getId(), afterVisit.get(2).getId());
+  }
+
+  /**
+   * Saves a space whose display name is chosen by the caller, so that a test
+   * can tell the name order apart from the insertion order.
+   *
+   * @param number number the space instance is built from
+   * @param displayName display name to give the space
+   * @return the saved space
+   * @throws Exception when the space cannot be saved
+   */
+  private Space saveSpaceNamed(int number, String displayName) throws Exception {
+    Space space = getSpaceInstance(number);
+    space.setDisplayName(displayName);
+    space.setPrettyName(displayName);
+    space.setUrl(space.getPrettyName());
+    spaceStorage.saveSpace(space, true);
+    return space;
+  }
+
   public void testGetLastAccessedSpace() {
     // create a new space
     Space space = getSpaceInstance(1);


### PR DESCRIPTION
A space list is ordered by one field and paginated, and **none of the three fields we sort on is unique**. The last visit is the extreme case: every space a user has never opened carries the same default `1970-01-02`, so below the handful they actually visit, the database is free to return them in any order it likes — and in a different one from one page, or one refetch, to the next.

A user paging through a long list therefore sees rows move for no reason they can observe. That is precisely the tail of the list, where they are already hunting for something.

### The change

`SpaceDAO` orders by the requested sort field, then by `s.displayName`:

- where the sort field **is** the display name, nothing changes;
- everywhere else the arbitrary part of the list becomes alphabetical — what a reader expects to find below the part ordered by something they recognise.

The primary order is untouched: a space visited yesterday still comes before one visited last year, whatever the two are called.

Two mechanical points behind the shape of the diff:

- the tie-break has to be **selected** as well as ordered by, since the query is a `SELECT DISTINCT` and may only be ordered by what it selects — hence the split between `getSelectedSortFields` and `getOrderByClause`;
- named-query identity already carries the sort field (`buildSortSuffixes`), so no cached query changes meaning under a running instance.

### Why now

Agenda's space calendar filter surfaced it: it now asks for the recent-spaces order (`exoplatform/agenda#1093`), and a user in dozens of spaces gets a long tail of never-visited ones that had no order at all. The two PRs are independent — that one stands without this; this one makes its tail stable, and does the same for the spaces sidebar and the spaces list, which share the query.

### Verification

`SpaceStorageTest.testLastAccessedSpacesAreOrderedByNameWithinTheSameLastVisit` saves three spaces in an order that is **neither alphabetical nor its reverse**, so a list that merely preserved insertion order cannot pass it. It then visits one and asserts the name only *breaks ties* rather than competing with the visit.

- `SpaceStorageTest`: **47 tests, all passing** (the existing `testLastAccess` included).
- Mutation-checked: reverting the ordering fails the new test and **only** it.
- Wider `*Space*Test` sweep over `component/core` + `component/service`: 308 run, and the 5 failures (`SpaceAccessTest` ×3, `SpaceCategorySidebarPluginTest`, plus two "no tests found" pattern artefacts) are **identical on the branch without this change** — baseline captured by stashing the diff and re-running.

Performance: the ordering already spanned two tables in the last-visit case, so no index could serve it alone; the sort is over one user's memberships. Unchanged query shape otherwise.

Board: [EXO-89908](https://community.exoplatform.com/portal/dw/tasks/taskDetail/89908)

Knowledge: none — behaviour-preserving ordering fix; no norm or mechanism the corpus records changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBNDMeUwyK3XCTg8YP6PG9