### PR TITLE
fix: [Contacts] honour the isCard flag on people cards EXO-89242

### DIFF
--- a/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/PeopleCardList.vue
@@ -171,7 +171,7 @@ export default {
     maxActionIconsCount() {
       return this.filteredPeople.reduce((max, user) => {
         const navigationIconsCount = this.userExtensions.filter(extension => extension.enabled(user)).length;
-        const actionIconsCount = this.profileActionExtensions.filter(extension => extension.enabled(user?.dataEntity || user)).length;
+        const actionIconsCount = this.profileActionExtensions.filter(extension => extension.enabled(user?.dataEntity || user, null, true)).length;
         return Math.max(max, navigationIconsCount + actionIconsCount);
       }, 0) + (this.spaceId && 1 || 0);
     },

--- a/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
+++ b/webapp/src/main/webapp/vue-apps/people-list/components/usercard/PeopleUserCard.vue
@@ -229,7 +229,9 @@ export default {
         && !this.ignoredNavigationExtensions.includes(extension?.id));
     },
     filteredProfileActionExtensions() {
-      return this.profileActionExtensions.filter(extension => extension.enabled(this.user?.dataEntity || this.user));
+      // isCard=true: an extension that opts out of card surfaces reads the third argument.
+      // spaceId stays unforwarded as it always was — the space-scoped actions belong to the menu.
+      return this.profileActionExtensions.filter(extension => extension.enabled(this.user?.dataEntity || this.user, null, true));
     },
     fieldsToDisplay() {
       return this.user?.properties?.filter(property => Object.values(this.preferences).includes(property.propertyName));


### PR DESCRIPTION
Backport to `develop` of the **social half** of **EXO-89242 — [Contacts] List contact option in the profile page**, validated on the `feature/ai-contribution` acceptance server.

| | |
|---|---|
| Tribe task | [EXO-89242](https://community.exoplatform.com/portal/dw/tasks/taskDetail/89242) |
| FB PR | Meeds-io/social#6058 |
| Cherry-picked commit | `94eb10801a` |
| Classification | **N3** — 2 Vue SFCs, no REST / DAO / schema / ACL surface touched |

### ⚠️ Merge order — this PR lands FIRST
EXO-89242 spans two repos. This one makes the people card pass its `isCard` flag to `('profile-extension', 'action')` consumers; the email-connector half (exoplatform/email-connector#390) relies on that flag to keep the "Add to my contacts" action off card surfaces.

**Merge this PR before the email-connector one.** In the reverse order there is a window in which the icon reappears on the people list, search results, org chart and popovers — the regression EXO-89226 originally fixed.

### Verification
- `git cherry-pick -x 94eb10801a` onto today's `develop`: **clean, no conflict** — diff-equivalent to the validated FB state, so review is scoped to that equivalence.
- `mvn install`: **BUILD SUCCESS**, full 10-module reactor including Social Webapp (webpack). 13 tests, 0 failures — note no Java test covers a Vue-only change; the webpack build is the meaningful check here.

### Scope
```
people-list/components/PeopleCardList.vue          | 2 +-
people-list/components/usercard/PeopleUserCard.vue | 4 +++-
```

Knowledge: none — a flag already declared by the extension point's contract is now actually passed; no mechanism, API or norm changes.