### PR TITLE
fix: align profile header action components on one row EXO-89242

### DIFF
--- a/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
+++ b/webapp/src/main/webapp/vue-apps/profile-header/components/ProfileHeaderActions.vue
@@ -129,7 +129,7 @@
         icon="fas fa-user-plus"
         icon-button
         @click="connect" />
-      <div class="profileHeaderActionComponents order-first mb-0">
+      <div class="profileHeaderActionComponents order-first mb-0 d-flex align-center">
         <div
           v-for="action in enabledProfileHeaderActionComponents"
           :key="action.key"


### PR DESCRIPTION
The profile header renders every ('profile-header', 'action-component') extension inside a plain block div, so its children stack vertically. It went unnoticed while webconferencing's call button was the point's only registrant; the contacts add-on's "Add to my contacts" action registers there too and lands on a second row, under the video icon instead of beside it.

Make the wrapper a flex row so the point renders its actions inline, whatever their number.