### PR TITLE
fix: display the drawers mask above an active dialog EXO-89861

### DIFF
--- a/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
+++ b/webapp/src/main/webapp/vue-apps/common/components/DrawersOverlay.vue
@@ -16,10 +16,28 @@ export default {
     openedDrawers: 0,
     uiPortalApplicationElement: null,
     drawerZIndex: 1035,
+    // Mirrors @zindexModal, the plane the skin clamps an active Vuetify dialog
+    // to inside #vuetify-apps, exactly as drawerZIndex mirrors @zindexDrawer
+    modalZIndex: 1050,
+    aboveDialog: false,
   }),
   computed: {
+    /**
+     * Computes the z-index of the shared drawers mask, which has to paint above
+     * everything it dims and below the topmost opened drawer.
+     * Its base plane is the drawer plane, unless the drawers were opened while
+     * a Vuetify dialog was active: such a dialog is clamped by the skin to
+     * @zindexModal, above the drawer plane, so basing the mask on the drawer
+     * plane would bury it under the dialog instead of dimming it. In that case
+     * the modal plane is used as base, which keeps the mask above the dialog
+     * and still below a drawer climbing to @zindexSnackBar.
+     * When no dialog is active, this returns the very same value as it did
+     * before the computation was made dialog aware.
+     * @returns {Number} z-index to apply on the mask
+     */
     zIndex() {
-      return this.overlay ? (this.drawerZIndex - 1 + (this.openedDrawers || 0)) : this.drawerZIndex - 1;
+      const baseZIndex = this.aboveDialog ? this.modalZIndex : this.drawerZIndex - 1;
+      return this.overlay ? (baseZIndex + (this.openedDrawers || 0)) : baseZIndex;
     },
     overlay() {
       return this.openedDrawers && !this.openedModals;
@@ -50,10 +68,22 @@ export default {
     closeDisplayedDrawerEffectively() {
       document.dispatchEvent(new CustomEvent('closeDisplayedDrawer'));
     },
+    /**
+     * Displays the shared mask when a drawer delegating its overlay to this
+     * component is opened.
+     * Probes the DOM for an active Vuetify dialog at that very moment, with the
+     * same selector and in the same tick as ExoDrawer does when it decides to
+     * climb above such a dialog, so that a drawer and its mask can never
+     * disagree on which plane they are being displayed on.
+     * @param {CustomEvent} event 'drawerOpened' event, its detail being true
+     *          when the drawer displays an overlay of its own
+     * @returns {void}
+     */
     showOverlay(event) {
       this.uiPortalApplicationElement.classList.add('decrease-z-index');
       const showOverlay = !event?.detail;
       if (showOverlay) {
+        this.aboveDialog = !!document.querySelector('.v-dialog--active');
         window.setTimeout(() => {
           this.openedDrawers += 1;
         }, 10);
@@ -70,12 +100,21 @@ export default {
       this.openedDrawers = 1;
       this.hideOverlay();
     },
+    /**
+     * Hides the shared mask when a drawer delegating its overlay to this
+     * component is closed, and gives the mask its drawer plane back once the
+     * last drawer is closed.
+     * @param {CustomEvent} event 'drawerClosed' event, its detail being true
+     *          when the drawer displays an overlay of its own
+     * @returns {void}
+     */
     hideOverlay(event) {
       const showOverlay = !event?.detail;
       if (showOverlay && this.openedDrawers > 0) {
         window.setTimeout(() => {
           this.openedDrawers -= 1;
           if (this.openedDrawers === 0) {
+            this.aboveDialog = false;
             this.uiPortalApplicationElement.classList.remove('decrease-z-index');
           }
         }, 10);


### PR DESCRIPTION
Backport to `develop` of **EXO-89861 — Agenda_US18.2: display the drawers mask above an active dialog**, validated on the `feature/ai-contribution` acceptance server.

| | |
|---|---|
| Tribe task | [EXO-89861](https://community.exoplatform.com/portal/dw/tasks/taskDetail/89861) |
| Cherry-picked commit | `360345e17d` |
| Classification | **N2 — shared component** |

### ⚠️ N2 — this needs a human ack, not an approval on AI review alone
`DrawersOverlay.vue` is a shared component. The task records the blast radius explicitly: **40 consumers across 11 add-ons**. The change is guarded to the dialog-active case and the no-dialog path is meant to be untouched bit-for-bit, but that claim is only worth what an eyes-on check confirms.

**What a reviewer should verify visually**: open any drawer with **no** fullscreen dialog active, anywhere on the platform, and confirm it looks exactly as before.

### Verification
- `git cherry-pick -x 360345e17d` onto today's `develop`: **clean, no conflict** — diff-equivalent to the validated FB state.
- `mvn install`: **BUILD SUCCESS**, 13 tests, 0 failures. Note this is a Vue-only change; no Java test covers it, so the build is a compile/webpack check, not behavioural evidence.

### Scope
```
vue-apps/common/components/DrawersOverlay.vue | 41 +++++++++++++++++-
```
With a fullscreen dialog at z-index 1050, a drawer's mask rendered at 1035/1036 — behind the dialog — so the page underneath stayed lit and the drawer did not read as modal. The mask is now based above the dialog (1050 + count).

Knowledge: none — a z-index base fix in an existing component; no mechanism, API or norm changes.
