### PR TITLE
fix: Restrict the Post Reported notification to email and onsite EXO-89476

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/notification-configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/social-extension/social/notification-configuration.xml
@@ -54,7 +54,6 @@
           <value>EditCommentPlugin</value>
           <value>LikePlugin</value>
           <value>LikeCommentPlugin</value>
-          <value>PostReportPlugin</value>
         </values-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
removes PostReportPlugin from the "Unread activities" channel (ActivitySpaceWebNotificationPlugin) — email and onsite only.