### PR TITLE
feat: Implement user spaces list service, storage and endpoint EXO-89465- #6050

### DIFF
--- a/component/api/src/main/java/io/meeds/social/space/constant/UserSpacesScope.java
+++ b/component/api/src/main/java/io/meeds/social/space/constant/UserSpacesScope.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/api/src/main/java/io/meeds/social/space/constant/UserSpacesScope.java
+++ b/component/api/src/main/java/io/meeds/social/space/constant/UserSpacesScope.java
@@ -16,28 +16,23 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.exoplatform.social.core.storage.cache.model.key;
+package io.meeds.social.space.constant;
 
-public enum SpaceType {
-  MEMBER,
-  MANAGER,
-  PENDING,
-  INVITED,
-  PUBLIC,
-  ACCESSIBLE,
-  VISIBLE,
-  ALL,
-  LATEST_ACCESSED,
-  MEMBER_IDENTITY_IDS,
-  MEMBER_IDS,
+/**
+ * Scope of a profile owner's spaces listing, as requested by a viewer.
+ * <p>
+ * This is a client input: it can only ever narrow what is returned. The Service
+ * layer forces {@link #COMMON} for an external viewer, whatever was requested.
+ */
+public enum UserSpacesScope {
   /**
-   * A profile owner's spaces, restricted to the ones shared with the viewer
-   * carried by {@link SpaceFilterKey#getViewerId()}.
+   * Only the spaces where both the viewer and the profile owner have the member
+   * role.
    */
-  USER_SPACES_COMMON,
+  COMMON,
   /**
-   * A profile owner's spaces, minus the hidden ones the viewer carried by
-   * {@link SpaceFilterKey#getViewerId()} is not a member of.
+   * Every space where the profile owner has the member role, minus the hidden
+   * ones the viewer is not a member of.
    */
-  USER_SPACES_ALL
+  ALL
 }

--- a/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
+++ b/component/api/src/main/java/org/exoplatform/social/core/space/spi/SpaceService.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import io.meeds.social.space.constant.UserSpacesScope;
 import io.meeds.social.space.invitation.model.SpaceInvitationLink;
 import io.meeds.social.space.model.SpaceCreationInstance;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -1139,6 +1140,60 @@ public interface SpaceService {
    * @return list of common spaces between two users in param
    */
   default ListAccess<Space> getCommonSpaces(String username, String otherUsername) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Lists the spaces of a profile owner, as they are visible to a given viewer.
+   * <p>
+   * This method is the single decision point of the profile spaces listing: it
+   * resolves the viewer's type, decides the effective scope and applies the
+   * visibility filter. The four cases it implements are:
+   * <ol>
+   * <li>internal viewer on their own profile: all their spaces, hidden ones
+   * included;</li>
+   * <li>internal viewer on an internal owner's profile: the owner's spaces,
+   * minus the hidden spaces the viewer is not a member of;</li>
+   * <li>internal viewer on an external owner's profile: common spaces only;</li>
+   * <li>external viewer, whoever the owner is: common spaces only, the
+   * requested scope being overridden.</li>
+   * </ol>
+   * Only the member role is taken into account: invitations and join requests
+   * are excluded. A PRIVATE space the viewer is not a member of is listed; only
+   * HIDDEN spaces are filtered out. Sub spaces are listed flat, alongside their
+   * parent.
+   *
+   * @param viewerUsername The remote user Id of the user viewing the profile
+   * @param profileOwnerUsername The remote user Id of the profile owner
+   * @param scope The requested {@link UserSpacesScope}. Narrowed by this method
+   *          when the viewer may not use it; never a cause of denial
+   * @param offset The starting point
+   * @param limit The maximum number of returned results
+   * @return {@link List} of {@link Space} visible to the viewer
+   * @throws ObjectNotFoundException when the profile owner does not exist
+   */
+  default List<Space> getUserSpaces(String viewerUsername,
+                                    String profileOwnerUsername,
+                                    UserSpacesScope scope,
+                                    long offset,
+                                    long limit) throws ObjectNotFoundException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Counts the spaces of a profile owner, as they are visible to a given viewer,
+   * applying the same rules as
+   * {@link #getUserSpaces(String, String, UserSpacesScope, long, long)}.
+   *
+   * @param viewerUsername The remote user Id of the user viewing the profile
+   * @param profileOwnerUsername The remote user Id of the profile owner
+   * @param scope The requested {@link UserSpacesScope}
+   * @return the number of spaces visible to the viewer
+   * @throws ObjectNotFoundException when the profile owner does not exist
+   */
+  default int countUserSpaces(String viewerUsername,
+                              String profileOwnerUsername,
+                              UserSpacesScope scope) throws ObjectNotFoundException {
     throw new UnsupportedOperationException();
   }
 

--- a/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/space/service/SpaceServiceImpl.java
@@ -81,6 +81,9 @@ import org.exoplatform.social.core.jpa.storage.SpaceStorage;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.model.BannerAttachment;
 import org.exoplatform.social.core.model.SpaceExternalInvitation;
+import org.exoplatform.social.core.search.Sorting;
+import org.exoplatform.social.core.search.Sorting.OrderBy;
+import org.exoplatform.social.core.search.Sorting.SortBy;
 import org.exoplatform.social.core.space.SpaceException;
 import org.exoplatform.social.core.space.SpaceException.Code;
 import org.exoplatform.social.core.space.SpaceFilter;
@@ -99,6 +102,7 @@ import org.exoplatform.web.security.security.CookieTokenService;
 import org.exoplatform.web.security.security.RemindPasswordTokenService;
 
 import io.meeds.social.search.SpaceSearchConnector;
+import io.meeds.social.space.constant.UserSpacesScope;
 import io.meeds.social.space.template.model.SpaceTemplate;
 import io.meeds.social.space.template.service.SpaceTemplateService;
 
@@ -385,6 +389,87 @@ public class SpaceServiceImpl implements SpaceService {
       return new ListAccessImpl<>(Space.class, Collections.emptyList());
     }
     return new SpaceListAccess(spaceStorage, spaceSearchConnector, SpaceListAccessType.COMMON, username, otherUserId);
+  }
+
+  @Override
+  public List<Space> getUserSpaces(String viewerUsername,
+                                   String profileOwnerUsername,
+                                   UserSpacesScope scope,
+                                   long offset,
+                                   long limit) throws ObjectNotFoundException {
+    if (userAcl.isAnonymousUser(viewerUsername)) {
+      return Collections.emptyList();
+    }
+    UserSpacesScope effectiveScope = getEffectiveUserSpacesScope(viewerUsername, profileOwnerUsername, scope);
+    return spaceStorage.getUserSpaces(viewerUsername,
+                                      profileOwnerUsername,
+                                      effectiveScope,
+                                      getUserSpacesSorting(),
+                                      offset,
+                                      limit);
+  }
+
+  @Override
+  public int countUserSpaces(String viewerUsername,
+                             String profileOwnerUsername,
+                             UserSpacesScope scope) throws ObjectNotFoundException {
+    if (userAcl.isAnonymousUser(viewerUsername)) {
+      return 0;
+    }
+    UserSpacesScope effectiveScope = getEffectiveUserSpacesScope(viewerUsername, profileOwnerUsername, scope);
+    return spaceStorage.countUserSpaces(viewerUsername, profileOwnerUsername, effectiveScope);
+  }
+
+  /**
+   * Decides which spaces of a profile owner a viewer may see. The binding axis
+   * is the <b>viewer</b>, never the profile owner: an external viewer visiting
+   * an internal profile gets the restrictive scope, whatever they requested.
+   * <p>
+   * The requested scope is client input. It is narrowed silently when the viewer
+   * may not use it — it is not a cause of denial.
+   *
+   * @param viewerUsername remote id of the user viewing the profile
+   * @param profileOwnerUsername remote id of the profile owner
+   * @param scope requested {@link UserSpacesScope}, may be null
+   * @return the effective {@link UserSpacesScope}
+   * @throws ObjectNotFoundException when the profile owner does not exist
+   */
+  private UserSpacesScope getEffectiveUserSpacesScope(String viewerUsername,
+                                                      String profileOwnerUsername,
+                                                      UserSpacesScope scope) throws ObjectNotFoundException {
+    Identity profileOwnerIdentity = identityManager.getOrCreateUserIdentity(profileOwnerUsername);
+    if (profileOwnerIdentity == null || profileOwnerIdentity.isDeleted()) {
+      throw new ObjectNotFoundException(String.format("Profile owner %s does not exist", profileOwnerUsername));
+    }
+    if (StringUtils.equals(viewerUsername, profileOwnerUsername)) {
+      // Own profile: every space the user is a member of, hidden ones included
+      return UserSpacesScope.ALL;
+    }
+    Identity viewerIdentity = identityManager.getOrCreateUserIdentity(viewerUsername);
+    if (viewerIdentity == null || viewerIdentity.isExternal()) {
+      // An external viewer never widens beyond the spaces they share with the
+      // profile owner. This check is the only discriminator on that axis: the
+      // REST annotation cannot tell an external user apart, since the externals
+      // role always carries the users role too. A viewer whose identity cannot
+      // be resolved takes the same restrictive path — an unresolvable viewer
+      // must not be treated as an internal one.
+      return UserSpacesScope.COMMON;
+    }
+    if (profileOwnerIdentity.isExternal()) {
+      return UserSpacesScope.COMMON;
+    }
+    return scope == null ? UserSpacesScope.ALL : scope;
+  }
+
+  /**
+   * Order of the profile spaces listing: alphabetical, as decided by the PO on
+   * 26/08/2026 (board stories US01, US02 and US05 of eXIP 7.3.0.18). Neutral by
+   * design: ordering by the profile owner's own last visit would disclose their
+   * browsing recency to whoever visits their profile, and would churn the cached
+   * entries on every navigation.
+   */
+  private Sorting getUserSpacesSorting() {
+    return new Sorting(SortBy.TITLE, OrderBy.ASC);
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/search/XSpaceFilter.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/search/XSpaceFilter.java
@@ -22,20 +22,38 @@ import java.util.Set;
 
 import org.exoplatform.social.core.space.SpaceFilter;
 
+import io.meeds.social.space.constant.UserSpacesScope;
+
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 public class XSpaceFilter extends SpaceFilter {
 
-  private Set<Long>   ids    = null;
+  private Set<Long>       ids    = null;
 
-  private boolean     includePrivate;
+  private boolean         includePrivate;
 
-  private boolean     notHidden;
+  private boolean         notHidden;
 
-  private boolean     lastAccess;
+  private boolean         lastAccess;
 
-  private boolean     visited;
+  private boolean         visited;
+
+  /**
+   * Remote id of a second user the listed spaces must be shared with, i.e. a
+   * user holding the member role on the same space. Used to express the "common
+   * with the viewer" condition of the profile spaces listing, alongside the
+   * profile owner carried by {@link #getRemoteId()}.
+   */
+  private String          commonWithUserId;
+
+  /**
+   * Scope of the "common with the viewer" condition:
+   * {@link UserSpacesScope#COMMON} keeps only the spaces shared with
+   * {@link #getCommonWithUserId()}, {@link UserSpacesScope#ALL} keeps the shared
+   * ones plus the ones that are not hidden.
+   */
+  private UserSpacesScope commonWithUserScope;
 
   public XSpaceFilter setSpaceFilter(SpaceFilter spaceFilter) {
     if (spaceFilter != null) {
@@ -63,6 +81,8 @@ public class XSpaceFilter extends SpaceFilter {
         this.setNotHidden(filter.isNotHidden());
         this.setLastAccess(filter.isLastAccess());
         this.setVisited(filter.isVisited());
+        this.setCommonWithUserId(filter.getCommonWithUserId());
+        this.setCommonWithUserScope(filter.getCommonWithUserScope());
       }
     }
     return this;
@@ -104,6 +124,24 @@ public class XSpaceFilter extends SpaceFilter {
 
   public Set<Long> getIds() {
     return ids;
+  }
+
+  public String getCommonWithUserId() {
+    return commonWithUserId;
+  }
+
+  public XSpaceFilter setCommonWithUserId(String commonWithUserId) {
+    this.commonWithUserId = commonWithUserId;
+    return this;
+  }
+
+  public UserSpacesScope getCommonWithUserScope() {
+    return commonWithUserScope;
+  }
+
+  public XSpaceFilter setCommonWithUserScope(UserSpacesScope commonWithUserScope) {
+    this.commonWithUserScope = commonWithUserScope;
+    return this;
   }
 
   public void setIds(Set<Long> ids) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/SpaceStorage.java
@@ -52,6 +52,7 @@ import org.exoplatform.social.core.jpa.storage.entity.SpaceEntity;
 import org.exoplatform.social.core.jpa.storage.entity.SpaceExternalInvitationEntity;
 import org.exoplatform.social.core.jpa.storage.entity.SpaceMemberEntity;
 import org.exoplatform.social.core.model.SpaceExternalInvitation;
+import org.exoplatform.social.core.search.Sorting;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.SpaceFilter;
 import org.exoplatform.social.core.space.model.Space;
@@ -64,6 +65,7 @@ import org.exoplatform.web.security.security.CookieTokenService;
 import org.exoplatform.web.security.security.RemindPasswordTokenService;
 
 import io.meeds.social.space.constant.SpaceMembershipStatus;
+import io.meeds.social.space.constant.UserSpacesScope;
 
 import jakarta.persistence.Tuple;
 
@@ -534,6 +536,111 @@ public class SpaceStorage {
 
   public int countExternalMembers(Long spaceId) {
     return spaceMemberDAO.countExternalMembers(spaceId);
+  }
+
+  /**
+   * Lists the spaces where a profile owner has the member role, restricted to
+   * what a viewer is allowed to see. The access decision itself belongs to the
+   * Service layer: this method only translates an already decided scope into a
+   * datastore filter.
+   *
+   * @param viewerUsername remote id of the viewer, mandatory. When it is the
+   *          profile owner themselves, both scopes list every space they are a
+   *          member of, hidden ones included — the viewer is a member of all of
+   *          them by definition
+   * @param profileOwnerUsername remote id of the profile owner
+   * @param scope effective {@link UserSpacesScope}, as decided by the Service
+   * @param sorting the {@link Sorting} to apply
+   * @param offset The starting point
+   * @param limit The maximum number of returned results
+   * @return {@link List} of {@link Space}
+   * @throws IllegalArgumentException when the viewer or the profile owner is
+   *           missing
+   */
+  public List<Space> getUserSpaces(String viewerUsername,
+                                   String profileOwnerUsername,
+                                   UserSpacesScope scope,
+                                   Sorting sorting,
+                                   long offset,
+                                   long limit) {
+    return getSpaces(profileOwnerUsername,
+                     SpaceMembershipStatus.MEMBER,
+                     buildUserSpacesFilter(viewerUsername, profileOwnerUsername, scope, sorting),
+                     offset,
+                     limit);
+  }
+
+  /**
+   * Counts the spaces returned by
+   * {@link #getUserSpaces(String, String, UserSpacesScope, Sorting, long, long)}.
+   *
+   * @param viewerUsername remote id of the viewer, mandatory
+   * @param profileOwnerUsername remote id of the profile owner
+   * @param scope effective {@link UserSpacesScope}, as decided by the Service
+   * @return the number of spaces
+   * @throws IllegalArgumentException when the viewer or the profile owner is
+   *           missing
+   */
+  public int countUserSpaces(String viewerUsername, String profileOwnerUsername, UserSpacesScope scope) {
+    return getSpacesCount(profileOwnerUsername,
+                          SpaceMembershipStatus.MEMBER,
+                          buildUserSpacesFilter(viewerUsername, profileOwnerUsername, scope, null));
+  }
+
+  /**
+   * Refuses a profile spaces listing that carries no viewer. An absent viewer is
+   * a caller error, not a licence to list the owner's hidden spaces, so it must
+   * never degenerate into the unfiltered listing. Validated by the cached
+   * storage before the cache is consulted, so the exception is not raised from
+   * inside a cache loader — which would surface it wrapped.
+   *
+   * @param viewerUsername remote id of the viewer
+   * @param profileOwnerUsername remote id of the profile owner
+   * @throws IllegalArgumentException when either is missing
+   */
+  protected void validateUserSpacesArguments(String viewerUsername, String profileOwnerUsername) {
+    if (StringUtils.isBlank(viewerUsername)) {
+      throw new IllegalArgumentException("space.viewerIsMandatory");
+    }
+    if (StringUtils.isBlank(profileOwnerUsername)) {
+      throw new IllegalArgumentException("space.profileOwnerIsMandatory");
+    }
+  }
+
+  /**
+   * Normalises the scope of a profile spaces listing: a missing scope is the
+   * restrictive one. The effective scope is decided by the Service, and this
+   * layer must never widen when it was not told which scope to apply. Both the
+   * filter and the cached storage's key derive from this single method, so the
+   * predicate and the cache key can never disagree on what a null scope means —
+   * a disagreement there is an access-control defect, not a staleness one.
+   *
+   * @param scope the requested {@link UserSpacesScope}, possibly null
+   * @return the scope to apply, never null
+   */
+  protected UserSpacesScope normalizeUserSpacesScope(UserSpacesScope scope) {
+    return scope == null ? UserSpacesScope.COMMON : scope;
+  }
+
+  /**
+   * Builds the filter of the profile spaces listing. The viewer axis is always
+   * set, own profile included: with the viewer as the profile owner the axis
+   * matches every space of the listing, so the result is the same as it would be
+   * without it, and no scope is ever silently dropped here. Deciding the
+   * effective scope stays the Service's job, in one place.
+   */
+  private XSpaceFilter buildUserSpacesFilter(String viewerUsername,
+                                             String profileOwnerUsername,
+                                             UserSpacesScope scope,
+                                             Sorting sorting) {
+    validateUserSpacesArguments(viewerUsername, profileOwnerUsername);
+    XSpaceFilter filter = new XSpaceFilter();
+    if (sorting != null) {
+      filter.setSorting(sorting);
+    }
+    filter.setCommonWithUserId(viewerUsername);
+    filter.setCommonWithUserScope(normalizeUserSpacesScope(scope));
+    return filter;
   }
 
   public List<Space> getCommonSpaces(String userId, String otherUserId, int offset, int limit) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
@@ -39,6 +39,7 @@ import org.exoplatform.social.core.space.model.Space;
 
 import io.meeds.social.space.constant.SpaceMembershipStatus;
 import io.meeds.social.space.constant.SpaceVisibility;
+import io.meeds.social.space.constant.UserSpacesScope;
 
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.Tuple;
@@ -83,6 +84,8 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
   private static final String                      PARAM_REGISTRATION          = "registration";
 
   private static final String                      PARAM_HIDDEN_VISIBILITY     = "hiddenVisibility";
+
+  private static final String                      PARAM_COMMON_WITH_USER_ID   = "commonWithUserId";
 
   private static final String                      QUERY_FILTER_FIND_PREFIX    = "Space.findSpaces";
 
@@ -263,6 +266,9 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
     if (parameterNames.contains(PARAM_USER_ID)) {
       query.setParameter(PARAM_USER_ID, filter.getRemoteId());
     }
+    if (parameterNames.contains(PARAM_COMMON_WITH_USER_ID)) {
+      query.setParameter(PARAM_COMMON_WITH_USER_ID, filter.getCommonWithUserId());
+    }
     if (parameterNames.contains(PARAM_STATUSES)) {
       query.setParameter(PARAM_STATUSES, filter.getStatusList());
     }
@@ -405,8 +411,42 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
       parameterNames.add(PARAM_PARENT_SPACE_ID);
     }
 
+    buildCommonWithUserPredicates(spaceFilter, suffixes, predicates, parameterNames);
     buildPermissionPredicates(spaceFilter, suffixes, predicates, parameterNames);
     buildSortSuffixes(spaceFilter, suffixes);
+  }
+
+  /**
+   * Adds the "common with a second user" condition of the profile spaces
+   * listing. The membership axis of {@link XSpaceFilter#getRemoteId()} (the
+   * profile owner) is handled by
+   * {@link #buildPermissionPredicates(XSpaceFilter, List, List, List)}; this one
+   * adds the axis of {@link XSpaceFilter#getCommonWithUserId()} (the viewer) as
+   * an EXISTS sub query, so that no second membership join duplicates rows or
+   * interferes with the sort.
+   */
+  private void buildCommonWithUserPredicates(XSpaceFilter spaceFilter,
+                                             List<String> suffixes,
+                                             List<String> predicates,
+                                             List<String> parameterNames) {
+    if (StringUtils.isBlank(spaceFilter.getCommonWithUserId())) {
+      return;
+    }
+    String commonWithUser = "EXISTS (SELECT smc.id FROM SocSpaceMember smc WHERE smc.space.id = s.id"
+        + " AND smc.userId = :commonWithUserId"
+        + " AND smc.status = io.meeds.social.space.constant.SpaceMembershipStatus.MEMBER)";
+    if (spaceFilter.getCommonWithUserScope() == UserSpacesScope.ALL) {
+      // Every space of the profile owner, minus the hidden ones the viewer is
+      // not a member of
+      suffixes.add("NotHiddenOrCommonWithUser");
+      predicates.add("(s.visibility <> :hiddenVisibility OR " + commonWithUser + ")");
+      parameterNames.add(PARAM_HIDDEN_VISIBILITY);
+    } else {
+      // Only the spaces shared with the viewer
+      suffixes.add("CommonWithUser");
+      predicates.add(commonWithUser);
+    }
+    parameterNames.add(PARAM_COMMON_WITH_USER_ID);
   }
 
   private void buildPermissionPredicates(XSpaceFilter spaceFilter, // NOSONAR

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
@@ -58,6 +58,8 @@ import org.exoplatform.social.core.storage.cache.selector.LastAccessedSpacesCach
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.web.security.security.RemindPasswordTokenService;
 
+import io.meeds.social.space.constant.UserSpacesScope;
+
 public class CachedSpaceStorage extends SpaceStorage {
 
   private static final SpaceKey                                                                    EMPTY_SPACE_KEY =
@@ -355,6 +357,104 @@ public class CachedSpaceStorage extends SpaceStorage {
       return buildIds(got);
     }, listKey);
     return buildSpaces(keys);
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Only the first page is cached. This listing is the first family of
+   * {@code spacesCache} keyed on a <b>pair</b> of users (owner x viewer x
+   * scope), where every other family is keyed on a single one, and the cache is
+   * shared: {@code exo.cache.social.SpacesCache.MaxNodes} defaults to 5000
+   * entries for every space listing of the instance (defined outside this
+   * repository, in {@code Meeds-io/meeds} ->
+   * {@code services/plf-configuration/src/main/resources/conf/platform/configuration.properties}). Caching the drawer's
+   * subsequent pages as well would let profile browsing evict the listings this
+   * cache exists for — the home spaces widget, the space directory. Bounding the
+   * new family to the page that renders on every profile view is the fallback
+   * the specification states for this cardinality (eXIP 7.3.0.18, note 50524
+   * §4).
+   * <p>
+   * The bypass removes the offset dimension, not the {@code limit} one:
+   * {@link ListSpacesKey} compares both, so a caller varying {@code limit} still
+   * multiplies entries. No caller does today — the widget and the drawer each
+   * pass a fixed page size — but the REST endpoint of WP1b takes {@code limit}
+   * from the client and owes that clamp.
+   */
+  @Override
+  public List<Space> getUserSpaces(String viewerUsername,
+                                   String profileOwnerUsername,
+                                   UserSpacesScope scope,
+                                   Sorting sorting,
+                                   long offset,
+                                   long limit) {
+    validateUserSpacesArguments(viewerUsername, profileOwnerUsername);
+    if (offset > 0) {
+      return super.getUserSpaces(viewerUsername, profileOwnerUsername, scope, sorting, offset, limit);
+    }
+    ListSpacesKey listKey = new ListSpacesKey(getUserSpacesCacheKey(viewerUsername, profileOwnerUsername, scope, sorting),
+                                              offset,
+                                              limit);
+    ListSpacesData keys = spacesFutureCache.get(() -> {
+      if (limit == 0) {
+        return buildIds(Collections.emptyList());
+      }
+      return buildIds(CachedSpaceStorage.super.getUserSpaces(viewerUsername,
+                                                             profileOwnerUsername,
+                                                             scope,
+                                                             sorting,
+                                                             offset,
+                                                             limit));
+    }, listKey);
+    return buildSpaces(keys);
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Cached for every page, unlike the listing above: the count carries neither an
+   * offset nor a limit dimension, so it adds at most one entry per (owner,
+   * viewer, scope) — and in {@code social.SpacesCountCache}, a budget of its own,
+   * separate from the listing cache. It is issued by the "See all" drawer only,
+   * never by the widget render (eXIP 7.3.0.18, note 50524 §2 query budget).
+   * Recomputing it means a full {@code COUNT(DISTINCT s.id)} over the membership
+   * scan, reasoned to be the more expensive of the two — not measured here, the
+   * unit suite proves the statement executes, not what it costs.
+   */
+  @Override
+  public int countUserSpaces(String viewerUsername, String profileOwnerUsername, UserSpacesScope scope) {
+    validateUserSpacesArguments(viewerUsername, profileOwnerUsername);
+    SpaceFilterKey key = getUserSpacesCacheKey(viewerUsername, profileOwnerUsername, scope, null);
+    return spacesCountFutureCache.get(() -> new IntegerData(CachedSpaceStorage.super.countUserSpaces(viewerUsername,
+                                                                                                     profileOwnerUsername,
+                                                                                                     scope)),
+                                      key)
+                                 .build();
+  }
+
+  /**
+   * Builds the cache key of the profile spaces listing. The two access-control
+   * discriminators are explicit key fields: the viewer is
+   * {@link SpaceFilterKey#getViewerId()} and the effective scope is
+   * {@link SpaceFilterKey#getType()}. Only the sorting rides the folded filter
+   * hash, since it does not decide what a viewer may see.
+   * <p>
+   * The scope goes through {@link #normalizeUserSpacesScope(UserSpacesScope)},
+   * the same method the predicate builder uses, so a missing scope cannot be
+   * restrictive in the query and permissive in the key — that disagreement would
+   * serve the wide listing to a caller whose predicate asked for the narrow one.
+   */
+  private SpaceFilterKey getUserSpacesCacheKey(String viewerUsername,
+                                               String profileOwnerUsername,
+                                               UserSpacesScope scope,
+                                               Sorting sorting) {
+    SpaceFilter sortingFilter = new SpaceFilter();
+    sortingFilter.setSorting(sorting);
+    return new SpaceFilterKey(profileOwnerUsername,
+                              viewerUsername,
+                              sortingFilter,
+                              normalizeUserSpacesScope(scope) == UserSpacesScope.ALL ? SpaceType.USER_SPACES_ALL
+                                                                                     : SpaceType.USER_SPACES_COMMON);
   }
 
   @Override

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/CachedSpaceStorage.java
@@ -435,8 +435,8 @@ public class CachedSpaceStorage extends SpaceStorage {
   /**
    * Builds the cache key of the profile spaces listing. The two access-control
    * discriminators are explicit key fields: the viewer is
-   * {@link SpaceFilterKey#getViewerId()} and the effective scope is
-   * {@link SpaceFilterKey#getType()}. Only the sorting rides the folded filter
+   * {@code SpaceFilterKey#getViewerId()} and the effective scope is
+   * {@code SpaceFilterKey#getType()}. Only the sorting rides the folded filter
    * hash, since it does not decide what a viewer may see.
    * <p>
    * The scope goes through {@link #normalizeUserSpacesScope(UserSpacesScope)},

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/SpaceFilterKey.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/SpaceFilterKey.java
@@ -38,11 +38,31 @@ public class SpaceFilterKey implements CacheKey {
 
   private final int         hash;
 
+  /**
+   * Remote id of the user the listing is filtered for, when it differs from
+   * {@link #getUserId()} — the profile spaces listing, where userId is the
+   * profile owner and this is the viewer whose visibility rules were applied.
+   * <p>
+   * It is an explicit, equals-compared field on purpose: key equality here is
+   * decided on {@link #hash}, an int folded from the whole filter, so two
+   * colliding filters are the same key. That is a stale-list risk for a
+   * viewer-agnostic listing, but an access-control one as soon as the key
+   * carries a viewer — a collision would serve one viewer's filtered list to
+   * another. The same reason puts the scope in {@link #getType()} rather than in
+   * the hash.
+   */
+  private final String      viewerId;
+
   public SpaceFilterKey(String userId, SpaceFilter filter, SpaceType type) {
+    this(userId, null, filter, type);
+  }
+
+  public SpaceFilterKey(String userId, String viewerId, SpaceFilter filter, SpaceType type) {
     this.hash = Objects.hash(filter);
     this.templateIds = filter == null ? null : filter.getTemplateIds();
     this.type = type;
     this.userId = userId;
+    this.viewerId = viewerId;
   }
 
 }

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/SpaceFilterKey.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/SpaceFilterKey.java
@@ -40,7 +40,7 @@ public class SpaceFilterKey implements CacheKey {
 
   /**
    * Remote id of the user the listing is filtered for, when it differs from
-   * {@link #getUserId()} — the profile spaces listing, where userId is the
+   * {@code getUserId()} — the profile spaces listing, where userId is the
    * profile owner and this is the viewer whose visibility rules were applied.
    * <p>
    * It is an explicit, equals-compared field on purpose: key equality here is
@@ -48,7 +48,7 @@ public class SpaceFilterKey implements CacheKey {
    * colliding filters are the same key. That is a stale-list risk for a
    * viewer-agnostic listing, but an access-control one as soon as the key
    * carries a viewer — a collision would serve one viewer's filtered list to
-   * another. The same reason puts the scope in {@link #getType()} rather than in
+   * another. The same reason puts the scope in {@code getType()} rather than in
    * the hash.
    */
   private final String      viewerId;

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/SpaceType.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/cache/model/key/SpaceType.java
@@ -32,12 +32,12 @@ public enum SpaceType {
   MEMBER_IDS,
   /**
    * A profile owner's spaces, restricted to the ones shared with the viewer
-   * carried by {@link SpaceFilterKey#getViewerId()}.
+   * carried by {@code SpaceFilterKey#getViewerId()}.
    */
   USER_SPACES_COMMON,
   /**
    * A profile owner's spaces, minus the hidden ones the viewer carried by
-   * {@link SpaceFilterKey#getViewerId()} is not a member of.
+   * {@code SpaceFilterKey#getViewerId()} is not a member of.
    */
   USER_SPACES_ALL
 }

--- a/component/core/src/test/java/io/meeds/social/space/service/UserSpacesServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/space/service/UserSpacesServiceTest.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/core/src/test/java/io/meeds/social/space/service/UserSpacesServiceTest.java
+++ b/component/core/src/test/java/io/meeds/social/space/service/UserSpacesServiceTest.java
@@ -1,0 +1,232 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.space.service;
+
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.security.IdentityConstants;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.jpa.storage.SpaceStorage;
+import org.exoplatform.social.core.jpa.test.AbstractCoreTest;
+import org.exoplatform.social.core.space.model.Space;
+
+import io.meeds.social.space.constant.UserSpacesScope;
+
+/**
+ * The four access-control cases of the profile spaces listing (eXIP 7.3.0.18,
+ * board stories US01, US02, US03 and US07), asserted on what a viewer actually
+ * receives rather than on the scope handed to the storage.
+ * <p>
+ * The external-viewer case is load-bearing: an external viewer is
+ * indistinguishable at the REST annotation level, since the externals role
+ * always carries the users role too, so {@code Identity.isExternal()} inside the
+ * Service is the only discriminator on that axis. Remove it, or branch on the
+ * profile owner instead of the viewer, and
+ * {@link #testExternalViewerCannotOptOutOfCommonScope()} fails.
+ * <p>
+ * This is a container test on purpose: {@code SpaceServiceImpl} cannot be built
+ * outside a container, because {@code AbstractLifeCycle}'s constructor calls
+ * {@code PortalContainer.getInstance()} — instantiating it in a plain Mockito
+ * test boots a half-configured container that then breaks every container test
+ * in the same JVM.
+ */
+public class UserSpacesServiceTest extends AbstractCoreTest {
+
+  private static final String OWNER           = "john";
+
+  private static final String VIEWER          = "mary";
+
+  private static final String EXTERNAL_VIEWER = "demo";
+
+  private static final String EXTERNAL_OWNER  = "ghost";
+
+  private SpaceStorage        spaceStorage;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    spaceStorage = getService(SpaceStorage.class);
+
+    createIdentity(OWNER);
+    createIdentity(VIEWER);
+    createIdentity(EXTERNAL_VIEWER);
+    createIdentity(EXTERNAL_OWNER);
+    markExternal(EXTERNAL_VIEWER);
+    markExternal(EXTERNAL_OWNER);
+
+    saveSpace(1, "Alpha space", Space.PUBLIC, OWNER, VIEWER);
+    saveSpace(2, "Beta space", Space.PUBLIC, OWNER, EXTERNAL_VIEWER);
+    saveSpace(3, "Gamma space", Space.PRIVATE, OWNER);
+    saveSpace(4, "Delta space", Space.HIDDEN, OWNER);
+    saveSpace(5, "Epsilon space", Space.PUBLIC, EXTERNAL_OWNER, VIEWER);
+    saveSpace(6, "Zeta space", Space.PUBLIC, EXTERNAL_OWNER);
+    restartTransaction();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    // The identity property rows outlive this test class in the shared test
+    // database, and other suites assert on the absence of external members
+    markExternal(EXTERNAL_VIEWER, false);
+    markExternal(EXTERNAL_OWNER, false);
+    restartTransaction();
+    super.tearDown();
+  }
+
+  public void testOwnProfileListsEverySpaceIncludingHidden() throws ObjectNotFoundException {
+    List<Space> spaces = spaceService.getUserSpaces(OWNER, OWNER, UserSpacesScope.COMMON, 0, 20);
+
+    // Own profile is not a scope the client chooses
+    assertEquals(4, spaces.size());
+    assertEquals(4, spaceService.countUserSpaces(OWNER, OWNER, UserSpacesScope.COMMON));
+    assertTrue(spaces.stream().anyMatch(space -> space.getVisibility().equals(Space.HIDDEN)));
+  }
+
+  public void testOwnProfileOfAnExternalUserIsNotNarrowed() throws ObjectNotFoundException {
+    List<Space> spaces = spaceService.getUserSpaces(EXTERNAL_VIEWER, EXTERNAL_VIEWER, UserSpacesScope.ALL, 0, 20);
+
+    assertEquals(1, spaces.size());
+    assertEquals("Beta space", spaces.get(0).getDisplayName());
+  }
+
+  public void testVisitedProfileHidesTheHiddenSpacesTheViewerIsNotIn() throws ObjectNotFoundException {
+    List<Space> spaces = spaceService.getUserSpaces(VIEWER, OWNER, UserSpacesScope.ALL, 0, 20);
+
+    // Alpha (common), Beta (public) and Gamma (private, not hidden). Delta is
+    // hidden and the viewer is not a member of it.
+    assertEquals(3, spaces.size());
+    assertEquals(3, spaceService.countUserSpaces(VIEWER, OWNER, UserSpacesScope.ALL));
+    assertFalse(spaces.stream().anyMatch(space -> space.getVisibility().equals(Space.HIDDEN)));
+    // PRIVATE is not HIDDEN: it stays listed
+    assertTrue(spaces.stream().anyMatch(space -> space.getDisplayName().equals("Gamma space")));
+  }
+
+  public void testVisitedProfileHonoursTheCommonScope() throws ObjectNotFoundException {
+    List<Space> spaces = spaceService.getUserSpaces(VIEWER, OWNER, UserSpacesScope.COMMON, 0, 20);
+
+    assertEquals(1, spaces.size());
+    assertEquals("Alpha space", spaces.get(0).getDisplayName());
+    assertEquals(1, spaceService.countUserSpaces(VIEWER, OWNER, UserSpacesScope.COMMON));
+  }
+
+  public void testInternalViewerOnExternalOwnerGetsCommonSpacesOnly() throws ObjectNotFoundException {
+    List<Space> spaces = spaceService.getUserSpaces(VIEWER, EXTERNAL_OWNER, UserSpacesScope.ALL, 0, 20);
+
+    // Zeta is public and the owner is a member of it, but the owner is external
+    assertEquals(1, spaces.size());
+    assertEquals("Epsilon space", spaces.get(0).getDisplayName());
+    assertEquals(1, spaceService.countUserSpaces(VIEWER, EXTERNAL_OWNER, UserSpacesScope.ALL));
+  }
+
+  public void testExternalViewerCannotOptOutOfCommonScope() throws ObjectNotFoundException {
+    // The client asks for the permissive scope, on an INTERNAL owner's profile
+    List<Space> spaces = spaceService.getUserSpaces(EXTERNAL_VIEWER, OWNER, UserSpacesScope.ALL, 0, 20);
+
+    // ... and the Service overrides it: only the space they share
+    assertEquals(1, spaces.size());
+    assertEquals("Beta space", spaces.get(0).getDisplayName());
+    assertEquals(1, spaceService.countUserSpaces(EXTERNAL_VIEWER, OWNER, UserSpacesScope.ALL));
+  }
+
+  public void testMissingScopeDefaultsToAllForAnInternalViewer() throws ObjectNotFoundException {
+    assertEquals(3, spaceService.getUserSpaces(VIEWER, OWNER, null, 0, 20).size());
+  }
+
+  public void testListingIsOrderedAlphabetically() throws ObjectNotFoundException {
+    List<Space> spaces = spaceService.getUserSpaces(OWNER, OWNER, UserSpacesScope.ALL, 0, 20);
+
+    // Board stories US01, US02 and US05: alphabetical, never the owner's last
+    // visit — that would disclose their browsing recency to a visitor
+    assertEquals("Alpha space", spaces.get(0).getDisplayName());
+    assertEquals("Beta space", spaces.get(1).getDisplayName());
+    assertEquals("Delta space", spaces.get(2).getDisplayName());
+    assertEquals("Gamma space", spaces.get(3).getDisplayName());
+  }
+
+  public void testListingIsPaged() throws ObjectNotFoundException {
+    assertEquals(2, spaceService.getUserSpaces(OWNER, OWNER, UserSpacesScope.ALL, 0, 2).size());
+    List<Space> secondPage = spaceService.getUserSpaces(OWNER, OWNER, UserSpacesScope.ALL, 2, 2);
+    assertEquals(2, secondPage.size());
+    assertEquals("Delta space", secondPage.get(0).getDisplayName());
+  }
+
+  public void testAnonymousViewerGetsNothing() throws ObjectNotFoundException {
+    // The Service is the layer that stops an unauthenticated caller: the Storage
+    // below refuses a blank viewer outright rather than widening
+    assertTrue(spaceService.getUserSpaces(null, OWNER, UserSpacesScope.ALL, 0, 20).isEmpty());
+    assertTrue(spaceService.getUserSpaces("", OWNER, UserSpacesScope.ALL, 0, 20).isEmpty());
+    assertTrue(spaceService.getUserSpaces(IdentityConstants.ANONIM, OWNER, UserSpacesScope.ALL, 0, 20).isEmpty());
+    assertTrue(spaceService.getUserSpaces(IdentityConstants.SYSTEM, OWNER, UserSpacesScope.ALL, 0, 20).isEmpty());
+    assertEquals(0, spaceService.countUserSpaces(null, OWNER, UserSpacesScope.ALL));
+    assertEquals(0, spaceService.countUserSpaces(IdentityConstants.ANONIM, OWNER, UserSpacesScope.ALL));
+  }
+
+  public void testUnresolvableViewerGetsTheRestrictiveScope() throws ObjectNotFoundException {
+    // Not anonymous, so the Service's first guard lets it through, but no
+    // identity resolves: isExternal() cannot answer, and an unresolvable viewer
+    // must not be treated as an internal one
+    assertTrue(spaceService.getUserSpaces("notauser", OWNER, UserSpacesScope.ALL, 0, 20).isEmpty());
+    assertEquals(0, spaceService.countUserSpaces("notauser", OWNER, UserSpacesScope.ALL));
+  }
+
+  public void testUnknownProfileOwnerIsNotFound() {
+    assertThrows(ObjectNotFoundException.class,
+                 () -> spaceService.getUserSpaces(VIEWER, "notauser", UserSpacesScope.ALL, 0, 20));
+    assertThrows(ObjectNotFoundException.class,
+                 () -> spaceService.countUserSpaces(VIEWER, "notauser", UserSpacesScope.ALL));
+  }
+
+  public void testExternalFlagIsEffectivelySetOnTheFixture() {
+    assertTrue(identityManager.getOrCreateUserIdentity(EXTERNAL_VIEWER).isExternal());
+    assertTrue(identityManager.getOrCreateUserIdentity(EXTERNAL_OWNER).isExternal());
+    assertFalse(identityManager.getOrCreateUserIdentity(OWNER).isExternal());
+    assertFalse(identityManager.getOrCreateUserIdentity(VIEWER).isExternal());
+  }
+
+  private void markExternal(String username) {
+    markExternal(username, true);
+  }
+
+  private void markExternal(String username, boolean external) {
+    Identity identity = identityManager.getOrCreateUserIdentity(username);
+    Profile profile = identity.getProfile();
+    profile.setProperty(Profile.EXTERNAL, String.valueOf(external));
+    identityManager.updateProfile(profile);
+  }
+
+  private void saveSpace(int number, String displayName, String visibility, String... members) {
+    Space space = new Space();
+    space.setDisplayName(displayName);
+    space.setPrettyName(displayName);
+    space.setRegistration(Space.OPEN);
+    space.setDescription("space " + number);
+    space.setVisibility(visibility);
+    space.setGroupId("/spaces/userspacesservice" + number);
+    space.setUrl(space.getPrettyName());
+    space.setManagers(new String[] { members[0] });
+    space.setMembers(members);
+    space.setInvitedUsers(new String[] {});
+    space.setPendingUsers(new String[] {});
+    spaceStorage.saveSpace(space, true);
+  }
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/UserSpacesStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/UserSpacesStorageTest.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/UserSpacesStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/UserSpacesStorageTest.java
@@ -1,0 +1,340 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.core.jpa.storage;
+
+import static org.junit.Assert.assertThrows;
+
+import org.exoplatform.services.cache.ExoCache;
+import org.exoplatform.social.core.storage.cache.model.data.ListSpacesData;
+import org.exoplatform.social.core.storage.cache.model.key.ListSpacesKey;
+
+import java.util.List;
+
+import org.exoplatform.social.core.jpa.test.AbstractCoreTest;
+import org.exoplatform.social.core.search.Sorting;
+import org.exoplatform.social.core.search.Sorting.OrderBy;
+import org.exoplatform.social.core.search.Sorting.SortBy;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.storage.cache.SocialStorageCacheService;
+
+import io.meeds.social.space.constant.UserSpacesScope;
+
+/**
+ * The profile spaces listing at storage level, run against the real
+ * {@link SocialStorageCacheService} caches — never mocks. A drift in the cache
+ * key of this listing does not merely miss the cache: the key carries an access
+ * control discriminator (the viewer and the scope), so a drift can serve one
+ * viewer's filtered list to another. Only a real cache can catch that.
+ */
+public class UserSpacesStorageTest extends AbstractCoreTest {
+
+  private static final String       OWNER   = "spacesowner";
+
+  private static final String       VIEWER_A = "viewera";
+
+  private static final String       VIEWER_B = "viewerb";
+
+  private SpaceStorage              spaceStorage;
+
+  private Space                     alphaSpace;
+
+  private Space                     betaSpace;
+
+  private Space                     gammaSpace;
+
+  private Space                     deltaSpace;
+
+  private SocialStorageCacheService cacheService;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    spaceStorage = getService(SpaceStorage.class);
+    cacheService = getService(SocialStorageCacheService.class);
+    cacheService.getSpacesCache().clearCache();
+    cacheService.getSpacesCountCache().clearCache();
+  }
+
+  public void testOwnProfileListsHiddenSpacesToo() {
+    createSpaces();
+
+    List<Space> spaces = getUserSpaces(OWNER, UserSpacesScope.ALL);
+
+    assertEquals(4, spaces.size());
+    assertEquals(4, spaceStorage.countUserSpaces(OWNER, OWNER, UserSpacesScope.ALL));
+  }
+
+  public void testVisitedProfileHidesTheHiddenSpacesTheViewerIsNotIn() {
+    createSpaces();
+
+    List<Space> spaces = getUserSpaces(VIEWER_A, UserSpacesScope.ALL);
+
+    // Alpha (common), Beta (common with the other viewer, but public) and
+    // Gamma (private, not hidden) — Delta is hidden and the viewer is not in it
+    assertEquals(3, spaces.size());
+    assertFalse(spaces.stream().anyMatch(space -> space.getVisibility().equals(Space.HIDDEN)));
+    assertEquals(3, spaceStorage.countUserSpaces(VIEWER_A, OWNER, UserSpacesScope.ALL));
+  }
+
+  public void testVisitedProfileListsPrivateSpacesTheViewerIsNotIn() {
+    createSpaces();
+
+    List<Space> spaces = getUserSpaces(VIEWER_A, UserSpacesScope.ALL);
+
+    // PRIVATE is not HIDDEN: it stays listed, the UI differentiates on
+    // membership
+    assertTrue(spaces.stream().anyMatch(space -> space.getDisplayName().equals("Gamma space")));
+  }
+
+  public void testVisitedProfileShowsAHiddenSpaceTheViewerIsAMemberOf() {
+    createSpaces();
+    updateSpace(deltaSpace, 4, "Delta space", Space.HIDDEN, new String[] { OWNER, VIEWER_A });
+
+    List<Space> spaces = getUserSpaces(VIEWER_A, UserSpacesScope.ALL);
+
+    assertEquals(4, spaces.size());
+  }
+
+  public void testCommonScopeKeepsOnlySharedSpaces() {
+    createSpaces();
+
+    List<Space> spaces = getUserSpaces(VIEWER_A, UserSpacesScope.COMMON);
+
+    assertEquals(1, spaces.size());
+    assertEquals("Alpha space", spaces.get(0).getDisplayName());
+    assertEquals(1, spaceStorage.countUserSpaces(VIEWER_A, OWNER, UserSpacesScope.COMMON));
+  }
+
+  public void testTwoViewersNeverShareACacheEntry() {
+    createSpaces();
+
+    // Back to back on the same profile owner and the same scope: the only
+    // difference is the viewer, which must be part of the key
+    List<Space> spacesOfViewerA = getUserSpaces(VIEWER_A, UserSpacesScope.COMMON);
+    List<Space> spacesOfViewerB = getUserSpaces(VIEWER_B, UserSpacesScope.COMMON);
+
+    assertEquals(1, spacesOfViewerA.size());
+    assertEquals(1, spacesOfViewerB.size());
+    assertEquals("Alpha space", spacesOfViewerA.get(0).getDisplayName());
+    assertEquals("Beta space", spacesOfViewerB.get(0).getDisplayName());
+    assertEquals(1, spaceStorage.countUserSpaces(VIEWER_A, OWNER, UserSpacesScope.COMMON));
+    assertEquals(1, spaceStorage.countUserSpaces(VIEWER_B, OWNER, UserSpacesScope.COMMON));
+  }
+
+  public void testScopeIsPartOfTheCacheKey() {
+    createSpaces();
+
+    // Same viewer, same owner, same paging: only the scope differs
+    List<Space> commonSpaces = getUserSpaces(VIEWER_A, UserSpacesScope.COMMON);
+    List<Space> allSpaces = getUserSpaces(VIEWER_A, UserSpacesScope.ALL);
+
+    assertEquals(1, commonSpaces.size());
+    assertEquals(3, allSpaces.size());
+    assertEquals(1, spaceStorage.countUserSpaces(VIEWER_A, OWNER, UserSpacesScope.COMMON));
+    assertEquals(3, spaceStorage.countUserSpaces(VIEWER_A, OWNER, UserSpacesScope.ALL));
+  }
+
+  public void testScopeIsPartOfTheCacheKeyInTheDisclosingDirection() {
+    createSpaces();
+
+    // The reverse order of the test above, which is the dangerous one: the wide
+    // listing is cached first, then the narrow scope is requested. A scope
+    // missing from the key would serve the owner's whole list to a viewer
+    // entitled to the common spaces only.
+    assertEquals(3, getUserSpaces(VIEWER_A, UserSpacesScope.ALL).size());
+    assertEquals(1, getUserSpaces(VIEWER_A, UserSpacesScope.COMMON).size());
+    assertEquals(1, spaceStorage.countUserSpaces(VIEWER_A, OWNER, UserSpacesScope.COMMON));
+  }
+
+  public void testMissingScopeNeverWidensThroughTheCache() {
+    createSpaces();
+
+    // The wide listing is cached first, then the same (viewer, owner) pair is
+    // requested with no scope at all. The predicate builder treats a missing
+    // scope as the restrictive one, and the cache key must classify it the same
+    // way: otherwise the entry cached for ALL answers a request whose predicate
+    // asked for COMMON.
+    assertEquals(3, getUserSpaces(VIEWER_A, UserSpacesScope.ALL).size());
+
+    List<Space> withoutScope = spaceStorage.getUserSpaces(VIEWER_A, OWNER, null, alphabetical(), 0, 20);
+    assertEquals(1, withoutScope.size());
+    assertEquals("Alpha space", withoutScope.get(0).getDisplayName());
+    assertEquals(1, spaceStorage.countUserSpaces(VIEWER_A, OWNER, null));
+  }
+
+  public void testPagesBeyondTheFirstAreNotCached() {
+    createSpaces();
+    ExoCache<ListSpacesKey, ListSpacesData> spacesCache = cacheService.getSpacesCache();
+
+    // The bound this listing accepts on a shared cache: only the page that
+    // renders on every profile view is cached
+    spacesCache.clearCache();
+    spaceStorage.getUserSpaces(VIEWER_A, OWNER, UserSpacesScope.ALL, alphabetical(), 1, 2);
+    assertEquals(0, spacesCache.getCacheSize());
+
+    spaceStorage.getUserSpaces(VIEWER_A, OWNER, UserSpacesScope.ALL, alphabetical(), 0, 2);
+    assertEquals(1, spacesCache.getCacheSize());
+  }
+
+  public void testViewerIsMandatory() {
+    createSpaces();
+
+    // A missing viewer must never degenerate into the unfiltered listing of the
+    // owner's spaces, hidden ones included
+    assertThrows(IllegalArgumentException.class,
+                 () -> spaceStorage.getUserSpaces(null, OWNER, UserSpacesScope.COMMON, alphabetical(), 0, 20));
+    assertThrows(IllegalArgumentException.class,
+                 () -> spaceStorage.getUserSpaces("", OWNER, UserSpacesScope.COMMON, alphabetical(), 0, 20));
+    assertThrows(IllegalArgumentException.class, () -> spaceStorage.countUserSpaces(null, OWNER, UserSpacesScope.COMMON));
+  }
+
+  public void testOwnProfileIsScopeIndependent() {
+    createSpaces();
+
+    // With the viewer as the profile owner the viewer axis matches every space
+    // of the listing, so both scopes return the same rows, hidden ones included.
+    // This is what lets the Service normalise the own profile to a single scope
+    // and the cache key carry it without a third key type.
+    assertEquals(4, getUserSpaces(OWNER, UserSpacesScope.ALL).size());
+    assertEquals(4, getUserSpaces(OWNER, UserSpacesScope.COMMON).size());
+    assertEquals(4, spaceStorage.countUserSpaces(OWNER, OWNER, UserSpacesScope.COMMON));
+  }
+
+  public void testPagesBeyondTheFirstAreNotCachedButStayCorrect() {
+    createSpaces();
+
+    // Only the first page is cached (shared-cache cardinality); the pages below
+    // must still be filtered and ordered identically
+    List<Space> secondPage = spaceStorage.getUserSpaces(VIEWER_A, OWNER, UserSpacesScope.ALL, alphabetical(), 1, 2);
+    assertEquals(2, secondPage.size());
+    assertEquals("Beta space", secondPage.get(0).getDisplayName());
+    assertEquals("Gamma space", secondPage.get(1).getDisplayName());
+    assertFalse(secondPage.stream().anyMatch(space -> space.getVisibility().equals(Space.HIDDEN)));
+  }
+
+  public void testEntryIsEvictedOnAMembershipChangeOfTheViewer() {
+    createSpaces();
+    assertEquals(1, getUserSpaces(VIEWER_B, UserSpacesScope.COMMON).size());
+
+    updateSpace(alphaSpace, 1, "Alpha space", Space.PUBLIC, new String[] { OWNER, VIEWER_A, VIEWER_B });
+
+    assertEquals(2, getUserSpaces(VIEWER_B, UserSpacesScope.COMMON).size());
+    assertEquals(2, spaceStorage.countUserSpaces(VIEWER_B, OWNER, UserSpacesScope.COMMON));
+  }
+
+  public void testEntryIsEvictedOnAMembershipChangeOfTheProfileOwner() {
+    createSpaces();
+    assertEquals(4, getUserSpaces(OWNER, UserSpacesScope.ALL).size());
+
+    updateSpace(alphaSpace, 1, "Alpha space", Space.PUBLIC, new String[] { VIEWER_A });
+
+    assertEquals(3, getUserSpaces(OWNER, UserSpacesScope.ALL).size());
+  }
+
+  public void testEntryIsEvictedWhenASpaceTurnsHidden() {
+    createSpaces();
+    assertEquals(3, getUserSpaces(VIEWER_A, UserSpacesScope.ALL).size());
+
+    updateSpace(gammaSpace, 3, "Gamma space", Space.HIDDEN, new String[] { OWNER });
+
+    // A stale entry here would keep exposing a space that has just been hidden
+    assertEquals(2, getUserSpaces(VIEWER_A, UserSpacesScope.ALL).size());
+  }
+
+  public void testOnlyMemberRoleIsListed() {
+    Space invited = getSpaceInstance(5, "Epsilon space", Space.PUBLIC, new String[] { "someoneelse" });
+    invited.setInvitedUsers(new String[] { OWNER });
+    invited.setPendingUsers(new String[] { VIEWER_A });
+    spaceStorage.saveSpace(invited, true);
+
+    // The profile owner is only invited to that space
+    assertEquals(0, getUserSpaces(OWNER, UserSpacesScope.ALL).size());
+    // ... and a pending viewer shares nothing with anybody
+    assertEquals(0, spaceStorage.countUserSpaces(VIEWER_A, "someoneelse", UserSpacesScope.COMMON));
+  }
+
+  public void testListingIsOrderedAlphabetically() {
+    createSpaces();
+
+    List<Space> spaces = getUserSpaces(OWNER, UserSpacesScope.ALL);
+
+    assertEquals("Alpha space", spaces.get(0).getDisplayName());
+    assertEquals("Beta space", spaces.get(1).getDisplayName());
+    assertEquals("Delta space", spaces.get(2).getDisplayName());
+    assertEquals("Gamma space", spaces.get(3).getDisplayName());
+  }
+
+  public void testListingIsPagedByTheDatastore() {
+    createSpaces();
+
+    List<Space> firstPage = spaceStorage.getUserSpaces(OWNER, OWNER, UserSpacesScope.ALL, alphabetical(), 0, 2);
+    List<Space> secondPage = spaceStorage.getUserSpaces(OWNER, OWNER, UserSpacesScope.ALL, alphabetical(), 2, 2);
+
+    assertEquals(2, firstPage.size());
+    assertEquals(2, secondPage.size());
+    assertEquals("Alpha space", firstPage.get(0).getDisplayName());
+    assertEquals("Delta space", secondPage.get(0).getDisplayName());
+  }
+
+  private List<Space> getUserSpaces(String viewerUsername, UserSpacesScope scope) {
+    return spaceStorage.getUserSpaces(viewerUsername, OWNER, scope, alphabetical(), 0, 20);
+  }
+
+  private Sorting alphabetical() {
+    return new Sorting(SortBy.TITLE, OrderBy.ASC);
+  }
+
+  private void createSpaces() {
+    alphaSpace = spaceStorage.saveSpace(getSpaceInstance(1, "Alpha space", Space.PUBLIC, new String[] { OWNER, VIEWER_A }),
+                                        true);
+    betaSpace = spaceStorage.saveSpace(getSpaceInstance(2, "Beta space", Space.PUBLIC, new String[] { OWNER, VIEWER_B }), true);
+    gammaSpace = spaceStorage.saveSpace(getSpaceInstance(3, "Gamma space", Space.PRIVATE, new String[] { OWNER }), true);
+    deltaSpace = spaceStorage.saveSpace(getSpaceInstance(4, "Delta space", Space.HIDDEN, new String[] { OWNER }), true);
+    restartTransaction();
+  }
+
+  /**
+   * Saves a full space definition over an existing one. A space reloaded from
+   * the cache can carry a simplified form with no membership array, so the
+   * update is built from the same helper as the creation and only reuses the
+   * stored identifier.
+   */
+  private void updateSpace(Space stored, int number, String displayName, String visibility, String[] members) {
+    Space update = getSpaceInstance(number, displayName, visibility, members);
+    update.setId(stored.getId());
+    spaceStorage.saveSpace(update, false);
+    restartTransaction();
+  }
+
+  private Space getSpaceInstance(int number, String displayName, String visibility, String[] members) {
+    Space space = new Space();
+    space.setDisplayName(displayName);
+    space.setPrettyName(displayName);
+    space.setRegistration(Space.OPEN);
+    space.setDescription("space " + number);
+    space.setVisibility(visibility);
+    space.setGroupId("/spaces/userspaces" + number);
+    space.setUrl(space.getPrettyName());
+    space.setManagers(new String[] { members[0] });
+    space.setMembers(members);
+    space.setInvitedUsers(new String[] {});
+    space.setPendingUsers(new String[] {});
+    return space;
+  }
+}

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/test/InitContainerTestSuite.java
@@ -38,6 +38,7 @@ import org.exoplatform.social.core.jpa.storage.ProfileLabelStorageTest;
 import org.exoplatform.social.core.jpa.storage.ProfileSettingStorageTest;
 import org.exoplatform.social.core.jpa.storage.RelationshipStorageTest;
 import org.exoplatform.social.core.jpa.storage.SpaceStorageTest;
+import org.exoplatform.social.core.jpa.storage.UserSpacesStorageTest;
 import org.exoplatform.social.core.jpa.storage.dao.ActivityDAOTest;
 import org.exoplatform.social.core.jpa.storage.dao.IdentityDAOTest;
 import org.exoplatform.social.core.jpa.storage.dao.ProfileLabelDAOTest;
@@ -67,6 +68,8 @@ import org.exoplatform.social.core.service.ProfileLabelServiceTest;
 import org.exoplatform.social.core.space.SpaceLifeCycleTest;
 import org.exoplatform.social.core.space.SpaceUtilsTest;
 import org.exoplatform.social.core.space.spi.SpaceServiceTest;
+
+import io.meeds.social.space.service.UserSpacesServiceTest;
 import org.exoplatform.social.core.thumbnail.ImageThumbnailServiceImplTest;
 import org.exoplatform.social.core.utils.MentionUtilsTest;
 import org.exoplatform.social.metadata.MetadataServiceTest;
@@ -86,6 +89,7 @@ import io.meeds.social.translation.service.TranslationServiceTest;
   StreamItemDAOTest.class,
   RelationshipStorageTest.class,
   SpaceStorageTest.class,
+  UserSpacesStorageTest.class,
   IdentityStorageTest.class,
   ProfileSettingStorageTest.class,
   ProfileLabelStorageTest.class,
@@ -101,6 +105,7 @@ import io.meeds.social.translation.service.TranslationServiceTest;
   ActivityManagerTest.class,
   IdentityManagerTest.class,
   SpaceServiceTest.class,
+  UserSpacesServiceTest.class,
   RelationshipManagerTest.class,
   SpaceUtilsTest.class,
   SpaceLifeCycleTest.class,

--- a/component/service/src/main/java/io/meeds/social/space/rest/UserSpacesRest.java
+++ b/component/service/src/main/java/io/meeds/social/space/rest/UserSpacesRest.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/service/src/main/java/io/meeds/social/space/rest/UserSpacesRest.java
+++ b/component/service/src/main/java/io/meeds/social/space/rest/UserSpacesRest.java
@@ -1,0 +1,126 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.space.rest;
+
+import java.util.List;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.social.space.constant.UserSpacesScope;
+import io.meeds.social.space.rest.model.UserSpace;
+import io.meeds.social.space.rest.model.UserSpaceList;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Lists the spaces of a profile owner as they are visible to the current user.
+ * <p>
+ * {@code @Secured("users")} is the correct and sufficient annotation, and an
+ * external viewer is deliberately served by it: the roles extractor adds the
+ * users role to any identity already carrying externals, so the annotation
+ * cannot discriminate an external viewer. That discrimination lives in the
+ * Service, which is also where the requested scope is narrowed (eXIP 7.3.0.18,
+ * note 50524, decision D5). This layer validates parameters and nothing else.
+ */
+@RestController
+@RequestMapping("/users")
+@Tag(name = "/social/rest/users", description = "Managing the spaces listed on a user profile")
+public class UserSpacesRest {
+
+  private static final int   MAX_LIMIT = 100;
+
+  @Autowired
+  private SpaceService       spaceService;
+
+  @GetMapping("/{username}/spaces")
+  @Secured("users")
+  @Operation(summary = "Retrieve the spaces of a user profile", method = "GET",
+             description = "This retrieves the spaces of the designated user, restricted to what the currently authenticated user is allowed to see")
+  @ApiResponses(value = {
+                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+                          @ApiResponse(responseCode = "400", description = "Invalid query input"),
+                          @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                          @ApiResponse(responseCode = "404", description = "User not found"),
+  })
+  public UserSpaceList getUserSpaces(HttpServletRequest request,
+                                     @Parameter(description = "User name of the profile owner", required = true)
+                                     @PathVariable("username")
+                                     String username,
+                                     @Parameter(description = "Whether to list the spaces shared with the viewer only, or every space of the profile owner the viewer may see. A scope the viewer may not use is narrowed by the service, it is not refused.")
+                                     @RequestParam(name = "scope", required = false)
+                                     UserSpacesScope scope,
+                                     @Parameter(description = "Offset of the first returned space")
+                                     @RequestParam(name = "offset", required = false, defaultValue = "0")
+                                     int offset,
+                                     @Parameter(description = "Maximum number of returned spaces")
+                                     @RequestParam(name = "limit", required = false, defaultValue = "20")
+                                     int limit,
+                                     @Parameter(description = "Whether to return the total size of the listing, which costs an extra query")
+                                     @RequestParam(name = "returnSize", required = false, defaultValue = "false")
+                                     boolean returnSize) {
+    if (offset < 0) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "space.offsetMustBePositive");
+    }
+    if (limit <= 0 || limit > MAX_LIMIT) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "space.limitOutOfRange");
+    }
+    String viewerUsername = request.getRemoteUser();
+    try {
+      List<UserSpace> spaces = spaceService.getUserSpaces(viewerUsername, username, scope, offset, limit)
+                                           .stream()
+                                           .map(space -> toUserSpace(space, viewerUsername))
+                                           .toList();
+      Integer size = returnSize ? spaceService.countUserSpaces(viewerUsername, username, scope) : null;
+      return new UserSpaceList(spaces, size);
+    } catch (ObjectNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+  }
+
+  private UserSpace toUserSpace(Space space, String viewerUsername) {
+    return new UserSpace(space.getSpaceId(),
+                         space.getDisplayName(),
+                         space.getPrettyName(),
+                         space.getUrl(),
+                         space.getAvatarUrl(),
+                         space.getVisibility(),
+                         ArrayUtils.getLength(space.getMembers()),
+                         spaceService.isMember(space, viewerUsername));
+  }
+
+}

--- a/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpace.java
+++ b/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpace.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpace.java
+++ b/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpace.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.space.rest.model;
+
+/**
+ * A space of a profile owner, as it is displayed to a viewer.
+ * <p>
+ * Everything the listing renders is carried here on purpose. A viewer may see a
+ * space they are not a member of — a PRIVATE space is listed, only HIDDEN ones
+ * are filtered out — and resolving such a space through the per-space endpoints
+ * would be refused, leaving the UI to render a placeholder for a space it was
+ * told to display. {@code member} lets the UI present the two cases
+ * differently instead.
+ *
+ * @param id space technical identifier
+ * @param displayName space name as displayed
+ * @param prettyName space name as used in URLs
+ * @param url space home URL
+ * @param avatarUrl space avatar URL, null when the space has none
+ * @param visibility space visibility
+ * @param membersCount number of members of the space
+ * @param member whether the viewer is a member of the space
+ */
+public record UserSpace(long id,
+                        String displayName,
+                        String prettyName,
+                        String url,
+                        String avatarUrl,
+                        String visibility,
+                        int membersCount,
+                        boolean member) {
+}

--- a/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpaceList.java
+++ b/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpaceList.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpaceList.java
+++ b/component/service/src/main/java/io/meeds/social/space/rest/model/UserSpaceList.java
@@ -16,28 +16,20 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.exoplatform.social.core.storage.cache.model.key;
+package io.meeds.social.space.rest.model;
 
-public enum SpaceType {
-  MEMBER,
-  MANAGER,
-  PENDING,
-  INVITED,
-  PUBLIC,
-  ACCESSIBLE,
-  VISIBLE,
-  ALL,
-  LATEST_ACCESSED,
-  MEMBER_IDENTITY_IDS,
-  MEMBER_IDS,
-  /**
-   * A profile owner's spaces, restricted to the ones shared with the viewer
-   * carried by {@link SpaceFilterKey#getViewerId()}.
-   */
-  USER_SPACES_COMMON,
-  /**
-   * A profile owner's spaces, minus the hidden ones the viewer carried by
-   * {@link SpaceFilterKey#getViewerId()} is not a member of.
-   */
-  USER_SPACES_ALL
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A page of a profile owner's spaces.
+ *
+ * @param spaces the page of spaces
+ * @param size the total number of spaces the viewer may see, null unless it was
+ *          requested — the widget displays no total and must not pay for the
+ *          count query, the "See all" drawer does (eXIP 7.3.0.18, note 50524 §2)
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record UserSpaceList(List<UserSpace> spaces, Integer size) {
 }

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRest.java
@@ -140,6 +140,7 @@ import io.meeds.social.core.identity.model.UserImportResult;
 import io.meeds.social.core.identity.service.UserExportService;
 import io.meeds.social.core.identity.service.UserImportService;
 import io.meeds.social.image.plugin.FileThumbnailPlugin;
+import io.meeds.social.space.constant.UserSpacesScope;
 import io.meeds.web.security.service.OtpService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -1614,10 +1615,18 @@ public class UserRest implements ResourceContainer, Startable {
     return EntityBuilder.getResponse(collectionUser, uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);
   }
 
+  /**
+   * @deprecated since 7.3.0, use {@code GET /social/rest/users/{username}/spaces}
+   *             (io.meeds.social.space.rest.UserSpacesRest) instead: it applies the
+   *             viewer's visibility rules in the Service layer and takes the scope
+   *             (common spaces or all visible spaces) as a parameter. Kept for the
+   *             integrations that still call it; not scheduled for removal yet.
+   */
+  @Deprecated
   @GET
   @Path("{id}/spaces")
   @RolesAllowed("users")
-  @Operation(summary = "Gets spaces of a specific user", method = "GET", description = "This returns a list of spaces in the following cases: <br/><ul><li>the given user is the authenticated user</li><li>the authenticated user is in the group /platform/administrators</li></ul>")
+  @Operation(summary = "Gets spaces of a specific user", method = "GET", deprecated = true, description = "Deprecated: use GET /social/rest/users/{username}/spaces. This returns the spaces of the given user to the authenticated user when they are the given user, a member of /platform/administrators or in a confirmed relationship with the given user. For a connection, the listing is restricted to what that connection may see: hidden spaces they are not a member of are left out.")
   public Response getSpacesOfUser(
                                   @Context
                                   UriInfo uriInfo,
@@ -1641,7 +1650,10 @@ public class UserRest implements ResourceContainer, Startable {
                                   String expand) throws Exception {
 
     offset = offset > 0 ? offset : RestUtils.getOffset(uriInfo);
-    limit = limit > 0 ? limit : RestUtils.getLimit(uriInfo);
+    // An explicit limit is bounded like the implicit one: the listing below is
+    // served from a first-page cache keyed on the limit, so an unbounded value
+    // would multiply its entries
+    limit = limit > 0 ? Math.min(limit, RestUtils.HARD_LIMIT) : RestUtils.getLimit(uriInfo);
 
     Identity target = identityManager.getOrCreateUserIdentity(id);
     // Check if the given user exists
@@ -1662,26 +1674,50 @@ public class UserRest implements ResourceContainer, Startable {
       }
     }
 
+    // The relationship gate above decides who may ask; what they receive is
+    // decided once, in SpaceService.getUserSpaces: a connection no longer gets
+    // the hidden spaces they are not a member of (eXIP note 50524, Security,
+    // point O1). The super user keeps the unfiltered listing this operation has
+    // always documented for administrators.
+    List<Space> spaces;
+    int size;
+    if (userACL.getSuperUser().equals(authenticatedUser)) {
+      ListAccess<Space> listAccess = spaceService.getMemberSpaces(id);
+      spaces = Arrays.asList(listAccess.load(offset, limit));
+      size = returnSize ? listAccess.getSize() : 0;
+    } else {
+      try {
+        spaces = spaceService.getUserSpaces(authenticatedUser, id, UserSpacesScope.ALL, offset, limit);
+        size = returnSize ? spaceService.countUserSpaces(authenticatedUser, id, UserSpacesScope.ALL) : 0;
+      } catch (ObjectNotFoundException e) {
+        throw new WebApplicationException(Response.Status.NOT_FOUND);
+      }
+    }
     List<DataEntity> spaceInfos = new ArrayList<>();
-    ListAccess<Space> listAccess = spaceService.getMemberSpaces(id);
-
-    for (Space space : listAccess.load(offset, limit)) {
+    for (Space space : spaces) {
       SpaceEntity spaceInfo = EntityBuilder.buildEntityFromSpace(space, id, uriInfo.getPath(), expand);
-      //
       spaceInfos.add(spaceInfo.getDataEntity());
     }
     CollectionEntity collectionSpace = new CollectionEntity(spaceInfos, EntityBuilder.SPACES_TYPE, offset, limit);
     if (returnSize) {
-      collectionSpace.setSize(listAccess.getSize());
+      collectionSpace.setSize(size);
     }
 
     return EntityBuilder.getResponse(collectionSpace, uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);
   }
 
+  /**
+   * @deprecated since 7.3.0, use {@code GET /social/rest/users/{username}/spaces?scope=COMMON}
+   *             (io.meeds.social.space.rest.UserSpacesRest) instead, which lists the
+   *             spaces shared between the authenticated user and the given profile
+   *             with the visibility rules applied in the Service layer. Kept for the
+   *             integrations that still call it; not scheduled for removal yet.
+   */
+  @Deprecated
   @GET
   @Path("{userId}/spaces/{profileId}")
   @RolesAllowed("users")
-  @Operation(summary = "Gets commons spaces of current user", method = "GET", description = "This returns a list of commons spaces in the following cases: <br/><ul><li>the given user is the authenticated user</li><li>the authenticated user is in the group /platform/administrators</li></ul>")
+  @Operation(summary = "Gets commons spaces of current user", method = "GET", deprecated = true, description = "Deprecated: use GET /social/rest/users/{username}/spaces?scope=COMMON. This returns a list of commons spaces in the following cases: <br/><ul><li>the given user is the authenticated user</li><li>the authenticated user is in the group /platform/administrators</li></ul>")
   public Response getCommonSpacesOfUser(
                                         @Context
                                         UriInfo uriInfo,

--- a/component/service/src/test/java/io/meeds/social/space/rest/UserSpacesRestTest.java
+++ b/component/service/src/test/java/io/meeds/social/space/rest/UserSpacesRestTest.java
@@ -1,7 +1,7 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/component/service/src/test/java/io/meeds/social/space/rest/UserSpacesRestTest.java
+++ b/component/service/src/test/java/io/meeds/social/space/rest/UserSpacesRestTest.java
@@ -1,0 +1,219 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.social.space.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.social.space.constant.UserSpacesScope;
+import io.meeds.spring.web.security.PortalAuthenticationManager;
+import io.meeds.spring.web.security.WebSecurityConfiguration;
+
+import jakarta.servlet.Filter;
+
+/**
+ * The REST contract of the profile spaces listing: parameter validation, the
+ * status mapping, and the role the annotation actually requires.
+ * <p>
+ * The controller decides nothing about visibility — the scope travels to the
+ * Service untouched, and these tests assert exactly that, because a controller
+ * that "helpfully" defaulted or rejected a scope would move an access-control
+ * decision out of the one place that owns it.
+ */
+@SpringBootTest(classes = { UserSpacesRest.class, PortalAuthenticationManager.class, })
+@ContextConfiguration(classes = { WebSecurityConfiguration.class })
+@AutoConfigureWebMvc
+@AutoConfigureMockMvc(addFilters = false)
+@RunWith(SpringRunner.class)
+public class UserSpacesRestTest {
+
+  private static final String   OWNER_SPACES_PATH = "/users/john/spaces";
+
+  private static final String   VIEWER            = "mary";
+
+  private static final String   OWNER             = "john";
+
+  private static final String   TEST_PASSWORD     = "testPassword";
+
+  @Autowired
+  private SecurityFilterChain   filterChain;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @MockBean
+  private SpaceService          spaceService;
+
+  private MockMvc               mockMvc;
+
+  @Before
+  public void setup() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                             .addFilters(filterChain.getFilters().toArray(new Filter[0]))
+                             .build();
+  }
+
+  @Test
+  public void testAnonymousIsRefused() throws Exception {
+    // 403, not 401: on a @Secured method an anonymous request is an access
+    // denial for this filter chain, as the sibling controllers' tests show
+    // (CategoryLinkRestTest, ContentLinkRestTest). The 401 of CategoryRestTest
+    // belongs to endpoints carrying no @Secured at all.
+    mockMvc.perform(get(OWNER_SPACES_PATH)).andExpect(status().isForbidden());
+    verify(spaceService, never()).getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong());
+  }
+
+  @Test
+  public void testExternalViewerIsGrantedAccessByTheUsersRole() throws Exception {
+    when(spaceService.getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong())).thenReturn(List.of());
+
+    // An external identity carries both roles: the roles extractor adds users to
+    // any identity holding externals. The annotation therefore lets them in, and
+    // the Service — not this layer — narrows what they see.
+    mockMvc.perform(get(OWNER_SPACES_PATH).with(externalViewer())).andExpect(status().isOk());
+    verify(spaceService).getUserSpaces("external", OWNER, null, 0L, 20L);
+  }
+
+  @Test
+  public void testViewerWithoutTheUsersRoleIsForbidden() throws Exception {
+    mockMvc.perform(get(OWNER_SPACES_PATH).with(user("guest").password(TEST_PASSWORD)
+                                                             .authorities(new SimpleGrantedAuthority("anything"))))
+           .andExpect(status().isForbidden());
+    verify(spaceService, never()).getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong());
+  }
+
+  @Test
+  public void testScopeTravelsToTheServiceUntouched() throws Exception {
+    when(spaceService.getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong())).thenReturn(List.of());
+
+    mockMvc.perform(get(OWNER_SPACES_PATH + "?scope=ALL").with(viewer())).andExpect(status().isOk());
+    verify(spaceService).getUserSpaces(VIEWER, OWNER, UserSpacesScope.ALL, 0L, 20L);
+
+    mockMvc.perform(get(OWNER_SPACES_PATH + "?scope=COMMON").with(viewer())).andExpect(status().isOk());
+    verify(spaceService).getUserSpaces(VIEWER, OWNER, UserSpacesScope.COMMON, 0L, 20L);
+  }
+
+  @Test
+  public void testListingCarriesWhatTheUiNeeds() throws Exception {
+    Space space = new Space();
+    space.setId("42");
+    space.setDisplayName("Alpha space");
+    space.setPrettyName("alpha_space");
+    space.setUrl("alpha_space");
+    space.setVisibility(Space.PRIVATE);
+    space.setMembers(new String[] { OWNER, "someoneelse" });
+    when(spaceService.getUserSpaces(eq(VIEWER), eq(OWNER), any(), anyLong(), anyLong())).thenReturn(List.of(space));
+    when(spaceService.isMember(space, VIEWER)).thenReturn(false);
+
+    mockMvc.perform(get(OWNER_SPACES_PATH).with(viewer()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.spaces[0].id").value(42))
+           .andExpect(jsonPath("$.spaces[0].displayName").value("Alpha space"))
+           .andExpect(jsonPath("$.spaces[0].visibility").value(Space.PRIVATE))
+           .andExpect(jsonPath("$.spaces[0].membersCount").value(2))
+           // A private space the viewer is not in is listed; the flag is what
+           // lets the UI render it without pretending the viewer belongs to it
+           .andExpect(jsonPath("$.spaces[0].member").value(false))
+           // doesNotExist() also passes for "size": null, so pin the raw shape
+           .andExpect(content().string(not(containsString("\"size\""))));
+  }
+
+  @Test
+  public void testTotalSizeIsOnlyComputedWhenAsked() throws Exception {
+    when(spaceService.getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong())).thenReturn(List.of());
+
+    mockMvc.perform(get(OWNER_SPACES_PATH).with(viewer())).andExpect(status().isOk());
+    verify(spaceService, never()).countUserSpaces(anyString(), anyString(), any());
+
+    when(spaceService.countUserSpaces(VIEWER, OWNER, null)).thenReturn(7);
+    mockMvc.perform(get(OWNER_SPACES_PATH + "?returnSize=true").with(viewer()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.size").value(7));
+  }
+
+  @Test
+  public void testUnknownProfileOwnerIsNotFound() throws Exception {
+    when(spaceService.getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong()))
+                                                                                          .thenThrow(ObjectNotFoundException.class);
+
+    mockMvc.perform(get(OWNER_SPACES_PATH).with(viewer())).andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void testInvalidPagingIsRejected() throws Exception {
+    mockMvc.perform(get(OWNER_SPACES_PATH + "?offset=-1").with(viewer())).andExpect(status().isBadRequest());
+    mockMvc.perform(get(OWNER_SPACES_PATH + "?limit=0").with(viewer())).andExpect(status().isBadRequest());
+    // The page size is bounded: it is a cache key dimension as well as a query
+    // bound, so an unbounded value is refused rather than clamped silently
+    mockMvc.perform(get(OWNER_SPACES_PATH + "?limit=1000").with(viewer())).andExpect(status().isBadRequest());
+    verify(spaceService, never()).getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong());
+  }
+
+  @Test
+  public void testUnknownScopeIsRejected() throws Exception {
+    mockMvc.perform(get(OWNER_SPACES_PATH + "?scope=EVERYTHING").with(viewer())).andExpect(status().isBadRequest());
+    verify(spaceService, never()).getUserSpaces(anyString(), anyString(), any(), anyLong(), anyLong());
+  }
+
+  private RequestPostProcessor viewer() {
+    return user(VIEWER).password(TEST_PASSWORD).authorities(new SimpleGrantedAuthority("users"));
+  }
+
+  private RequestPostProcessor externalViewer() {
+    return user("external").password(TEST_PASSWORD)
+                           .authorities(new SimpleGrantedAuthority("users"), new SimpleGrantedAuthority("externals"));
+  }
+
+}

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/users/UserRestResourcesTest.java
@@ -736,6 +736,51 @@ public class UserRestResourcesTest extends AbstractResourceTest {
     assertEquals(2, collections.getEntities().size());
   }
 
+  public void testGetSpacesOfUserHidesTheHiddenSpacesAConnectionIsNotIn() throws Exception {
+    // john has a public space and a hidden one. mary and demo are both connected
+    // to john; only demo is a member of the hidden space.
+    getSpaceInstance(10, "john");
+    Space hiddenSpace = getSpaceInstance(11, "john");
+    hiddenSpace.setVisibility(Space.HIDDEN);
+    hiddenSpace.setMembers(new String[] { "john", "demo" });
+    spaceService.updateSpace(hiddenSpace);
+
+    relationshipManager.inviteToConnect(maryIdentity, johnIdentity);
+    relationshipManager.confirm(johnIdentity, maryIdentity);
+    relationshipManager.inviteToConnect(demoIdentity, johnIdentity);
+    relationshipManager.confirm(johnIdentity, demoIdentity);
+
+    // A connection who is not a member of the hidden space does not receive it
+    // (eXIP note 50524, Security, point O1): the legacy listing applies the same
+    // visibility rules as GET /social/rest/users/{username}/spaces
+    startSessionAs("mary");
+    ContainerResponse response = service("GET", getURLResource("users/john/spaces?limit=5&offset=0&returnSize=true"), "", null, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    CollectionEntity collections = (CollectionEntity) response.getEntity();
+    assertEquals(1, collections.getEntities().size());
+    assertEquals(1, collections.getSize());
+
+    // A connection who is a member of the hidden space still receives it
+    startSessionAs("demo");
+    response = service("GET", getURLResource("users/john/spaces?limit=5&offset=0&returnSize=true"), "", null, null);
+    assertEquals(200, response.getStatus());
+    collections = (CollectionEntity) response.getEntity();
+    assertEquals(2, collections.getEntities().size());
+    assertEquals(2, collections.getSize());
+
+    // The owner and the super user keep the whole listing
+    startSessionAs("john");
+    response = service("GET", getURLResource("users/john/spaces?limit=5&offset=0"), "", null, null);
+    assertEquals(200, response.getStatus());
+    assertEquals(2, ((CollectionEntity) response.getEntity()).getEntities().size());
+
+    startSessionAs("root");
+    response = service("GET", getURLResource("users/john/spaces?limit=5&offset=0"), "", null, null);
+    assertEquals(200, response.getStatus());
+    assertEquals(2, ((CollectionEntity) response.getEntity()).getEntities().size());
+  }
+
   public void testGetCommonSpaces() throws Exception {
     Space spaceTest = getSpaceInstance(0, "root");
     Space spaceTest1 = getSpaceInstance(1, "demo");

--- a/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
@@ -19,6 +19,8 @@
 package org.exoplatform.social.service.test;
 
 import io.meeds.social.security.rest.LoginRestTest;
+import io.meeds.social.security.rest.OtpRestTest;
+import io.meeds.social.space.rest.UserSpacesRestTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -66,6 +68,7 @@ import io.meeds.social.translation.rest.TranslationRestResourcesTest;
   FavoriteRestTest.class,
   TranslationRestResourcesTest.class,
   ObserverRestTest.class,
+  UserSpacesRestTest.class,
   SkinRestTest.class,
   SiteRestTest.class,
   CategoryRestTest.class,

--- a/component/web/src/main/java/org/exoplatform/social/webui/URLUtils.java
+++ b/component/web/src/main/java/org/exoplatform/social/webui/URLUtils.java
@@ -39,6 +39,34 @@ import org.exoplatform.web.application.RequestContext;
 public class URLUtils {
 
   /**
+   * @return the user carried by the current page URL — the profile owner on a
+   *         profile or activity-stream page — or null when the URL carries
+   *         none. Unlike {@link #getCurrentUser()}, no accessibility filtering
+   *         is applied: this answers "is this page about a user, and which one",
+   *         while what the viewer may see of that user belongs to the service
+   *         consuming the answer. getCurrentUser() returns null for an external
+   *         viewer on a profile it may not access, which conflates "not a
+   *         user-scoped page" with "not accessible" — a widget switching modes
+   *         on that null would silently fall back to its non-profile behaviour
+   *         on a profile page.
+   */
+  public static String getStreamOwnerId() {
+    PortalRequestContext pcontext = getPortalRequestContext();
+    String requestPath = "/" + pcontext.getControllerContext().getParameter(RequestNavigationData.REQUEST_PATH);
+    Route route = ExoRouter.route(requestPath);
+    if (route == null) {
+      return null;
+    }
+    String currentUserName = route.localArgs.get("streamOwnerId");
+    if (currentUserName == null) {
+      return null;
+    }
+    IdentityManager identityManager = ExoContainerContext.getService(IdentityManager.class);
+    Identity identity = identityManager.getOrCreateUserIdentity(currentUserName);
+    return identity == null ? null : identity.getRemoteId();
+  }
+
+  /**
    * @return current user name base on analysis of current url
    */
   public static String getCurrentUser() {

--- a/component/web/src/main/java/org/exoplatform/social/webui/URLUtils.java
+++ b/component/web/src/main/java/org/exoplatform/social/webui/URLUtils.java
@@ -25,6 +25,7 @@ import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.application.RequestNavigationData;
+import org.exoplatform.portal.mop.SiteType;
 import org.exoplatform.social.common.router.ExoRouter;
 import org.exoplatform.social.common.router.ExoRouter.Route;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -53,6 +54,16 @@ public class URLUtils {
   public static String getStreamOwnerId() {
     PortalRequestContext pcontext = getPortalRequestContext();
     String requestPath = "/" + pcontext.getControllerContext().getParameter(RequestNavigationData.REQUEST_PATH);
+    // Opening one's own profile through the navigation carries no username
+    // segment (/profile, not /profile/{username}): the owner is the viewer —
+    // the fallback Utils.getOwnerRemoteId() has always applied. Scoped by
+    // path shape AND site type: a group/space site whose nav path is also
+    // the single segment "profile" (a space named "Profile") must not gain
+    // an implicit owner.
+    if (("/profile".equals(requestPath) || "/profile/".equals(requestPath))
+        && SiteType.PORTAL == pcontext.getSiteType()) {
+      return pcontext.getRemoteUser();
+    }
     Route route = ExoRouter.route(requestPath);
     if (route == null) {
       return null;

--- a/component/web/src/test/java/org/exoplatform/social/webui/URLUtilsTest.java
+++ b/component/web/src/test/java/org/exoplatform/social/webui/URLUtilsTest.java
@@ -1,0 +1,133 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.social.webui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.application.RequestNavigationData;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.social.common.router.ExoRouter;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.web.ControllerContext;
+import org.exoplatform.web.application.RequestContext;
+
+/**
+ * The profile-mode discriminator of the User Spaces List widget (EXO-89465):
+ * {@link URLUtils#getStreamOwnerId()} must name the profile owner on BOTH
+ * shapes of the profile URL — /profile/{username} (visited profile) and the
+ * bare /profile the navigation uses for one's own profile — and stay null on
+ * any other page, or the widget silently falls back to analytics mode.
+ */
+class URLUtilsTest {
+
+  private static final String        VIEWER = "mary";
+
+  private MockedStatic<RequestContext> requestContext;
+
+  private PortalRequestContext        pcontext;
+
+  private ControllerContext           controllerContext;
+
+  @BeforeEach
+  void setUp() {
+    pcontext = mock(PortalRequestContext.class);
+    controllerContext = mock(ControllerContext.class);
+    when(pcontext.getControllerContext()).thenReturn(controllerContext);
+    when(pcontext.getSiteType()).thenReturn(SiteType.PORTAL);
+    requestContext = mockStatic(RequestContext.class);
+    requestContext.when(RequestContext::getCurrentInstance).thenReturn(pcontext);
+    // The same route the production config registers for the profile page
+    ExoRouter.reset();
+    ExoRouter.addRoute("/profile/{streamOwnerId}", "profile.owner.show");
+  }
+
+  @AfterEach
+  void tearDown() {
+    requestContext.close();
+    ExoRouter.reset();
+  }
+
+  private void givenRequestPath(String path) {
+    when(controllerContext.getParameter(RequestNavigationData.REQUEST_PATH)).thenReturn(path);
+  }
+
+  @Test
+  void ownProfileWithoutUsernameSegmentReturnsTheViewer() {
+    givenRequestPath("profile");
+    when(pcontext.getRemoteUser()).thenReturn(VIEWER);
+    assertEquals(VIEWER, URLUtils.getStreamOwnerId());
+  }
+
+  @Test
+  void visitedProfileReturnsTheUserCarriedByTheUrl() {
+    givenRequestPath("profile/john");
+    Identity identity = mock(Identity.class);
+    when(identity.getRemoteId()).thenReturn("john");
+    IdentityManager identityManager = mock(IdentityManager.class);
+    when(identityManager.getOrCreateUserIdentity("john")).thenReturn(identity);
+    try (MockedStatic<ExoContainerContext> containerContext = mockStatic(ExoContainerContext.class)) {
+      containerContext.when(() -> ExoContainerContext.getService(IdentityManager.class)).thenReturn(identityManager);
+      assertEquals("john", URLUtils.getStreamOwnerId());
+    }
+  }
+
+  @Test
+  void nonProfilePageCarriesNoOwner() {
+    givenRequestPath("home");
+    assertNull(URLUtils.getStreamOwnerId());
+  }
+
+  @Test
+  void bareProfileWithoutAuthenticatedViewerCarriesNoOwner() {
+    givenRequestPath("profile");
+    when(pcontext.getRemoteUser()).thenReturn(null);
+    assertNull(URLUtils.getStreamOwnerId());
+  }
+
+  @Test
+  void bareProfileWithTrailingSlashReturnsTheViewer() {
+    givenRequestPath("profile/");
+    when(pcontext.getRemoteUser()).thenReturn(VIEWER);
+    assertEquals(VIEWER, URLUtils.getStreamOwnerId());
+  }
+
+  @Test
+  void groupSitePageNamedProfileCarriesNoOwner() {
+    // A space whose pretty name is "profile" navigates with the same
+    // single-segment path on a GROUP site — it must not gain an implicit
+    // owner. The viewer stub matters: without it a guard that wrongly fires
+    // here still returns null and the pin passes against the very bug.
+    givenRequestPath("profile");
+    when(pcontext.getSiteType()).thenReturn(SiteType.GROUP);
+    when(pcontext.getRemoteUser()).thenReturn(VIEWER);
+    assertNull(URLUtils.getStreamOwnerId());
+  }
+}

--- a/webapp/src/main/webapp/vue-apps/common/js/SpaceService.js
+++ b/webapp/src/main/webapp/vue-apps/common/js/SpaceService.js
@@ -138,6 +138,30 @@ export function getSpaces(query, offset, limit, filter, expand, templateId, sort
   });
 }
 
+export function getUserSpaces(username, offset, limit, scope, returnSize) {
+  const params = new URLSearchParams({
+    // ?? and not ||: a deliberate 0 must reach the endpoint's own validation
+    // rather than being silently rewritten
+    offset: offset ?? 0,
+    limit: limit ?? 20,
+  });
+  if (scope) {
+    params.append('scope', scope);
+  }
+  if (returnSize) {
+    params.append('returnSize', 'true');
+  }
+  return fetch(`/social/rest/users/${encodeURIComponent(username)}/spaces?${params.toString()}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error(`Error ${resp && resp.status} while listing the spaces of user ${username}`);
+    }
+    return resp.json();
+  });
+}
+
 export function getSpacesByFilter(options) {
   const formData = new FormData();
   if (options.expand) {

--- a/webapp/src/main/webapp/vue-apps/idm-groups-management/components/members/GroupMembersList.vue
+++ b/webapp/src/main/webapp/vue-apps/idm-groups-management/components/members/GroupMembersList.vue
@@ -48,13 +48,13 @@
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
             <v-btn
-                v-on="on"
-                v-bind="attrs"
-                icon>
+              v-on="on"
+              v-bind="attrs"
+              icon>
               <v-icon
-                  size="18"
-                  class="d-flex justify-center"
-                  :title="item.userRoleIconTitle">
+                size="18"
+                class="d-flex justify-center"
+                :title="item.userRoleIconTitle">
                 {{ item.userRoleIcon }}
               </v-icon>
             </v-btn>

--- a/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
+++ b/webapp/src/main/webapp/vue-apps/search-page/components/SearchPageCard.vue
@@ -35,8 +35,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
             <v-list-item-subtitle
               v-if="excerptHtml"
               class="pt-1 text-wrap text-body-2 text-color text-break text-truncate-3"
-              v-sanitized-html="excerptHtml">
-            </v-list-item-subtitle>
+              v-sanitized-html="excerptHtml" />
           </v-list-item-content>
           <v-list-item-action v-if="result && result.id" v-show="hover || isMobile">
             <favorite-button


### PR DESCRIPTION
Prior to this change, there was no way to list the spaces of a given profile owner as seen by a viewer, so a profile page could only show the viewer's own spaces.
This change will add a SpaceService listing of a profile owner's spaces, filtered by the viewer's access rights and narrowed to common spaces for external viewers, with the viewer as an explicit cache key field.
It exposes that listing on GET /social/rest/users/{username}/spaces with offset paging, an optional total count and a bounded page size.
It also adds the stream owner accessor and the space JS service call that the profile spaces widget and its See-all drawer use.