### PR TITLE
feat: Digest capture on the social side, recap snackbar and discard on cancellation - EXO-89485 - eXIP7.3.0.22

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
@@ -37,9 +37,12 @@ import org.exoplatform.social.core.space.SpaceListenerPlugin;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
 import org.exoplatform.social.notification.Utils;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.social.notification.plugin.RequestJoinSpacePlugin;
 import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
 import org.exoplatform.social.notification.plugin.SpaceInvitationPlugin;
+
+import io.meeds.commons.digest.DigestService;
 
 public class SpaceNotificationImpl extends SpaceListenerPlugin {
 
@@ -118,12 +121,30 @@ public class SpaceNotificationImpl extends SpaceListenerPlugin {
   }
 
   private void removeNotifications(String spaceId, String userId, String pluginId) {
+    discardDigestItems(spaceId, userId, pluginId);
     WebNotificationFilter webNotificationFilter = new WebNotificationFilter(userId);
     webNotificationFilter.setParameter("spaceId", spaceId);
     webNotificationFilter.setPluginKey(new PluginKey(pluginId));
     List<NotificationInfo> webNotifs = getWebNotificationService().getNotificationInfos(webNotificationFilter, 0, -1);
     for (NotificationInfo notificationInfo : webNotifs) {
       getWebNotificationService().remove(notificationInfo.getId());
+    }
+  }
+
+  /**
+   * The digest must not announce an invitation or a request that was undone
+   * before it went out, the same way the on-site notification is removed. The
+   * digest service is a Spring bean looked up lazily; a digest failure never
+   * prevents the on-site removal.
+   */
+  private void discardDigestItems(String spaceId, String userId, String pluginId) {
+    try {
+      DigestService digestService = ExoContainerContext.getService(DigestService.class);
+      if (digestService != null) {
+        digestService.discard(userId, pluginId, "spaceId", spaceId);
+      }
+    } catch (Exception e) {
+      LOG.warn("Error discarding the waiting digest items of user {} about space {}", userId, spaceId, e);
     }
   }
 

--- a/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
+++ b/webapp/src/main/resources/locale/portlet/social/UserSettings_en.properties
@@ -73,7 +73,7 @@ UserSettings.button.tooltip.unmute=Unmute space notifications
 UserSettings.drawer.title.digest=Set Digest Mail Notifications
 UserSettings.drawer.label.dailyDigest=Receive daily digest notification
 UserSettings.drawer.label.weeklyDigest=Receive weekly digest notification
-UserSettings.digest.success.save=Your digest mail notifications have been saved
+UserSettings.digest.success.fromNow=Any selected notification from now will be part of your digest
 UserSettings.digest.error.save=Your digest mail notifications could not be saved
 UserSettings.digest.error.load=Your digest mail notifications could not be loaded
 

--- a/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/notification-user-settings/components/UserSettingDigestDrawer.vue
@@ -204,7 +204,11 @@ export default {
       const weeklyCategories = this.weekly && this.weeklyCategories || [];
       return this.$digestService.saveDigestSettings(this.daily, dailyCategories, this.weekly, weeklyCategories)
         .then(() => {
-          this.$root.$emit('alert-message', this.$t('UserSettings.digest.success.save'), 'success');
+          if (this.daily || this.weekly) {
+            // US05: the recap starts collecting from now on. Nothing is shown
+            // when the user switched his digest off: there is nothing to say
+            this.$root.$emit('alert-message', this.$t('UserSettings.digest.success.fromNow'), 'success');
+          }
           this.close();
         })
         .catch(() => this.$root.$emit('alert-message', this.$t('UserSettings.digest.error.save'), 'error'))


### PR DESCRIPTION
Social half of US05 (the capture itself lives in Meeds-io/commons#774). Two commits, one per concern.

## 1. The recap snackbar on Apply

Through the product standard success mechanism (`alert-message`): **'Any selected notification from now will be part of your digest'** — the exact task wording, matching the capture rule (items are stored from the enablement on, never before).

Per the assignee's ruling: shown **only when the saved state keeps at least one frequency on**. Switching the digest off entirely saves silently — there is nothing to announce, and the drawer's dirty-state logic already guarantees an Apply is a real change.

## 2. Forget the waiting items of a cancelled invitation or request

Found by functional testing: cancelling a space invitation or a join request and redoing it stacked several identical items in `NTF_DIGEST_ITEMS`.

`SpaceNotificationImpl` — the space lifecycle listener that already removes the on-site notifications when an invitation is cancelled (`removeInvitedUser`) or a request withdrawn (`removePendingUser`) — now discards the matching digest items in the same place, through `DigestService.discard(username, pluginId, "spaceId", spaceId)` brought by commons#774. Lazy lookup of the digest service (a Spring bean reaching the Kernel after the contexts start), fail-safe: a digest failure never prevents the on-site removal. The commons side completes it: the same notification fired again is stored only once per recipient.

**Requires commons#774 to be merged first** (`discard`).

## AI contribution
Classified **N1** — human-driven, no auto-merge, author ≠ approver.