### PR TITLE
fix: Remove dangling OtpRestTest import that breaks test compilation 

### DIFF
--- a/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/test/InitContainerTestSuite.java
@@ -19,7 +19,6 @@
 package org.exoplatform.social.service.test;
 
 import io.meeds.social.security.rest.LoginRestTest;
-import io.meeds.social.security.rest.OtpRestTest;
 import io.meeds.social.space.rest.UserSpacesRestTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;


### PR DESCRIPTION
Prior to this change, InitContainerTestSuite imported io.meeds.social.security.rest.OtpRestTest while its @SuiteClasses list no longer referenced OtpRestTest.class and OtpRestTest.java is not present on this branch, so the test compilation failed with "cannot find symbol" on the FB CI.
This change will remove the orphan import. All 22 classes listed in @SuiteClasses resolve to existing test sources.
