### PR TITLE
fix: Invite members drawer isn't displayed for invite-only spaces - EXO-89865

### DIFF
--- a/webapp/src/main/webapp/vue-apps/space-invitation/components/SpaceInviteButtonsGroup.vue
+++ b/webapp/src/main/webapp/vue-apps/space-invitation/components/SpaceInviteButtonsGroup.vue
@@ -20,7 +20,9 @@
 -->
 <template>
   <div class="d-flex align-center">
-    <space-invite-button />
+    <space-invite-button
+      :invitation-link-allowed="invitationLinkAllowed"
+      :go-back-button="goBackButton" />
     <v-badge
       v-if="pendingCount"
       color="white pa-0"
@@ -60,6 +62,7 @@
       v-if="$root.isExternalFeatureEnabled"
       ref="emailInvitationDrawer" />
     <space-invitation-link-drawer
+      v-if="invitationLinkAllowed"
       :space-id="spaceId"
       :go-back-button="goBackButton" />
   </div>
@@ -80,6 +83,9 @@ export default {
     },
     spaceId() {
       return this.$root?.space?.id;
+    },
+    invitationLinkAllowed() {
+      return ['validation', 'open'].includes(this.$root?.space?.subscription);
     }
   }
 };

--- a/webapp/src/main/webapp/vue-apps/space-invitation/components/drawer/SpaceInvitationLinkDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/space-invitation/components/drawer/SpaceInvitationLinkDrawer.vue
@@ -83,6 +83,9 @@ export default {
     this.$root.$on('space-settings-invite-link', this.open);
     this.generateInvitationLink();
   },
+  beforeDestroy() {
+    this.$root.$off('space-settings-invite-link', this.open);
+  },
   watch: {
     spaceId() {
       this.generateInvitationLink();

--- a/webapp/src/main/webapp/vue-apps/space-invitation/components/form/SpaceInviteButton.vue
+++ b/webapp/src/main/webapp/vue-apps/space-invitation/components/form/SpaceInviteButton.vue
@@ -45,7 +45,7 @@
       <v-list-item
         id="InvitePlatformUserToSpaceButton"
         link
-        @click="$root.$emit('space-settings-invite-member', true)">
+        @click="$root.$emit('space-settings-invite-member', goBackButton)">
         <v-list-item-content class="d-inline">
           <v-list-item-title>{{ $t('SpaceSettings.users.button.inviteInternalMembers') }}</v-list-item-title>
           <v-list-item-subtitle class="text-truncate-3 text-wrap">{{ $t('SpaceSettings.users.button.inviteInternalMembers.description') }}</v-list-item-subtitle>
@@ -96,13 +96,17 @@
 
 <script>
 export default {
+  props: {
+    invitationLinkAllowed: {
+      type: Boolean,
+      default: false
+    },
+    goBackButton: {
+      type: Boolean,
+      default: false
+    }
+  },
   computed: {
-    invitationLinkAllowed() {
-      return ['validation', 'open'].includes(this.spaceSubscription);
-    },
-    spaceSubscription() {
-      return this.$root?.space?.subscription;
-    },
     showInviteButton() {
       return this.canEdit || this.invitationLinkAllowed;
     },
@@ -115,8 +119,8 @@ export default {
   },
   methods: {
     openInvite() {
-      if (this.isManager) {
-        this.$root.$emit('space-settings-invite-member');
+      if (this.canEdit) {
+        this.$root.$emit('space-settings-invite-member', this.goBackButton);
       } else {
         this.$root.$emit('space-settings-invite-link');
       }


### PR DESCRIPTION
The fallback Invite button routed on an undefined `isManager` property, so space managers of an invite-only space (external users disabled) always got the invitation link drawer instead of the members invitation drawer. Route on `canEdit`, mount the invitation link drawer only when the space subscription allows links, and unsubscribe it from $root on destroy.

