### PR TITLE
fix: Place the Report entry just before Delete in the activity and comment menus EXO-89471

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/extensions.js
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/extensions.js
@@ -222,7 +222,8 @@ extensionRegistry.registerComponent('ActivityStream', 'activity-stream-drawers',
 
 extensionRegistry.registerExtension('activity', 'action', {
   id: 'report',
-  rank: 28,
+  // just before Delete (rank 100), per the design
+  rank: 90,
   labelKey: 'activityStream.label.report',
   disabledLabelKey: 'activityStream.label.reported',
   disabledTitleKey: 'activityStream.report.alreadyReported',
@@ -239,7 +240,8 @@ extensionRegistry.registerExtension('activity', 'action', {
 
 extensionRegistry.registerExtension('activity', 'comment-action', {
   id: 'report',
-  rank: 28,
+  // just before Delete (rank 100), per the design
+  rank: 90,
   labelKey: 'activityStream.label.report',
   disabledLabelKey: 'activityStream.label.reported',
   disabledTitleKey: 'activityStream.report.alreadyReportedComment',


### PR DESCRIPTION
PO feedback on task 89471 (US01, tested and not validated): the design places the Report action immediately before Delete in the "..." contextual menu.

The menus sort actions by ascending rank and Delete sits at rank 100; the Report action and comment-action move from rank 28 to rank 90 — last entry before Delete, below every other entry (ranks 10-40). No behavior change.

Follow-up of #6039 (merged).