### PR TITLE
fix: The digest space lines link to the space pages - EXO-90021 - eXIP7.3.0.22

### DIFF
--- a/component/notification/src/main/java/io/meeds/social/notification/digest/SocialDigestLinePlugin.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/digest/SocialDigestLinePlugin.java
@@ -21,7 +21,6 @@ package io.meeds.social.notification.digest;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
@@ -94,7 +93,7 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
   @Override
   public DigestLine buildLine(DigestItem item, DigestLineContext context) {
     return switch (item.getPluginId()) {
-      case SPACE_INVITATION_PLUGIN -> invitationLine(item, context);
+      case SPACE_INVITATION_PLUGIN -> invitationLine(item);
       case REQUEST_JOIN_SPACE_PLUGIN -> requestLine(item);
       case POST_ACTIVITY_SPACE_PLUGIN -> activityLine(item, true);
       case ACTIVITY_COMMENT_WATCH_PLUGIN -> activityLine(item, false);
@@ -103,19 +102,16 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
   }
 
   /**
-   * "{actor} invited you to join {space}": the link goes to the space once the
-   * invitation is accepted, to the received invitations page while it is not
-   * (EXO-90021)
+   * "{actor} invited you to join {space}", linking to the space page, which
+   * lets the user accept the invitation while it is pending (EXO-90021)
    */
-  private DigestLine invitationLine(DigestItem item, DigestLineContext context) {
+  private DigestLine invitationLine(DigestItem item) {
     Space space = findSpace(item.getParam(SPACE_ID_PARAM));
     if (space == null) {
       return null;
     }
-    String url = getSpaceService().isMember(space, context.getUsername()) ? spaceUrl(space)
-                                                                          : redirectUrl("space_invitation", space.getId());
     return DigestLine.of(LINE_KEY_PREFIX + item.getPluginId(), fullName(item.getParam(INVITER_PARAM)), space.getDisplayName())
-                     .withUrl(url);
+                     .withUrl(spaceUrl(space));
   }
 
   /**
@@ -185,21 +181,14 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
     return LinkProviderUtils.getRedirectUrl(type, objectId);
   }
 
-  /** The members page of a space, /portal/s/{id}/members */
-  protected String spaceMembersUrl(Space space) {
-    return CommonsUtils.getCurrentDomain() + "/" + LinkProvider.getPortalName(null) + "/s/" + space.getId() + "/members";
+  /** The space page, /portal/s/{id} */
+  protected String spaceUrl(Space space) {
+    return CommonsUtils.getCurrentDomain() + "/" + LinkProvider.getPortalName(null) + "/s/" + space.getId();
   }
 
-  /**
-   * The permanent link of a space, the one the platform resolves for the
-   * current user at click time
-   */
-  protected String spaceUrl(Space space) {
-    try {
-      return CommonsUtils.getCurrentDomain() + LinkProvider.getSpaceLink(space.getId());
-    } catch (ObjectNotFoundException e) {
-      return null;
-    }
+  /** The members page of a space, /portal/s/{id}/members */
+  protected String spaceMembersUrl(Space space) {
+    return spaceUrl(space) + "/members";
   }
 
   private SpaceService getSpaceService() {

--- a/component/notification/src/main/java/io/meeds/social/notification/digest/SocialDigestLinePlugin.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/digest/SocialDigestLinePlugin.java
@@ -95,7 +95,7 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
   public DigestLine buildLine(DigestItem item, DigestLineContext context) {
     return switch (item.getPluginId()) {
       case SPACE_INVITATION_PLUGIN -> invitationLine(item, context);
-      case REQUEST_JOIN_SPACE_PLUGIN -> spaceLine(item, item.getParam(REQUESTER_PARAM), "space_members");
+      case REQUEST_JOIN_SPACE_PLUGIN -> requestLine(item);
       case POST_ACTIVITY_SPACE_PLUGIN -> activityLine(item, true);
       case ACTIVITY_COMMENT_WATCH_PLUGIN -> activityLine(item, false);
       default -> null;
@@ -118,14 +118,17 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
                      .withUrl(url);
   }
 
-  /** "{actor} requested to join {space}", linking to the members of the space */
-  private DigestLine spaceLine(DigestItem item, String actor, String redirectType) {
+  /**
+   * "{actor} requested to join {space}", linking to the members page of the
+   * space where the manager handles the request
+   */
+  private DigestLine requestLine(DigestItem item) {
     Space space = findSpace(item.getParam(SPACE_ID_PARAM));
     if (space == null) {
       return null;
     }
-    return DigestLine.of(LINE_KEY_PREFIX + item.getPluginId(), fullName(actor), space.getDisplayName())
-                     .withUrl(redirectUrl(redirectType, space.getId()));
+    return DigestLine.of(LINE_KEY_PREFIX + item.getPluginId(), fullName(item.getParam(REQUESTER_PARAM)), space.getDisplayName())
+                     .withUrl(spaceMembersUrl(space));
   }
 
   /**
@@ -180,6 +183,11 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
    */
   protected String redirectUrl(String type, String objectId) {
     return LinkProviderUtils.getRedirectUrl(type, objectId);
+  }
+
+  /** The members page of a space, /portal/s/{id}/members */
+  protected String spaceMembersUrl(Space space) {
+    return CommonsUtils.getCurrentDomain() + "/" + LinkProvider.getPortalName(null) + "/s/" + space.getId() + "/members";
   }
 
   /**

--- a/component/notification/src/main/java/io/meeds/social/notification/digest/SocialDigestLinePlugin.java
+++ b/component/notification/src/main/java/io/meeds/social/notification/digest/SocialDigestLinePlugin.java
@@ -21,12 +21,15 @@ package io.meeds.social.notification.digest;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.notification.LinkProviderUtils;
@@ -91,7 +94,7 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
   @Override
   public DigestLine buildLine(DigestItem item, DigestLineContext context) {
     return switch (item.getPluginId()) {
-      case SPACE_INVITATION_PLUGIN -> spaceLine(item, item.getParam(INVITER_PARAM), "space");
+      case SPACE_INVITATION_PLUGIN -> invitationLine(item, context);
       case REQUEST_JOIN_SPACE_PLUGIN -> spaceLine(item, item.getParam(REQUESTER_PARAM), "space_members");
       case POST_ACTIVITY_SPACE_PLUGIN -> activityLine(item, true);
       case ACTIVITY_COMMENT_WATCH_PLUGIN -> activityLine(item, false);
@@ -99,7 +102,23 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
     };
   }
 
-  /** "{actor} invited you to join {space}" / "{actor} requested to join {space}" */
+  /**
+   * "{actor} invited you to join {space}": the link goes to the space once the
+   * invitation is accepted, to the received invitations page while it is not
+   * (EXO-90021)
+   */
+  private DigestLine invitationLine(DigestItem item, DigestLineContext context) {
+    Space space = findSpace(item.getParam(SPACE_ID_PARAM));
+    if (space == null) {
+      return null;
+    }
+    String url = getSpaceService().isMember(space, context.getUsername()) ? spaceUrl(space)
+                                                                          : redirectUrl("space_invitation", space.getId());
+    return DigestLine.of(LINE_KEY_PREFIX + item.getPluginId(), fullName(item.getParam(INVITER_PARAM)), space.getDisplayName())
+                     .withUrl(url);
+  }
+
+  /** "{actor} requested to join {space}", linking to the members of the space */
   private DigestLine spaceLine(DigestItem item, String actor, String redirectType) {
     Space space = findSpace(item.getParam(SPACE_ID_PARAM));
     if (space == null) {
@@ -161,6 +180,18 @@ public class SocialDigestLinePlugin extends DigestLinePlugin {
    */
   protected String redirectUrl(String type, String objectId) {
     return LinkProviderUtils.getRedirectUrl(type, objectId);
+  }
+
+  /**
+   * The permanent link of a space, the one the platform resolves for the
+   * current user at click time
+   */
+  protected String spaceUrl(Space space) {
+    try {
+      return CommonsUtils.getCurrentDomain() + LinkProvider.getSpaceLink(space.getId());
+    } catch (ObjectNotFoundException e) {
+      return null;
+    }
   }
 
   private SpaceService getSpaceService() {

--- a/component/notification/src/test/java/io/meeds/social/notification/digest/SocialDigestLinePluginTest.java
+++ b/component/notification/src/test/java/io/meeds/social/notification/digest/SocialDigestLinePluginTest.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -118,21 +116,12 @@ public class SocialDigestLinePluginTest {
   }
 
   @Test
-  public void testPendingInvitationLinksToTheReceivedInvitations() {
+  public void testInvitationLinksToTheSpace() {
     DigestLine line = plugin.buildLine(item(SocialDigestLinePlugin.SPACE_INVITATION_PLUGIN, "profile", "john", "spaceId", "42"),
                                        CONTEXT);
     assertNotNull(line);
     assertEquals("digest.line.SpaceInvitationPlugin", line.getLabelKey());
     assertEquals(List.of("John Smith", "Product team"), line.getArgs());
-    assertEquals("redirect:space_invitation:42", line.getUrl());
-  }
-
-  @Test
-  public void testAcceptedInvitationLinksToTheSpace() {
-    when(spaceService.isMember(any(Space.class), eq("ayoub"))).thenReturn(true);
-    DigestLine line = plugin.buildLine(item(SocialDigestLinePlugin.SPACE_INVITATION_PLUGIN, "profile", "john", "spaceId", "42"),
-                                       CONTEXT);
-    assertNotNull(line);
     assertEquals("space:42", line.getUrl());
   }
 

--- a/component/notification/src/test/java/io/meeds/social/notification/digest/SocialDigestLinePluginTest.java
+++ b/component/notification/src/test/java/io/meeds/social/notification/digest/SocialDigestLinePluginTest.java
@@ -97,6 +97,11 @@ public class SocialDigestLinePluginTest {
       protected String spaceUrl(Space space) {
         return "space:" + space.getId();
       }
+
+      @Override
+      protected String spaceMembersUrl(Space space) {
+        return "members:" + space.getId();
+      }
     };
 
     Space space = new Space();
@@ -137,7 +142,7 @@ public class SocialDigestLinePluginTest {
                                        CONTEXT);
     assertNotNull(line);
     assertEquals(List.of("John Smith", "Product team"), line.getArgs());
-    assertEquals("redirect:space_members:42", line.getUrl());
+    assertEquals("members:42", line.getUrl());
   }
 
   @Test

--- a/component/notification/src/test/java/io/meeds/social/notification/digest/SocialDigestLinePluginTest.java
+++ b/component/notification/src/test/java/io/meeds/social/notification/digest/SocialDigestLinePluginTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -90,6 +92,11 @@ public class SocialDigestLinePluginTest {
       protected String redirectUrl(String type, String objectId) {
         return "redirect:" + type + ":" + objectId;
       }
+
+      @Override
+      protected String spaceUrl(Space space) {
+        return "space:" + space.getId();
+      }
     };
 
     Space space = new Space();
@@ -106,13 +113,22 @@ public class SocialDigestLinePluginTest {
   }
 
   @Test
-  public void testSpaceInvitationLine() {
+  public void testPendingInvitationLinksToTheReceivedInvitations() {
     DigestLine line = plugin.buildLine(item(SocialDigestLinePlugin.SPACE_INVITATION_PLUGIN, "profile", "john", "spaceId", "42"),
                                        CONTEXT);
     assertNotNull(line);
     assertEquals("digest.line.SpaceInvitationPlugin", line.getLabelKey());
     assertEquals(List.of("John Smith", "Product team"), line.getArgs());
-    assertEquals("redirect:space:42", line.getUrl());
+    assertEquals("redirect:space_invitation:42", line.getUrl());
+  }
+
+  @Test
+  public void testAcceptedInvitationLinksToTheSpace() {
+    when(spaceService.isMember(any(Space.class), eq("ayoub"))).thenReturn(true);
+    DigestLine line = plugin.buildLine(item(SocialDigestLinePlugin.SPACE_INVITATION_PLUGIN, "profile", "john", "spaceId", "42"),
+                                       CONTEXT);
+    assertNotNull(line);
+    assertEquals("space:42", line.getUrl());
   }
 
   @Test


### PR DESCRIPTION
eXIP 7.3.0.22 Digest Mail Notifications — feedback task EXO-90021 from the functional tests.

The space lines of the digest linked to the legacy space redirections (`/rest/social/notifications/redirectUrl/space/<id>` and `space_members`), which build `/portal/g/:spaces:…` URLs and land on a not found page. They now link to the space pages of the platform:

- "{actor} invited you to join {space}" → `<domain>/portal/s/<spaceId>`, the space page, which lets the user accept the invitation while it is pending and opens the space once accepted;
- "{actor} requested to join {space}" → `<domain>/portal/s/<spaceId>/members`, where the manager handles the request.

Tests: `SocialDigestLinePluginTest` (9 green). Classification: **N2**. Knowledge: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
