### PR TITLE
feat: Forget the waiting digest items of a cancelled invitation or request - EXO-89485 - eXIP7.3.0.22

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/impl/SpaceNotificationImpl.java
@@ -37,9 +37,12 @@ import org.exoplatform.social.core.space.SpaceListenerPlugin;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
 import org.exoplatform.social.notification.Utils;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.social.notification.plugin.RequestJoinSpacePlugin;
 import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
 import org.exoplatform.social.notification.plugin.SpaceInvitationPlugin;
+
+import io.meeds.commons.digest.DigestService;
 
 public class SpaceNotificationImpl extends SpaceListenerPlugin {
 
@@ -118,12 +121,30 @@ public class SpaceNotificationImpl extends SpaceListenerPlugin {
   }
 
   private void removeNotifications(String spaceId, String userId, String pluginId) {
+    discardDigestItems(spaceId, userId, pluginId);
     WebNotificationFilter webNotificationFilter = new WebNotificationFilter(userId);
     webNotificationFilter.setParameter("spaceId", spaceId);
     webNotificationFilter.setPluginKey(new PluginKey(pluginId));
     List<NotificationInfo> webNotifs = getWebNotificationService().getNotificationInfos(webNotificationFilter, 0, -1);
     for (NotificationInfo notificationInfo : webNotifs) {
       getWebNotificationService().remove(notificationInfo.getId());
+    }
+  }
+
+  /**
+   * The digest must not announce an invitation or a request that was undone
+   * before it went out, the same way the on-site notification is removed. The
+   * digest service is a Spring bean looked up lazily; a digest failure never
+   * prevents the on-site removal.
+   */
+  private void discardDigestItems(String spaceId, String userId, String pluginId) {
+    try {
+      DigestService digestService = ExoContainerContext.getService(DigestService.class);
+      if (digestService != null) {
+        digestService.discard(userId, pluginId, "spaceId", spaceId);
+      }
+    } catch (Exception e) {
+      LOG.warn("Error discarding the waiting digest items of user {} about space {}", userId, spaceId, e);
     }
   }
 


### PR DESCRIPTION
Part of US05 (capture), found by functional testing: cancelling a space invitation or a join request and redoing it stacked several identical items in `NTF_DIGEST_ITEMS`.

Two complementary layers fix it:
- **commons** (Meeds-io/commons#774): the capture stores the same notification only once per recipient, and `DigestService.discard(username, pluginId, parameterName, parameterValue)` forgets the waiting items about one object.
- **this PR**: `SpaceNotificationImpl` — the space lifecycle listener that already removes the on-site notifications when an invitation is cancelled (`removeInvitedUser`) or a request withdrawn (`removePendingUser`) — discards the matching digest items in the same place, matched on the stored `spaceId`. Lazy lookup of the digest service (a Spring bean reaching the Kernel after the contexts start), fail-safe: a digest failure never prevents the on-site removal.

Requires commons#774 to be merged first (brings `discard`).

## AI contribution
Classified **N1** — human-driven, no auto-merge, author ≠ approver.