### PR TITLE
fix: honour the isCard flag on people cards EXO-89242

### DIFF
--- a/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -171,7 +171,7 @@ export default {
     maxActionIconsCount() {
       return this.filteredPeople.reduce((max, user) => {
         const navigationIconsCount = this.userExtensions.filter(extension => extension.enabled(user)).length;
-        const actionIconsCount = this.profileActionExtensions.filter(extension => extension.enabled(user?.dataEntity || user)).length;
+        const actionIconsCount = this.profileActionExtensions.filter(extension => extension.enabled(user?.dataEntity || user, null, true)).length;
         return Math.max(max, navigationIconsCount + actionIconsCount);
       }, 0) + (this.spaceId && 1 || 0);
     },

--- a/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -229,7 +229,9 @@ export default {
         && !this.ignoredNavigationExtensions.includes(extension?.id));
     },
     filteredProfileActionExtensions() {
-      return this.profileActionExtensions.filter(extension => extension.enabled(this.user?.dataEntity || this.user));
+      // isCard=true: an extension that opts out of card surfaces reads the third argument.
+      // spaceId stays unforwarded as it always was — the space-scoped actions belong to the menu.
+      return this.profileActionExtensions.filter(extension => extension.enabled(this.user?.dataEntity || this.user, null, true));
     },
     fieldsToDisplay() {
       return this.user?.properties?.filter(property => Object.values(this.preferences).includes(property.propertyName));


### PR DESCRIPTION
A ('profile-extension', 'action') extension opts out of card surfaces by reading the third argument of enabled(user, spaceId, isCard). Only the people overflow menu ever passed it, so an extension that opted out was still rendered on the card itself — the contacts add-on's "Add to my contacts" action among them.

Pass isCard from the card and from the icon-count computation that sizes it, so both agree on what the card shows.

spaceId stays unforwarded, as it has always been here: forwarding it would light up the space-scoped actions (open profile, copy link) on space member cards, where they have never been shown.