### PR TITLE
fix: Align the digest drawer toggles with their labels - EXO-89484 - eXIP7.3.0.22

### DIFF
--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
@@ -28,32 +28,42 @@
       {{ $t('UserSettings.drawer.title.digest') }}
     </template>
     <template #content>
-      <v-flex v-if="!loading" class="pa-4">
-        <div class="d-flex align-center">
-          <span class="text-color">{{ $t('UserSettings.drawer.label.dailyDigest') }}</span>
-          <v-switch
-            v-model="daily"
-            :aria-label="$t('UserSettings.drawer.label.dailyDigest')"
-            class="ms-auto my-auto me-0"
-            hide-details />
-        </div>
+      <v-flex v-if="!loading">
+        <v-list-item>
+          <v-list-item-content>
+            <v-list-item-title class="text-color">
+              {{ $t('UserSettings.drawer.label.dailyDigest') }}
+            </v-list-item-title>
+          </v-list-item-content>
+          <v-list-item-action>
+            <v-switch
+              v-model="daily"
+              :aria-label="$t('UserSettings.drawer.label.dailyDigest')" />
+          </v-list-item-action>
+        </v-list-item>
         <user-setting-digest-categories
           v-if="daily"
           v-model="dailyCategories"
-          :categories="categories" />
+          :categories="categories"
+          class="px-4" />
 
-        <div class="d-flex align-center mt-4">
-          <span class="text-color">{{ $t('UserSettings.drawer.label.weeklyDigest') }}</span>
-          <v-switch
-            v-model="weekly"
-            :aria-label="$t('UserSettings.drawer.label.weeklyDigest')"
-            class="ms-auto my-auto me-0"
-            hide-details />
-        </div>
+        <v-list-item>
+          <v-list-item-content>
+            <v-list-item-title class="text-color">
+              {{ $t('UserSettings.drawer.label.weeklyDigest') }}
+            </v-list-item-title>
+          </v-list-item-content>
+          <v-list-item-action>
+            <v-switch
+              v-model="weekly"
+              :aria-label="$t('UserSettings.drawer.label.weeklyDigest')" />
+          </v-list-item-action>
+        </v-list-item>
         <user-setting-digest-categories
           v-if="weekly"
           v-model="weeklyCategories"
-          :categories="categories" />
+          :categories="categories"
+          class="px-4" />
       </v-flex>
     </template>
     <template #footer>


### PR DESCRIPTION
PO UI feedback on the merged US03 (task 89484, comment of 2026-09-02): *'toggles are not aligned to the option'*.

The frequency rows were hand-rolled `d-flex` lines, leaving the `v-switch` sitting lower than its label (the switch keeps its own vertical padding that `my-auto` doesn't neutralize). They now use the exact structure every other row of this settings screen uses — `v-list-item` with the title in `v-list-item-content` and the switch in `v-list-item-action`, the validated idiom of `UserSettingNotificationChannel.vue` — which vertically centers toggle and label on the same line. The category blocks keep their indentation under each frequency.

Template-only change: the drawer logic (dirty-state Apply, auto-uncheck) is untouched.

## AI contribution
Classified **N1** — human-driven, no auto-merge, author ≠ approver.