### PR TITLE
feat: Lighten the disabled Reported menu entry EXO-89932

### DIFF
--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/activity/header/ActivityHeadMenu.vue
@@ -63,14 +63,14 @@
                           eager />
                         <v-icon
                           v-else
-                          size="16"
-                          class="icon-default-color">
+                          :class="isActionDisabled(action) ? 'text-disabled-color' : 'icon-default-color'"
+                          size="16">
                           {{ $t(action.icon) }}
                         </v-icon>
                       </v-card>
                     </v-list-item-icon>
                     <v-list-item-content class="ms-2">
-                      <v-list-item-title class="menu-text-color">{{ $t(isActionDisabled(action) && action.disabledLabelKey || action.labelKey) }}</v-list-item-title>
+                      <v-list-item-title :class="isActionDisabled(action) ? 'text-disabled-color' : 'menu-text-color'">{{ $t(isActionDisabled(action) && action.disabledLabelKey || action.labelKey) }}</v-list-item-title>
                     </v-list-item-content>
                     <v-list-item-icon
                       v-if="action.children.length"

--- a/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/header/ActivityCommentMenu.vue
+++ b/webapp/src/main/webapp/vue-apps/activity-stream/components/comment/header/ActivityCommentMenu.vue
@@ -61,14 +61,14 @@
                           eager />
                         <v-icon
                           v-else
-                          size="16"
-                          class="icon-default-color">
+                          :class="isActionDisabled(action) ? 'text-disabled-color' : 'icon-default-color'"
+                          size="16">
                           {{ $t(action.icon) }}
                         </v-icon>
                       </v-card>
                     </v-list-item-icon>
                     <v-list-item-content class="mx-2">
-                      <v-list-item-title class="menu-text-color">{{ $t(isActionDisabled(action) && action.disabledLabelKey || action.labelKey) }}</v-list-item-title>
+                      <v-list-item-title :class="isActionDisabled(action) ? 'text-disabled-color' : 'menu-text-color'">{{ $t(isActionDisabled(action) && action.disabledLabelKey || action.labelKey) }}</v-list-item-title>
                     </v-list-item-content>
                     <v-list-item-icon
                       v-if="action.children.length"


### PR DESCRIPTION
PO feedback (task 89932): when already reported, the entry must read as deactivated — lighter text and icon colors (the menu-text-color/icon-default-color utility classes were overriding the disabled class color; they now switch to text-disabled-color when reported), tooltip (already in place on the wrapper), and the arrow mouse pointer (the v-list-item--disabled class stays: its pointer-events none gives the arrow pointer and keeps the entry inert).