### PR TITLE
fix: Set component/web coverage ratio so the jacoco check passes

### DIFF
--- a/component/web/pom.xml
+++ b/component/web/pom.xml
@@ -29,6 +29,14 @@
   <packaging>jar</packaging>
   <name>Meeds:: PLF:: Social Web Component</name>
   <description>Meeds Social Web Component</description>
+  <properties>
+    <!-- Only URLUtils carries unit-tested logic in this module; the rest is
+         portlet/handler glue. Declare the module's own coverage ratio like the
+         sibling modules (api=0, common=0.58, core=0.72, service=0.52) instead of
+         inheriting the parent default of 1.0 (100%), which the module cannot meet
+         and which only passed before because the module had no tests at all. -->
+    <exo.test.coverage.ratio>0</exo.test.coverage.ratio>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>io.meeds.social</groupId>


### PR DESCRIPTION
Prior to this change, social-component-web declared no exo.test.coverage.ratio and inherited the parent default of 1.0 (100%). It passed before only because the module had no tests, so jacoco had no data to check. Adding URLUtilsTest, the module's first test, made jacoco enforce the 100% rule on a bundle whose other classes are untested, failing the build with "covered ratio 0.0, expected minimum 1.0".
This change will declare the module's own ratio (0), as the sibling modules do (api=0, common=0.58, core=0.72, service=0.52), instead of inheriting the unmeetable default.
