### PR TITLE
fix: Fix categories display with several link permissions - EXO-90031

### DIFF
--- a/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
+++ b/component/core/src/main/java/io/meeds/social/category/service/CategoryServiceImpl.java
@@ -305,7 +305,11 @@ public class CategoryServiceImpl implements CategoryService {
       return category != null && isManagerOf(identityManager, spaceService, userAcl, category.getOwnerId(), username);
     } else {
       org.exoplatform.services.security.Identity identity = StringUtils.isBlank(username) ? null : userAcl.getUserIdentity(username);
-      return userAcl.isMemberOf(identity, StringUtils.join(category.getLinkPermissions(), ","));
+      // Each entry is a single "membershipType:groupId" expression: evaluate them
+      // one by one, a joined string is never a valid expression for UserACL
+      return category.getLinkPermissions()
+                     .stream()
+                     .anyMatch(permission -> userAcl.isMemberOf(identity, permission));
     }
   }
 

--- a/component/core/src/test/java/io/meeds/social/category/service/CategoryServiceUnitTest.java
+++ b/component/core/src/test/java/io/meeds/social/category/service/CategoryServiceUnitTest.java
@@ -343,4 +343,32 @@ public class CategoryServiceUnitTest {
     assertEquals(3, result.getNextOffset());
   }
 
+  @Test
+  public void testCanManageLinkWithSeveralPermissions() {
+    org.exoplatform.services.security.Identity userAclIdentity = mock(org.exoplatform.services.security.Identity.class);
+    when(userAcl.getUserIdentity(TEST_USER)).thenReturn(userAclIdentity);
+    // Member of space2 only
+    when(userAcl.isMemberOf(userAclIdentity, "*:" + SPACE_GROUP_ID_2)).thenReturn(true);
+
+    Category category = new Category();
+    category.setId(CATEGORY_ID);
+    category.setOwnerId(OWNER_ID);
+
+    // EXO-90031: a category shared with several groups must stay linkable
+    // for a member of any one of them
+    category.setLinkPermissions(Arrays.asList("*:" + SPACE_GROUP_ID_1, "*:" + SPACE_GROUP_ID_2));
+    assertTrue(categoryService.canManageLink(category, TEST_USER));
+
+    category.setLinkPermissions(Arrays.asList("*:" + SPACE_GROUP_ID_2, "*:" + SPACE_GROUP_ID_1, "*:" + A_GROUP_ID));
+    assertTrue(categoryService.canManageLink(category, TEST_USER));
+
+    // Not a member of any listed group
+    category.setLinkPermissions(Arrays.asList("*:" + SPACE_GROUP_ID_1, "*:" + A_GROUP_ID));
+    assertFalse(categoryService.canManageLink(category, TEST_USER));
+
+    // Single permission keeps working
+    category.setLinkPermissions(Collections.singletonList("*:" + SPACE_GROUP_ID_2));
+    assertTrue(categoryService.canManageLink(category, TEST_USER));
+  }
+
 }


### PR DESCRIPTION
Prior to this change, a category whose link permissions listed two or more groups was never listed nor linkable, because canManageLink joined all permissions into one comma-separated string that UserACL.isMemberOf cannot parse as a single membershipType:groupId expression.
This change will evaluate each link permission on its own and grant on any match, so members of any listed group can link the category, with a regression test covering two and three entries, a non-member and the single-entry case.