### PR TITLE
fix: Require the timezone sync script from a body template - EXO-89484 - eXIP7.3.0.22

### DIFF
--- a/webapp/src/main/webapp/groovy/social/webui/UISocialBottomContainer.gtmpl
+++ b/webapp/src/main/webapp/groovy/social/webui/UISocialBottomContainer.gtmpl
@@ -1,4 +1,9 @@
 <%
   def rcontext = _ctx.getRequestContext();
   rcontext.getJavascriptManager().require("SHARED/AttachmentPreviewListener", "AttachmentPreviewListener");
+  if (rcontext.getRemoteUser() != null) {
+    // Keeps the platform timezone of the user aligned on his browser one; the
+    // head template prints the known value this script compares against
+    rcontext.getJavascriptManager().require("SHARED/userTimeZoneSync");
+  }
 %>

--- a/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
+++ b/webapp/src/main/webapp/groovy/social/webui/UISocialPortalApplicationHead.gtmpl
@@ -38,7 +38,8 @@
   ProfilePropertySetting profilePropertySetting = profilePropertyService.getProfileSettingByName("manager");
   // The timezone the platform knows for the user: the userTimeZoneSync script
   // compares it to the browser one and refreshes it when they differ. The
-  // module only runs because it is required here.
+  // module is required by UISocialBottomContainer.gtmpl: a require issued
+  // from this head template never reaches the page execution list.
   OrganizationService organizationService = uicomponent.getApplicationComponent(OrganizationService.class);
   UserProfile organizationUserProfile = userName == null ? null : organizationService.getUserProfileHandler().findUserProfileByName(userName);
   String userTimezone = organizationUserProfile == null ? null : organizationUserProfile.getAttribute(Profile.USER_TIME_ZONE);
@@ -50,9 +51,6 @@
     }
   } catch (Exception e) {
     userTimezone = null;
-  }
-  if (userName != null) {
-    rcontext.getJavascriptManager().require("SHARED/userTimeZoneSync");
   }
 %>
 <script type="text/javascript" id="socialHeadScripts">


### PR DESCRIPTION
Follow-up fix of the platform timezone synchronization (US03, task 89484) — found by functional testing: **new users never got a timezone**, on acceptance as on a local platform (`eXo.env.portal.userTimezone` stayed `null`, and the `TIMEZONE` column of `NTF_DIGEST_USERS` snapshotted `null` on Apply). Existing users looked fine only because they carried values written over the years by the agenda script this mechanism replaced.

**Root cause, proven on a running platform:** the `userTimeZoneSync` module was required from `UISocialPortalApplicationHead.gtmpl`, a **head** template extension. A `require()` issued there is added to the page's module **paths map** but never to the page's **execution `require([...])` call** — the head renders outside the cycle where the JavascriptManager serializes that list. Result: `SHARED/userTimeZoneSync` appeared exactly once in the rendered page (the map), while every working module (`bodyScrollListener`, `topbarLoading`, `AttachmentPreviewListener`…) appears twice. The script never ran; no POST was ever sent.

**Fix:** the require moves to `UISocialBottomContainer.gtmpl`, a body template extension whose existing require (`AttachmentPreviewListener`) does reach the execution list; it is issued for logged-in users only. The head template keeps printing `eXo.env.portal.userTimezone`, which the script compares against — that order (head value first, body-required module after) is what the mechanism needs.

**Verification, live:** after applying the same change to the deployed template, the rendered page carries the module in its execution require call; `POST /social/rest/timezone` answers **200** and the next page render prints the saved zone. The server side had already been proven healthy separately (a container test against the real `OrganizationService`, plus the endpoint exercised with a session).

Lesson worth keeping for the platform: **a `JavascriptManager.require()` must be issued from a body-rendered template, never from a `UIPortalApplication-head` extension** — the head can only print inline scripts.

## AI contribution
Classified **N1** — human-driven, no auto-merge, author ≠ approver.
