### PR TITLE
fix: translate the site background attachment in the branding preview EXO-90087

### DIFF
--- a/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
+++ b/webapp/src/main/webapp/vue-apps/general-settings/components/branding/SiteBranding.vue
@@ -601,7 +601,7 @@ export default {
         pageBackgroundSize: backgroundProperties?.backgroundSize || 'unset',
         pageBackgroundRepeat: backgroundProperties?.backgroundRepeat || 'no-repeat',
         pageBackgroundPosition: backgroundProperties?.backgroundPosition || 'unset',
-        pageBackgroundAttachment: backgroundProperties?.backgroundAttachment || 'scroll',
+        pageBackgroundAttachment: backgroundProperties?.backgroundAttachment || null,
         pageBackgroundColor: backgroundProperties?.backgroundColor ,
         pageBackgroundEffect: backgroundProperties?.backgroundEffect,
         borderRadius: borderRadius,
@@ -635,7 +635,11 @@ export default {
       });
       this.$root.$emit('refresh-body-style-property', {
         name: '--allPagesBackgroundAttachment',
-        value: this.pageStylingProperties.pageBackgroundAttachment || 'scroll',
+        // The site background paints on the scroll container, where 'scroll'
+        // would mean "fixed with regard to that box"; 'local' is what makes it
+        // follow the scrolled content. Mirrors UIPortalApplication.gtmpl.
+        value: this.pageStylingProperties.pageBackgroundAttachment === 'scroll'
+          && 'local' || this.pageStylingProperties.pageBackgroundAttachment || 'scroll',
       });
       this.$root.$emit('refresh-body-style-property', {
         name: 'background-image',


### PR DESCRIPTION
Follow-up to `#6089` (merged), for [task 90087](https://community.exoplatform.com/portal/dw/tasks/taskDetail/90087). Requires `Meeds-io/platform-ui#1004`.

Mirrors `Meeds-io/portal#1320` so the drawer's **live preview** matches what a full page load renders. The site background paints on the scrolling container (`Meeds-io/platform-ui#1004`), where `scroll` would mean *"fixed with regard to that box"*, so the preview emits `local` instead. The stored value keeps the user's intent (`fixed` / `scroll`).

Without this the preview and the reloaded page would disagree — the exact kind of mismatch that makes an option look broken while the data is right.

### Second change
`updatePageStylingProperties` no longer defaults the saved value to `'scroll'` when no image is set; it stays `null`, so nothing is persisted and the CSS default applies. The previous `|| 'scroll'` invented a value for a background that has no image, where attachment is meaningless.

### Tests
`eslint` on `general-settings`: 0 errors. Bundle rebuilt and deployed to a local 7.3.x-ai-contribution bundle.

Knowledge: none — one value translation, no architectural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)