### PR TITLE
feat: break ties in the space list order by name EXO-89908

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/SpaceDAO.java
@@ -84,6 +84,8 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
 
   private static final String                      PARAM_HIDDEN_VISIBILITY     = "hiddenVisibility";
 
+  private static final String                      DISPLAY_NAME_SORT_FIELD     = "s.displayName";
+
   private static final String                      QUERY_FILTER_FIND_PREFIX    = "Space.findSpaces";
 
   private static final String                      QUERY_FILTER_COUNT_PREFIX   = "Space.countSpaces";
@@ -309,7 +311,7 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
                                        List<String> parameterNames,
                                        boolean count) {
     String querySelect = count ? "SELECT COUNT(DISTINCT s.id) FROM SocSpaceEntity s " :
-                               "SELECT DISTINCT(s.id), " + getSortField(spaceFilter) + " FROM SocSpaceEntity s ";
+                               "SELECT DISTINCT(s.id), " + getSelectedSortFields(spaceFilter) + " FROM SocSpaceEntity s ";
     boolean lastAccess = isLastAccess(spaceFilter);
     if (parameterNames.contains(PARAM_USER_ID) || lastAccess) {
       if (StringUtils.isNotBlank(spaceFilter.getRemoteId()) && lastAccess) {
@@ -336,8 +338,7 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
       queryContent = querySelect + " WHERE " + StringUtils.join(predicates, " AND ");
     }
     if (!count) {
-      queryContent += " ORDER BY " + getSortField(spaceFilter) +
-          (isSortDescending(spaceFilter) ? " DESC " : " ASC ");
+      queryContent += " ORDER BY " + getOrderByClause(spaceFilter);
     }
     return queryContent;
   }
@@ -491,8 +492,46 @@ public class SpaceDAO extends GenericDAOJPAImpl<SpaceEntity, Long> {
     } else if (sorting.sortBy.equals(SortBy.DATE)) {
       return "s.createdDate";
     } else {
-      return "s.displayName";
+      return DISPLAY_NAME_SORT_FIELD;
     }
+  }
+
+  /**
+   * Gives the fields the query has to select for its own ordering: the sort
+   * field, and the display name it is broken ties with. Both are needed in the
+   * select list because the query is a SELECT DISTINCT, which may only be
+   * ordered by what it selects.
+   *
+   * @param spaceFilter filter the query is built from
+   * @return the sort fields, comma separated, without the ordering direction
+   */
+  private String getSelectedSortFields(XSpaceFilter spaceFilter) {
+    String sortField = getSortField(spaceFilter);
+    return DISPLAY_NAME_SORT_FIELD.equals(sortField) ? sortField : sortField + ", " + DISPLAY_NAME_SORT_FIELD;
+  }
+
+  /**
+   * Builds the ordering of a space list: the requested sort field, then the
+   * display name as a tie-break.
+   * <p>
+   * <strong>The tie-break is what makes a paginated list stable.</strong>
+   * Neither of the other two sort fields is unique across spaces, and the last
+   * visit is the extreme case: every space a user has never opened carries the
+   * same default date, so on the ordering alone the database is free to return
+   * them in any order it likes, and in a different one from one page — or one
+   * refetch — to the next. A caller paging through such a list sees rows move
+   * under it for no reason it can observe. Ordering by the name after the sort
+   * field costs nothing where the field is already unique, and turns the rest
+   * of the list from arbitrary into alphabetical.
+   *
+   * @param spaceFilter filter the query is built from
+   * @return the ORDER BY clause content, directions included
+   */
+  private String getOrderByClause(XSpaceFilter spaceFilter) {
+    String sortField = getSortField(spaceFilter);
+    String direction = isSortDescending(spaceFilter) ? " DESC " : " ASC ";
+    return DISPLAY_NAME_SORT_FIELD.equals(sortField) ? sortField + direction
+                                                     : sortField + direction + ", " + DISPLAY_NAME_SORT_FIELD + " ASC ";
   }
 
   private boolean isSortDescending(XSpaceFilter spaceFilter) {

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/SpaceStorageTest.java
@@ -1569,6 +1569,66 @@ public class SpaceStorageTest extends AbstractCoreTest {
     assertEquals(space3.getId(), result.get(0).getId());
   }
 
+  /**
+   * The last-visit order alone does not order anything below the spaces the
+   * user has actually opened: every other space carries the same default date,
+   * so on that field alone the database may return them in any order, and in a
+   * different one from one page or one refetch to the next. Rows then move
+   * under a user paging through a long list for no reason they can observe.
+   * <p>
+   * The spaces below are saved in an order that is neither alphabetical nor
+   * the reverse, so a list that came back sorted by name cannot be the
+   * insertion order having survived by chance.
+   *
+   * @throws Exception when the space cannot be saved
+   */
+  public void testLastAccessedSpacesAreOrderedByNameWithinTheSameLastVisit() throws Exception {
+    Space middle = saveSpaceNamed(21, "my space test middle");
+    Space last = saveSpaceNamed(22, "my space test zulu");
+    Space first = saveSpaceNamed(23, "my space test alpha");
+
+    SpaceFilter filter = new SpaceFilter();
+    filter.setRemoteId("ghost");
+
+    restartTransaction();
+    cacheService.getSpacesCache().clearCache();
+
+    List<Space> neverVisited = spaceStorage.getLastAccessedSpace(filter, 0, -1);
+    assertEquals(3, neverVisited.size());
+    assertEquals(first.getId(), neverVisited.get(0).getId());
+    assertEquals(middle.getId(), neverVisited.get(1).getId());
+    assertEquals(last.getId(), neverVisited.get(2).getId());
+
+    // a visited space still comes first: the name only breaks ties
+    spaceStorage.updateSpaceAccessed("ghost", last);
+    restartTransaction();
+    cacheService.getSpacesCache().clearCache();
+
+    List<Space> afterVisit = spaceStorage.getLastAccessedSpace(filter, 0, -1);
+    assertEquals(3, afterVisit.size());
+    assertEquals(last.getId(), afterVisit.get(0).getId());
+    assertEquals(first.getId(), afterVisit.get(1).getId());
+    assertEquals(middle.getId(), afterVisit.get(2).getId());
+  }
+
+  /**
+   * Saves a space whose display name is chosen by the caller, so that a test
+   * can tell the name order apart from the insertion order.
+   *
+   * @param number number the space instance is built from
+   * @param displayName display name to give the space
+   * @return the saved space
+   * @throws Exception when the space cannot be saved
+   */
+  private Space saveSpaceNamed(int number, String displayName) throws Exception {
+    Space space = getSpaceInstance(number);
+    space.setDisplayName(displayName);
+    space.setPrettyName(displayName);
+    space.setUrl(space.getPrettyName());
+    spaceStorage.saveSpace(space, true);
+    return space;
+  }
+
   public void testGetLastAccessedSpace() {
     // create a new space
     Space space = getSpaceInstance(1);


### PR DESCRIPTION
Backport to `develop` of the **social half** of **EXO-89908 — Agenda_US21.2: recent-first space ordering in the Agenda filter**, validated on the `feature/ai-contribution` acceptance server.

| | |
|---|---|
| Tribe task | [EXO-89908](https://community.exoplatform.com/portal/dw/tasks/taskDetail/89908) |
| Cherry-picked commit | `1a9ed072e4` |
| Classification | **N2** — a DAO ordering change on a paginated list endpoint |

### ⚠️ Merge order — this PR lands FIRST
EXO-89908 spans two repos. This one adds the **`displayName` tiebreak** to `SpaceDAO`'s recency ordering; the agenda half (exoplatform/agenda#1104) switches the filter to `filterType=lastVisited`.

**Merge this PR before the agenda one.** Never-visited spaces all share the same default timestamp, so without the tiebreak the tail of a long list **shuffles between "Load more" fetches** — exactly the symptom the agenda half would otherwise expose.

### ⚠️ N2 — needs a human ack
`SpaceDAO` is a shared storage component and this changes the `ORDER BY` on a **paginated** query. Worth a reviewer's eye on: the ordering is stable across pages (the point of the change), and the added sort column does not defeat an index the query relied on. The corpus is explicit that an all-ascending composite index will not serve a mixed `DESC, ASC` scan — confirming the index situation on a real database is not something a unit test can show.

### Verification
- `git cherry-pick -x 1a9ed072e4` onto today's `develop`: **clean, no conflict** — diff-equivalent to the validated FB state.
- `mvn install`: **BUILD SUCCESS**, 13 tests, 0 failures, including the added `SpaceStorageTest` cases (60 lines) which exercise the ordering through the real storage rather than a mock.

### Scope
```
core/jpa/storage/dao/jpa/SpaceDAO.java   | 47 +++++++++--
core/jpa/storage/SpaceStorageTest.java   | 60 ++++++++++++++  (new cases)
```

Knowledge: none — a tiebreak on an existing ordering; no new mechanism, API or norm.